### PR TITLE
docs: go-public pass — README/deploy story, LICENSE/SECURITY/CONTRIBUTING, configurable storage quota

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,7 @@ Read this before making changes — it captures conventions that aren't obvious 
 
 ## What projektor is
 
-A wiki + Jira-style issue tracker that is **MCP-native**: AI agents are a first-class client,
-not an afterthought. It runs entirely on Cloudflare's edge.
+A project management tool deployed on Cloudflare. Bringing together AI native design and tried and tested principles.
 
 Design principles
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+projektor is a personal project, built and maintained by one person (with AI
+agents). It's open source under the [MIT licence](./LICENSE) — fork it, deploy
+it, modify it, learn from it.
+
+## Issues and pull requests
+
+**External issues and pull requests are automatically closed.** This isn't
+hostility — it's how a solo project stays sustainable. But **everything is
+read.** If you open an issue or PR:
+
+- it will be closed automatically, and
+- the maintainer will still review it, and may act on it (fix the bug, adopt the
+  idea, reply) on their own schedule.
+
+So: a closed issue is not an ignored issue. If something is broken or you have an
+idea, you're welcome to file it — just don't expect a back-and-forth thread.
+
+For security issues, follow [SECURITY.md](./SECURITY.md) (report privately, not
+via a public issue).
+
+## Working in the code
+
+If you're modifying a fork, [AGENTS.md](./AGENTS.md) is the source of truth for
+conventions: file layout, the service-layer contract (REST and MCP must stay at
+parity), and how to work in parallel without conflicts. Read it before changing
+anything.
+
+Both checks must be green:
+
+```bash
+pnpm --filter @projektor/api test   # vitest against an in-process Worker + Miniflare D1
+pnpm turbo type-check               # tsc --noEmit across the monorepo
+```

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Thomas Dickson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # projektor
 
-> A self-hosted Jira + Notion hybrid that runs in a single Cloudflare Worker — no servers, no containers.
+> A self-hosted Jira + Notion hybrid that runs on serverless Cloudflare resources.
 
-Wiki + Jira-style issue tracker built MCP-native, running entirely on Cloudflare's edge.
-AI agents are a first-class client: the primary surface is a JSON-RPC 2.0 MCP endpoint, not a browser UI.
 
 ## What it is
 
@@ -28,6 +26,10 @@ AI agents are a first-class client: the primary surface is a JSON-RPC 2.0 MCP en
 
 ## Features
 
+A complete project tracker — issues, boards, sprints, a wiki — built so an AI agent can
+do everything a person can. The shape of the tool follows from that; see
+[the philosophy](./docs/philosophy.md).
+
 - Issues with status, priority, assignee, labels, parent/child hierarchy, and issue links
 - Kanban board + list view + sprint planning
 - Wiki with nested pages, markdown, full-text search, and revision history
@@ -37,84 +39,47 @@ AI agents are a first-class client: the primary surface is a JSON-RPC 2.0 MCP en
 - API tokens for agent access, workspace-scoped
 - PWA — installable, offline shell
 
-## Self-hosting in 5 minutes
+## Self-hosting
 
-projektor deploys from a **config-only repo** that downloads a pre-built release
-artifact — no source checkout, no submodule, no build step. The fastest path is to
-**fork the deploy example** and deploy from there.
+projektor deploys to **your own Cloudflare account** from a small **config-only repo**
+([`projektor-deploy-example`](https://github.com/TAJD/projektor-deploy-example)) that
+downloads a pre-built release artifact — no source checkout, no build step. Three ways
+in, easiest first.
 
-You need a Cloudflare account and `wrangler` (`npm i -g wrangler`).
+### One click
 
-### 1. Fork the deploy example
+Use the **Deploy to Cloudflare** button in the
+[deploy repo](https://github.com/TAJD/projektor-deploy-example): Cloudflare clones it
+into your account, **auto-provisions D1, KV, and R2**, and deploys. Fill in your admin
+email on the setup page and you're live.
 
-Fork **[`projektor-deploy-example`](https://github.com/TAJD/projektor-deploy-example)** —
-your fork becomes the deploy repo (config only: a `wrangler.toml`, a pinned
-`projektor.version`, and a deploy workflow).
+### One command — or one prompt
 
-```bash
-gh repo fork TAJD/projektor-deploy-example --clone
-cd projektor-deploy-example
-```
-
-> A fork is public. If you'd rather keep your config (Cloudflare resource IDs)
-> private, create from the template instead:
-> `gh repo create my-projektor-deploy --private --template TAJD/projektor-deploy-example`.
-
-### 2. Provision Cloudflare resources
+Clone the deploy repo and run the zero-config script; wrangler auto-provisions the
+resources, applies migrations, and deploys:
 
 ```bash
-wrangler d1 create projektor
-wrangler kv namespace create projektor
-wrangler r2 bucket create projektor-files
+PROJEKTOR_REPO=you/projektor ADMIN_EMAILS=you@example.com ./deploy-auto.sh
 ```
 
-### 3. Configure wrangler.toml
+Or hand the repo to an AI agent — *"deploy projektor to my Cloudflare account"* — and
+let it run the same flow. See
+[AGENT-DEPLOY.md](https://github.com/TAJD/projektor-deploy-example/blob/main/AGENT-DEPLOY.md).
 
-Pin a version and run the deploy script once — it downloads the release and
-scaffolds `wrangler.toml` from the template:
+### Then: configure access
 
-```bash
-echo "v1.0.0" > projektor.version    # a published release tag
-./deploy.sh                          # creates wrangler.toml, then asks you to fill it in
-```
+The Worker is live, but **Cloudflare Access** must front it before anyone can log in
+(a `*.workers.dev` toggle, or a custom domain). Then log in — the first user in
+`ADMIN_EMAILS` becomes owner — and mint a token for agents. Full handoff:
+[CONFIGURE.md](https://github.com/TAJD/projektor-deploy-example/blob/main/CONFIGURE.md).
 
-Fill the `REPLACE_` values — D1 `database_id`, KV `id`, your Cloudflare Access team
-domain + audience, and `ADMIN_EMAILS`. The `./vendor/...` paths are artifact-owned;
-leave them.
+### Manual / CI
 
-> **Cloudflare Access is required** for browser auth (SSO / Zero Trust). Set up an
-> Access application pointing at your Worker URL before deploying.
+Prefer to create the resources yourself, keep your config private, or deploy from CI on
+every push? See **[docs/deploying.md](./docs/deploying.md)** for the manual flow, the
+Cloudflare API token recipe (it **must include D1**), and push-based auto-updates.
 
-### 4. Set secrets
-
-On the Worker (set once; persists across deploys):
-
-```bash
-wrangler secret put JWT_SECRET   # any long random string — signs API tokens
-```
-
-For CI deploys, add `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` as repo
-Actions secrets. **The API token must include D1** — Cloudflare's built-in "Edit
-Cloudflare Workers" template omits it, which silently breaks migrations. The exact
-token recipe is in the [deploy guide](./docs/deploying.md).
-
-### 5. Deploy
-
-```bash
-./deploy.sh    # locally (wrangler OAuth), or
-git push       # CI deploys on push to main
-```
-
-On first load the Worker auto-provisions a workspace for the first user in
-`ADMIN_EMAILS`. Open your Worker URL, log in through Cloudflare Access, and you're
-running. To connect an AI agent immediately (dev/staging only), use the bootstrap
-endpoint — see [Connect an AI agent](#connect-an-ai-agent) below.
-
-**Full reference** — release contents, the Cloudflare token, push-based automatic
-updates, and troubleshooting — is in **[docs/deploying.md](./docs/deploying.md)**.
-
-**Updating later:** bump `projektor.version`, commit, and push — CI deploys it (or
-wire push-based auto-updates so new releases deploy themselves).
+**Updating later:** bump `projektor.version` and re-deploy (or just push, if you wired CI).
 
 ## Connect an AI agent
 
@@ -144,14 +109,11 @@ Once connected, the agent has access to the full tool catalog — create issues,
 
 ### Production — mint a long-lived token
 
-```bash
-curl -s -X POST "https://<your-worker>.workers.dev/auth/tokens" \
-  -H "Authorization: Bearer <cf-access-jwt>" \
-  -H "Content-Type: application/json" \
-  -d '{"name":"my-agent","workspaceId":"<uuid>","scopes":["read","write"]}'
-```
-
-Then wire up the agent the same way as above.
+`/bootstrap` is disabled in production. Instead, log in through Cloudflare Access and
+open **Settings → Tokens**: create a token and copy the ready-to-run `claude mcp add`
+command shown beside it (token + workspace pre-filled). The full walkthrough — Access
+setup, first login, token, MCP — is in
+[CONFIGURE.md](https://github.com/TAJD/projektor-deploy-example/blob/main/CONFIGURE.md).
 
 See **[docs/mcp.md](./docs/mcp.md)** for the full connection guide, protocol reference, and tool catalog (64 tools across 14 domains — project data plus agent-coordination primitives).
 
@@ -197,6 +159,10 @@ Bypass for WIP commits: `git commit --no-verify -m "wip: …"`
 
 ## Architecture (brief)
 
+For a visual of what the system can do, see the
+[marketecture diagram](./docs/marketecture.md); the deep architecture lives in
+[AGENTS.md](./AGENTS.md).
+
 projektor has two surfaces over one service layer:
 
 ```
@@ -211,13 +177,12 @@ Runtime: **Hono on Cloudflare Workers** — no Node.js, no containers.
 Storage: **D1** (relational), **KV** (sessions/cache), **R2** (attachments).
 Frontend: **Astro + Preact**, served as static assets via Workers Static Assets; `/api/*` and `/mcp/*` always hit the Worker.
 
-See [AGENTS.md](./AGENTS.md) for contributor conventions and the full architecture contract.
-See [docs/marketecture.md](./docs/marketecture.md) for a Mermaid system diagram.
-
 ## Roadmap / Contributing
 
 Feature requests and bugs are tracked in the live projektor dogfood instance — projektor is built with itself.
 
 [AGENTS.md](./AGENTS.md) is the contributor guide: conventions, file layout, the service-layer contract, and how to work in parallel without conflicts. Read it before opening a PR.
 
-CONTRIBUTING.md is not yet written; AGENTS.md is the current source of truth.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for how issues and PRs are handled,
+[SECURITY.md](./SECURITY.md) to report vulnerabilities, and [AGENTS.md](./AGENTS.md) for
+the engineering conventions. Licensed under [MIT](./LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security issues **privately** — do not open a public issue.
+
+Email the maintainer directly at **tajdickson@protonmail.com** with:
+
+- a description of the vulnerability and its impact,
+- steps to reproduce (a proof of concept if you have one),
+- the affected version or commit.
+
+You'll get an acknowledgement, and a fix or mitigation will be prioritised over
+other work. Please give a reasonable window to address the issue before any
+public disclosure.
+
+## Scope
+
+projektor is a self-hosted application: each deployment runs on the operator's
+own Cloudflare account, behind their own Cloudflare Access configuration. Reports
+about the projektor codebase itself are in scope; misconfiguration of an
+individual deployment (e.g. a missing Access policy) is the operator's
+responsibility — see [CONFIGURE.md in the deploy repo](https://github.com/TAJD/projektor-deploy-example/blob/main/CONFIGURE.md).

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -28,8 +28,14 @@ const ALLOWED_UPLOAD_TYPES = new Set([
 	"application/json",
 ]);
 
-// TODO: make this a configurable env var
-const STORAGE_QUOTA_BYTES = 1024 * 1024 * 1024; // 1 GB per workspace
+const DEFAULT_STORAGE_QUOTA_BYTES = 1024 * 1024 * 1024; // 1 GiB per workspace
+
+// Resolve the per-workspace storage quota from env (STORAGE_QUOTA_BYTES), falling
+// back to the default for unset/invalid/non-positive values.
+function storageQuotaBytes(env: { STORAGE_QUOTA_BYTES?: string }): number {
+	const n = Number(env.STORAGE_QUOTA_BYTES);
+	return Number.isFinite(n) && n > 0 ? n : DEFAULT_STORAGE_QUOTA_BYTES;
+}
 
 router.get("/", async (c) => {
 	const workspace = c.get("workspace") as { id: string };
@@ -92,8 +98,10 @@ router.post("/", async (c) => {
 		.bind(workspace.id)
 		.first<{ total: number }>();
 	const bytesUsed = quotaRow?.total ?? 0;
-	if (bytesUsed + file.size > STORAGE_QUOTA_BYTES) {
-		return c.json({ error: "Workspace storage quota exceeded (1 GB)" }, 413);
+	const quota = storageQuotaBytes(c.env);
+	if (bytesUsed + file.size > quota) {
+		const quotaMb = Math.round(quota / (1024 * 1024));
+		return c.json({ error: `Workspace storage quota exceeded (${quotaMb} MB)` }, 413);
 	}
 
 	const id = crypto.randomUUID();

--- a/apps/api/src/test/files.test.ts
+++ b/apps/api/src/test/files.test.ts
@@ -307,6 +307,6 @@ describe("Files API", () => {
 		});
 		expect(res.status).toBe(413);
 		const body = (await res.json()) as { error: string };
-		expect(body.error).toBe("Workspace storage quota exceeded (1 GB)");
+		expect(body.error).toBe("Workspace storage quota exceeded (1024 MB)");
 	});
 });

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -7,7 +7,10 @@ instance, how releases are cut, and how to keep an instance updated automaticall
 
 > Looking for the 5-minute version? See [Self-hosting](/projektor/guides/self-hosting/).
 > A ready-to-fork template lives at
-> [github.com/TAJD/projektor-deploy-example](https://github.com/TAJD/projektor-deploy-example).
+> [github.com/TAJD/projektor-deploy-example](https://github.com/TAJD/projektor-deploy-example) —
+> including a **Deploy to Cloudflare** button and a zero-config `deploy-auto.sh` (plus
+> `AGENT-DEPLOY.md` / `CONFIGURE.md`) that auto-provision D1/KV/R2 with no manual setup.
+> This page is the manual / CI reference.
 
 ## The model
 

--- a/packages/types/src/env.ts
+++ b/packages/types/src/env.ts
@@ -24,6 +24,9 @@ export interface Env {
 	RATE_LIMIT_API_MAX?: string; // max requests per token per window when a bearer token is present
 	RATE_LIMIT_WINDOW_SECS?: string; // window size in seconds (default 60)
 	RATE_LIMIT_AUTH_FAIL_MAX?: string; // max failed bearer-token auths per IP per window before 429 (default 50)
+	// Per-workspace attachment storage quota in bytes (default 1 GiB). Override in
+	// wrangler.toml [vars]; invalid or non-positive values fall back to the default.
+	STORAGE_QUOTA_BYTES?: string;
 	// Static assets binding (production wrangler.toml only — absent in local dev).
 	ASSETS?: Fetcher;
 }


### PR DESCRIPTION
Go-public documentation + housekeeping pass.

## Deploy story (workstream A/B/D)
- **README** Self-hosting rewritten to lead with the three real paths, easiest first: **One click** (Deploy to Cloudflare button), **One command / one prompt** (`deploy-auto.sh` or hand the repo to an agent), **Then configure access** (CONFIGURE.md), and **Manual / CI** (docs/deploying.md).
- **Connect an AI agent** fixed: production token flow now points at Settings → Tokens (ready-made `claude mcp add`), not the disabled `/bootstrap`; corrected MCP endpoint + token endpoint references.
- **docs/deploying.md** top callout now mentions the Deploy button + zero-config `deploy-auto.sh` and frames itself as the manual/CI reference.
- Removed stale README TODOs (marketecture/diagram), reframed Features intro via docs/philosophy.md.

## Legal / policy (workstream C)
- **LICENSE** — MIT.
- **SECURITY.md** — private disclosure; self-hosting misconfiguration is operator responsibility (links deploy-example CONFIGURE.md).
- **CONTRIBUTING.md** — solo-project policy; AGENTS.md is the engineering source of truth.

## Code TODOs (workstream E)
- `files.ts` per-workspace storage quota is now env-configurable via `STORAGE_QUOTA_BYTES` (default 1 GiB), replacing the hard-coded constant + TODO. Added the typed env field and updated the quota-exceeded message/test.

Full API suite green (499 passing); type-check clean.