### PR TITLE
fix(api): chunk batchLoadCustomFields to stay under D1's 100-param cap

### DIFF
--- a/apps/api/src/services/custom-fields.ts
+++ b/apps/api/src/services/custom-fields.ts
@@ -310,34 +310,43 @@ export async function batchLoadCustomFields(
 	if (issueIds.length === 0) return {};
 
 	const orm = drizzle(db, { schema });
-	// PROJ-197: scope by the field definition's workspace. Custom field definitions are
-	// workspace-owned, so this confines results to the caller's workspace even if a
-	// cross-workspace issueId is ever passed in — values whose definition lives in another
-	// workspace are filtered out rather than leaked.
-	const rows = await orm
-		.select({
-			issueId: schema.customFieldValues.issueId,
-			key: schema.customFieldDefinitions.key,
-			label: schema.customFieldDefinitions.label,
-			type: schema.customFieldDefinitions.type,
-			value: schema.customFieldValues.value,
-		})
-		.from(schema.customFieldValues)
-		.innerJoin(
-			schema.customFieldDefinitions,
-			eq(schema.customFieldDefinitions.id, schema.customFieldValues.fieldId)
-		)
-		.where(
-			and(
-				inArray(schema.customFieldValues.issueId, issueIds),
-				eq(schema.customFieldDefinitions.workspaceId, workspaceId)
-			)
-		);
-
 	const byIssue: Record<string, CustomFieldValue[]> = {};
-	for (const r of rows) {
-		if (!byIssue[r.issueId]) byIssue[r.issueId] = [];
-		byIssue[r.issueId].push({ key: r.key, label: r.label, type: r.type, value: r.value });
+
+	// D1 caps a query at 100 bound parameters. We bind one per issue id plus one for
+	// workspaceId, so a full 100-issue page would bind 101 and fail at runtime. Chunk the
+	// ids to stay under the cap. (The test runner is SQLite, whose cap is 32766, so this
+	// limit is invisible there — it only bites on real D1.)
+	const CHUNK_SIZE = 90;
+	for (let i = 0; i < issueIds.length; i += CHUNK_SIZE) {
+		const chunk = issueIds.slice(i, i + CHUNK_SIZE);
+		// PROJ-197: scope by the field definition's workspace. Custom field definitions are
+		// workspace-owned, so this confines results to the caller's workspace even if a
+		// cross-workspace issueId is ever passed in — values whose definition lives in another
+		// workspace are filtered out rather than leaked.
+		const rows = await orm
+			.select({
+				issueId: schema.customFieldValues.issueId,
+				key: schema.customFieldDefinitions.key,
+				label: schema.customFieldDefinitions.label,
+				type: schema.customFieldDefinitions.type,
+				value: schema.customFieldValues.value,
+			})
+			.from(schema.customFieldValues)
+			.innerJoin(
+				schema.customFieldDefinitions,
+				eq(schema.customFieldDefinitions.id, schema.customFieldValues.fieldId)
+			)
+			.where(
+				and(
+					inArray(schema.customFieldValues.issueId, chunk),
+					eq(schema.customFieldDefinitions.workspaceId, workspaceId)
+				)
+			);
+
+		for (const r of rows) {
+			if (!byIssue[r.issueId]) byIssue[r.issueId] = [];
+			byIssue[r.issueId].push({ key: r.key, label: r.label, type: r.type, value: r.value });
+		}
 	}
 	return byIssue;
 }

--- a/apps/api/src/test/custom-fields.test.ts
+++ b/apps/api/src/test/custom-fields.test.ts
@@ -606,4 +606,30 @@ describe("PROJ-197: batchLoadCustomFields is workspace-scoped", () => {
 		// The foreign workspace's issue must be absent entirely — no cross-tenant leak.
 		expect(loaded[issueB.id]).toBeUndefined();
 	});
+
+	// Regression: a full 100-issue page bound 100 ids + 1 workspaceId = 101 params,
+	// exceeding D1's 100-bound-parameter cap → the query threw and listIssues 500'd
+	// (invisible in CI because SQLite allows 32766 params). batchLoadCustomFields now
+	// chunks the ids; this proves results still merge correctly across chunk boundaries.
+	it("loads values for more issues than the chunk size (spans multiple D1 queries)", async () => {
+		const ws = await seedFixture({ role: "owner" });
+		const proj = await seedProject(ws.workspace.id, "CHK");
+		const def = await seedCustomFieldDef(ws.workspace.id, { key: "sp", label: "Story Points" });
+
+		const COUNT = 95; // > CHUNK_SIZE (90), so ids span two queries
+		const issueIds: string[] = [];
+		for (let i = 0; i < COUNT; i++) {
+			const issue = await seedIssue(ws.workspace.id, proj.id, ws.user.id);
+			await seedCustomFieldValue(issue.id, def.id, String(i));
+			issueIds.push(issue.id);
+		}
+
+		const loaded = await batchLoadCustomFields(env.DB, ws.workspace.id, issueIds);
+
+		expect(Object.keys(loaded)).toHaveLength(COUNT);
+		for (let i = 0; i < COUNT; i++) {
+			expect(loaded[issueIds[i]]).toHaveLength(1);
+			expect(loaded[issueIds[i]][0].value).toBe(String(i));
+		}
+	});
 });


### PR DESCRIPTION
## Symptom
`GET /api/issues?limit=100` (and MCP `list_issues` at the max page size) returned **500** on the live instance after v0.2.4. Smaller pages were fine — `limit=99` worked, `limit=100` failed; the DEV project (1 issue) at `limit=100` worked, a large result set didn't.

## Root cause
Cloudflare **D1 caps a query at 100 bound parameters.** `batchLoadCustomFields` runs `WHERE issue_id IN (...) AND custom_field_definitions.workspace_id = ?`. A full 100-issue page binds **100 ids + 1 workspaceId = 101 params → over the cap → the query throws → 500.** The `workspace_id` predicate was added in PROJ-197 (#3), which first reached production in v0.2.4 — pushing the count from 100 (exactly at the cap) to 101.

## Why CI was green
The test runner is Miniflare/**SQLite**, whose variable cap is 32766, not D1's 100 — so the over-limit query passes in tests and only fails on real D1. Tests also never seeded a ~100-issue page.

## Fix
Chunk the issue ids (90 per query) so each query stays well under D1's cap. Added a regression test that spans multiple chunks (95 > chunk size) and asserts results merge correctly.

Verified locally: full API suite green (500 passing), type-check clean.