### PR TITLE
Security hardening: MCP error allowlist + CORS allowlist + id validation (PROJ-203/204/205)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,4 @@
-import type { HonoEnv } from "@projektor/types";
+import type { Env, HonoEnv } from "@projektor/types";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { logger } from "hono/logger";
@@ -32,10 +32,21 @@ import { createWorkspace, listUserWorkspaces } from "./services/workspaces";
 const app = new Hono<HonoEnv>();
 
 app.use("*", logger());
+// CORS is an allowlist, not "*" (PROJ-203). The served SPA is same-origin, so it
+// is unaffected by CORS; this only governs cross-origin *browser* clients. Set
+// CORS_ALLOWED_ORIGINS (comma-separated) to permit a browser app on another
+// origin. Unset/empty = deny cross-origin. Non-browser bearer clients never send
+// an Origin header and so are never constrained here.
 app.use(
 	"*",
 	cors({
-		origin: "*",
+		origin: (origin, c) => {
+			const allowed = ((c.env as Env).CORS_ALLOWED_ORIGINS ?? "")
+				.split(",")
+				.map((s) => s.trim())
+				.filter(Boolean);
+			return allowed.includes(origin) ? origin : null;
+		},
 		allowHeaders: ["Authorization", "Content-Type", "Cf-Access-Jwt-Assertion", "X-Workspace-Slug"],
 	})
 );

--- a/apps/api/src/mcp/error-adapter.ts
+++ b/apps/api/src/mcp/error-adapter.ts
@@ -5,7 +5,21 @@ export function toMcpError(err: unknown): { code: number; message: string } {
 		return { code: -32602, message: "Invalid params" };
 	}
 	if (err instanceof ServiceError) {
-		return { code: -32000, message: err.message };
+		// Only the kinds whose messages are deliberately client-facing are
+		// surfaced (audited 2026-06-30: not_found / forbidden / conflict messages
+		// are controlled domain strings — "Issue not found", "Slug already taken",
+		// or the caller's own key echoed back — never internals). Any other
+		// ServiceError kind is treated as internal so a future subclass can't
+		// leak its message to clients by default. (PROJ-204)
+		switch (err.kind) {
+			case "not_found":
+			case "forbidden":
+			case "conflict":
+				return { code: -32000, message: err.message };
+			default:
+				console.error("[mcp] unhandled ServiceError kind in tools/call:", err.kind, err);
+				return { code: -32000, message: "Internal error" };
+		}
 	}
 	console.error("[mcp] unhandled error in tools/call:", err);
 	return { code: -32000, message: "Internal error" };

--- a/apps/api/src/schemas/common.ts
+++ b/apps/api/src/schemas/common.ts
@@ -12,6 +12,11 @@ export const StatusEnum = z.enum([
 ]);
 export const PriorityEnum = z.enum(["urgent", "high", "medium", "low", "none"]);
 
+// Identifier guard for single-id mutations (deletes, complete) whose handlers
+// otherwise only cast/typeof-check the id. Co-locates a Zod check with the write
+// so no caller can reach the DB with an empty/non-string id. (PROJ-205)
+export const IdSchema = z.string().min(1, "id is required");
+
 // Task-type and task-status IDs come in two shapes: runtime-created ones use
 // crypto.randomUUID() (dashed UUID), while seeded defaults use 32-char hex
 // hashes (e.g. "ea3df70345804c3d26ebf139816cae8f"). Accept both so the seeded

--- a/apps/api/src/services/custom-fields.ts
+++ b/apps/api/src/services/custom-fields.ts
@@ -1,5 +1,6 @@
 import { drizzle, schema } from "@projektor/db";
 import { and, asc, eq, inArray, isNull, or, sql } from "drizzle-orm";
+import { IdSchema } from "../schemas/common";
 import { CreateCustomFieldDefSchema, UpdateCustomFieldDefSchema } from "../schemas/custom-fields";
 import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from "./errors";
 import { inChunks } from "./sql";
@@ -158,6 +159,9 @@ export async function updateCustomFieldDef(ctx: ServiceCtx, id: string, raw: unk
 }
 
 export async function deleteCustomFieldDef(ctx: ServiceCtx, id: string) {
+	const idCheck = IdSchema.safeParse(id);
+	if (!idCheck.success)
+		throw new ValidationError({ formErrors: idCheck.error.flatten().formErrors, fieldErrors: {} });
 	if (ctx.role === "member" || ctx.role === "viewer") throw new ForbiddenError();
 
 	const orm = drizzle(ctx.db, { schema });

--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -13,6 +13,7 @@ import {
 	or,
 	sql,
 } from "drizzle-orm";
+import { IdSchema } from "../schemas/common";
 import {
 	CreateIssueSchema,
 	GetIssueSchema,
@@ -633,6 +634,9 @@ export async function updateIssue(ctx: ServiceCtx, id: string, raw: unknown) {
 }
 
 export async function deleteIssue(ctx: ServiceCtx, id: string) {
+	const idCheck = IdSchema.safeParse(id);
+	if (!idCheck.success)
+		throw new ValidationError({ formErrors: idCheck.error.flatten().formErrors, fieldErrors: {} });
 	if (ctx.role !== "admin" && ctx.role !== "owner")
 		throw new ForbiddenError("Insufficient permissions");
 	const orm = drizzle(ctx.db, { schema });

--- a/apps/api/src/services/projects.ts
+++ b/apps/api/src/services/projects.ts
@@ -1,5 +1,6 @@
 import { drizzle, schema } from "@projektor/db";
 import { and, asc, eq } from "drizzle-orm";
+import { IdSchema } from "../schemas/common";
 import { CreateProjectSchema, UpdateProjectSchema } from "../schemas/projects";
 import { recordActivity } from "./activity";
 import * as cache from "./cache";
@@ -147,6 +148,9 @@ export async function updateProject(ctx: ServiceCtx, id: string, input: unknown)
 }
 
 export async function deleteProject(ctx: ServiceCtx, id: string) {
+	const idCheck = IdSchema.safeParse(id);
+	if (!idCheck.success)
+		throw new ValidationError({ formErrors: idCheck.error.flatten().formErrors, fieldErrors: {} });
 	if (ctx.role !== "owner") throw new ForbiddenError();
 
 	const orm = drizzle(ctx.db, { schema });

--- a/apps/api/src/services/sprints.ts
+++ b/apps/api/src/services/sprints.ts
@@ -1,5 +1,6 @@
 import { drizzle, schema } from "@projektor/db";
 import { and, asc, eq, inArray } from "drizzle-orm";
+import { IdSchema } from "../schemas/common";
 import {
 	CreateSprintSchema,
 	ListSprintsSchema,
@@ -111,6 +112,9 @@ export async function updateSprint(ctx: ServiceCtx, id: string, raw: unknown) {
 }
 
 export async function completeSprint(ctx: ServiceCtx, id: string) {
+	const idCheck = IdSchema.safeParse(id);
+	if (!idCheck.success)
+		throw new ValidationError({ formErrors: idCheck.error.flatten().formErrors, fieldErrors: {} });
 	if (ctx.role === "viewer") throw new ForbiddenError("Insufficient permissions");
 	const orm = drizzle(ctx.db, { schema });
 	const sprint = await orm
@@ -137,6 +141,9 @@ export async function completeSprint(ctx: ServiceCtx, id: string) {
 }
 
 export async function deleteSprint(ctx: ServiceCtx, id: string) {
+	const idCheck = IdSchema.safeParse(id);
+	if (!idCheck.success)
+		throw new ValidationError({ formErrors: idCheck.error.flatten().formErrors, fieldErrors: {} });
 	if (ctx.role === "viewer") throw new ForbiddenError("Insufficient permissions");
 	const orm = drizzle(ctx.db, { schema });
 	const existing = await orm

--- a/apps/api/src/services/task-statuses.ts
+++ b/apps/api/src/services/task-statuses.ts
@@ -1,5 +1,6 @@
 import { drizzle, schema } from "@projektor/db";
 import { and, asc, eq } from "drizzle-orm";
+import { IdSchema } from "../schemas/common";
 import { CreateTaskStatusSchema, UpdateTaskStatusSchema } from "../schemas/task-statuses";
 import * as cache from "./cache";
 import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from "./errors";
@@ -108,6 +109,9 @@ export async function updateTaskStatus(ctx: ServiceCtx, id: string, raw: unknown
 }
 
 export async function deleteTaskStatus(ctx: ServiceCtx, id: string) {
+	const idCheck = IdSchema.safeParse(id);
+	if (!idCheck.success)
+		throw new ValidationError({ formErrors: idCheck.error.flatten().formErrors, fieldErrors: {} });
 	if (ctx.role === "member" || ctx.role === "viewer") throw new ForbiddenError();
 
 	const orm = drizzle(ctx.db, { schema });

--- a/apps/api/src/services/task-types.ts
+++ b/apps/api/src/services/task-types.ts
@@ -1,5 +1,6 @@
 import { drizzle, schema } from "@projektor/db";
 import { and, asc, eq } from "drizzle-orm";
+import { IdSchema } from "../schemas/common";
 import { CreateTaskTypeSchema, UpdateTaskTypeSchema } from "../schemas/task-types";
 import * as cache from "./cache";
 import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from "./errors";
@@ -102,6 +103,9 @@ export async function updateTaskType(ctx: ServiceCtx, id: string, raw: unknown) 
 }
 
 export async function deleteTaskType(ctx: ServiceCtx, id: string) {
+	const idCheck = IdSchema.safeParse(id);
+	if (!idCheck.success)
+		throw new ValidationError({ formErrors: idCheck.error.flatten().formErrors, fieldErrors: {} });
 	if (ctx.role === "member" || ctx.role === "viewer") throw new ForbiddenError();
 
 	const orm = drizzle(ctx.db, { schema });

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -1,5 +1,6 @@
 import { drizzle, schema } from "@projektor/db";
 import { and, asc, desc, eq, or } from "drizzle-orm";
+import { IdSchema } from "../schemas/common";
 import {
 	CreatePageSchema,
 	ListPagesInputSchema,
@@ -285,7 +286,11 @@ export async function updateWikiPage(ctx: ServiceCtx, idOrSlug: string, input: u
 }
 
 export async function deleteWikiPage(ctx: ServiceCtx, slug: string) {
-	if (ctx.role !== "admin" && ctx.role !== "owner") throw new ForbiddenError("Insufficient permissions");
+	const idCheck = IdSchema.safeParse(slug);
+	if (!idCheck.success)
+		throw new ValidationError({ formErrors: idCheck.error.flatten().formErrors, fieldErrors: {} });
+	if (ctx.role !== "admin" && ctx.role !== "owner")
+		throw new ForbiddenError("Insufficient permissions");
 	const orm = drizzle(ctx.db, { schema });
 	const page = await orm
 		.select({ id: schema.wikiPages.id })

--- a/apps/api/src/services/workspaces.ts
+++ b/apps/api/src/services/workspaces.ts
@@ -1,5 +1,6 @@
 import { drizzle, schema } from "@projektor/db";
 import { and, asc, desc, eq, sql } from "drizzle-orm";
+import { IdSchema } from "../schemas/common";
 import {
 	CreateTokenSchema,
 	CreateWorkspaceSchema,
@@ -138,6 +139,9 @@ export async function inviteMember(ctx: ServiceCtx, input: unknown) {
 }
 
 export async function removeMember(ctx: ServiceCtx, targetUserId: string) {
+	const idCheck = IdSchema.safeParse(targetUserId);
+	if (!idCheck.success)
+		throw new ValidationError({ formErrors: idCheck.error.flatten().formErrors, fieldErrors: {} });
 	if (ctx.role !== "owner") throw new ForbiddenError();
 	if (ctx.userId === targetUserId) {
 		throw new ValidationError({ formErrors: ["Cannot remove yourself as owner"], fieldErrors: {} });

--- a/packages/types/src/env.ts
+++ b/packages/types/src/env.ts
@@ -27,6 +27,12 @@ export interface Env {
 	// Per-workspace attachment storage quota in bytes (default 1 GiB). Override in
 	// wrangler.toml [vars]; invalid or non-positive values fall back to the default.
 	STORAGE_QUOTA_BYTES?: string;
+	// Comma-separated allowlist of browser origins permitted for cross-origin
+	// requests (CORS). The served SPA is same-origin, so it never needs this;
+	// set it only when a browser app on a DIFFERENT origin calls this API.
+	// Unset/empty = no cross-origin browser access (non-browser bearer clients
+	// are unaffected — CORS only constrains browsers). (PROJ-203)
+	CORS_ALLOWED_ORIGINS?: string;
 	// Static assets binding (production wrangler.toml only — absent in local dev).
 	ASSETS?: Fetcher;
 }


### PR DESCRIPTION
Security hardening pass across the MCP and HTTP surface. Three audited fixes, one PR.

## PROJ-204 — stop MCP error-message leak
`toMcpError` now allowlists which `ServiceError` kinds may surface their message
(`not_found` / `forbidden` / `conflict` — audited as controlled domain strings).
Any other kind is logged server-side and returned as a generic `Internal error`,
so a future `ServiceError` subclass can't leak internals by default.

## PROJ-203 — CORS is an allowlist, not `*`
Replaced `origin: "*"` with an allowlist read from a new `CORS_ALLOWED_ORIGINS`
env var (comma-separated). **Behaviour change:** cross-origin *browser* clients are
denied unless their origin is listed. The served SPA is same-origin so it is
unaffected; non-browser bearer clients send no `Origin` header and are never
constrained. Set `CORS_ALLOWED_ORIGINS` only for a browser app on a different origin.

## PROJ-205 — validate id on unguarded MCP write paths
Added `IdSchema` (`z.string().min(1)`) and applied it as the first statement in the
9 single-id mutation services that previously only typeof/cast-checked the id:
`deleteProject`, `deleteIssue`, `completeSprint`, `deleteSprint`, `deleteTaskStatus`,
`deleteTaskType`, `deleteCustomFieldDef`, `deleteWikiPage`, `removeMember`. This
keeps validation in the service layer (where REST and MCP both funnel) rather than
duplicating it in the MCP dispatcher.

## Verification
- type-check: 7/7 packages green
- api tests: 515 passed, 5 todo
- biome/lint: green (2 pre-existing warnings left untouched per surgical discipline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
