### PR TITLE
docs: add Philosophy section — where Projektor fits

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ curl -s -X POST "https://<your-worker>.workers.dev/auth/tokens" \
 
 Then wire up the agent the same way as above.
 
-See **[docs/mcp.md](./docs/mcp.md)** for the full connection guide, protocol reference, and tool catalog (54 tools across workspaces, projects, issues, sprints, wiki, comments, issue links, task types, task statuses, and custom fields).
+See **[docs/mcp.md](./docs/mcp.md)** for the full connection guide, protocol reference, and tool catalog (64 tools across 14 domains — project data plus agent-coordination primitives).
 
 ## Development
 

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -24,6 +24,7 @@ export default defineConfig({
 				// each page's `sidebar.order` frontmatter, set in build-content.mjs).
 				{ label: "Agents & MCP", autogenerate: { directory: "agents" } },
 				{ label: "Architecture", autogenerate: { directory: "architecture" } },
+				{ label: "Philosophy", autogenerate: { directory: "philosophy" } },
 				{ label: "Contributing", autogenerate: { directory: "contributing" } },
 			],
 		}),

--- a/apps/docs/scripts/build-content.mjs
+++ b/apps/docs/scripts/build-content.mjs
@@ -70,6 +70,14 @@ const PAGES = [
 		description: "How Projektor is put together: surfaces, service layer, and storage.",
 	},
 	{
+		src: "docs/philosophy.md",
+		slug: "philosophy/where-projektor-fits",
+		order: 1,
+		title: "Where Projektor fits",
+		description:
+			"How Projektor sits in the agentic dev-tools stack: layers as concerns, the MCP narrow waist, and the empty middle between Jira and beads.",
+	},
+	{
 		src: "AGENTS.md",
 		slug: "contributing/conventions",
 		order: 1,
@@ -88,6 +96,7 @@ function rewriteLinks(md) {
 		"mcp-tools.generated.md": `${BASE}/agents/tool-catalog/`,
 		"agent-workflows.md": `${BASE}/agents/agent-workflows/`,
 		"marketecture.md": `${BASE}/architecture/system-design/`,
+		"philosophy.md": `${BASE}/philosophy/where-projektor-fits/`,
 	};
 	return md.replace(/\]\(([^)]+)\)/g, (whole, target) => {
 		if (/^(https?:|mailto:|#)/.test(target)) return whole;

--- a/docs/agent-workflows.md
+++ b/docs/agent-workflows.md
@@ -10,12 +10,16 @@ which is why the end-to-end loop is hard to see. Here they are as one picture:
 
 | Layer | Runs where | What it does | Reference |
 |------|-----------|--------------|-----------|
-| **1 · Lifecycle** | The client machine | Spawns an isolated workspace per agent (git worktree + branch + terminal), and reaps it cleanly when done | This page (§1) |
+| **1 · Lifecycle** *(implementation)* | The client machine | Spawns an isolated workspace per agent (git worktree + branch + terminal), and reaps it cleanly when done | This page (§1) |
 | **2 · Coordination** | Projektor MCP | Lets parallel agents announce themselves, claim files, and message each other so they don't clobber each other's work | [Contributor conventions](./AGENTS.md) (Fleet coordination protocol) |
 | **3 · Project management** | Projektor MCP | The actual work: issues, sprints, wiki, links — and "what should I work on next?" | [MCP tool catalog](./mcp-tools.generated.md), [Connect an agent](./mcp.md) |
 
 Layers 2 and 3 are Projektor itself. Layer 1 is the harness around it. You can use any
 layer alone — a single agent needs only Layer 3 — but the power comes from combining them.
+
+> **Where this fits.** For how these three layers sit relative to other tools (Jira,
+> Notion, beads) and why Projektor deliberately spans layers 2–3, see
+> [Where Projektor fits](./philosophy.md). That page is the *why*; this one is the *how*.
 
 ---
 

--- a/docs/marketecture.md
+++ b/docs/marketecture.md
@@ -61,7 +61,7 @@ flowchart TB
 |-------|------|---------|-------|
 | Frontend | Vite + React 18 | `apps/web` | **Stub** — single static `<h1>`. Dev-proxies `/api` + `/mcp` to `:8787`. |
 | API / edge runtime | Hono on Cloudflare Workers | `apps/api` | REST + MCP, two-mode auth, workspace tenancy. |
-| MCP server | JSON-RPC 2.0 over HTTP | `apps/api/src/routes/mcp.ts` | 13 core tools (projects, issues, comments, wiki). Primary surface. |
+| MCP server | JSON-RPC 2.0 over HTTP | `apps/api/src/routes/mcp.ts` | 64 tools across 14 domains (coordination + project data). Primary surface. |
 | Plugin system | Registry + SDK | `apps/api/src/plugins`, `packages/plugin-sdk` | `definePlugin` / `defineMCPTool`. **Not loaded at runtime.** |
 | Data model | Drizzle ORM → D1 | `packages/db` | 11 tables, 1 migration. Raw `c.env.DB.prepare` used everywhere — Drizzle is schema-only. |
 | Shared types | TS | `packages/types` | `HonoEnv`, `Plugin`, `MCPTool`, `PluginContext`. |

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -1,0 +1,114 @@
+# Philosophy: where Projektor fits
+
+Agentic dev tooling stacks in three layers of *concern*. The trap is treating
+those layers as products. They aren't — **the layers are concerns; the product
+boundary is the API.** With MCP as the narrow waist, one clean tool can cut a
+*vertical slice* across several layers and stay coherent, because the API stays
+coherent. That is what Projektor is: not a layer, a slice.
+
+This page is the *why*. For the *how* — the actual multi-agent loop these layers
+combine into — see [Agentic workflows](./agent-workflows.md).
+
+## The three layers (concerns, not products)
+
+1. **Implementation — the runtime.** Spawning, worktrees, job objects;
+   *routing* (which model: opus plans, sonnet builds, haiku looks up) and
+   *conditioning* (prompt and context optimisation, token terseness); and
+   verification *transitions* — running the tests, the human review. (The
+   operational guide calls the spawn-and-reap slice of this layer the
+   *lifecycle* layer; here we take the wider runtime view.)
+2. **Coordination — communication.** A message bus, agent presence,
+   context-fetch and skills. For a fleet this layer is largely *subsumed* by the
+   one above it: the issue graph **is** shared memory, and status changes **are**
+   events.
+3. **Project management — the source of truth.** The durable state: the
+   issue / epic / sprint graph, machine-readable prioritisation, and the
+   state-machine *nodes* that record what verification decided.
+
+Projektor is a single MCP surface spanning coordination and project management;
+through file claims it even reaches into a runtime concern — who may write which
+file. It owns the **nodes** of the
+work state machine; the implementation layer owns the **transitions**. Projektor
+never runs a test or judges a diff — it records the outcome.
+
+```mermaid
+flowchart TB
+    human(["Human / lead agent — intent, priorities, final review"])
+
+    subgraph L3["Project management — source of truth"]
+        graph3["Issue / epic / sprint graph = shared memory"]
+        prio["Prioritise & decompose (machine-readable)"]
+        state["State-machine NODES — records verification outcome"]
+    end
+
+    subgraph L2["Coordination — communication"]
+        prim["Agent-native primitives: file claims · registry · heartbeat"]
+        evt["Comments · status · messages = event log / bus"]
+        ctx["Context fetch · skills · repo memory"]
+    end
+
+    subgraph L1["Implementation — runtime"]
+        spawn["Spawn · worktrees · job objects"]
+        route["Routing: opus plans · sonnet builds · haiku looks up"]
+        cond["Conditioning: prompt / context optimisation"]
+        verify{{"Transitions: tests + human review"}}
+    end
+
+    projektor["Projektor — one MCP surface, vertical slice"]
+    projektor -.-> graph3
+    projektor -.-> prim
+    projektor -.-> state
+
+    human --> prio --> graph3 --> prim
+    prim <--> evt
+    evt --> ctx --> spawn
+    spawn --> route --> cond --> verify
+    verify -->|pass / fail| state
+    state -->|feedback / replan| human
+```
+
+## The empty middle
+
+Projektor sits between two kinds of tool that already exist:
+
+- **Jira / Notion** are mature and scalable, but *human-first*: agent
+  interaction is bolted on, the API is not the primary surface, and you can't
+  cheaply self-host a slice of them.
+- **beads** is genuinely agent-native, but it's a *git-file* tracker — issues as
+  JSONL versioned in the repo. That gives offline resilience and issues that
+  version alongside the code, but it is structurally per-repo and merge-bound.
+
+Projektor claims the gap between them: **agent-native like beads, deployed and
+cross-project like Jira, and cheap enough to run on serverless for a small
+project.** When you outgrow it, you swap the database — not the system. Workers
+scale compute for free; D1 is the one bottleneck, and it's a swap, not a rewrite.
+
+| | beads (git-file) | Projektor (deployed) | Jira / Notion |
+|---|---|---|---|
+| Primary surface | agent-native | agent-native (MCP) | human-first |
+| Scope | per-repo | cross-project | cross-project |
+| Concurrency | git merge on JSONL | claims · heartbeats | human process |
+| Presence / bus | none native | registry + messages | none native |
+| Self-host cost | free (no server) | cheap (serverless) | heavy / SaaS |
+
+## Honest tradeoffs
+
+These are deliberate bets, not oversights:
+
+1. **A central coordinator on the write path.** Becoming a deployed tracker puts
+   Projektor's availability on every worker's critical line — the price of
+   cross-project claims and presence that beads, being offline and git-backed,
+   never pays. The bet: fleet-scale coordination is worth more than git's offline
+   resilience and the issue-versioned-with-code property.
+2. **Task↔code links by convention.** Agents cite `PROJ-123` in commits, exactly
+   like humans. That link is grep-able, not queryable — a field to buy back later
+   if it earns its place, not a rewrite.
+3. **Coordination, not judgment.** Design, test types, and what "done" means stay
+   with the engineer. Projektor records the decision; it never makes it.
+
+## Where to go next
+
+- **The operational loop:** [Agentic workflows](./agent-workflows.md) — how the
+  three layers combine into a real multi-agent dev cycle.
+- **The system underneath:** [System design](./marketecture.md).
+- **Connect an agent:** [Connect an AI agent](./mcp.md).


### PR DESCRIPTION
## What

Adds a **Philosophy** section to the docs site explaining where Projektor sits in the agentic dev-tools stack, and aligns the rest of the site with it.

### New page — `docs/philosophy.md` → *Philosophy → Where Projektor fits*
- **Layers are concerns, not products; the product boundary is the API** (MCP = narrow waist). Projektor is a vertical slice across coordination + project management.
- Three layers (Implementation / Coordination / Project management), nodes-vs-transitions split.
- **Empty-middle positioning**: agent-native like beads, deployed/cross-project like Jira, cheap on serverless until you swap the DB. Includes a beads/Projektor/Jira comparison table.
- **Honest tradeoffs**: central coordinator on the write path; task↔code links by convention; coordination not judgment.

### Alignment changes
- Reconcile the "three layers" model with `docs/agent-workflows.md` — shared *Coordination* vocabulary, Lifecycle↔Implementation mapping, and why/how cross-links so the two treatments read as one model.
- Fix **stale MCP tool counts** (README "54", marketecture "13") → **64 tools / 14 domains**, matching the generated catalog (source of truth).
- Wire `philosophy.md` into `build-content.mjs` (PAGES + link rewriting) and add the **Philosophy** sidebar group in `astro.config.mjs`.

## Verification
- `pnpm --filter @projektor/docs build` passes — 10 pages built, all four cross-document links resolve to correct site routes, `llms.txt` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)