### PR TITLE
feat(mcp): auto-inject fleet coordination protocol via initialize instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,23 @@ This repo is built out via parallel workers in separate git worktrees. To avoid 
 - **Never let two parallel workers edit `routes/mcp.ts`, `index.ts`, or `test/mcp.test.ts`** — serialize those, or assign to exactly one worker.
 - Large refactors that touch shared files go in a **foundation phase first** (behavior-preserving), then fan out per-domain.
 
+### Spawn prompt requirement
+
+Workers will not use the coordination primitives unless explicitly told to. Every spawn prompt for a parallel worker **must** include a `## Coordination` section:
+
+```
+## Coordination (required)
+You are working in a parallel fleet. Use the projektor MCP to coordinate:
+
+1. `register_agent` at session start — link to your issue ID, save the returned `id`.
+2. `claim_files` before touching any file — check `list_file_claims` first; back off if another agent holds a file.
+3. `post_message` to `scope: "issue:<uuid>"` when you start, hit a blocker, and finish. Use `scope: "workspace"` for fleet-wide announcements (e.g. "rebasing mcp.ts, hold off").
+4. `heartbeat_agent` every ~60 s while working (sessions time out after 120 s of silence).
+5. `release_files` then `end_agent` when done.
+```
+
+See `~/.claude/docs/spawning-sessions.md` for the full prompt template (Coordination + Finish line are both required sections).
+
 ### Fleet planning rules (for the `/fleet` skill and human planners)
 
 These are the constraints the fleet skill reads to plan batches. Keep them current when the codebase changes.

--- a/apps/api/src/routes/mcp.ts
+++ b/apps/api/src/routes/mcp.ts
@@ -18,6 +18,25 @@ import { wikiTools } from "../mcp/wiki";
 import { workspacesTools } from "../mcp/workspaces";
 import { pluginRegistry } from "../plugins/registry";
 
+// Surfaced to every MCP client at `initialize` (the MCP spec's optional
+// `instructions` field). Clients like Claude Code inject this into the model's
+// context, so any session with the Projektor MCP connected learns the fleet
+// coordination protocol without it being repeated in each spawn prompt. Framed
+// conditionally so it's a no-op for solo sessions. Keep in sync with the
+// "Fleet coordination protocol" in AGENTS.md.
+const SERVER_INSTRUCTIONS = `Projektor is an MCP-native issue tracker + wiki. Every project-management action a browser user can take is available here as a tool.
+
+Handy entry points: get_issue accepts a ref like "PROJ-42" (no UUID needed); get_prioritized_issues answers "what should I work on next?"; search_issues / search_wiki ground you in existing context before you act.
+
+Fleet coordination — only when you are one of several agents working in parallel on a shared repo. Use these primitives so parallel agents don't collide:
+1. register_agent at session start — link the issue you're implementing; save the returned id.
+2. claim_files before editing any file — check list_file_claims first and back off if another issue already holds it (don't force).
+3. post_message to scope "issue:<uuid>" when you start, hit a blocker, and finish; use scope "workspace" for fleet-wide notices (e.g. "rebasing mcp.ts, hold off").
+4. heartbeat_agent every ~60s while working (sessions time out after 120s of silence).
+5. release_files then end_agent when done.
+
+A single agent acting alone can ignore the coordination steps and just use the project-management tools directly.`;
+
 const router = new Hono<HonoEnv>();
 
 // MCP endpoint: POST /mcp/{workspaceId}
@@ -53,6 +72,7 @@ router.post("/:workspaceId", async (c) => {
 					protocolVersion: "2024-11-05",
 					capabilities: { tools: {} },
 					serverInfo: { name: "projektor", version: "0.1.0" },
+					instructions: SERVER_INSTRUCTIONS,
 				})
 			);
 

--- a/apps/api/src/test/mcp.test.ts
+++ b/apps/api/src/test/mcp.test.ts
@@ -51,9 +51,13 @@ describe("MCP endpoint", () => {
 		const res = (await mcpCall(workspaceId, "initialize", {}, headers)) as JsonRpcResult<{
 			protocolVersion: string;
 			serverInfo: { name: string };
+			instructions: string;
 		}>;
 		expect(res.result.protocolVersion).toBe("2024-11-05");
 		expect(res.result.serverInfo.name).toBe("projektor");
+		// Coordination protocol is surfaced to every client (PROJ fleet injection).
+		expect(res.result.instructions).toContain("register_agent");
+		expect(res.result.instructions).toContain("claim_files");
 	});
 
 	it("tools/list returns core tools", async () => {


### PR DESCRIPTION
## What

Two related changes around the fleet coordination protocol:

1. **`docs(AGENTS.md)`** — document the spawn-prompt `## Coordination` requirement (register/claim/message/heartbeat/release) that every parallel-worker prompt must include.
2. **`feat(mcp)`** — surface that same protocol automatically via the MCP spec's optional **`instructions`** field in the `initialize` response.

## Why

Workers don't use the coordination primitives unless explicitly told to. Repeating the protocol in every spawn prompt is fragile. The MCP `instructions` field is injected into the model's context by clients like Claude Code (the same mechanism that surfaces other MCP servers' instructions), so **any session with the Projektor MCP connected learns the protocol automatically** — portable across repos and sessions, no per-session config.

The instructions are framed conditionally ("only when you are one of several agents working in parallel") so a solo agent filing a ticket can ignore the coordination steps and just use the project tools.

## Verification
- `pnpm turbo type-check` — clean
- `pnpm --filter @projektor/api test` — 494 passed; new assertions confirm `initialize` returns `instructions` containing `register_agent` / `claim_files`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)