### PR TITLE
Server-side issue filters + date-range filtering (PROJ-211, PROJ-212)

### DIFF
--- a/apps/api/src/mcp/issues.ts
+++ b/apps/api/src/mcp/issues.ts
@@ -40,6 +40,22 @@ export const issuesTools: MCPTool[] = [
 					type: "string",
 					description: "Comma-separated task type IDs to exclude (e.g. the epic type)",
 				},
+				completedAfter: {
+					type: "number",
+					description: "Only issues marked completed at or after this epoch-seconds time",
+				},
+				completedBefore: {
+					type: "number",
+					description: "Only issues marked completed at or before this epoch-seconds time",
+				},
+				updatedAfter: {
+					type: "number",
+					description: "Only issues last edited at or after this epoch-seconds time",
+				},
+				updatedBefore: {
+					type: "number",
+					description: "Only issues last edited at or before this epoch-seconds time",
+				},
 				cursor: { type: "number", description: "Pagination cursor (created_at of last item)" },
 				limit: { type: "number", default: 50, description: "Max 100" },
 			},

--- a/apps/api/src/routes/issues.ts
+++ b/apps/api/src/routes/issues.ts
@@ -33,6 +33,10 @@ router.get("/", async (c) => {
 		cfKey,
 		cfOp,
 		cfValue,
+		completedAfter,
+		completedBefore,
+		updatedAfter,
+		updatedBefore,
 		cursor,
 		limit,
 	} = c.req.query();
@@ -55,6 +59,10 @@ router.get("/", async (c) => {
 				cfKey,
 				cfOp,
 				cfValue,
+				completedAfter,
+				completedBefore,
+				updatedAfter,
+				updatedBefore,
 				cursor,
 				limit,
 			})

--- a/apps/api/src/schemas/issues.ts
+++ b/apps/api/src/schemas/issues.ts
@@ -47,6 +47,11 @@ export const ListIssuesSchema = z.object({
 	cfKey: z.string().optional(),
 	cfOp: z.enum(["eq", "gt", "gte", "lt", "lte"]).optional(),
 	cfValue: z.string().optional(),
+	// Date-range filters (PROJ-212), epoch seconds; inclusive bounds.
+	completedAfter: z.coerce.number().optional(),
+	completedBefore: z.coerce.number().optional(),
+	updatedAfter: z.coerce.number().optional(),
+	updatedBefore: z.coerce.number().optional(),
 	cursor: z.coerce.number().optional(),
 	limit: z.coerce.number().min(1).max(100).default(30),
 });

--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -1,5 +1,18 @@
 import { drizzle, schema } from "@projektor/db";
-import { and, desc, eq, inArray, isNotNull, isNull, like, notInArray, or, sql } from "drizzle-orm";
+import {
+	and,
+	desc,
+	eq,
+	gte,
+	inArray,
+	isNotNull,
+	isNull,
+	like,
+	lte,
+	notInArray,
+	or,
+	sql,
+} from "drizzle-orm";
 import {
 	CreateIssueSchema,
 	GetIssueSchema,
@@ -98,6 +111,10 @@ export async function listIssues(ctx: ServiceCtx, raw: unknown) {
 		cfKey,
 		cfOp,
 		cfValue,
+		completedAfter,
+		completedBefore,
+		updatedAfter,
+		updatedBefore,
 		cursor,
 		limit,
 	} = result.data;
@@ -182,6 +199,12 @@ export async function listIssues(ctx: ServiceCtx, raw: unknown) {
 		}
 	}
 
+	// Date-range filters (PROJ-212) — inclusive bounds, index-backed.
+	if (completedAfter) conditions.push(gte(schema.issues.completedAt, completedAfter));
+	if (completedBefore) conditions.push(lte(schema.issues.completedAt, completedBefore));
+	if (updatedAfter) conditions.push(gte(schema.issues.updatedAt, updatedAfter));
+	if (updatedBefore) conditions.push(lte(schema.issues.updatedAt, updatedBefore));
+
 	if (cursor) conditions.push(sql`${schema.issues.createdAt} < ${cursor}`);
 
 	// Select with snake_case aliases to preserve the same response shape as the raw-SQL version.
@@ -207,6 +230,7 @@ export async function listIssues(ctx: ServiceCtx, raw: unknown) {
 			created_by_id: schema.issues.createdById,
 			created_at: schema.issues.createdAt,
 			updated_at: schema.issues.updatedAt,
+			completed_at: schema.issues.completedAt,
 			assignee_name: schema.users.name,
 			project_key: schema.projects.key,
 			project_name: schema.projects.name,
@@ -275,6 +299,7 @@ export async function getIssue(ctx: ServiceCtx, raw: unknown) {
 		created_by_id: schema.issues.createdById,
 		created_at: schema.issues.createdAt,
 		updated_at: schema.issues.updatedAt,
+		completed_at: schema.issues.completedAt,
 		type_key: schema.taskTypes.key,
 		type_name: schema.taskTypes.name,
 		status_key: schema.taskStatuses.key,
@@ -498,7 +523,12 @@ export async function updateIssue(ctx: ServiceCtx, id: string, raw: unknown) {
 	const orm = drizzle(ctx.db, { schema });
 
 	const existing = await orm
-		.select({ id: schema.issues.id, parentId: schema.issues.parentId })
+		.select({
+			id: schema.issues.id,
+			parentId: schema.issues.parentId,
+			status: schema.issues.status,
+			statusCategory: schema.issues.statusCategory,
+		})
 		.from(schema.issues)
 		.where(and(eq(schema.issues.id, id), eq(schema.issues.workspaceId, ctx.workspaceId)))
 		.get();
@@ -524,6 +554,23 @@ export async function updateIssue(ctx: ServiceCtx, id: string, raw: unknown) {
 		setValues.status = resolvedStatusKey;
 		setValues.statusId = resolvedStatusId;
 		setValues.statusCategory = sql`COALESCE((SELECT category FROM task_statuses WHERE id = ${resolvedStatusId}), '')`;
+
+		// PROJ-212: stamp completed_at when an issue first enters a done-category
+		// status, clear it when it leaves. We keep the original completion time if
+		// the issue was already done and is merely re-saved. Done is detected from
+		// either the configured status category or the legacy `status` enum, so it
+		// works whether or not the workspace uses custom task statuses.
+		const newStatus = resolvedStatusId
+			? await orm
+					.select({ category: schema.taskStatuses.category })
+					.from(schema.taskStatuses)
+					.where(eq(schema.taskStatuses.id, resolvedStatusId))
+					.get()
+			: undefined;
+		const wasDone = existing.statusCategory === "done" || existing.status === "done";
+		const isDone = newStatus?.category === "done" || resolvedStatusKey === "done";
+		if (isDone && !wasDone) setValues.completedAt = now;
+		else if (!isDone && wasDone) setValues.completedAt = null;
 	}
 
 	if ("typeId" in data) {

--- a/apps/api/src/test/issues.test.ts
+++ b/apps/api/src/test/issues.test.ts
@@ -913,6 +913,91 @@ describe("Issues API", () => {
 		// The epic is excluded; the untyped (NULL type_id) issue must NOT be dropped.
 		expect(titles).toEqual(["A plain issue"]);
 	});
+
+	// ─── PROJ-212: completed_at + date-range filters ──────────────────────────
+	// The test rate limiter allows only RATE_LIMIT_API_MAX (5) API requests per
+	// window, so set up state via env.DB and assert via env.DB where possible —
+	// DB access bypasses both the rate limiter and the getIssue KV cache.
+	async function patch(id: string, body: Record<string, unknown>) {
+		return SELF.fetch(`http://localhost/api/issues/${id}`, {
+			method: "PATCH",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify(body),
+		});
+	}
+
+	async function completedAtOf(id: string): Promise<number | null> {
+		const row = await env.DB.prepare("SELECT completed_at FROM issues WHERE id = ?")
+			.bind(id)
+			.first<{ completed_at: number | null }>();
+		return row?.completed_at ?? null;
+	}
+
+	it("stamps completed_at when an issue enters a done status and clears it on exit (PROJ-212)", async () => {
+		// 3 API requests (DB seed + 3 patch), under the rate-limit window.
+		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Will complete" });
+		const id = issue.id;
+		expect(await completedAtOf(id)).toBeNull();
+
+		await patch(id, { status: "done" });
+		const completed = await completedAtOf(id);
+		expect(typeof completed).toBe("number");
+
+		// Re-saving while still done keeps the original completion time.
+		await patch(id, { priority: "high" });
+		expect(await completedAtOf(id)).toBe(completed);
+
+		// Leaving done clears it.
+		await patch(id, { status: "in_progress" });
+		expect(await completedAtOf(id)).toBeNull();
+	});
+
+	it("filters by completedAfter / completedBefore (PROJ-212)", async () => {
+		// Seed + stamp completion via env.DB so only the 2 list calls hit the API.
+		const older = await seedIssue(workspaceId, projectId, userId, { title: "Completed long ago" });
+		const recent = await seedIssue(workspaceId, projectId, userId, { title: "Completed just now" });
+		const now = Math.floor(Date.now() / 1000);
+		await env.DB.prepare("UPDATE issues SET completed_at = ? WHERE id = ?")
+			.bind(now - 10 * 86400, older.id)
+			.run();
+		await env.DB.prepare("UPDATE issues SET completed_at = ? WHERE id = ?")
+			.bind(now, recent.id)
+			.run();
+
+		const cutoff = now - 86400; // 1 day ago
+
+		const before = await listIssues(`http://localhost/api/issues?completedBefore=${cutoff}`);
+		expect((before.page.items as Array<{ title: string }>).map((i) => i.title)).toEqual([
+			"Completed long ago",
+		]);
+
+		const after = await listIssues(`http://localhost/api/issues?completedAfter=${cutoff}`);
+		expect((after.page.items as Array<{ title: string }>).map((i) => i.title)).toEqual([
+			"Completed just now",
+		]);
+	});
+
+	it("filters by updatedAfter / updatedBefore (PROJ-212)", async () => {
+		const now = Math.floor(Date.now() / 1000);
+		const stale = await seedIssue(workspaceId, projectId, userId, { title: "Edited long ago" });
+		const fresh = await seedIssue(workspaceId, projectId, userId, { title: "Edited just now" });
+		await env.DB.prepare("UPDATE issues SET updated_at = ? WHERE id = ?")
+			.bind(now - 10 * 86400, stale.id)
+			.run();
+		await env.DB.prepare("UPDATE issues SET updated_at = ? WHERE id = ?").bind(now, fresh.id).run();
+
+		const cutoff = now - 86400;
+
+		const before = await listIssues(`http://localhost/api/issues?updatedBefore=${cutoff}`);
+		expect((before.page.items as Array<{ title: string }>).map((i) => i.title)).toEqual([
+			"Edited long ago",
+		]);
+
+		const after = await listIssues(`http://localhost/api/issues?updatedAfter=${cutoff}`);
+		expect((after.page.items as Array<{ title: string }>).map((i) => i.title)).toEqual([
+			"Edited just now",
+		]);
+	});
 });
 
 describe("Issues MCP — typeId", () => {

--- a/apps/api/src/test/migrations.ts
+++ b/apps/api/src/test/migrations.ts
@@ -22,6 +22,7 @@ import m0018 from "../../../../packages/db/migrations/0018_agent_sessions.sql?ra
 import m0019 from "../../../../packages/db/migrations/0019_issue_file_claims.sql?raw";
 import m0020 from "../../../../packages/db/migrations/0020_agent_messages.sql?raw";
 import m0021 from "../../../../packages/db/migrations/0021_issue_leases.sql?raw";
+import m0022 from "../../../../packages/db/migrations/0022_issue_completed_at.sql?raw";
 
 export const MIGRATIONS = [
 	m0000,
@@ -46,4 +47,5 @@ export const MIGRATIONS = [
 	m0019,
 	m0020,
 	m0021,
+	m0022,
 ];

--- a/apps/web/src/islands/IssueList.test.tsx
+++ b/apps/web/src/islands/IssueList.test.tsx
@@ -339,97 +339,127 @@ describe("filter pill toggle", () => {
 	});
 });
 
-// ─── PROJ-84/86: epic filter ──────────────────────────────────────────────────
+// ─── PROJ-84/86/211: epic filter (server-side) ───────────────────────────────
+//
+// Filtering runs server-side (PROJ-211): the island sends query params and the
+// API filters. These tests assert the request contract — that the right params
+// reach /api/issues — not client-side DOM filtering (the mock returns a fixed
+// set regardless of params, exactly as a real server boundary would hide from
+// the client). The epic dropdown is also fetched independently (typeId=epic),
+// so it must be awaited rather than read synchronously.
 
-describe("epic filter", () => {
-	beforeEach(() => {
-		setupFetch(EPIC_ISSUES);
+function setupEpicFetch() {
+	const mockFetch = vi.fn().mockImplementation((url: string) => {
+		const u = String(url);
+		let body: unknown;
+		if (u.includes("task-statuses")) body = STATUSES;
+		else if (u.includes("task-types")) body = [{ id: "type-epic", key: "epic", name: "Epic" }];
+		else if (u.includes("/api/projects")) body = [];
+		else if (u.includes("typeId=type-epic"))
+			body = { items: [EPIC_ISSUE] }; // epic-dropdown lookup
+		else body = { items: EPIC_ISSUES }; // main list
+		return Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
 	});
+	vi.stubGlobal("fetch", mockFetch);
+	return mockFetch;
+}
 
-	it("filtering by a specific epic ID shows only issues that are children of that epic", async () => {
+/** Latest /api/issues *list* request URL (excludes the epic-dropdown lookup). */
+function lastListUrl(mockFetch: ReturnType<typeof vi.fn>): string {
+	const urls = (mockFetch.mock.calls as [string, RequestInit][])
+		.map((c) => String(c[0]))
+		.filter((u) => u.includes("/api/issues") && !u.includes("typeId=type-epic"));
+	return urls[urls.length - 1] ?? "";
+}
+
+async function selectEpicOption(name: string) {
+	fireEvent.click(await screen.findByRole("combobox", { name: "Filter by epic" }));
+	fireEvent.click(await screen.findByRole("option", { name }));
+}
+
+describe("epic filter (server-side, PROJ-211)", () => {
+	it("sends parentId when a specific epic is selected", async () => {
+		const mockFetch = setupEpicFetch();
 		render(<IssueList />);
 		await waitForLoaded();
 
-		// Select uses a custom combobox (button + listbox) — must click to open then click option
-		fireEvent.click(screen.getByRole("combobox", { name: "Filter by epic" }));
-		fireEvent.click(await screen.findByRole("option", { name: "PROJ-10 Epic One" }));
+		await selectEpicOption("PROJ-10 Epic One");
+
+		await waitFor(() => expect(lastListUrl(mockFetch)).toContain("parentId=epic1"));
+	});
+
+	it("sends noParent + excludeTypeIds for the 'No epic' option", async () => {
+		const mockFetch = setupEpicFetch();
+		render(<IssueList />);
+		await waitForLoaded();
+
+		await selectEpicOption("No epic");
 
 		await waitFor(() => {
-			expect(screen.getAllByText("Child of Epic").length).toBeGreaterThan(0);
-			expect(screen.queryAllByText("Orphan issue")).toHaveLength(0);
-			expect(screen.queryAllByText("Epic One")).toHaveLength(0);
+			const url = lastListUrl(mockFetch);
+			expect(url).toContain("noParent=true");
+			expect(url).toContain("excludeTypeIds=type-epic");
 		});
 	});
 
-	it("the 'No epic' filter shows only issues with parent_id null that are not themselves epics", async () => {
+	it("sends neither parentId nor noParent when reset to all epics", async () => {
+		const mockFetch = setupEpicFetch();
 		render(<IssueList />);
 		await waitForLoaded();
 
-		fireEvent.click(screen.getByRole("combobox", { name: "Filter by epic" }));
-		fireEvent.click(await screen.findByRole("option", { name: "No epic" }));
+		await selectEpicOption("PROJ-10 Epic One");
+		await waitFor(() => expect(lastListUrl(mockFetch)).toContain("parentId=epic1"));
 
+		await selectEpicOption("All epics");
 		await waitFor(() => {
-			expect(screen.getAllByText("Orphan issue").length).toBeGreaterThan(0);
-			expect(screen.queryAllByText("Child of Epic")).toHaveLength(0);
-			// The epic itself (parent_id null, type_key "epic") should not appear
-			expect(screen.queryAllByText("Epic One")).toHaveLength(0);
-		});
-	});
-
-	it("clearing the epic filter restores the full list", async () => {
-		render(<IssueList />);
-		await waitForLoaded();
-
-		fireEvent.click(screen.getByRole("combobox", { name: "Filter by epic" }));
-		fireEvent.click(await screen.findByRole("option", { name: "PROJ-10 Epic One" }));
-		await waitFor(() => expect(screen.queryAllByText("Orphan issue")).toHaveLength(0));
-
-		fireEvent.click(screen.getByRole("combobox", { name: "Filter by epic" }));
-		fireEvent.click(await screen.findByRole("option", { name: "All epics" }));
-
-		await waitFor(() => {
-			expect(screen.getAllByText("Epic One").length).toBeGreaterThan(0);
-			expect(screen.getAllByText("Child of Epic").length).toBeGreaterThan(0);
-			expect(screen.getAllByText("Orphan issue").length).toBeGreaterThan(0);
+			const url = lastListUrl(mockFetch);
+			expect(url).not.toContain("parentId=");
+			expect(url).not.toContain("noParent=");
 		});
 	});
 
 	it("writes the epic filter to URL when a specific epic is selected", async () => {
+		setupEpicFetch();
 		render(<IssueList />);
 		await waitForLoaded();
 
-		fireEvent.click(screen.getByRole("combobox", { name: "Filter by epic" }));
-		fireEvent.click(await screen.findByRole("option", { name: "PROJ-10 Epic One" }));
+		await selectEpicOption("PROJ-10 Epic One");
 
-		await waitFor(() => {
-			const params = new URLSearchParams(window.location.search);
-			expect(params.get("epic")).toBe("epic1");
-		});
+		await waitFor(() =>
+			expect(new URLSearchParams(window.location.search).get("epic")).toBe("epic1")
+		);
 	});
 
-	it("reads ?epic= from URL on mount and pre-selects the epic filter", async () => {
+	it("reads ?epic= from URL on mount and sends parentId on the first fetch", async () => {
 		history.replaceState(null, "", "/?epic=epic1");
+		const mockFetch = setupEpicFetch();
 		render(<IssueList />);
 		await waitForLoaded();
 
-		await waitFor(() => {
-			expect(screen.queryAllByText("Orphan issue")).toHaveLength(0);
-			expect(screen.getAllByText("Child of Epic").length).toBeGreaterThan(0);
-		});
+		await waitFor(() => expect(lastListUrl(mockFetch)).toContain("parentId=epic1"));
 	});
 
 	it("removes the epic param from URL when filter is reset to all", async () => {
 		history.replaceState(null, "", "/?epic=epic1");
+		setupEpicFetch();
 		render(<IssueList />);
 		await waitForLoaded();
 
-		fireEvent.click(screen.getByRole("combobox", { name: "Filter by epic" }));
-		fireEvent.click(await screen.findByRole("option", { name: "All epics" }));
+		await selectEpicOption("All epics");
 
-		await waitFor(() => {
-			const params = new URLSearchParams(window.location.search);
-			expect(params.get("epic")).toBeNull();
-		});
+		await waitFor(() => expect(new URLSearchParams(window.location.search).get("epic")).toBeNull());
+	});
+});
+
+describe("hide epics (server-side, PROJ-211)", () => {
+	it("sends excludeTypeIds for the epic type when 'Hide epics' is checked", async () => {
+		const mockFetch = setupEpicFetch();
+		render(<IssueList />);
+		await waitForLoaded();
+
+		fireEvent.click(await screen.findByRole("checkbox", { name: /Hide epics/i }));
+
+		await waitFor(() => expect(lastListUrl(mockFetch)).toContain("excludeTypeIds=type-epic"));
 	});
 });
 

--- a/apps/web/src/islands/IssueList.test.tsx
+++ b/apps/web/src/islands/IssueList.test.tsx
@@ -695,3 +695,112 @@ describe("sprint banner", () => {
 		});
 	});
 });
+
+// ─── PROJ-212: date-range filter (server-side) ───────────────────────────────
+//
+// The range bounds run server-side: the island converts the chosen field +
+// from/to dates into completed*/updated* query params. These assert the request
+// contract reaching /api/issues, not client-side filtering.
+
+function setupDateFetch() {
+	const mock = vi.fn().mockImplementation((url: string) =>
+		Promise.resolve({
+			ok: true,
+			json: () =>
+				Promise.resolve(String(url).includes("task-statuses") ? STATUSES : { items: ISSUES }),
+		})
+	);
+	vi.stubGlobal("fetch", mock);
+	return mock;
+}
+
+/** Latest /api/issues list request URL. */
+function lastIssuesUrl(mock: ReturnType<typeof vi.fn>): string {
+	const urls = (mock.mock.calls as [string, RequestInit][])
+		.map((c) => String(c[0]))
+		.filter((u) => u.includes("/api/issues"));
+	return urls[urls.length - 1] ?? "";
+}
+
+describe("date-range filter (server-side, PROJ-212)", () => {
+	it("sends completedAfter when field=Completed and a From date is set", async () => {
+		const mock = setupDateFetch();
+		render(<IssueList />);
+		await waitForLoaded();
+		openFiltersPopover();
+
+		fireEvent.change(screen.getByRole("combobox", { name: "Date filter field" }), {
+			target: { value: "completed" },
+		});
+		fireEvent.input(screen.getByLabelText("From date"), { target: { value: "2026-01-01" } });
+
+		await waitFor(() => expect(lastIssuesUrl(mock)).toMatch(/completedAfter=\d+/));
+		expect(lastIssuesUrl(mock)).not.toContain("updatedAfter=");
+	});
+
+	it("sends updatedBefore when field=Last edited and a To date is set", async () => {
+		const mock = setupDateFetch();
+		render(<IssueList />);
+		await waitForLoaded();
+		openFiltersPopover();
+
+		fireEvent.change(screen.getByRole("combobox", { name: "Date filter field" }), {
+			target: { value: "updated" },
+		});
+		fireEvent.input(screen.getByLabelText("To date"), { target: { value: "2026-03-01" } });
+
+		await waitFor(() => expect(lastIssuesUrl(mock)).toMatch(/updatedBefore=\d+/));
+		expect(lastIssuesUrl(mock)).not.toContain("completedBefore=");
+	});
+
+	it("sends no date params while the field is 'No date filter' even with dates entered", async () => {
+		const mock = setupDateFetch();
+		render(<IssueList />);
+		await waitForLoaded();
+		openFiltersPopover();
+
+		// Pick a field, set a date, then switch the field back off.
+		fireEvent.change(screen.getByRole("combobox", { name: "Date filter field" }), {
+			target: { value: "completed" },
+		});
+		fireEvent.input(screen.getByLabelText("From date"), { target: { value: "2026-01-01" } });
+		await waitFor(() => expect(lastIssuesUrl(mock)).toContain("completedAfter="));
+
+		fireEvent.change(screen.getByRole("combobox", { name: "Date filter field" }), {
+			target: { value: "" },
+		});
+
+		await waitFor(() => {
+			const url = lastIssuesUrl(mock);
+			expect(url).not.toContain("completedAfter=");
+			expect(url).not.toContain("updatedAfter=");
+		});
+	});
+
+	it("syncs the date filter to the URL and reads it back on mount", async () => {
+		setupDateFetch();
+		render(<IssueList />);
+		await waitForLoaded();
+		openFiltersPopover();
+
+		fireEvent.change(screen.getByRole("combobox", { name: "Date filter field" }), {
+			target: { value: "completed" },
+		});
+		fireEvent.input(screen.getByLabelText("From date"), { target: { value: "2026-01-01" } });
+
+		await waitFor(() => {
+			const params = new URLSearchParams(window.location.search);
+			expect(params.get("dateField")).toBe("completed");
+			expect(params.get("dateFrom")).toBe("2026-01-01");
+		});
+
+		// Remount from the synced URL — the field + From date are restored and
+		// the very first list request already carries completedAfter.
+		cleanup();
+		const mock2 = setupDateFetch();
+		render(<IssueList />);
+		await waitForLoaded();
+
+		await waitFor(() => expect(lastIssuesUrl(mock2)).toMatch(/completedAfter=\d+/));
+	});
+});

--- a/apps/web/src/islands/IssueList.tsx
+++ b/apps/web/src/islands/IssueList.tsx
@@ -8,7 +8,6 @@ import {
 	assigneeInitials,
 	BOARD_COLUMNS,
 	categoryColor,
-	filterIssues,
 	getBacklogIssues,
 	getBoardColumnIssues,
 	getFirstStatusForCategory,
@@ -89,6 +88,10 @@ export default function IssueList({ workspaceSlug }: Props) {
 	const [issues, setIssues] = useState<Issue[]>([]);
 	const [statuses, setStatuses] = useState<TaskStatus[]>([]);
 	const [projects, setProjects] = useState<ProjectMeta[]>([]);
+	// Epics for the epic filter dropdown — fetched independently of the paginated
+	// list (PROJ-211) so the dropdown is complete and survives "Hide epics", which
+	// now excludes epic-typed issues from the list server-side.
+	const [epics, setEpics] = useState<Issue[]>([]);
 	const [loading, setLoading] = useState(true);
 	const hasLoadedOnce = useRef(false);
 	const [error, setError] = useState<string | null>(null);
@@ -185,6 +188,11 @@ export default function IssueList({ workspaceSlug }: Props) {
 		if (filterEpicId && filterEpicId !== "none") qs.set("parentId", filterEpicId);
 		if (filterEpicId === "none") qs.set("noParent", "true");
 		if (filterSprintId) qs.set("sprintId", filterSprintId);
+		// Epic exclusion runs server-side (PROJ-211): both "Hide epics" and the
+		// "No epic" option drop epic-typed issues via excludeTypeIds, so the result
+		// is correct across pagination rather than only on the loaded page.
+		const epicTypeId = taskTypes.find((t) => t.key === "epic")?.id;
+		if (epicTypeId && (hideEpics || filterEpicId === "none")) qs.set("excludeTypeIds", epicTypeId);
 		return qs;
 	}, [
 		filterStatuses,
@@ -193,6 +201,7 @@ export default function IssueList({ workspaceSlug }: Props) {
 		filterType,
 		filterEpicId,
 		filterSprintId,
+		hideEpics,
 		projects,
 		taskTypes,
 	]);
@@ -341,6 +350,31 @@ export default function IssueList({ workspaceSlug }: Props) {
 			}
 		})();
 	}, [workspaceSlug]);
+
+	// Fetch epics for the epic filter dropdown, independent of the paginated list
+	// (PROJ-211). Scoped to the active project filter when set.
+	useEffect(() => {
+		const epicTypeId = taskTypes.find((t) => t.key === "epic")?.id;
+		if (!epicTypeId) {
+			setEpics([]);
+			return;
+		}
+		(async () => {
+			try {
+				const qs = new URLSearchParams({ typeId: epicTypeId, limit: "100" });
+				const projectId = filterProject
+					? projects.find((p) => p.key === filterProject)?.id
+					: undefined;
+				if (projectId) qs.set("project", projectId);
+				const data = await apiFetch<{ items: Issue[] }>(`/api/issues?${qs.toString()}`, {
+					workspaceSlug,
+				});
+				setEpics(Array.isArray(data.items) ? data.items : []);
+			} catch {
+				// non-fatal — epic dropdown just won't populate
+			}
+		})();
+	}, [workspaceSlug, taskTypes, filterProject, projects]);
 
 	// Fetch project's sprints when project filter is active, or when a sprintId is set
 	// (so the sprint selector appears even when navigating directly to a ?sprintId= URL).
@@ -763,19 +797,10 @@ export default function IssueList({ workspaceSlug }: Props) {
 		).entries(),
 	];
 
-	const epics = issues.filter((i) => i.type_key === "epic");
-
-	const filtered = sortIssues(
-		filterIssues(issues, filterStatuses, filterPriorities, filterProject, filterType)
-			.filter((i) => !hideEpics || i.type_key !== "epic")
-			.filter((i) => {
-				if (!filterEpicId) return true;
-				if (filterEpicId === "none") return i.parent_id === null && i.type_key !== "epic";
-				return i.parent_id === filterEpicId;
-			}),
-		sortBy,
-		sortDir
-	);
+	// Filtering happens server-side (PROJ-211): `issues` is already the filtered,
+	// paginated result set, so the client only sorts the loaded rows. (Sorting is
+	// still page-local — tracked separately as a follow-up.)
+	const filtered = sortIssues(issues, sortBy, sortDir);
 
 	// Project description derived from loaded projects
 	const projectDescription = filterProject

--- a/apps/web/src/islands/IssueList.tsx
+++ b/apps/web/src/islands/IssueList.tsx
@@ -76,6 +76,14 @@ function tsToDateInput(ts: number): string {
 	return `${y}-${m}-${day}`;
 }
 
+// Convert a YYYY-MM-DD date-input value to epoch seconds in local time
+// (PROJ-212). `endOfDay` makes the upper bound inclusive of the whole day.
+function dateInputToTs(dateStr: string, endOfDay: boolean): number {
+	const [y, m, d] = dateStr.split("-").map(Number);
+	const date = endOfDay ? new Date(y, m - 1, d, 23, 59, 59) : new Date(y, m - 1, d, 0, 0, 0);
+	return Math.floor(date.getTime() / 1000);
+}
+
 function spBadge(pts: string) {
 	return (
 		<span class="text-[0.68rem] text-text-muted bg-surface border border-border rounded-[3px] px-[0.3rem] font-semibold whitespace-nowrap leading-[1.6]">
@@ -106,6 +114,11 @@ export default function IssueList({ workspaceSlug }: Props) {
 	const [filterType, setFilterType] = useState("");
 	const [filterEpicId, setFilterEpicId] = useState("");
 	const [hideEpics, setHideEpics] = useState(false);
+	// Date-range filter (PROJ-212): which timestamp to bound ("" = off), plus
+	// inclusive from/to as YYYY-MM-DD date-input strings.
+	const [filterDateField, setFilterDateField] = useState<"" | "completed" | "updated">("");
+	const [filterDateFrom, setFilterDateFrom] = useState("");
+	const [filterDateTo, setFilterDateTo] = useState("");
 	const [filterSprintId, setFilterSprintId] = useState("");
 	const [sortBy, setSortBy] = useState<SortKey>("created_at");
 	const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
@@ -193,6 +206,14 @@ export default function IssueList({ workspaceSlug }: Props) {
 		// is correct across pagination rather than only on the loaded page.
 		const epicTypeId = taskTypes.find((t) => t.key === "epic")?.id;
 		if (epicTypeId && (hideEpics || filterEpicId === "none")) qs.set("excludeTypeIds", epicTypeId);
+		// Date-range filter (PROJ-212) runs server-side against the chosen
+		// timestamp column; bounds are inclusive (from = start of day, to = end).
+		if (filterDateField && (filterDateFrom || filterDateTo)) {
+			const afterKey = filterDateField === "completed" ? "completedAfter" : "updatedAfter";
+			const beforeKey = filterDateField === "completed" ? "completedBefore" : "updatedBefore";
+			if (filterDateFrom) qs.set(afterKey, String(dateInputToTs(filterDateFrom, false)));
+			if (filterDateTo) qs.set(beforeKey, String(dateInputToTs(filterDateTo, true)));
+		}
 		return qs;
 	}, [
 		filterStatuses,
@@ -202,6 +223,9 @@ export default function IssueList({ workspaceSlug }: Props) {
 		filterEpicId,
 		filterSprintId,
 		hideEpics,
+		filterDateField,
+		filterDateFrom,
+		filterDateTo,
 		projects,
 		taskTypes,
 	]);
@@ -265,6 +289,12 @@ export default function IssueList({ workspaceSlug }: Props) {
 		if (e) setFilterEpicId(e);
 		if (spr) setFilterSprintId(spr);
 		if (params.get("hideEpics") === "1") setHideEpics(true);
+		const df = params.get("dateField");
+		if (df === "completed" || df === "updated") setFilterDateField(df);
+		const dfrom = params.get("dateFrom");
+		const dto = params.get("dateTo");
+		if (dfrom) setFilterDateFrom(dfrom);
+		if (dto) setFilterDateTo(dto);
 
 		// safe-ls: cosmetic view preference (list/board/backlog). No API dependency — a stale
 		// or missing value falls back to the "list" default; it never influences API requests.
@@ -300,9 +330,33 @@ export default function IssueList({ workspaceSlug }: Props) {
 		} else {
 			params.delete("hideEpics");
 		}
+		if (filterDateField) {
+			params.set("dateField", filterDateField);
+		} else {
+			params.delete("dateField");
+		}
+		if (filterDateFrom) {
+			params.set("dateFrom", filterDateFrom);
+		} else {
+			params.delete("dateFrom");
+		}
+		if (filterDateTo) {
+			params.set("dateTo", filterDateTo);
+		} else {
+			params.delete("dateTo");
+		}
 		const qs = params.toString();
 		history.replaceState(null, "", qs ? `?${qs}` : window.location.pathname);
-	}, [filterStatuses, filterPriorities, filterEpicId, filterSprintId, hideEpics]);
+	}, [
+		filterStatuses,
+		filterPriorities,
+		filterEpicId,
+		filterSprintId,
+		hideEpics,
+		filterDateField,
+		filterDateFrom,
+		filterDateTo,
+	]);
 
 	// safe-ls: cosmetic view preference — no API dependency (see getItem above).
 	useEffect(() => {
@@ -512,6 +566,9 @@ export default function IssueList({ workspaceSlug }: Props) {
 			epicId: filterEpicId,
 			sprintId: filterSprintId,
 			hideEpics,
+			dateField: filterDateField,
+			dateFrom: filterDateFrom,
+			dateTo: filterDateTo,
 		};
 		if (!filtersMatch(current, activeView.filters)) setActiveViewName(null);
 	}, [
@@ -522,6 +579,9 @@ export default function IssueList({ workspaceSlug }: Props) {
 		filterEpicId,
 		filterSprintId,
 		hideEpics,
+		filterDateField,
+		filterDateFrom,
+		filterDateTo,
 		activeViewName,
 		savedViews,
 	]);
@@ -665,6 +725,9 @@ export default function IssueList({ workspaceSlug }: Props) {
 			epicId: filterEpicId,
 			sprintId: filterSprintId,
 			hideEpics,
+			dateField: filterDateField,
+			dateFrom: filterDateFrom,
+			dateTo: filterDateTo,
 		});
 		const key = viewsStorageKey(filterProject);
 		const updated = upsertView(savedViews, newView);
@@ -740,6 +803,13 @@ export default function IssueList({ workspaceSlug }: Props) {
 		setFilterEpicId(view.filters.epicId);
 		setFilterSprintId(view.filters.sprintId);
 		setHideEpics(view.filters.hideEpics);
+		setFilterDateField(
+			view.filters.dateField === "completed" || view.filters.dateField === "updated"
+				? view.filters.dateField
+				: ""
+		);
+		setFilterDateFrom(view.filters.dateFrom);
+		setFilterDateTo(view.filters.dateTo);
 		setActiveViewName(view.name);
 		setShowViewsMenu(false);
 	}
@@ -1402,7 +1472,9 @@ export default function IssueList({ workspaceSlug }: Props) {
 
 				{/* Filters button + popover (status & priority) */}
 				{(() => {
-					const activeFilterCount = filterStatuses.length + filterPriorities.length;
+					const dateFilterActive = !!(filterDateField && (filterDateFrom || filterDateTo));
+					const activeFilterCount =
+						filterStatuses.length + filterPriorities.length + (dateFilterActive ? 1 : 0);
 					const PILL_COLORS: Record<string, { bg: string; text: string }> = {
 						urgent: { bg: "#dc2626", text: "#fff" },
 						high: { bg: "#d97706", text: "#fff" },
@@ -1521,6 +1593,48 @@ export default function IssueList({ workspaceSlug }: Props) {
 											);
 										})}
 									</div>
+									{/* Date range (PROJ-212) — bound a chosen timestamp column server-side */}
+									<div class="text-[0.7rem] font-semibold text-text-muted uppercase tracking-[0.04em] mb-2 mt-3">
+										Date range
+									</div>
+									<select
+										aria-label="Date filter field"
+										value={filterDateField}
+										onChange={(e) =>
+											setFilterDateField(
+												(e.target as HTMLSelectElement).value as "" | "completed" | "updated"
+											)
+										}
+										class="w-full px-2 py-[0.3rem] border border-border rounded text-sm bg-bg text-text-base cursor-pointer"
+									>
+										<option value="">No date filter</option>
+										<option value="completed">Completed date</option>
+										<option value="updated">Last edited date</option>
+									</select>
+									{filterDateField && (
+										<div class="flex gap-2 mt-2">
+											<label class="flex-1 text-[0.7rem] text-text-muted">
+												From
+												<input
+													type="date"
+													aria-label="From date"
+													value={filterDateFrom}
+													onInput={(e) => setFilterDateFrom((e.target as HTMLInputElement).value)}
+													class="w-full px-2 py-[0.3rem] border border-border rounded text-sm bg-bg text-text-base mt-[0.2rem]"
+												/>
+											</label>
+											<label class="flex-1 text-[0.7rem] text-text-muted">
+												To
+												<input
+													type="date"
+													aria-label="To date"
+													value={filterDateTo}
+													onInput={(e) => setFilterDateTo((e.target as HTMLInputElement).value)}
+													class="w-full px-2 py-[0.3rem] border border-border rounded text-sm bg-bg text-text-base mt-[0.2rem]"
+												/>
+											</label>
+										</div>
+									)}
 									{activeFilterCount > 0 && (
 										<div class="border-t border-border pt-2 mt-3">
 											<button
@@ -1528,6 +1642,9 @@ export default function IssueList({ workspaceSlug }: Props) {
 												onClick={() => {
 													setFilterStatuses([]);
 													setFilterPriorities([]);
+													setFilterDateField("");
+													setFilterDateFrom("");
+													setFilterDateTo("");
 												}}
 												class="bg-transparent border-none text-text-muted cursor-pointer text-[0.8rem] p-0"
 											>

--- a/apps/web/src/islands/saved-views.test.ts
+++ b/apps/web/src/islands/saved-views.test.ts
@@ -20,6 +20,9 @@ function makeFilters(overrides: Partial<SavedViewFilters> = {}): SavedViewFilter
 		epicId: "",
 		sprintId: "",
 		hideEpics: false,
+		dateField: "",
+		dateFrom: "",
+		dateTo: "",
 		...overrides,
 	};
 }
@@ -105,6 +108,18 @@ describe("filtersMatch", () => {
 		const a = makeFilters({ statuses: ["a", "b"], priorities: ["high", "low"] });
 		const b = makeFilters({ statuses: ["b", "a"], priorities: ["low", "high"] });
 		expect(filtersMatch(a, b)).toBe(true);
+	});
+
+	it("distinguishes on the date-range filter (PROJ-212)", () => {
+		expect(
+			filtersMatch(
+				makeFilters({ dateField: "completed", dateFrom: "2026-01-01" }),
+				makeFilters({ dateField: "completed", dateFrom: "2026-02-01" })
+			)
+		).toBe(false);
+		expect(
+			filtersMatch(makeFilters({ dateField: "completed" }), makeFilters({ dateField: "updated" }))
+		).toBe(false);
 	});
 
 	it("distinguishes on hideEpics", () => {

--- a/apps/web/src/islands/saved-views.ts
+++ b/apps/web/src/islands/saved-views.ts
@@ -19,6 +19,11 @@ export interface SavedViewFilters {
 	epicId: string;
 	sprintId: string;
 	hideEpics: boolean;
+	/** Date-range filter field: "" (off), "completed", or "updated" (PROJ-212). */
+	dateField: string;
+	/** Inclusive range bounds as YYYY-MM-DD date-input strings ("" when unset). */
+	dateFrom: string;
+	dateTo: string;
 }
 
 export interface SavedView {
@@ -51,6 +56,9 @@ export function normalizeFilters(
 		epicId: str(r.epicId),
 		sprintId: str(r.sprintId),
 		hideEpics: r.hideEpics === true,
+		dateField: str(r.dateField),
+		dateFrom: str(r.dateFrom),
+		dateTo: str(r.dateTo),
 	};
 }
 
@@ -104,6 +112,9 @@ export function filtersMatch(a: SavedViewFilters, b: SavedViewFilters): boolean 
 		a.type === b.type &&
 		a.epicId === b.epicId &&
 		a.sprintId === b.sprintId &&
-		a.hideEpics === b.hideEpics
+		a.hideEpics === b.hideEpics &&
+		a.dateField === b.dateField &&
+		a.dateFrom === b.dateFrom &&
+		a.dateTo === b.dateTo
 	);
 }

--- a/packages/db/migrations/0022_issue_completed_at.sql
+++ b/packages/db/migrations/0022_issue_completed_at.sql
@@ -1,0 +1,14 @@
+-- Track when an issue was marked completed, for date-range filtering (PROJ-212).
+-- completed_at is stamped when an issue first enters a done-category status and
+-- cleared when it leaves (see updateIssue). An indexed column keeps "completed
+-- between X and Y" an index range scan rather than a derive-on-read over the
+-- activity log, so it stays scalable as history grows.
+ALTER TABLE issues ADD COLUMN completed_at INTEGER;
+
+-- Best-effort backfill for issues already done: use updated_at as an approximate
+-- completion time. Imperfect (a later edit moved updated_at), but lets historical
+-- done issues participate in completed-date filters immediately.
+UPDATE issues SET completed_at = updated_at
+  WHERE status_category = 'done' OR status = 'done';
+
+CREATE INDEX idx_issues_workspace_completed ON issues(workspace_id, completed_at);

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -95,6 +95,9 @@ export const issues = sqliteTable(
 			.references(() => users.id),
 		createdAt: integer("created_at").notNull(),
 		updatedAt: integer("updated_at").notNull(),
+		// Stamped when the issue enters a done-category status, cleared when it
+		// leaves (PROJ-212). Indexed for completed-date range filtering.
+		completedAt: integer("completed_at"),
 	},
 	(t) => ({
 		projectIdx: index("issues_project_idx").on(t.projectId),
@@ -108,6 +111,7 @@ export const issues = sqliteTable(
 			t.statusCategory,
 			t.createdAt
 		),
+		wsCompletedIdx: index("idx_issues_workspace_completed").on(t.workspaceId, t.completedAt),
 	})
 );
 


### PR DESCRIPTION
## Summary

Two related issue-list filtering improvements.

### PROJ-211 — run filters server-side
Filters were being applied to the already-fetched page rather than the database, so results were wrong across pagination (e.g. "hide epics" only hid epics on the loaded page). The island now sends filter params to `/api/issues` and the API filters; the epic dropdown is fetched independently so it stays complete.

### PROJ-212 — date-range filtering
Filter issues by **when they were completed** or **last edited**.

**Backend**
- New `completed_at` column (migration `0022`), indexed on `(workspace_id, completed_at)`; stamped when an issue enters a done status, cleared when it leaves. Best-effort backfill from `updated_at` for existing done issues.
- `listIssues` gains `completedAfter/Before` and `updatedAfter/Before` bounds (epoch seconds, inclusive) — wired through the REST route, MCP `list_issues` schema, and Zod validation. Range scans hit the index rather than post-filtering fetched rows.

**UI**
- Date range section in the Filters popover: field selector (Completed / Last edited) + inclusive From/To date inputs.
- Participates in the active-filter count, Clear-all, URL sync (`dateField`/`dateFrom`/`dateTo`), and saved views (`SavedViewFilters` gains the three fields with legacy backfill).

## Tests
- API: 515 passing — PROJ-212 service tests seed + assert via `env.DB` to stay under the test rate-limit window and avoid the `getIssue` KV cache.
- Web: 234 passing — new date-filter request-contract tests + saved-views date-field test.
- Type-check clean on api / db / web.

No release/tag cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)