### PR TITLE
Workspace-scope batchLoadCustomFields + IP-throttle failed bearer auth (PROJ-197, PROJ-198)

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -2,6 +2,20 @@ import type { Env, HonoEnv } from "@projektor/types";
 import type { Context, Next } from "hono";
 import { capabilityForMethod, parseScopes, tokenAllows } from "../auth/scopes";
 import { provisionUserOnLogin } from "../services/provisioning";
+import { bumpRateCounter } from "./rate-limit";
+
+// PROJ-198: bound bearer-token guessing per source IP. The request rate-limiter keys
+// authenticated traffic by token fingerprint, so a flood of *distinct* invalid tokens
+// from one IP would otherwise each land in its own bucket and never throttle. Count
+// failed bearer auths per IP and 429 once they exceed RATE_LIMIT_AUTH_FAIL_MAX. Tokens
+// are 256-bit random, so this is defense-in-depth, not the primary control.
+async function tooManyAuthFailures(c: Context<HonoEnv>): Promise<boolean> {
+	const ip = c.req.header("CF-Connecting-IP") ?? "127.0.0.1";
+	const windowSecs = parseInt(c.env.RATE_LIMIT_WINDOW_SECS ?? "60", 10);
+	const limit = parseInt(c.env.RATE_LIMIT_AUTH_FAIL_MAX ?? "50", 10);
+	const count = await bumpRateCounter(c.env.DB, `authfail:${ip}`, windowSecs);
+	return count > limit;
+}
 
 export interface AuthUser {
 	id: string;
@@ -52,9 +66,15 @@ export async function authMiddleware(c: Context<HonoEnv>, next: Next) {
 				scopes: string | null;
 			}>();
 
-		if (!row) return c.json({ error: "Unauthorized" }, 401);
+		if (!row) {
+			return (await tooManyAuthFailures(c))
+				? c.json({ error: "Too Many Requests" }, 429)
+				: c.json({ error: "Unauthorized" }, 401);
+		}
 		if (row.expires_at && row.expires_at < Date.now() / 1000) {
-			return c.json({ error: "Token expired" }, 401);
+			return (await tooManyAuthFailures(c))
+				? c.json({ error: "Too Many Requests" }, 429)
+				: c.json({ error: "Token expired" }, 401);
 		}
 
 		// PROJ-17: enforce the token's scope. REST is gated here by HTTP method

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -57,6 +57,20 @@ export async function rateLimitMiddleware(
 	await next();
 }
 
+/**
+ * Bump a fixed-window counter and return the new count. Shared so the auth-failure
+ * throttle (middleware/auth.ts, PROJ-198) reuses the same backing table and window math
+ * as the request limiter above.
+ */
+export async function bumpRateCounter(
+	db: D1Database,
+	key: string,
+	windowSecs: number
+): Promise<number> {
+	const slot = Math.floor(Math.floor(Date.now() / 1000) / windowSecs) * windowSecs;
+	return incrementCounter(db, key, slot);
+}
+
 async function sha256Prefix(input: string): Promise<string> {
 	const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
 	return Array.from(new Uint8Array(buf).slice(0, 8))

--- a/apps/api/src/services/custom-fields.ts
+++ b/apps/api/src/services/custom-fields.ts
@@ -304,11 +304,16 @@ export async function writeCustomFieldValues(
 
 export async function batchLoadCustomFields(
 	db: D1Database,
+	workspaceId: string,
 	issueIds: string[]
 ): Promise<Record<string, CustomFieldValue[]>> {
 	if (issueIds.length === 0) return {};
 
 	const orm = drizzle(db, { schema });
+	// PROJ-197: scope by the field definition's workspace. Custom field definitions are
+	// workspace-owned, so this confines results to the caller's workspace even if a
+	// cross-workspace issueId is ever passed in — values whose definition lives in another
+	// workspace are filtered out rather than leaked.
 	const rows = await orm
 		.select({
 			issueId: schema.customFieldValues.issueId,
@@ -322,7 +327,12 @@ export async function batchLoadCustomFields(
 			schema.customFieldDefinitions,
 			eq(schema.customFieldDefinitions.id, schema.customFieldValues.fieldId)
 		)
-		.where(inArray(schema.customFieldValues.issueId, issueIds));
+		.where(
+			and(
+				inArray(schema.customFieldValues.issueId, issueIds),
+				eq(schema.customFieldDefinitions.workspaceId, workspaceId)
+			)
+		);
 
 	const byIssue: Record<string, CustomFieldValue[]> = {};
 	for (const r of rows) {

--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -216,7 +216,7 @@ export async function listIssues(ctx: ServiceCtx, raw: unknown) {
 	const nextCursor = hasMore && lastItem ? lastItem.created_at : null;
 
 	const issueIds = (items as Array<{ id: string }>).map((i) => i.id);
-	const customFieldsByIssue = await batchLoadCustomFields(ctx.db, issueIds);
+	const customFieldsByIssue = await batchLoadCustomFields(ctx.db, ctx.workspaceId, issueIds);
 	const itemsWithFields = (items as Array<Record<string, unknown>>).map((i) => ({
 		...i,
 		customFields: customFieldsByIssue[i.id as string] ?? [],
@@ -322,7 +322,7 @@ export async function getIssue(ctx: ServiceCtx, raw: unknown) {
 
 	const links = await listLinksForIssue(ctx, { issueId });
 
-	const customFieldsByIssue = await batchLoadCustomFields(ctx.db, [issueId]);
+	const customFieldsByIssue = await batchLoadCustomFields(ctx.db, ctx.workspaceId, [issueId]);
 	const customFields = customFieldsByIssue[issueId] ?? [];
 
 	const fullIssue = {

--- a/apps/api/src/test/custom-fields.test.ts
+++ b/apps/api/src/test/custom-fields.test.ts
@@ -1,5 +1,6 @@
 import { env, SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
+import { batchLoadCustomFields } from "../services/custom-fields";
 import {
 	authHeaders,
 	seedCustomFieldDef,
@@ -577,5 +578,32 @@ describe("Custom Fields — MCP parity", () => {
 		expect(names).toContain("create_custom_field_def");
 		expect(names).toContain("update_custom_field_def");
 		expect(names).toContain("delete_custom_field_def");
+	});
+});
+
+// ─── PROJ-197: batchLoadCustomFields workspace scoping ─────────────────────────
+
+describe("PROJ-197: batchLoadCustomFields is workspace-scoped", () => {
+	it("never returns custom field values from another workspace, even for foreign issue IDs", async () => {
+		const wsA = await seedFixture({ role: "owner" });
+		const wsB = await seedFixture({ role: "owner" });
+		const projA = await seedProject(wsA.workspace.id, "AAA");
+		const projB = await seedProject(wsB.workspace.id, "BBB");
+
+		const issueA = await seedIssue(wsA.workspace.id, projA.id, wsA.user.id);
+		const issueB = await seedIssue(wsB.workspace.id, projB.id, wsB.user.id);
+
+		const defA = await seedCustomFieldDef(wsA.workspace.id, { key: "sev", label: "Severity" });
+		const defB = await seedCustomFieldDef(wsB.workspace.id, { key: "sev", label: "Severity" });
+		await seedCustomFieldValue(issueA.id, defA.id, "high-A");
+		await seedCustomFieldValue(issueB.id, defB.id, "high-B");
+
+		// Pass BOTH issue IDs but scope to workspace A — only A's value may come back.
+		const loaded = await batchLoadCustomFields(env.DB, wsA.workspace.id, [issueA.id, issueB.id]);
+
+		expect(loaded[issueA.id]).toHaveLength(1);
+		expect(loaded[issueA.id][0].value).toBe("high-A");
+		// The foreign workspace's issue must be absent entirely — no cross-tenant leak.
+		expect(loaded[issueB.id]).toBeUndefined();
 	});
 });

--- a/apps/api/src/test/rate-limit.test.ts
+++ b/apps/api/src/test/rate-limit.test.ts
@@ -103,3 +103,39 @@ describe("PROJ-19: rate limiting", () => {
 		});
 	});
 });
+
+describe("PROJ-198: failed bearer-auth throttle (IP-keyed)", () => {
+	const ENDPOINT = "http://localhost/api/workspaces";
+	const AUTH_FAIL_LIMIT = 3; // RATE_LIMIT_AUTH_FAIL_MAX in wrangler.test.toml
+
+	it("returns 401 for an invalid bearer token while under the failure limit", async () => {
+		const res = await SELF.fetch(ENDPOINT, {
+			headers: { Authorization: "Bearer pk_not_a_real_token" },
+		});
+		expect(res.status).toBe(401);
+	});
+
+	it("returns 429 once invalid bearer auths from one IP exceed the limit", async () => {
+		// Pre-seed the IP's failure counter at the limit; the next invalid-token attempt trips it.
+		// Without CF-Connecting-IP the middleware keys by the 127.0.0.1 fallback.
+		await seedCounter("authfail:127.0.0.1", AUTH_FAIL_LIMIT);
+
+		const res = await SELF.fetch(ENDPOINT, {
+			headers: { Authorization: "Bearer pk_still_not_a_real_token" },
+		});
+		expect(res.status).toBe(429);
+	});
+
+	it("does not throttle a valid token even when the IP's failure counter is high", async () => {
+		// A successful auth never touches the authfail counter, so legit clients sharing an IP
+		// with an attacker are unaffected.
+		await seedCounter("authfail:127.0.0.1", AUTH_FAIL_LIMIT + 5);
+		const fixture = await seedFixture();
+
+		const res = await SELF.fetch(ENDPOINT, {
+			headers: authHeaders(fixture.token, fixture.workspace.slug),
+		});
+		expect(res.status).not.toBe(429);
+		expect(res.status).not.toBe(401);
+	});
+});

--- a/apps/api/wrangler.test.toml
+++ b/apps/api/wrangler.test.toml
@@ -26,3 +26,7 @@ BOOTSTRAP_SECRET = "test-bootstrap-secret-do-not-use-in-production"
 RATE_LIMIT_AUTH_MAX = "3"
 RATE_LIMIT_API_MAX = "5"
 RATE_LIMIT_WINDOW_SECS = "60"
+# Failed-bearer-auth throttle (PROJ-198). Low so the test can trip 429 by seeding a few
+# failures. Safe for existing tests: setup.ts wipes rate_limit before each test, and no
+# single test makes >3 failed bearer-auth requests from the same IP.
+RATE_LIMIT_AUTH_FAIL_MAX = "3"

--- a/packages/types/src/env.ts
+++ b/packages/types/src/env.ts
@@ -23,6 +23,7 @@ export interface Env {
 	RATE_LIMIT_AUTH_MAX?: string; // max requests per IP per window when no bearer token is present
 	RATE_LIMIT_API_MAX?: string; // max requests per token per window when a bearer token is present
 	RATE_LIMIT_WINDOW_SECS?: string; // window size in seconds (default 60)
+	RATE_LIMIT_AUTH_FAIL_MAX?: string; // max failed bearer-token auths per IP per window before 429 (default 50)
 	// Static assets binding (production wrangler.toml only — absent in local dev).
 	ASSETS?: Fetcher;
 }


### PR DESCRIPTION
Two low-severity follow-ups from the PROJ-193 security audit. Independent of the PROJ-193 PR (#3); branched off `main`.

## PROJ-197 — workspace-scope `batchLoadCustomFields`
`custom-fields.ts` exported `batchLoadCustomFields(db, issueIds)` and queried `custom_field_values` by `issue_id` only. Safe today — both callers in `issues.ts` pass workspace-verified issue IDs — but the signature invited a future cross-workspace leak. Now takes `(db, workspaceId, issueIds)` and constrains the join to the caller's workspace via the field definition's `workspace_id`, so foreign issue IDs return nothing. Both call sites updated.

## PROJ-198 — IP-throttle failed bearer auth
The request rate-limiter keys bearer traffic by token fingerprint, so a flood of **distinct** invalid tokens from one IP each got its own bucket and never throttled — token-guessing wasn't bounded per IP. Added an IP-keyed failed-bearer-auth counter (`RATE_LIMIT_AUTH_FAIL_MAX`, default 50) in `auth.ts` that returns 429 once exceeded, reusing the `rate_limit` table/window through a shared `bumpRateCounter` helper. Successful auth never touches the counter, so legit clients sharing an IP are unaffected. Defense-in-depth — API tokens are 256-bit random, so this isn't the primary control.

## Tests
- `custom-fields.test.ts`: `batchLoadCustomFields` scoped to workspace A never returns workspace B's values, even when a foreign issue ID is passed.
- `rate-limit.test.ts`: invalid token returns 401 under the limit, 429 once exceeded, and a valid token is unaffected when the IP's failure counter is high.
- New `RATE_LIMIT_AUTH_FAIL_MAX = "3"` in `wrangler.test.toml` (safe — `setup.ts` wipes `rate_limit` before each test).

## Verification
- `pnpm --filter @projektor/api type-check` ✅
- `pnpm --filter @projektor/api test` ✅ (498 passed, full suite green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)