### PR TITLE
fix(api): chunk all variable-length IN/inArray loads under D1's 100-param cap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,20 @@ mcp/<domain>.ts      (MCP wrapper)   ─┘     (ALL business logic + SQL live h
 ### The security invariant: always scope by workspace
 Every query MUST be scoped by `workspace_id` (directly, or via a parent entity that was itself workspace-checked — e.g. comments verify their issue belongs to the workspace first). A missing scope is a cross-tenant data leak. This is the single most important correctness rule in the codebase.
 
+### The D1 limit: never bind a row-scaled array into one query
+Cloudflare **D1 rejects any query with more than 100 bound parameters.** A query whose parameter count grows with an input array — drizzle `inArray`, a raw `IN (...)`, or a batched mutation keyed by ids — will throw at runtime (a 500) once the array is large enough. **This is invisible in tests:** the vitest runner backs D1 with SQLite (cap 32766), so an un-chunked query passes CI and only fails on real D1.
+
+Route every variable-length `IN`/`inArray` load through **`inChunks` (`services/sql.ts`)**, which splits the array so each query stays under the cap:
+
+```ts
+const rows = await inChunks(issueIds, (chunk) =>
+  orm.select(...).from(...).where(and(inArray(table.id, chunk), eq(table.workspaceId, ctx.workspaceId)))
+);
+// for a mutation that returns nothing, have the callback return []
+```
+
+Bounded arrays (enums like priority) are fine to bind directly. When in doubt, chunk.
+
 ## File layout per domain
 
 When adding/changing a domain (issues, projects, wiki, comments, …):

--- a/apps/api/src/services/custom-fields.ts
+++ b/apps/api/src/services/custom-fields.ts
@@ -2,6 +2,7 @@ import { drizzle, schema } from "@projektor/db";
 import { and, asc, eq, inArray, isNull, or, sql } from "drizzle-orm";
 import { CreateCustomFieldDefSchema, UpdateCustomFieldDefSchema } from "../schemas/custom-fields";
 import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from "./errors";
+import { inChunks } from "./sql";
 import type { ServiceCtx } from "./types";
 
 export interface CustomFieldDef {
@@ -310,20 +311,15 @@ export async function batchLoadCustomFields(
 	if (issueIds.length === 0) return {};
 
 	const orm = drizzle(db, { schema });
-	const byIssue: Record<string, CustomFieldValue[]> = {};
 
-	// D1 caps a query at 100 bound parameters. We bind one per issue id plus one for
-	// workspaceId, so a full 100-issue page would bind 101 and fail at runtime. Chunk the
-	// ids to stay under the cap. (The test runner is SQLite, whose cap is 32766, so this
-	// limit is invisible there — it only bites on real D1.)
-	const CHUNK_SIZE = 90;
-	for (let i = 0; i < issueIds.length; i += CHUNK_SIZE) {
-		const chunk = issueIds.slice(i, i + CHUNK_SIZE);
+	// inChunks keeps each query under D1's 100-bound-parameter cap (one param per issue id
+	// plus the workspaceId predicate). See services/sql.ts.
+	const rows = await inChunks(issueIds, (chunk) =>
 		// PROJ-197: scope by the field definition's workspace. Custom field definitions are
 		// workspace-owned, so this confines results to the caller's workspace even if a
 		// cross-workspace issueId is ever passed in — values whose definition lives in another
 		// workspace are filtered out rather than leaked.
-		const rows = await orm
+		orm
 			.select({
 				issueId: schema.customFieldValues.issueId,
 				key: schema.customFieldDefinitions.key,
@@ -341,12 +337,13 @@ export async function batchLoadCustomFields(
 					inArray(schema.customFieldValues.issueId, chunk),
 					eq(schema.customFieldDefinitions.workspaceId, workspaceId)
 				)
-			);
+			)
+	);
 
-		for (const r of rows) {
-			if (!byIssue[r.issueId]) byIssue[r.issueId] = [];
-			byIssue[r.issueId].push({ key: r.key, label: r.label, type: r.type, value: r.value });
-		}
+	const byIssue: Record<string, CustomFieldValue[]> = {};
+	for (const r of rows) {
+		if (!byIssue[r.issueId]) byIssue[r.issueId] = [];
+		byIssue[r.issueId].push({ key: r.key, label: r.label, type: r.type, value: r.value });
 	}
 	return byIssue;
 }

--- a/apps/api/src/services/file-claims.ts
+++ b/apps/api/src/services/file-claims.ts
@@ -3,6 +3,7 @@ import { and, eq, inArray, isNull } from "drizzle-orm";
 import { ClaimFilesSchema, ListFileClaimsSchema, ReleaseFilesSchema } from "../schemas/file-claims";
 import { postMessage } from "./agent-messages";
 import { ConflictError, NotFoundError, ValidationError } from "./errors";
+import { inChunks } from "./sql";
 import type { ServiceCtx } from "./types";
 
 export async function claimFiles(ctx: ServiceCtx, raw: unknown) {
@@ -35,17 +36,20 @@ export async function claimFiles(ctx: ServiceCtx, raw: unknown) {
 		if (!agent) throw new NotFoundError("Agent session not found");
 	}
 
-	// Pre-check all paths for active claims — all-or-nothing on conflict
-	const activeClaims = await orm
-		.select()
-		.from(schema.issueFileClaims)
-		.where(
-			and(
-				eq(schema.issueFileClaims.workspaceId, ctx.workspaceId),
-				inArray(schema.issueFileClaims.path, paths),
-				isNull(schema.issueFileClaims.releasedAt)
+	// Pre-check all paths for active claims — all-or-nothing on conflict.
+	// inChunks keeps each query under D1's 100-bound-parameter cap. See services/sql.ts.
+	const activeClaims = await inChunks(paths, (chunk) =>
+		orm
+			.select()
+			.from(schema.issueFileClaims)
+			.where(
+				and(
+					eq(schema.issueFileClaims.workspaceId, ctx.workspaceId),
+					inArray(schema.issueFileClaims.path, chunk),
+					isNull(schema.issueFileClaims.releasedAt)
+				)
 			)
-		);
+	);
 
 	const claimsByPath = new Map(activeClaims.map((c) => [c.path, c]));
 
@@ -114,49 +118,47 @@ export async function releaseFiles(ctx: ServiceCtx, raw: unknown) {
 	const orm = drizzle(ctx.db, { schema });
 	const now = Math.floor(Date.now() / 1000);
 
-	const conditions = [
-		eq(schema.issueFileClaims.workspaceId, ctx.workspaceId),
-		inArray(schema.issueFileClaims.path, paths),
-		isNull(schema.issueFileClaims.releasedAt),
-	];
-
-	if (issueId) {
-		conditions.push(eq(schema.issueFileClaims.issueId, issueId));
-	}
-
+	// inChunks on every variable-length IN below keeps each query under D1's
+	// 100-bound-parameter cap (paths and ids are caller-/row-scaled). See services/sql.ts.
 	// Fetch the rows that will be released
-	const toRelease = await orm
-		.select()
-		.from(schema.issueFileClaims)
-		.where(and(...conditions));
+	const toRelease = await inChunks(paths, (chunk) => {
+		const conditions = [
+			eq(schema.issueFileClaims.workspaceId, ctx.workspaceId),
+			inArray(schema.issueFileClaims.path, chunk),
+			isNull(schema.issueFileClaims.releasedAt),
+		];
+		if (issueId) {
+			conditions.push(eq(schema.issueFileClaims.issueId, issueId));
+		}
+		return orm
+			.select()
+			.from(schema.issueFileClaims)
+			.where(and(...conditions));
+	});
 
 	if (toRelease.length === 0) {
 		return { released: [], count: 0 };
 	}
 
-	await orm
-		.update(schema.issueFileClaims)
-		.set({ releasedAt: now })
-		.where(
-			and(
-				eq(schema.issueFileClaims.workspaceId, ctx.workspaceId),
-				inArray(
-					schema.issueFileClaims.id,
-					toRelease.map((r) => r.id)
-				),
-				isNull(schema.issueFileClaims.releasedAt)
-			)
-		);
+	const releaseIds = toRelease.map((r) => r.id);
 
-	const released = await orm
-		.select()
-		.from(schema.issueFileClaims)
-		.where(
-			inArray(
-				schema.issueFileClaims.id,
-				toRelease.map((r) => r.id)
-			)
-		);
+	await inChunks(releaseIds, async (chunk) => {
+		await orm
+			.update(schema.issueFileClaims)
+			.set({ releasedAt: now })
+			.where(
+				and(
+					eq(schema.issueFileClaims.workspaceId, ctx.workspaceId),
+					inArray(schema.issueFileClaims.id, chunk),
+					isNull(schema.issueFileClaims.releasedAt)
+				)
+			);
+		return [];
+	});
+
+	const released = await inChunks(releaseIds, (chunk) =>
+		orm.select().from(schema.issueFileClaims).where(inArray(schema.issueFileClaims.id, chunk))
+	);
 
 	return { released, count: released.length };
 }

--- a/apps/api/src/services/issue-links.ts
+++ b/apps/api/src/services/issue-links.ts
@@ -6,6 +6,7 @@ import {
 	ListIssueLinksSchema,
 } from "../schemas/issues";
 import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from "./errors";
+import { inChunks } from "./sql";
 import type { ServiceCtx } from "./types";
 
 type StoredLinkType = "blocks" | "relates_to" | "duplicates";
@@ -189,19 +190,20 @@ export async function listLinksForIssue(ctx: ServiceCtx, raw: unknown) {
 
 	// Batch-fetch linked issue metadata (title, number, project_key, status_category)
 	const linkedIds = [...new Set(enriched.map((e) => e.linkedIssueId))];
-	const issueRows = await orm
-		.select({
-			id: schema.issues.id,
-			title: schema.issues.title,
-			number: schema.issues.number,
-			statusCategory: schema.issues.statusCategory,
-			projectKey: schema.projects.key,
-		})
-		.from(schema.issues)
-		.leftJoin(schema.projects, eq(schema.issues.projectId, schema.projects.id))
-		.where(
-			and(inArray(schema.issues.id, linkedIds), eq(schema.issues.workspaceId, ctx.workspaceId))
-		);
+	// inChunks keeps the batch fetch under D1's 100-bound-parameter cap. See services/sql.ts.
+	const issueRows = await inChunks(linkedIds, (chunk) =>
+		orm
+			.select({
+				id: schema.issues.id,
+				title: schema.issues.title,
+				number: schema.issues.number,
+				statusCategory: schema.issues.statusCategory,
+				projectKey: schema.projects.key,
+			})
+			.from(schema.issues)
+			.leftJoin(schema.projects, eq(schema.issues.projectId, schema.projects.id))
+			.where(and(inArray(schema.issues.id, chunk), eq(schema.issues.workspaceId, ctx.workspaceId)))
+	);
 
 	const issueMap = new Map((issueRows as LinkedIssueRow[]).map((r) => [r.id, r]));
 

--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -16,6 +16,7 @@ import {
 } from "./custom-fields";
 import { ForbiddenError, NotFoundError, ValidationError } from "./errors";
 import { listLinksForIssue } from "./issue-links";
+import { inChunks } from "./sql";
 import { resolveStatus } from "./task-statuses";
 import type { ServiceCtx } from "./types";
 
@@ -645,42 +646,48 @@ export async function getPrioritizedIssues(ctx: ServiceCtx, raw: unknown) {
 
 	const issueIds = issues.map((i) => i.id);
 
-	const links = await orm
-		.select({ target_issue_id: schema.issueLinks.targetIssueId })
-		.from(schema.issueLinks)
-		.where(
-			and(
-				eq(schema.issueLinks.workspaceId, ctx.workspaceId),
-				inArray(schema.issueLinks.targetIssueId, issueIds)
+	// inChunks: issueIds is every open issue, so this would otherwise blow past D1's
+	// 100-bound-parameter cap on any reasonably busy workspace. See services/sql.ts.
+	const links = await inChunks(issueIds, (chunk) =>
+		orm
+			.select({ target_issue_id: schema.issueLinks.targetIssueId })
+			.from(schema.issueLinks)
+			.where(
+				and(
+					eq(schema.issueLinks.workspaceId, ctx.workspaceId),
+					inArray(schema.issueLinks.targetIssueId, chunk)
+				)
 			)
-		);
+	);
 
 	const inDegree: Record<string, number> = {};
 	for (const link of links) {
 		inDegree[link.target_issue_id] = (inDegree[link.target_issue_id] ?? 0) + 1;
 	}
 
-	const cfValues = await orm
-		.select({
-			issue_id: schema.customFieldValues.issueId,
-			sp: sql<number>`CAST(${schema.customFieldValues.value} AS REAL)`,
-		})
-		.from(schema.customFieldValues)
-		.innerJoin(
-			schema.customFieldDefinitions,
-			eq(schema.customFieldValues.fieldId, schema.customFieldDefinitions.id)
-		)
-		.where(
-			and(
-				inArray(schema.customFieldValues.issueId, issueIds),
-				or(
-					like(schema.customFieldDefinitions.key, "%story%"),
-					like(schema.customFieldDefinitions.key, "%point%"),
-					like(schema.customFieldDefinitions.label, "%story%"),
-					like(schema.customFieldDefinitions.label, "%point%")
+	const cfValues = await inChunks(issueIds, (chunk) =>
+		orm
+			.select({
+				issue_id: schema.customFieldValues.issueId,
+				sp: sql<number>`CAST(${schema.customFieldValues.value} AS REAL)`,
+			})
+			.from(schema.customFieldValues)
+			.innerJoin(
+				schema.customFieldDefinitions,
+				eq(schema.customFieldValues.fieldId, schema.customFieldDefinitions.id)
+			)
+			.where(
+				and(
+					inArray(schema.customFieldValues.issueId, chunk),
+					or(
+						like(schema.customFieldDefinitions.key, "%story%"),
+						like(schema.customFieldDefinitions.key, "%point%"),
+						like(schema.customFieldDefinitions.label, "%story%"),
+						like(schema.customFieldDefinitions.label, "%point%")
+					)
 				)
 			)
-		);
+	);
 
 	const storyPoints: Record<string, number> = {};
 	for (const cf of cfValues) {

--- a/apps/api/src/services/sprints.ts
+++ b/apps/api/src/services/sprints.ts
@@ -7,6 +7,7 @@ import {
 	UpdateSprintSchema,
 } from "../schemas/sprints";
 import { ForbiddenError, NotFoundError, ValidationError } from "./errors";
+import { inChunks } from "./sql";
 import type { ServiceCtx } from "./types";
 
 export async function listSprints(ctx: ServiceCtx, raw: unknown) {
@@ -166,12 +167,16 @@ export async function moveIssuesToSprint(ctx: ServiceCtx, raw: unknown) {
 		.get();
 	if (!sprint) throw new NotFoundError("Sprint not found");
 
-	await orm
-		.update(schema.issues)
-		.set({ sprintId, updatedAt: Math.floor(Date.now() / 1000) })
-		.where(
-			and(inArray(schema.issues.id, issueIds), eq(schema.issues.workspaceId, ctx.workspaceId))
-		);
+	const now = Math.floor(Date.now() / 1000);
+	// inChunks: issueIds is a caller-supplied batch, so keep each UPDATE under D1's
+	// 100-bound-parameter cap. See services/sql.ts.
+	await inChunks(issueIds, async (chunk) => {
+		await orm
+			.update(schema.issues)
+			.set({ sprintId, updatedAt: now })
+			.where(and(inArray(schema.issues.id, chunk), eq(schema.issues.workspaceId, ctx.workspaceId)));
+		return [];
+	});
 
 	return { ok: true, count: issueIds.length };
 }

--- a/apps/api/src/services/sql.ts
+++ b/apps/api/src/services/sql.ts
@@ -1,0 +1,32 @@
+// Cloudflare D1 rejects any query carrying more than 100 bound parameters. A query
+// whose parameter count grows with an input array — drizzle `inArray`, a raw `IN (...)`,
+// or a batched mutation keyed by ids — will therefore throw at runtime once the array is
+// large enough (manifesting as a 500). The boundary is invisible in tests: the vitest
+// runner backs D1 with SQLite, whose limit is 32766, so an un-chunked query passes CI and
+// only fails on real D1.
+//
+// RULE: never bind a row- or user-scaled array straight into a query. Split it with
+// `inChunks` so each underlying query stays under the cap.
+export const D1_BOUND_PARAM_LIMIT = 100;
+
+// Conservative chunk size: leaves ~10 parameters of headroom for the other predicates in
+// the same query (a workspaceId filter, status filters, etc.). Every current caller binds
+// fewer than 10 extra params, so 90 is safe; shrink it if a query ever needs more.
+const CHUNK_SIZE = 90;
+
+/**
+ * Run `op` over `items` in chunks small enough that each resulting query stays under D1's
+ * bound-parameter cap, concatenating the rows each chunk returns. For mutations that
+ * return nothing, have `op` return an empty array.
+ */
+export async function inChunks<I, O>(
+	items: readonly I[],
+	op: (chunk: I[]) => Promise<O[]>
+): Promise<O[]> {
+	if (items.length === 0) return [];
+	const out: O[] = [];
+	for (let i = 0; i < items.length; i += CHUNK_SIZE) {
+		out.push(...(await op(items.slice(i, i + CHUNK_SIZE) as I[])));
+	}
+	return out;
+}

--- a/apps/api/src/test/issues.test.ts
+++ b/apps/api/src/test/issues.test.ts
@@ -1247,6 +1247,22 @@ describe("get_prioritized_issues MCP tool", () => {
 		}
 	});
 
+	it("handles more open issues than a single D1 query can bind (chunked enrichment)", async () => {
+		// getPrioritizedIssues fetches every open issue, then batch-loads links + story points
+		// keyed by those ids. On real D1 (100-param cap) an un-chunked load throws once there
+		// are ~100 open issues; this guards the inChunks split and that results merge across
+		// chunk boundaries. (SQLite's cap is higher, so this asserts correctness, not the cap.)
+		const COUNT = 105;
+		for (let i = 0; i < COUNT; i++) {
+			await seedIssue(workspaceId, projectId, userId, { title: `Open ${i}`, priority: "medium" });
+		}
+
+		const body = await callPrioritized({ limit: 100 });
+		expect(body.error).toBeUndefined();
+		const data = JSON.parse(body.result!.content[0].text) as { issues: Array<{ title: string }> };
+		expect(data.issues).toHaveLength(100);
+	});
+
 	it("excludes done and cancelled issues", async () => {
 		await seedIssue(workspaceId, projectId, userId, { title: "Open" });
 		await seedIssue(workspaceId, projectId, userId, { title: "Done", status: "done" });


### PR DESCRIPTION
Follow-up sweep after #8 (the custom-fields fix). Same root cause — **Cloudflare D1 caps a query at 100 bound parameters** — applied across every site whose parameter count grows with an input array.

## Found by the sweep
| Site | Scales with | Status before |
|---|---|---|
| `getPrioritizedIssues` — links (`issues.ts`) | **all open issues** | 🔴 500 live (112 open in dogfood) |
| `getPrioritizedIssues` — story points | **all open issues** | 🔴 500 live |
| `moveIssuesToSprint` (`sprints.ts`) | issues per call | 🟡 latent |
| `claimFiles` / `releaseFiles` ×4 (`file-claims.ts`) | files per call | 🟡 latent |
| linked-issue metadata (`issue-links.ts`) | links on an issue | 🟡 latent |
| `batchLoadCustomFields` | page size | ✅ already fixed in #8 |

`get_prioritized_issues` was already failing on the live instance (matches the "get_prioritized_issues errors" note in PROJ-200).

## The scalable fix
- **`services/sql.ts` → `inChunks(items, op)`** — the single sanctioned way to run a query whose param count grows with an array. Splits at 90 (≥10 params headroom for other predicates) and concatenates results.
- Routed every variable-length `IN`/`inArray` load through it.
- **AGENTS.md**: documented the rule beside the workspace-scope invariant, including the CI blind spot — the vitest runner backs D1 with **SQLite (cap 32766)**, so an un-chunked query passes CI and only fails on real D1. That's why #8 slipped through.
- Regression test: `get_prioritized_issues` with 105 open issues.

Full API suite green (501 passing), type-check + biome clean.