### PR TITLE
fix(web): preserve Epics filters on back-nav from epic detail (PROJ-215)

### DIFF
--- a/apps/web/src/islands/IssueDetail.tsx
+++ b/apps/web/src/islands/IssueDetail.tsx
@@ -209,7 +209,7 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 			const ref = document.referrer;
 			if (!ref) return;
 			const url = new URL(ref);
-			if (url.pathname.startsWith("/issues") && url.search) {
+			if ((url.pathname.startsWith("/issues") || url.pathname.startsWith("/epics")) && url.search) {
 				setBackHref(url.pathname + url.search);
 			}
 		} catch {
@@ -755,9 +755,15 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 		<article class="max-w-[900px] mx-auto">
 			{/* Breadcrumb */}
 			<nav class="text-sm text-text-muted mb-5">
-				<a href={backHref ?? `/issues${issue.project_key ? `?project=${issue.project_key}` : ""}`} class="text-text-muted no-underline">
-					← Issues
-				</a>
+				{issue.type_key === "epic" ? (
+					<a href={backHref ?? "/epics"} class="text-text-muted no-underline">
+						← Epics
+					</a>
+				) : (
+					<a href={backHref ?? `/issues${issue.project_key ? `?project=${issue.project_key}` : ""}`} class="text-text-muted no-underline">
+						← Issues
+					</a>
+				)}
 			</nav>
 
 			{/* Blocked-by banner */}


### PR DESCRIPTION
## Summary
- `IssueDetail.tsx` is shared between issue and epic detail pages. Its referrer-based back-nav logic only recognized `/issues` paths, so navigating back from an epic dropped the Epics list filters (status/priority/projectId) that `EpicList.tsx` already syncs to the URL (added in #13).
- Extended the referrer check to also preserve `/epics?...` query strings.
- Fixed the breadcrumb fallback (used when there's no referrer) to link to `/epics` with an "← Epics" label for epic issues, instead of always falling back to `/issues`.

Note: the issues→issues fallback continues to pass `?project=<key>` (matching `IssueList`'s key-based lookup). I deliberately did **not** add an equivalent `projectId` query param to the epics fallback, since `EpicList` expects a raw project UUID there (not a key) and `IssueDetail`'s issue payload doesn't carry one — passing the key would silently break the epics filter. The referrer-preserving path (the primary fix) is unaffected by this.

## Test plan
- [x] `pnpm -C apps/web build` — succeeds
- [x] `node_modules/.bin/biome check` on the changed file — no new issues (confirmed pre-existing formatting warnings are unrelated, present before this change too)
- [x] Pre-push hook test suite (234 tests) — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)