### PR TITLE
docs: strip em dashes from docs and prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 Guidance for AI agents (and humans) working **on** the projektor codebase.
-Read this before making changes — it captures conventions that aren't obvious from the code alone.
+Read this before making changes - it captures conventions that aren't obvious from the code alone.
 
 > Portable source of truth across agent tools (Claude Code, Codex, Cursor, …). `CLAUDE.md` points here.
 
@@ -19,13 +19,13 @@ Implementation details:
 - When implementing features or fixing bugs you must always implement a test or tests to confirm the functionality is implemented.
 - **Runtime:** Hono on Cloudflare Workers
 - **Data:** D1 (SQLite) for relational data, KV for sessions/caches, R2 for file attachments
-- **Schema:** Drizzle (migration + schema source of truth) — but query execution is raw `DB.prepare(...)`
-- **Monorepo:** pnpm workspaces + turbo. `apps/api` (the Worker), `apps/web` (Astro + Preact static site, served in production via CF Workers Static Assets — see below), `packages/*` (db, types, plugin-sdk), `plugins/*`
-- **Deploy:** projektor publishes a self-contained **release artifact** on each `v*` tag; a config-only deploy repo (e.g. `projektor-workspace`) downloads it and ships it with `wrangler` — no submodule, no source checkout downstream. The Worker (`apps/api`) and the built frontend (`apps/web/dist`) ship together: `wrangler.toml` declares an `[assets]` binding with `run_worker_first = ["/api/*", "/mcp/*"]`, so `/api/*` and `/mcp/*` always hit the Hono Worker while every other path serves the static Astro output (per-route HTML, asset-first). The release build compiles `apps/web` and bundles the Worker into a single `worker.js`.
+- **Schema:** Drizzle (migration + schema source of truth) - but query execution is raw `DB.prepare(...)`
+- **Monorepo:** pnpm workspaces + turbo. `apps/api` (the Worker), `apps/web` (Astro + Preact static site, served in production via CF Workers Static Assets - see below), `packages/*` (db, types, plugin-sdk), `plugins/*`
+- **Deploy:** projektor publishes a self-contained **release artifact** on each `v*` tag; a config-only deploy repo (e.g. `projektor-workspace`) downloads it and ships it with `wrangler` - no submodule, no source checkout downstream. The Worker (`apps/api`) and the built frontend (`apps/web/dist`) ship together: `wrangler.toml` declares an `[assets]` binding with `run_worker_first = ["/api/*", "/mcp/*"]`, so `/api/*` and `/mcp/*` always hit the Hono Worker while every other path serves the static Astro output (per-route HTML, asset-first). The release build compiles `apps/web` and bundles the Worker into a single `worker.js`.
 
 ## Architecture: the service-layer contract (most important)
 
-There are **two surfaces** over the same data — a REST API and an MCP (JSON-RPC) server.
+There are **two surfaces** over the same data - a REST API and an MCP (JSON-RPC) server.
 They MUST behave identically. The mechanism that guarantees this:
 
 ```
@@ -35,19 +35,19 @@ mcp/<domain>.ts      (MCP wrapper)   ─┘     (ALL business logic + SQL live h
 ```
 
 **Rules:**
-1. **All business logic and SQL live in `services/<domain>.ts`.** Routes and MCP tools are thin wrappers — resolve context, call the service, adapt the result/error. No SQL in `routes/` or `mcp/`.
+1. **All business logic and SQL live in `services/<domain>.ts`.** Routes and MCP tools are thin wrappers - resolve context, call the service, adapt the result/error. No SQL in `routes/` or `mcp/`.
 2. **REST and MCP must stay at parity.** If you add or change behavior, do it in the service so *both* surfaces get it. Adding a feature to only one surface is a bug.
-3. **Validation happens inside the service** via a shared Zod schema in `schemas/<domain>.ts` — so REST and MCP are validated identically. Never trust raw `unknown` input in a wrapper.
+3. **Validation happens inside the service** via a shared Zod schema in `schemas/<domain>.ts` - so REST and MCP are validated identically. Never trust raw `unknown` input in a wrapper.
 4. **Services throw typed errors** from `services/errors.ts` (`ValidationError`, `NotFoundError`, `ForbiddenError`, `ConflictError`). The wrappers translate them:
    - REST: `http/error-adapter.ts` → HTTP status (400/404/403/409)
    - MCP: `mcp/error-adapter.ts` → JSON-RPC code (`-32602` for validation, `-32000` otherwise). Never return raw `String(err)` to clients.
 5. **Context** is a `ServiceCtx` (`services/types.ts`): `{ db, kv, r2, workspaceId, userId, role? }`. Build it with `ctxFromHono(c)` in REST; the MCP dispatch (`routes/mcp.ts`) builds the equivalent and passes `role` through `PluginContext`.
 
 ### The security invariant: always scope by workspace
-Every query MUST be scoped by `workspace_id` (directly, or via a parent entity that was itself workspace-checked — e.g. comments verify their issue belongs to the workspace first). A missing scope is a cross-tenant data leak. This is the single most important correctness rule in the codebase.
+Every query MUST be scoped by `workspace_id` (directly, or via a parent entity that was itself workspace-checked - e.g. comments verify their issue belongs to the workspace first). A missing scope is a cross-tenant data leak. This is the single most important correctness rule in the codebase.
 
 ### The D1 limit: never bind a row-scaled array into one query
-Cloudflare **D1 rejects any query with more than 100 bound parameters.** A query whose parameter count grows with an input array — drizzle `inArray`, a raw `IN (...)`, or a batched mutation keyed by ids — will throw at runtime (a 500) once the array is large enough. **This is invisible in tests:** the vitest runner backs D1 with SQLite (cap 32766), so an un-chunked query passes CI and only fails on real D1.
+Cloudflare **D1 rejects any query with more than 100 bound parameters.** A query whose parameter count grows with an input array - drizzle `inArray`, a raw `IN (...)`, or a batched mutation keyed by ids - will throw at runtime (a 500) once the array is large enough. **This is invisible in tests:** the vitest runner backs D1 with SQLite (cap 32766), so an un-chunked query passes CI and only fails on real D1.
 
 Route every variable-length `IN`/`inArray` load through **`inChunks` (`services/sql.ts`)**, which splits the array so each query stays under the cap:
 
@@ -72,25 +72,25 @@ When adding/changing a domain (issues, projects, wiki, comments, …):
 | `apps/api/src/mcp/<domain>.ts` | MCP tool array (composed in `routes/mcp.ts`) |
 | `apps/api/src/test/<domain>.test.ts` | **domain tests go here** |
 
-**Test convention (don't skip this):** put a domain's tests in its own `<domain>.test.ts`. Do **not** pile MCP tests into the shared `test/mcp.test.ts` — parallel work on multiple domains will collide there on merge. (`mcp.test.ts` is for cross-cutting dispatch behavior only.)
+**Test convention (don't skip this):** put a domain's tests in its own `<domain>.test.ts`. Do **not** pile MCP tests into the shared `test/mcp.test.ts` - parallel work on multiple domains will collide there on merge. (`mcp.test.ts` is for cross-cutting dispatch behavior only.)
 
 ## Conventions & gotchas
 
 - **Adding a migration?** After adding a new `.sql` file to `packages/db/migrations/`, you must also add a corresponding `?raw` import to `apps/api/src/test/migrations.ts` and append it to the `MIGRATIONS` array. Without this the test DB won't have the new table and integration tests will silently fail or error.
 - **camelCase at the boundary, snake_case in the DB.** Input schemas use `assigneeId`, `parentId`, etc.; the service maps to the `assignee_id` column. Keep both surfaces on the same naming.
-- **JSON columns** (`labels`, `scopes`) are stored via `JSON.stringify` and returned as raw JSON strings — callers `JSON.parse` on read. There is no automatic (de)serialization.
+- **JSON columns** (`labels`, `scopes`) are stored via `JSON.stringify` and returned as raw JSON strings - callers `JSON.parse` on read. There is no automatic (de)serialization.
 - **Timestamps** are unix seconds: `Math.floor(Date.now() / 1000)`.
 - **IDs** are `crypto.randomUUID()`.
-- **Issue numbers** use `COALESCE(MAX(number),0)+1` per project — known race under concurrency (tracked as a follow-up).
-- **Auth** (`middleware/auth.ts`): Cloudflare Access JWT (browser) OR `Authorization: Bearer <token>` (agents) OR a dev bypass (`DEV_USER_EMAIL`, non-prod only). API tokens are workspace-scoped — don't widen that.
-- **Login provisioning** (`services/provisioning.ts`): runs on every CF Access / dev-bypass login (not the token path). Cloudflare Access is the gate; config decides what a user gets inside — `ADMIN_EMAILS` → `owner` (first admin login also creates the `DEFAULT_WORKSPACE_SLUG` workspace), everyone else → `AUTO_JOIN_ROLE` (default `viewer`; `none` = invite-only). Idempotent; safe to run per request.
+- **Issue numbers** use `COALESCE(MAX(number),0)+1` per project - known race under concurrency (tracked as a follow-up).
+- **Auth** (`middleware/auth.ts`): Cloudflare Access JWT (browser) OR `Authorization: Bearer <token>` (agents) OR a dev bypass (`DEV_USER_EMAIL`, non-prod only). API tokens are workspace-scoped - don't widen that.
+- **Login provisioning** (`services/provisioning.ts`): runs on every CF Access / dev-bypass login (not the token path). Cloudflare Access is the gate; config decides what a user gets inside - `ADMIN_EMAILS` → `owner` (first admin login also creates the `DEFAULT_WORKSPACE_SLUG` workspace), everyone else → `AUTO_JOIN_ROLE` (default `viewer`; `none` = invite-only). Idempotent; safe to run per request.
 - **Roles** (`owner`/`admin`/`member`/`viewer`) are enforced in services via `ctx.role`. Mutations generally block `viewer`; destructive ops may require `owner`.
 - **The plugin system is not wired at runtime yet** (`pluginRegistry` is empty; `enabled_plugins` is unread). Treat `plugins/*` as not-yet-functional until that lands.
 
 ## localStorage policy (frontend)
 
 `localStorage` may only store **cosmetic preferences** (theme, view mode, layout choices).
-Never store server-side entity references (workspace slug, project ID, user ID) — a deleted
+Never store server-side entity references (workspace slug, project ID, user ID) - a deleted
 or renamed entity leaves a stale value that will silently cause API 4xx errors.
 
 **Before adding a new `localStorage.setItem` call, ask:**
@@ -105,8 +105,8 @@ degrades gracefully). This is the convention established in PR #99.
 ## Frontend: islands and the API layer
 
 All island↔API calls go through `apps/web/src/utils/api-client.ts`:
-- `buildHeaders(workspaceSlug, extra?)` — adds the X-Workspace-Slug header
-- `apiFetch<T>(path, opts)` — wraps fetch with headers, credentials, JSON parse, and error throwing
+- `buildHeaders(workspaceSlug, extra?)` - adds the X-Workspace-Slug header
+- `apiFetch<T>(path, opts)` - wraps fetch with headers, credentials, JSON parse, and error throwing
 
 No raw `fetch(` calls in island components. No local `buildHeaders` copies.
 This mirrors the backend service-layer contract: routes are thin wrappers; islands are thin callers.
@@ -122,7 +122,7 @@ pnpm --filter @projektor/api test      # vitest against an in-process Worker + D
 cp apps/api/.dev.vars.example apps/api/.dev.vars   # DEV_USER_EMAIL + BOOTSTRAP_SECRET
 cp apps/web/.env.example apps/web/.env             # PUBLIC_WORKSPACE_SLUG=projektor
 
-pnpm dev                               # local dev — API on :8787, web on :4321
+pnpm dev                               # local dev - API on :8787, web on :4321
 # `dev` auto-applies D1 migrations to the local Miniflare DB first (db:migrate:local),
 # so /api/* won't 500 with "no such table" on a fresh checkout.
 ```
@@ -134,7 +134,7 @@ pnpm dev                               # local dev — API on :8787, web on :432
 curl -H "X-Bootstrap-Secret: localdev" http://127.0.0.1:8787/bootstrap
 ```
 
-Then open **http://localhost:4321** — with `DEV_USER_EMAIL` set, the dev auth bypass logs you in
+Then open **http://localhost:4321** - with `DEV_USER_EMAIL` set, the dev auth bypass logs you in
 as that user (a member of the seeded `projektor` workspace), and the islands load real data.
 
 **Before opening a PR:** `pnpm turbo type-check` and `pnpm --filter @projektor/api test` must both be green. CI runs exactly these.
@@ -143,8 +143,8 @@ as that user (a member of the seeded `projektor` workspace), and the islands loa
 
 `pnpm install` runs `prepare`, which calls `lefthook install` and wires two hooks:
 
-- **pre-commit** — `pnpm turbo type-check` (fast; leverages turbo's cache, near-instant on unchanged packages).
-- **pre-push** — `pnpm --filter @projektor/api test` (the ~8s vitest suite; too slow for every commit but catches the failures that most often break CI).
+- **pre-commit** - `pnpm turbo type-check` (fast; leverages turbo's cache, near-instant on unchanged packages).
+- **pre-push** - `pnpm --filter @projektor/api test` (the ~8s vitest suite; too slow for every commit but catches the failures that most often break CI).
 
 These mirror CI (`.github/workflows/ci.yml`) exactly. New contributors get them automatically after `pnpm install`.
 
@@ -169,7 +169,7 @@ Call `register_agent` at the top of every session. Link to the issue you are imp
 { "name": "wt/my-feature", "issueId": "<issue-uuid>", "kind": "agent" }
 ```
 
-Save the returned `id` — you'll need it for heartbeats and messages.
+Save the returned `id` - you'll need it for heartbeats and messages.
 
 ### 2. Claim files before touching them
 
@@ -215,7 +215,7 @@ Sessions time out after 120 s without a heartbeat. Keep alive while working:
 
 This repo is built out via parallel workers in separate git worktrees. To avoid conflicts:
 - Give each worker a **disjoint file set** (one domain = its 4-5 files above). Domains don't share files *except* read-only shared scaffolding (`services/types.ts`, `services/errors.ts`, `schemas/common.ts`, the adapters) and `routes/mcp.ts`/`index.ts`.
-- **Never let two parallel workers edit `routes/mcp.ts`, `index.ts`, or `test/mcp.test.ts`** — serialize those, or assign to exactly one worker.
+- **Never let two parallel workers edit `routes/mcp.ts`, `index.ts`, or `test/mcp.test.ts`** - serialize those, or assign to exactly one worker.
 - Large refactors that touch shared files go in a **foundation phase first** (behavior-preserving), then fan out per-domain.
 
 ### Spawn prompt requirement
@@ -226,8 +226,8 @@ Workers will not use the coordination primitives unless explicitly told to. Ever
 ## Coordination (required)
 You are working in a parallel fleet. Use the projektor MCP to coordinate:
 
-1. `register_agent` at session start — link to your issue ID, save the returned `id`.
-2. `claim_files` before touching any file — check `list_file_claims` first; back off if another agent holds a file.
+1. `register_agent` at session start - link to your issue ID, save the returned `id`.
+2. `claim_files` before touching any file - check `list_file_claims` first; back off if another agent holds a file.
 3. `post_message` to `scope: "issue:<uuid>"` when you start, hit a blocker, and finish. Use `scope: "workspace"` for fleet-wide announcements (e.g. "rebasing mcp.ts, hold off").
 4. `heartbeat_agent` every ~60 s while working (sessions time out after 120 s of silence).
 5. `release_files` then `end_agent` when done.
@@ -239,15 +239,15 @@ See `~/.claude/docs/spawning-sessions.md` for the full prompt template (Coordina
 
 These are the constraints the fleet skill reads to plan batches. Keep them current when the codebase changes.
 
-**Serialized files** — only one worker at a time, ever:
+**Serialized files** - only one worker at a time, ever:
 
 | File | Reason |
 |------|--------|
-| `apps/api/src/routes/mcp.ts` | MCP tool registry — all domains compose here |
-| `apps/api/src/index.ts` | Hono app root — route mounting |
-| `apps/api/src/test/mcp.test.ts` | Cross-cutting dispatch tests — domain tests go in `test/<domain>.test.ts` |
+| `apps/api/src/routes/mcp.ts` | MCP tool registry - all domains compose here |
+| `apps/api/src/index.ts` | Hono app root - route mounting |
+| `apps/api/src/test/mcp.test.ts` | Cross-cutting dispatch tests - domain tests go in `test/<domain>.test.ts` |
 
-**Domain → file ownership** — one agent per row, no overlap:
+**Domain → file ownership** - one agent per row, no overlap:
 
 | Domain | Service | Schema | Routes | MCP | Tests |
 |--------|---------|--------|--------|-----|-------|
@@ -262,7 +262,7 @@ These are the constraints the fleet skill reads to plan batches. Keep them curre
 Frontend islands are **not** domain-locked in the same way, but two agents must never
 own the same island file. Assign each island to exactly one agent per batch.
 
-**Deploy:** tag a release (`git tag vX.Y.Z && git push --tags`) — `release.yml`
+**Deploy:** tag a release (`git tag vX.Y.Z && git push --tags`) - `release.yml`
 builds the artifact and the config-only deploy repo (`projektor-workspace`) picks
 it up. See the [deploy guide](https://tajd.github.io/projektor/guides/deploying/).
 
@@ -288,11 +288,11 @@ claude mcp add projektor --transport http https://<host>/mcp/<workspaceId> \
   --header "Authorization: Bearer <token>"
 ```
 
-**The full tool list is generated from source — do not hand-maintain a copy here.**
+**The full tool list is generated from source - do not hand-maintain a copy here.**
 See the **[MCP tool catalog](https://tajd.github.io/projektor/agents/tool-catalog/)**
 (generated into `apps/docs/src/content/docs/agents/tool-catalog.md` by
 `apps/api/scripts/gen-mcp-catalog.ts` from `apps/api/src/mcp/*.ts`; CI fails if it is
 stale). The grouping there separates **Coordination** tools (the agent-native primitives
 used by the fleet protocol above) from **Project data** tools.
 
-**Tip:** `get_issue` accepts `ref: "PROJ-42"` (project key + number) — you don't need the UUID when you have the display key.
+**Tip:** `get_issue` accepts `ref: "PROJ-42"` (project key + number) - you don't need the UUID when you have the display key.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,13 @@
 # Contributing
 
 projektor is a personal project, built and maintained by one person (with AI
-agents). It's open source under the [MIT licence](./LICENSE) — fork it, deploy
+agents). It's open source under the [MIT licence](./LICENSE) - fork it, deploy
 it, modify it, learn from it.
 
 ## Issues and pull requests
 
 **External issues and pull requests are automatically closed.** This isn't
-hostility — it's how a solo project stays sustainable. But **everything is
+hostility - it's how a solo project stays sustainable. But **everything is
 read.** If you open an issue or PR:
 
 - it will be closed automatically, and
@@ -15,7 +15,7 @@ read.** If you open an issue or PR:
   idea, reply) on their own schedule.
 
 So: a closed issue is not an ignored issue. If something is broken or you have an
-idea, you're welcome to file it — just don't expect a back-and-forth thread.
+idea, you're welcome to file it - just don't expect a back-and-forth thread.
 
 For security issues, follow [SECURITY.md](./SECURITY.md) (report privately, not
 via a public issue).

--- a/README.md
+++ b/README.md
@@ -2,38 +2,38 @@
 
 > A self-hosted Jira + Notion hybrid that runs on serverless Cloudflare resources.
 
-**Documentation:** <https://tajd.github.io/projektor/> — self-hosting, connecting an
+**Documentation:** <https://tajd.github.io/projektor/> - self-hosting, connecting an
 agent, architecture, and the full MCP tool catalog.
 
 ## What it is
 
-![Projektor issue backlog — list view with projects sidebar, issue refs, status, priority, and assignees](docs/images/backlog.png)
+![Projektor issue backlog - list view with projects sidebar, issue refs, status, priority, and assignees](docs/images/backlog.png)
 
-- **Projects** — named with short keys (`PROJ`, `BE`, …); issues reference as `PROJ-42`
-- **Issues** — Jira-style tickets with status, priority, assignee, labels, parent/child hierarchy, and cross-issue links
-- **Wiki** — nested markdown pages with revision history and full-text search
-- **MCP server** — AI agents connect directly; every action available to the browser is available to an agent
+- **Projects** - named with short keys (`PROJ`, `BE`, …); issues reference as `PROJ-42`
+- **Issues** - Jira-style tickets with status, priority, assignee, labels, parent/child hierarchy, and cross-issue links
+- **Wiki** - nested markdown pages with revision history and full-text search
+- **MCP server** - AI agents connect directly; every action available to the browser is available to an agent
 
 ## Features
 
-A complete project tracker — issues, boards, sprints, a wiki — built so an AI agent can
+A complete project tracker - issues, boards, sprints, a wiki - built so an AI agent can
 do everything a person can. The shape of the tool follows from that; see
 [the philosophy](https://tajd.github.io/projektor/philosophy/where-projektor-fits/).
 
 - Issues with status, priority, assignee, labels, parent/child hierarchy, and issue links
 - Kanban board + list view + sprint planning
 - Wiki with nested pages, markdown, full-text search, and revision history
-- MCP server — AI-native; Claude Code connects via `claude mcp add`
+- MCP server - AI-native; Claude Code connects via `claude mcp add`
 - File attachments (R2)
 - Workspace + project + member management with role-based access (`owner` / `admin` / `member` / `viewer`)
 - API tokens for agent access, workspace-scoped
-- PWA — installable, offline shell
+- PWA - installable, offline shell
 
 ## Self-hosting
 
 projektor deploys to **your own Cloudflare account** from a small **config-only repo**
 ([`projektor-deploy-example`](https://github.com/TAJD/projektor-deploy-example)) that
-downloads a pre-built release artifact — no source checkout, no build step. Three ways
+downloads a pre-built release artifact - no source checkout, no build step. Three ways
 in, easiest first.
 
 ### One click
@@ -43,7 +43,7 @@ Use the **Deploy to Cloudflare** button in the
 into your account, **auto-provisions D1, KV, and R2**, and deploys. Fill in your admin
 email on the setup page and you're live.
 
-### One command — or one prompt
+### One command - or one prompt
 
 Clone the deploy repo and run the zero-config script; wrangler auto-provisions the
 resources, applies migrations, and deploys:
@@ -52,15 +52,15 @@ resources, applies migrations, and deploys:
 PROJEKTOR_REPO=you/projektor ADMIN_EMAILS=you@example.com ./deploy-auto.sh
 ```
 
-Or hand the repo to an AI agent — *"deploy projektor to my Cloudflare account"* — and
+Or hand the repo to an AI agent - *"deploy projektor to my Cloudflare account"* - and
 let it run the same flow. See
 [AGENT-DEPLOY.md](https://github.com/TAJD/projektor-deploy-example/blob/main/AGENT-DEPLOY.md).
 
 ### Then: configure access
 
 The Worker is live, but **Cloudflare Access** must front it before anyone can log in
-(a `*.workers.dev` toggle, or a custom domain). Then log in — the first user in
-`ADMIN_EMAILS` becomes owner — and mint a token for agents. Full handoff:
+(a `*.workers.dev` toggle, or a custom domain). Then log in - the first user in
+`ADMIN_EMAILS` becomes owner - and mint a token for agents. Full handoff:
 [CONFIGURE.md](https://github.com/TAJD/projektor-deploy-example/blob/main/CONFIGURE.md).
 
 ### Manual / CI
@@ -76,7 +76,7 @@ Cloudflare API token recipe (it **must include D1**), and push-based auto-update
 projektor exposes a JSON-RPC 2.0 MCP endpoint at `POST /mcp/<workspaceId>`.
 Any MCP-compatible agent (Claude Code, custom agents via the Anthropic SDK) can connect.
 
-### Development — one command
+### Development - one command
 
 ```bash
 # Provision workspace + user + token in one shot (dev/staging only)
@@ -95,17 +95,17 @@ claude mcp add --transport http \
   "https://<your-worker>.workers.dev/mcp/<workspace-uuid>"
 ```
 
-Once connected, the agent has access to the full tool catalog — create issues, update statuses, search the wiki, plan sprints — anything a browser user can do.
+Once connected, the agent has access to the full tool catalog - create issues, update statuses, search the wiki, plan sprints - anything a browser user can do.
 
-### Production — mint a long-lived token
+### Production - mint a long-lived token
 
 `/bootstrap` is disabled in production. Instead, log in through Cloudflare Access and
 open **Settings → Tokens**: create a token and copy the ready-to-run `claude mcp add`
-command shown beside it (token + workspace pre-filled). The full walkthrough — Access
-setup, first login, token, MCP — is in
+command shown beside it (token + workspace pre-filled). The full walkthrough - Access
+setup, first login, token, MCP - is in
 [CONFIGURE.md](https://github.com/TAJD/projektor-deploy-example/blob/main/CONFIGURE.md).
 
-See the **[agent connection guide](https://tajd.github.io/projektor/agents/mcp-connection/)** for the full connection guide, protocol reference, and tool catalog (64 tools across 14 domains — project data plus agent-coordination primitives).
+See the **[agent connection guide](https://tajd.github.io/projektor/agents/mcp-connection/)** for the full connection guide, protocol reference, and tool catalog (64 tools across 14 domains - project data plus agent-coordination primitives).
 
 ## Development
 
@@ -127,7 +127,7 @@ Seed a local workspace in one shot:
 curl -H "X-Bootstrap-Secret: localdev" http://127.0.0.1:8787/bootstrap
 ```
 
-Then open **http://localhost:4321** — with `DEV_USER_EMAIL` set, the dev-auth bypass logs you in automatically.
+Then open **http://localhost:4321** - with `DEV_USER_EMAIL` set, the dev-auth bypass logs you in automatically.
 
 ### Tests
 
@@ -136,14 +136,14 @@ pnpm --filter @projektor/api test   # vitest against an in-process Worker + Mini
 pnpm turbo type-check               # tsc --noEmit across the monorepo
 ```
 
-Both must be green before opening a PR — they mirror CI exactly (`.github/workflows/ci.yml`).
+Both must be green before opening a PR - they mirror CI exactly (`.github/workflows/ci.yml`).
 
 ### Git hooks (lefthook)
 
 `pnpm install` wires two hooks automatically:
 
-- **pre-commit** — `pnpm turbo type-check` (fast; turbo-cached)
-- **pre-push** — `pnpm --filter @projektor/api test` (~8 s vitest suite)
+- **pre-commit** - `pnpm turbo type-check` (fast; turbo-cached)
+- **pre-push** - `pnpm --filter @projektor/api test` (~8 s vitest suite)
 
 Bypass for WIP commits: `git commit --no-verify -m "wip: …"`
 
@@ -161,15 +161,15 @@ REST  /api/*         ─┐
 MCP   /mcp/:wsId    ─┘
 ```
 
-Routes and MCP tools are thin wrappers. All business logic and SQL live in `services/`. Both surfaces must stay at parity — adding a feature to only one is a bug.
+Routes and MCP tools are thin wrappers. All business logic and SQL live in `services/`. Both surfaces must stay at parity - adding a feature to only one is a bug.
 
-Runtime: **Hono on Cloudflare Workers** — no Node.js, no containers.
+Runtime: **Hono on Cloudflare Workers** - no Node.js, no containers.
 Storage: **D1** (relational), **KV** (sessions/cache), **R2** (attachments).
 Frontend: **Astro + Preact**, served as static assets via Workers Static Assets; `/api/*` and `/mcp/*` always hit the Worker.
 
 ## Roadmap / Contributing
 
-Feature requests and bugs are tracked in the live projektor dogfood instance — projektor is built with itself.
+Feature requests and bugs are tracked in the live projektor dogfood instance - projektor is built with itself.
 
 [AGENTS.md](./AGENTS.md) is the contributor guide: conventions, file layout, the service-layer contract, and how to work in parallel without conflicts. Read it before opening a PR.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a vulnerability
 
-Please report security issues **privately** — do not open a public issue.
+Please report security issues **privately** - do not open a public issue.
 
 Email the maintainer directly at **tajdickson@protonmail.com** with:
 
@@ -20,4 +20,4 @@ projektor is a self-hosted application: each deployment runs on the operator's
 own Cloudflare account, behind their own Cloudflare Access configuration. Reports
 about the projektor codebase itself are in scope; misconfiguration of an
 individual deployment (e.g. a missing Access policy) is the operator's
-responsibility — see [CONFIGURE.md in the deploy repo](https://github.com/TAJD/projektor-deploy-example/blob/main/CONFIGURE.md).
+responsibility - see [CONFIGURE.md in the deploy repo](https://github.com/TAJD/projektor-deploy-example/blob/main/CONFIGURE.md).

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -1,5 +1,5 @@
 # Local development config. The REAL Cloudflare resource IDs for the deployed
-# instance live in the private projektor-workspace repo's wrangler.toml — never
+# instance live in the private projektor-workspace repo's wrangler.toml - never
 # commit real account/database/KV IDs here. Local dev (`wrangler dev` + `--local`
 # migrations) uses Miniflare and does not need real IDs, so placeholders are fine.
 name = "projektor-api"
@@ -42,4 +42,4 @@ AUTO_JOIN_ROLE = "viewer"
 # CF_ACCESS_TEAM_DOMAIN  (override here or via secret)
 # CF_ACCESS_AUDIENCE     (override here or via secret)
 # DEV_USER_EMAIL         (local dev only)
-# BOOTSTRAP_SECRET       (local dev only — required to use GET /bootstrap; if unset, the endpoint is disabled)
+# BOOTSTRAP_SECRET       (local dev only - required to use GET /bootstrap; if unset, the endpoint is disabled)

--- a/apps/docs/src/content/docs/agents/agent-workflows.md
+++ b/apps/docs/src/content/docs/agents/agent-workflows.md
@@ -15,10 +15,10 @@ It's possible to analyse agentic development through three different concerns. P
 |------|-----------|--------------|-----------|
 | **1 · Lifecycle** *(implementation)* | The client machine | Spawns an isolated workspace per agent (git worktree + branch + terminal), and reaps it cleanly when done | This page (§1) |
 | **2 · Coordination** | Projektor MCP | Lets parallel agents announce themselves, claim files, and message each other so they don't clobber each other's work | [Contributor conventions](https://github.com/TAJD/projektor/blob/main/AGENTS.md) (Fleet coordination protocol) |
-| **3 · Project management** | Projektor MCP | The actual work: issues, sprints, wiki, links — and "what should I work on next?" | [MCP tool catalog](/projektor/agents/tool-catalog/), [Connect an agent](/projektor/agents/mcp-connection/) |
+| **3 · Project management** | Projektor MCP | The actual work: issues, sprints, wiki, links - and "what should I work on next?" | [MCP tool catalog](/projektor/agents/tool-catalog/), [Connect an agent](/projektor/agents/mcp-connection/) |
 
 Layers 2 and 3 are Projektor itself. Layer 1 is the harness around it. You can use any
-layer alone — a single agent needs only Layer 3 — but the power comes from combining them.
+layer alone - a single agent needs only Layer 3 - but the power comes from combining them.
 
 > **Where this fits.** For how these three layers sit relative to other tools (Jira,
 > Notion, beads) and why Projektor deliberately spans layers 2–3, see
@@ -37,7 +37,7 @@ without stepping on other agents or your main checkout. The durable pattern:
   hold the working directory" contention.
 - **One terminal/tab per agent**, launched into that worktree. On Windows, wrapping the
   agent's process tree in a Job Object means closing the tab reaps the *whole* dev-stack
-  subtree — no orphaned `node`/`workerd` processes holding file locks.
+  subtree - no orphaned `node`/`workerd` processes holding file locks.
 - **Cleanup is close-then-remove, in that order.** The naive approach (delete all the
   worktree directories, then close the tabs) fails on Windows because the OS re-acquires
   directory handles between the two phases. Closing the tab first releases the locks, so
@@ -45,8 +45,8 @@ without stepping on other agents or your main checkout. The durable pattern:
 
 > The reference implementation of this layer is a pair of shell scripts (`spawn-claude`
 > to create a worktree+tab, `closedown-tabs` to reap them). They are tooling that lives
-> outside this repo; the *pattern* — isolated worktree, contained process tree,
-> close-before-remove — is what matters and is reproducible with plain `git worktree` and
+> outside this repo; the *pattern* - isolated worktree, contained process tree,
+> close-before-remove - is what matters and is reproducible with plain `git worktree` and
 > your terminal multiplexer of choice.
 
 The trade-off: worktree setup costs ~200–500 ms per agent, so it is not worth it for a
@@ -60,17 +60,17 @@ Once several agents are live in the same repo, they need shared state so two of 
 edit `routes/mcp.ts` at the same time. Projektor provides three agent-native primitives,
 backed by MCP tools:
 
-- **Agent sessions** — `register_agent` / `heartbeat_agent` / `end_agent` / `list_active_agents`.
+- **Agent sessions** - `register_agent` / `heartbeat_agent` / `end_agent` / `list_active_agents`.
   Register on start (linking the issue you're implementing), heartbeat ~every 60 s (sessions
   time out after 120 s of silence), end on finish.
-- **File claims** — `claim_files` / `release_files` / `list_file_claims`. Claim the paths you're
+- **File claims** - `claim_files` / `release_files` / `list_file_claims`. Claim the paths you're
   about to edit; check who else holds a file before you start; release on completion.
-- **Coordination messages** — `post_message` / `list_messages`. Post to an *issue channel* when
+- **Coordination messages** - `post_message` / `list_messages`. Post to an *issue channel* when
   you start, hit a blocker, or finish; post to the *workspace channel* for fleet-wide
   announcements ("rebasing `mcp.ts`, hold off"). Poll with a cursor to read what's new.
 
-The **step-by-step protocol** — exact call order, payloads, and the file-ownership rules
-that keep agents on disjoint file sets — lives in
+The **step-by-step protocol** - exact call order, payloads, and the file-ownership rules
+that keep agents on disjoint file sets - lives in
 [Contributor conventions → Fleet coordination protocol](https://github.com/TAJD/projektor/blob/main/AGENTS.md). That's the operational
 home; this page is the why.
 
@@ -78,17 +78,17 @@ home; this page is the why.
 
 ## 3 · Project management: the actual work
 
-This is the layer most people start with — and a single agent needs nothing else. Over MCP,
+This is the layer most people start with - and a single agent needs nothing else. Over MCP,
 an agent can do everything the UI does: create and triage issues, plan sprints, write wiki
 pages, link related issues, manage members. See the full, generated-from-source list in the
 [MCP tool catalog](/projektor/agents/tool-catalog/), and [Connect an agent](/projektor/agents/mcp-connection/) to wire one up.
 
 Two tools matter especially for *autonomous* work:
 
-- **`get_prioritized_issues`** — the "what should I work on next?" entry point. Returns open
+- **`get_prioritized_issues`** - the "what should I work on next?" entry point. Returns open
   issues ranked by a composite score (issue-link-network centrality + priority), so an agent
   can pick the highest-leverage work without a human assigning it.
-- **`search_issues` / `search_wiki`** — let an agent ground itself in existing context before
+- **`search_issues` / `search_wiki`** - let an agent ground itself in existing context before
   acting, instead of duplicating work or contradicting documented decisions.
 
 Natural-language prompts that map onto this layer:
@@ -131,6 +131,6 @@ each layer looks like a curiosity; together they're a reliable multi-agent dev l
 ## Where to go next
 
 - **Run a single agent:** [Connect an agent](/projektor/agents/mcp-connection/) → then try the prompts in §3.
-- **Run a fleet on this repo:** [Contributor conventions](https://github.com/TAJD/projektor/blob/main/AGENTS.md) — the coordination
+- **Run a fleet on this repo:** [Contributor conventions](https://github.com/TAJD/projektor/blob/main/AGENTS.md) - the coordination
   protocol, serialized-file rules, and per-domain file ownership.
 - **Every tool, by domain:** [MCP tool catalog](/projektor/agents/tool-catalog/).

--- a/apps/docs/src/content/docs/agents/mcp-connection.md
+++ b/apps/docs/src/content/docs/agents/mcp-connection.md
@@ -13,8 +13,8 @@ Connect Claude Code (or any MCP-compatible agent) to your projektor instance.
 - **A running projektor instance.** See the [self-hosting guide](/projektor/guides/self-hosting/) or the full [deploy guide](/projektor/guides/deploying/).
 - **Claude Code installed.** `npm install -g @anthropic-ai/claude-code` (or the desktop/IDE app).
 - **A projektor API token.** Two ways to get one:
-  - **Development** — use the bootstrap endpoint (see §2 below). No login required; needs `BOOTSTRAP_SECRET`.
-  - **Production** — log in through the UI → Settings → Tokens → "New token"; or mint one via the REST API (see §3).
+  - **Development** - use the bootstrap endpoint (see §2 below). No login required; needs `BOOTSTRAP_SECRET`.
+  - **Production** - log in through the UI → Settings → Tokens → "New token"; or mint one via the REST API (see §3).
 
 ---
 
@@ -27,7 +27,7 @@ The bootstrap endpoint provisions a workspace, user, and token in a single call,
 curl -s "https://<your-worker>.workers.dev/bootstrap" \
   -H "X-Bootstrap-Secret: <your-secret>"
 
-# Response includes mcpAddCommand — pipe it straight to your shell:
+# Response includes mcpAddCommand - pipe it straight to your shell:
 curl -s "https://<your-worker>.workers.dev/bootstrap" \
   -H "X-Bootstrap-Secret: <your-secret>" \
   | jq -r .mcpAddCommand | sh
@@ -41,7 +41,7 @@ curl -s http://127.0.0.1:8787/bootstrap \
   | jq -r .mcpAddCommand | sh
 ```
 
-The bootstrap endpoint is disabled when `ENVIRONMENT=production`. It is safe to call multiple times — it is idempotent.
+The bootstrap endpoint is disabled when `ENVIRONMENT=production`. It is safe to call multiple times - it is idempotent.
 
 ---
 
@@ -84,7 +84,7 @@ curl -s -X POST "https://<your-worker>.workers.dev/auth/tokens" \
 # projektor should appear in the list
 claude mcp list
 
-# Smoke test — list issues (returns empty array if no issues yet)
+# Smoke test - list issues (returns empty array if no issues yet)
 claude mcp call projektor list_issues '{}'
 
 # Get workspace membership
@@ -95,13 +95,13 @@ claude mcp call projektor list_members '{}'
 
 ## 5. Tool catalog
 
-The complete, always-current catalog is **generated from source** — every tool,
+The complete, always-current catalog is **generated from source** - every tool,
 grouped by domain, rendered from `apps/api/src/mcp/*.ts`:
 
 ➡️ **[MCP tool catalog](/projektor/agents/tool-catalog/)** (on the docs site: *Agents & MCP → MCP tool catalog*).
 
 It is regenerated and freshness-checked by CI, so it can never drift from the code.
-This guide intentionally does **not** repeat the table — there is one source of truth.
+This guide intentionally does **not** repeat the table - there is one source of truth.
 
 ---
 
@@ -110,22 +110,22 @@ This guide intentionally does **not** repeat the table — there is one source o
 Once connected, give Claude Code natural-language instructions:
 
 **Create and triage issues**
-> "Create a ticket for fixing the login redirect in the PROJ project — high priority, assign it to me."
+> "Create a ticket for fixing the login redirect in the PROJ project - high priority, assign it to me."
 
 **Query and summarise work**
-> "Show me all open issues in PROJ, grouped by status."  
+> "Show me all open issues in PROJ, grouped by status."
 > "What are the highest-priority issues I should work on next?"
 
 **Sprint planning**
-> "Create a sprint called 'Week 24' in PROJ, then move all in-progress and high-priority backlog issues into it."  
+> "Create a sprint called 'Week 24' in PROJ, then move all in-progress and high-priority backlog issues into it."
 > "Mark the current sprint complete and show me what's left unfinished."
 
 **Wiki writing**
-> "Write a wiki page summarising what we shipped in this sprint — use the completed issues as your source."  
+> "Write a wiki page summarising what we shipped in this sprint - use the completed issues as your source."
 > "Search the wiki for 'auth flow' and show me what we've documented."
 
 **Member management**
-> "List workspace members and their roles."  
+> "List workspace members and their roles."
 > "Invite user@example.com as a member."
 
 **Cross-issue work**
@@ -149,7 +149,7 @@ claude mcp add --transport http \
   "https://<your-worker>.workers.dev/mcp/<workspace-uuid>"
 ```
 
-Without a valid CF Access service token, the Worker will return a `403` before the MCP layer is reached — the agent connection will silently fail. The bootstrap flow bypasses Access; agent workflows in production need both headers. (Tracked in PROJ-129.)
+Without a valid CF Access service token, the Worker will return a `403` before the MCP layer is reached - the agent connection will silently fail. The bootstrap flow bypasses Access; agent workflows in production need both headers. (Tracked in PROJ-129.)
 
 ---
 
@@ -162,7 +162,7 @@ POST /mcp/<workspaceId>
 Content-Type: application/json
 ```
 
-**Transport:** MCP Streamable HTTP (JSON-RPC 2.0).  
+**Transport:** MCP Streamable HTTP (JSON-RPC 2.0).
 **`<workspaceId>`** is the workspace UUID (not the slug). The bootstrap response and `GET /api/workspaces` both return it.
 
 ### Required headers
@@ -172,7 +172,7 @@ Content-Type: application/json
 | `Authorization` | `Bearer pk_<64 hex chars>` |
 | `X-Workspace-Slug` | `<slug>` |
 
-The token is workspace-scoped — a token from workspace A is rejected for workspace B.
+The token is workspace-scoped - a token from workspace A is rejected for workspace B.
 
 ### initialize
 
@@ -205,9 +205,9 @@ Error codes: `-32600` invalid request, `-32601` method/tool not found, `-32602` 
 
 ### Stable API contracts
 
-These are the load-bearing shapes the Worker enforces — verified against the source:
+These are the load-bearing shapes the Worker enforces - verified against the source:
 
-- **MCP URL shape:** `POST /mcp/<workspaceId>` — UUID in the path, slug only in the header.
+- **MCP URL shape:** `POST /mcp/<workspaceId>` - UUID in the path, slug only in the header.
 - **Required headers:** both `Authorization` and `X-Workspace-Slug` must be present on every call.
 - **Token prefix:** `pk_` (64 hex chars); verified via SHA-256 hash lookup against D1.
 - **CORS:** both headers are in the Worker's explicit `allowHeaders` list.

--- a/apps/docs/src/content/docs/agents/tool-catalog.md
+++ b/apps/docs/src/content/docs/agents/tool-catalog.md
@@ -9,7 +9,7 @@ All inputs and outputs are JSON. The table below is generated from
 `apps/api/src/mcp/*.ts` and freshness-checked by CI, so it always matches the
 running server.
 
-<!-- gen-mcp-catalog:start — generated block; run `pnpm --filter @projektor/api gen:catalog` to refresh -->
+<!-- gen-mcp-catalog:start - generated block; run `pnpm --filter @projektor/api gen:catalog` to refresh -->
 
 **67 tools across 15 domains.**
 
@@ -84,7 +84,7 @@ running server.
 | `list_issues` | List issues in the workspace, optionally filtered by status, priority, project, or assignee |
 | `get_issue` | Get a single issue by ID or project key + number (e.g. "PROJ-42") |
 | `create_issue` | Create a new issue in a project |
-| `update_issue` | Update an issue — status, priority, title, body, assignee, or labels |
+| `update_issue` | Update an issue - status, priority, title, body, assignee, or labels |
 | `search_issues` | Search issues by keyword in title or body |
 | `delete_issue` | Delete an issue by ID |
 | `get_prioritized_issues` | Return open issues ranked by a composite score: link-network centrality (in-degree) + priority + inverse story points. Useful for deciding what to work on next. |
@@ -154,7 +154,7 @@ running server.
 | `list_sprints` | List sprints for a project, ordered by creation date |
 | `get_sprint` | Get a sprint by ID |
 | `create_sprint` | Create a new sprint in a project |
-| `update_sprint` | Update sprint fields — name, goal, status, start/end dates |
+| `update_sprint` | Update sprint fields - name, goal, status, start/end dates |
 | `complete_sprint` | Mark an active sprint as completed |
 | `delete_sprint` | Delete a sprint (issues in the sprint will have their sprint_id cleared) |
 | `move_issues_to_sprint` | Bulk move issues into a sprint by setting their sprint_id |

--- a/apps/docs/src/content/docs/architecture/system-design.md
+++ b/apps/docs/src/content/docs/architecture/system-design.md
@@ -7,8 +7,8 @@ sidebar:
 > Wiki + Jira-style issue tracker built MCP-native, running entirely on Cloudflare's edge.
 > Monorepo (pnpm + turbo).
 
-This page is an accurate map of how Projektor is actually built — its surfaces, the
-service layer, and storage — and it stays honest about what is wired up versus what
+This page is an accurate map of how Projektor is actually built - its surfaces, the
+service layer, and storage - and it stays honest about what is wired up versus what
 isn't yet. It describes the real system as it stands today, not an idealised summary of it.
 
 ## How it works
@@ -16,18 +16,18 @@ isn't yet. It describes the real system as it stands today, not an idealised sum
 Projektor runs as a **single Cloudflare Worker** (`apps/api`, built on Hono). That one
 Worker exposes two surfaces over a shared request pipeline: a **REST API** for the
 browser SPA, and an **MCP endpoint** (JSON-RPC 2.0) that is the primary, first-class
-surface for AI agents. Every request flows through auth middleware — Cloudflare Access
-JWTs for human browser sessions, hashed API tokens for agents — and then workspace
+surface for AI agents. Every request flows through auth middleware - Cloudflare Access
+JWTs for human browser sessions, hashed API tokens for agents - and then workspace
 middleware that resolves the tenant from the slug and verifies membership before any
 handler runs.
 
-State lives entirely on Cloudflare's edge. **D1** (SQLite) holds the relational data —
+State lives entirely on Cloudflare's edge. **D1** (SQLite) holds the relational data -
 workspaces, users, projects, issues, comments, wiki pages, tokens, activity, and
 revisions. **KV** caches sessions, Access certs, and email lookups. **R2** is bound for
 file attachments. There are no servers and no containers: the whole system deploys as a
 Worker plus its bound data stores, which is what makes a five-minute self-host possible.
 
-The sections below give the picture in increasing detail — first a diagram, then a
+The sections below give the picture in increasing detail - first a diagram, then a
 layer-by-layer breakdown, then the request flow through a single agent call.
 
 ## System diagram
@@ -86,7 +86,7 @@ flowchart TB
 
 | Layer | Tech | Package | Notes |
 |-------|------|---------|-------|
-| Frontend | Astro + Preact | `apps/web` | Full SPA — issues, board, sprints, wiki, settings, tokens. Dev-proxies `/api` + `/mcp` to `:8787`. |
+| Frontend | Astro + Preact | `apps/web` | Full SPA - issues, board, sprints, wiki, settings, tokens. Dev-proxies `/api` + `/mcp` to `:8787`. |
 | API / edge runtime | Hono on Cloudflare Workers | `apps/api` | REST + MCP, two-mode auth, workspace tenancy. |
 | MCP server | JSON-RPC 2.0 over HTTP | `apps/api/src/routes/mcp.ts` | 64 tools across 14 domains (coordination + project data). Primary surface. |
 | Plugin system | Registry + SDK | `apps/api/src/plugins`, `packages/plugin-sdk` | `definePlugin` / `defineMCPTool`. **Not loaded at runtime.** |

--- a/apps/docs/src/content/docs/guides/deploying.md
+++ b/apps/docs/src/content/docs/guides/deploying.md
@@ -11,7 +11,7 @@ instance, how releases are cut, and how to keep an instance updated automaticall
 
 > Looking for the 5-minute version? See [Self-hosting](/projektor/guides/self-hosting/).
 > A ready-to-fork template lives at
-> [github.com/TAJD/projektor-deploy-example](https://github.com/TAJD/projektor-deploy-example) —
+> [github.com/TAJD/projektor-deploy-example](https://github.com/TAJD/projektor-deploy-example) -
 > including a **Deploy to Cloudflare** button and a zero-config `deploy-auto.sh` (plus
 > `AGENT-DEPLOY.md` / `CONFIGURE.md`) that auto-provision D1/KV/R2 with no manual setup.
 > This page is the manual / CI reference.
@@ -32,15 +32,15 @@ flowchart LR
     cfg -->|"wrangler"| cf
 ```
 
-- **`projektor`** — the source. Tagging `v*` builds a release artifact and publishes
+- **`projektor`** - the source. Tagging `v*` builds a release artifact and publishes
   it to a GitHub Release. Stays generic: it knows nothing about any particular
   deployment.
-- **Your deploy repo** — holds *only* configuration: a `wrangler.toml` with your
+- **Your deploy repo** - holds *only* configuration: a `wrangler.toml` with your
   Cloudflare resource IDs, a pinned `projektor.version`, and a deploy workflow.
   [`projektor-deploy-example`](https://github.com/TAJD/projektor-deploy-example) is
   the public template; copy it.
 
-The deploy machine needs only **`wrangler`** and **`gh`** — never `pnpm`,
+The deploy machine needs only **`wrangler`** and **`gh`** - never `pnpm`,
 `node_modules`, or the projektor source.
 
 ## What's in a release
@@ -49,13 +49,13 @@ Each `projektor-<version>.tar.gz`, extracted into `./vendor`:
 
 | Path | Contents |
 |------|----------|
-| `vendor/worker.js` | the entire Worker, bundled and self-contained (Hono, Drizzle, all deps inlined — only `node:*` builtins remain, provided by `nodejs_compat`) |
+| `vendor/worker.js` | the entire Worker, bundled and self-contained (Hono, Drizzle, all deps inlined - only `node:*` builtins remain, provided by `nodejs_compat`) |
 | `vendor/web/` | the pre-built frontend, served as static assets |
 | `vendor/migrations/` | D1 migrations |
 | `vendor/wrangler.example.toml` | the config template (`compatibility_date` baked from source) |
 | `vendor/VERSION` | the version string |
 
-These four travel together at one version — a migration, the code that reads it,
+These four travel together at one version - a migration, the code that reads it,
 and the frontend that calls it are always in lockstep.
 
 ## Deploy your own instance
@@ -63,7 +63,7 @@ and the frontend that calls it are always in lockstep.
 ### 1. Fork the deploy example
 
 The recommended path is to **fork
-[`projektor-deploy-example`](https://github.com/TAJD/projektor-deploy-example)** —
+[`projektor-deploy-example`](https://github.com/TAJD/projektor-deploy-example)** -
 your fork becomes the deploy repo.
 
 ```bash
@@ -85,7 +85,7 @@ wrangler r2 bucket create projektor-files
 
 ### 3. Configure `wrangler.toml`
 
-Pin a version and run the deploy script once — it downloads the release and
+Pin a version and run the deploy script once - it downloads the release and
 scaffolds your `wrangler.toml` from the template:
 
 ```bash
@@ -97,9 +97,9 @@ Fill in the `REPLACE_` values: D1 `database_id`, KV `id`, your Cloudflare Access
 team domain + audience, and `ADMIN_EMAILS`. The artifact-owned paths
 (`main = ./vendor/worker.js`, `[assets].directory = ./vendor/web`,
 `migrations_dir = ./vendor/migrations`) and `compatibility_flags = ["nodejs_compat"]`
-are already set — leave them.
+are already set - leave them.
 
-### 4. Cloudflare API token — include D1
+### 4. Cloudflare API token - include D1
 
 This is the step that most often goes wrong. **Do not** use Cloudflare's built-in
 "Edit Cloudflare Workers" token template: it omits D1, so `wrangler deploy`
@@ -136,15 +136,15 @@ If `d1 list` errors, the token is missing the D1 permission.
 |--------|---------|
 | `CLOUDFLARE_API_TOKEN` | the custom token from step 4 |
 | `CLOUDFLARE_ACCOUNT_ID` | target account (`wrangler whoami`) |
-| `PROJEKTOR_RELEASE_PAT` | only if `projektor` is **private** — a fine-grained PAT with `Contents: Read` on it, so CI can download the release asset. For a public projektor, use the built-in `GITHUB_TOKEN` instead. |
+| `PROJEKTOR_RELEASE_PAT` | only if `projektor` is **private** - a fine-grained PAT with `Contents: Read` on it, so CI can download the release asset. For a public projektor, use the built-in `GITHUB_TOKEN` instead. |
 
-**On the Worker** (set once; persists across every deploy — *not* a GitHub secret):
+**On the Worker** (set once; persists across every deploy - *not* a GitHub secret):
 
 ```bash
 wrangler secret put JWT_SECRET     # any long random string, used to sign API tokens
 ```
 
-CI never manages runtime secrets — it only needs the deploy token. Rotating
+CI never manages runtime secrets - it only needs the deploy token. Rotating
 `JWT_SECRET` invalidates existing API tokens, so set it once and leave it.
 
 ### 6. Deploy
@@ -156,7 +156,7 @@ git push             # CI deploys on push to main
 
 ## How a deploy works
 
-`deploy.sh` is the whole contract — it runs identically locally and in CI:
+`deploy.sh` is the whole contract - it runs identically locally and in CI:
 
 ```bash
 gh release download "$(cat projektor.version)" -R OWNER/projektor -p 'projektor-*.tar.gz'
@@ -182,7 +182,7 @@ Release with `projektor-v1.2.0.tar.gz` attached.
 
 ## Automatic updates
 
-An instance can track the latest release automatically — push-based, so a new
+An instance can track the latest release automatically - push-based, so a new
 release deploys within seconds and the producer stays generic.
 
 How it's wired:
@@ -192,17 +192,17 @@ How it's wired:
    that can POST dispatches to it:
    - **Classic PAT:** the `repo` scope.
    - **Fine-grained PAT:** the deploy repo must be in *Repository access* **and**
-     the token must grant *Repository permissions → Contents: Read and write* —
+     the token must grant *Repository permissions → Contents: Read and write* -
      you need **both**. Granting the permission without selecting the repo (or vice
      versa) silently fails.
 
    > **Gotcha:** if the PAT can't see the repo or lacks `Contents: write`, the
-   > dispatch fails with **HTTP 404 "Not Found"** — *not* 403. GitHub masks a
+   > dispatch fails with **HTTP 404 "Not Found"** - *not* 403. GitHub masks a
    > permission failure as a missing resource, so a 404 on the dispatch step means
    > "fix the PAT's repo access / Contents permission," not "wrong URL."
 
    The release workflow's final step fires a `repository_dispatch`
-   (`projektor-release`, payload `version`) — but only if `DEPLOY_DISPATCH_REPO`
+   (`projektor-release`, payload `version`) - but only if `DEPLOY_DISPATCH_REPO`
    is set, so projektor remains generic for everyone else.
 2. Your deploy workflow listens for that dispatch, records the released tag into
    `projektor.version` (a `[skip ci]` commit), and deploys.
@@ -214,10 +214,10 @@ commit, and push.
 ## Operating notes
 
 - **Roll out a specific version:** `echo "v1.3.0" > projektor.version && git commit -am … && git push`.
-- **Migrations** apply automatically on every deploy and are idempotent — only
+- **Migrations** apply automatically on every deploy and are idempotent - only
   unapplied ones run (`✅ No migrations to apply!` when there are none).
 - **Deploy triggers** are scoped: the deploy workflow runs on changes to
-  `projektor.version`, `wrangler.toml`, `deploy.sh`, or the workflow itself — so
+  `projektor.version`, `wrangler.toml`, `deploy.sh`, or the workflow itself - so
   documentation edits don't trigger redeploys, but version bumps do.
 
 ## Troubleshooting
@@ -225,7 +225,7 @@ commit, and push.
 | Symptom | Cause / fix |
 |---------|-------------|
 | `wrangler d1 migrations apply` fails with an auth error | The API token is missing **D1: Edit** (the "Edit Cloudflare Workers" template omits it). Recreate as a custom token; verify with `wrangler d1 list`. |
-| `Wrangler requires at least Node.js v22` | Your workflow uses an older Node. wrangler 4.x needs **Node ≥ 22** — set `node-version: '22'` in `setup-node`. |
+| `Wrangler requires at least Node.js v22` | Your workflow uses an older Node. wrangler 4.x needs **Node ≥ 22** - set `node-version: '22'` in `setup-node`. |
 | Release published but the instance didn't auto-deploy | The `DEPLOY_DISPATCH_REPO` variable is unset, or `WORKSPACE_PAT` can't dispatch to the deploy repo. The dispatch step fails with **HTTP 404** (GitHub masks a permission failure as "Not Found"). Fix: a fine-grained `WORKSPACE_PAT` needs the deploy repo selected in *Repository access* **and** *Contents: Read and write*. |
 | `gh release download` 404 in CI | `projektor` is private and `PROJEKTOR_RELEASE_PAT` (with `Contents: Read`) is missing or expired. |
 | Auto-bump commit triggers a second deploy | The bump commit must include `[skip ci]` and be pushed by `GITHUB_TOKEN` (which doesn't re-trigger workflows). |

--- a/apps/docs/src/content/docs/guides/self-hosting.md
+++ b/apps/docs/src/content/docs/guides/self-hosting.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 Projektor deploys to **your own Cloudflare account** from a small **config-only repo**
 ([`projektor-deploy-example`](https://github.com/TAJD/projektor-deploy-example)) that
-downloads a pre-built release artifact — no source checkout and no build step. Pick the
+downloads a pre-built release artifact - no source checkout and no build step. Pick the
 path that suits you; they're ordered easiest first.
 
 ## One click
@@ -16,7 +16,7 @@ Use the **Deploy to Cloudflare** button in the
 into your account, **auto-provisions D1, KV, and R2**, and deploys. Fill in your admin
 email on the setup page and you're live.
 
-## One command — or one prompt
+## One command - or one prompt
 
 Clone the deploy repo and run the zero-config script; wrangler auto-provisions the
 resources, applies migrations, and deploys:
@@ -25,15 +25,15 @@ resources, applies migrations, and deploys:
 PROJEKTOR_REPO=you/projektor ADMIN_EMAILS=you@example.com ./deploy-auto.sh
 ```
 
-Or hand the repo to an AI agent — *"deploy projektor to my Cloudflare account"* — and
+Or hand the repo to an AI agent - *"deploy projektor to my Cloudflare account"* - and
 let it run the same flow. See
 [AGENT-DEPLOY.md](https://github.com/TAJD/projektor-deploy-example/blob/main/AGENT-DEPLOY.md).
 
 ## Then: configure access
 
 The Worker is live, but **Cloudflare Access** must front it before anyone can log in
-(a `*.workers.dev` toggle, or a custom domain). Then log in — the first user in
-`ADMIN_EMAILS` becomes owner — and mint a token for agents. Full handoff:
+(a `*.workers.dev` toggle, or a custom domain). Then log in - the first user in
+`ADMIN_EMAILS` becomes owner - and mint a token for agents. Full handoff:
 [CONFIGURE.md](https://github.com/TAJD/projektor-deploy-example/blob/main/CONFIGURE.md).
 
 **Updating later:** bump `projektor.version` and re-deploy (or just push, if you wired CI).
@@ -46,5 +46,5 @@ API token recipe (it **must include D1**), and push-based auto-updates.
 
 ## Next: connect an agent
 
-Once your instance is up, [connect an AI agent](/projektor/agents/mcp-connection/) over MCP — that's the primary
+Once your instance is up, [connect an AI agent](/projektor/agents/mcp-connection/) over MCP - that's the primary
 way to drive Projektor. Anything a browser user can do, an agent can do too.

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Projektor
 description: A self-hosted, MCP-native Jira + wiki that runs in a single Cloudflare Worker.
 template: splash
 hero:
-  tagline: A self-hosted Jira + wiki, MCP-native, running entirely on Cloudflare's edge. AI agents are a first-class client — not an afterthought.
+  tagline: A self-hosted Jira + wiki, MCP-native, running entirely on Cloudflare's edge. AI agents are a first-class client - not an afterthought.
   actions:
     - text: Connect an agent
       link: /projektor/agents/mcp-connection/

--- a/apps/docs/src/content/docs/philosophy/where-projektor-fits.md
+++ b/apps/docs/src/content/docs/philosophy/where-projektor-fits.md
@@ -6,59 +6,59 @@ sidebar:
 ---
 Tools for agentic development split into three concerns: running the agents,
 coordinating them, and tracking the work. The mistake is to treat each concern
-as its own product. They are not products — they are concerns, and the real
+as its own product. They are not products - they are concerns, and the real
 product boundary is the API. With MCP as the shared interface, one tool can cut
 a vertical slice through several concerns and stay coherent, because the
 interface stays coherent. That is what Projektor is: not one layer, but a slice
 across several.
 
-This page is the *why*. For the *how* — the multi-agent loop these concerns
-combine into — see [Agentic workflows](/projektor/agents/agent-workflows/).
+This page is the *why*. For the *how* - the multi-agent loop these concerns
+combine into - see [Agentic workflows](/projektor/agents/agent-workflows/).
 
 ## The three concerns
 
-1. **Implementation — the runtime.** Spawning agents, worktrees, job objects.
+1. **Implementation - the runtime.** Spawning agents, worktrees, job objects.
    Choosing which model runs (Opus plans, Sonnet builds, Haiku looks up). Tuning
    prompts and context to keep tokens cheap. And the verification steps that move
    work forward: running the tests, doing the human review.
-2. **Coordination — communication.** A message bus, agent presence, context
+2. **Coordination - communication.** A message bus, agent presence, context
    fetching, shared skills. For a fleet, most of this collapses into project
    management: the issue graph **is** the shared memory, and status changes
    **are** the events.
-3. **Project management — the source of truth.** The durable state: the issue,
+3. **Project management - the source of truth.** The durable state: the issue,
    epic, and sprint graph; machine-readable priorities; and the state-machine
    nodes that record what verification decided.
 
 Projektor is a single MCP surface spanning coordination and project management.
-Through file claims it also reaches into the runtime — deciding who may write
+Through file claims it also reaches into the runtime - deciding who may write
 which file. It owns the **nodes** of the work state machine; the implementation
 layer owns the **transitions**. Projektor never runs a test or judges a diff. It
 records the outcome.
 
 ```mermaid
 flowchart TB
-    human(["Human / lead agent — intent, priorities, final review"])
+    human(["Human / lead agent - intent, priorities, final review"])
 
-    subgraph L3["Project management — source of truth"]
+    subgraph L3["Project management - source of truth"]
         graph3["Issue / epic / sprint graph = shared memory"]
         prio["Prioritise & decompose (machine-readable)"]
-        state["State-machine NODES — records verification outcome"]
+        state["State-machine NODES - records verification outcome"]
     end
 
-    subgraph L2["Coordination — communication"]
+    subgraph L2["Coordination - communication"]
         prim["Agent-native primitives: file claims · registry · heartbeat"]
         evt["Comments · status · messages = event log / bus"]
         ctx["Context fetch · skills · repo memory"]
     end
 
-    subgraph L1["Implementation — runtime"]
+    subgraph L1["Implementation - runtime"]
         spawn["Spawn · worktrees · job objects"]
         route["Routing: opus plans · sonnet builds · haiku looks up"]
         cond["Conditioning: prompt / context optimisation"]
         verify{{"Transitions: tests + human review"}}
     end
 
-    projektor["Projektor — one MCP surface, vertical slice"]
+    projektor["Projektor - one MCP surface, vertical slice"]
     projektor -.-> graph3
     projektor -.-> prim
     projektor -.-> state
@@ -78,7 +78,7 @@ Projektor sits between two kinds of tool that already exist:
 - **Jira / Notion** are mature and scalable, but human-first: agent access is
   bolted on, the API is not the primary surface, and you cannot cheaply
   self-host a slice of them.
-- **beads** is genuinely agent-native, but it is a git-file tracker — issues
+- **beads** is genuinely agent-native, but it is a git-file tracker - issues
   stored as JSONL in the repo. That gives offline resilience and issues that
   version alongside the code, but it is structurally per-repo and bound to git
   merges.
@@ -102,12 +102,12 @@ not a rewrite.
 These are deliberate bets, not oversights:
 
 1. **A central coordinator on the write path.** A deployed tracker puts
-   Projektor's availability on every worker's critical path — the price of
+   Projektor's availability on every worker's critical path - the price of
    cross-project claims and presence that beads, being offline and git-backed,
    never pays. The bet: fleet-scale coordination is worth more than git's offline
    resilience and the issue-versioned-with-code property.
 2. **Task↔code links by convention.** Agents cite `PROJ-123` in commits, exactly
-   as humans do. That link is grep-able, not queryable — a field to add later if
+   as humans do. That link is grep-able, not queryable - a field to add later if
    it earns its place, not a rewrite.
 3. **Coordination, not judgment.** Design, test strategy, and the meaning of
    "done" stay with the engineer. Projektor records the decision; it never makes
@@ -115,7 +115,7 @@ These are deliberate bets, not oversights:
 
 ## Where to go next
 
-- **The operational loop:** [Agentic workflows](/projektor/agents/agent-workflows/) — how the
+- **The operational loop:** [Agentic workflows](/projektor/agents/agent-workflows/) - how the
   three concerns combine into a real multi-agent dev cycle.
 - **The system underneath:** [Architecture](/projektor/architecture/system-design/).
 - **Connect an agent:** [Connect an AI agent](/projektor/agents/mcp-connection/).

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -12,11 +12,11 @@ PUBLIC_WORKSPACE_SLUG=projektor
 # URL of the deployed dev instance (e.g. https://dev.your-instance.workers.dev)
 # E2E_BASE_URL=
 
-# Cloudflare Access service token — injected as CF-Access-Client-Id /
+# Cloudflare Access service token - injected as CF-Access-Client-Id /
 # CF-Access-Client-Secret on every Playwright browser request.
 # CF_ACCESS_CLIENT_ID=
 # CF_ACCESS_CLIENT_SECRET=
 
-# App bearer token — injected as Authorization: Bearer <token>.
+# App bearer token - injected as Authorization: Bearer <token>.
 # Use an existing user-scoped API token or create a dedicated test token.
 # PROJEKTOR_API_TOKEN=

--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -1,4 +1,4 @@
-# Playwright E2E — Kanban Board (PROJ-61)
+# Playwright E2E - Kanban Board (PROJ-61)
 
 End-to-end tests for the board drag-and-drop feature and its mobile guards.
 These tests target a **deployed dev instance**, not a local dev server.
@@ -76,7 +76,7 @@ Removes `e2e/.e2e-ctx.json`.  The test workspace itself is left on the deploymen
 (no delete-workspace API endpoint exists); old `e2e-*` workspaces can be cleaned
 up manually via the API if needed.
 
-### Test: Desktop drag (`board.spec.ts` — `desktop` project)
+### Test: Desktop drag (`board.spec.ts` - `desktop` project)
 
 1. Navigates to `/issues`, injects the test workspace slug + board view into
    `localStorage`, reloads.
@@ -109,7 +109,7 @@ The `onDragStart` handler in IssueList.tsx calls `e.preventDefault()` when
 | Check | Status |
 |---|---|
 | `pnpm lint` (Biome) | ✅ Run against this codebase |
-| `pnpm --filter @projektor/web type-check` (astro check) | ✅ Run — e2e/ is outside `src/` so not processed |
+| `pnpm --filter @projektor/web type-check` (astro check) | ✅ Run - e2e/ is outside `src/` so not processed |
 | `playwright test --list` (config parse) | ✅ Run after `pnpm install` |
 | Actual browser tests (drag, PATCH, mobile layout) | ⏳ **Requires** `E2E_BASE_URL` pointing at a live dev deployment |
 

--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -24,7 +24,7 @@ const navItems = [
     <meta name="theme-color" content="#6366f1" />
     <link rel="apple-touch-icon" href="/icon-192.png" />
     <title>{title}</title>
-    <!-- safe-ls: 'theme' is a cosmetic preference (dark/light). No API dependency — a
+    <!-- safe-ls: 'theme' is a cosmetic preference (dark/light). No API dependency - a
          stale or missing value falls back to the system color-scheme media query. -->
     <script is:inline>
       (function () {
@@ -69,10 +69,10 @@ const navItems = [
         --priority-low-bg: rgba(107, 114, 128, 0.12);
         --priority-none-text: var(--priority-low-text);
         --priority-none-bg: var(--priority-low-bg);
-        /* Code tokens (light) — dark text on clearly-distinct slate-200 bg */
+        /* Code tokens (light) - dark text on clearly-distinct slate-200 bg */
         --code-color: #1e293b;
         --code-bg: #dde3ea;
-        /* Epic badge tokens (light) — violet-700 on near-white bg */
+        /* Epic badge tokens (light) - violet-700 on near-white bg */
         --epic-text: #7c3aed;
         --epic-bg: rgba(124, 58, 237, 0.10);
         --epic-border: rgba(124, 58, 237, 0.30);
@@ -94,25 +94,25 @@ const navItems = [
           --surface: #1a1f2e;
           --text: #f3f5f9;
           --text-strong: #ffffff;
-          --text-muted: #94a3b8;     /* slate-400 — ~7.4:1 on --bg, passes WCAG AA */
+          --text-muted: #94a3b8;     /* slate-400 - ~7.4:1 on --bg, passes WCAG AA */
           --border: #2a3242;
           --nav-bg: #12161f;          /* sits between bg and surface */
-          --accent: #6366f1;          /* indigo-500 — distinctive on dark */
+          --accent: #6366f1;          /* indigo-500 - distinctive on dark */
           --on-accent: #fff;
           --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.45);
-          /* Priority badge tokens (dark) — lighter tints for WCAG AA on dark surfaces */
+          /* Priority badge tokens (dark) - lighter tints for WCAG AA on dark surfaces */
           --priority-urgent-text: #fca5a5;
           --priority-urgent-bg: rgba(248, 113, 113, 0.18);
           --priority-high-text: #fcd34d;
           --priority-high-bg: rgba(251, 191, 36, 0.18);
-          --priority-medium-text: #a5b4fc;   /* indigo-300 — aligns with accent */
+          --priority-medium-text: #a5b4fc;   /* indigo-300 - aligns with accent */
           --priority-medium-bg: rgba(129, 140, 248, 0.18);
           --priority-low-text: #cbd5e1;
           --priority-low-bg: rgba(148, 163, 184, 0.18);
-          /* Code tokens (dark) — light text on slightly deeper slate bg */
+          /* Code tokens (dark) - light text on slightly deeper slate bg */
           --code-color: #e2e8f0;
           --code-bg: #141b2b;
-          /* Epic badge tokens (dark) — violet-300 on near-black bg */
+          /* Epic badge tokens (dark) - violet-300 on near-black bg */
           --epic-text: #c4b5fd;
           --epic-bg: rgba(196, 181, 253, 0.15);
           --epic-border: rgba(196, 181, 253, 0.30);
@@ -122,7 +122,7 @@ const navItems = [
           --status-in-review: #c4b5fd;
           --status-done: #4ade80;
           --status-cancelled: #f87171;
-          /* Danger action tokens (dark) — brighter red stays readable on near-black */
+          /* Danger action tokens (dark) - brighter red stays readable on near-black */
           --danger-text: #f87171;
           --danger-bg: rgba(248, 113, 113, 0.12);
           --danger-border: rgba(248, 113, 113, 0.32);

--- a/llms.txt
+++ b/llms.txt
@@ -22,10 +22,10 @@ Required headers:
   Authorization: Bearer pk_<64 hex chars>
   X-Workspace-Slug: <slug>
 
-Protocol: JSON-RPC 2.0 (MCP Streamable HTTP — not SSE)
+Protocol: JSON-RPC 2.0 (MCP Streamable HTTP - not SSE)
 Methods: initialize  tools/list  tools/call
 
-## Core tools (13 essentials; 64 total — see https://tajd.github.io/projektor/agents/tool-catalog/)
+## Core tools (13 essentials; 64 total - see https://tajd.github.io/projektor/agents/tool-catalog/)
 
 Projects:   list_projects  create_project
 Issues:     list_issues  get_issue  create_issue  update_issue
@@ -34,7 +34,7 @@ Wiki:       list_wiki_pages  search_wiki  get_wiki_page  create_wiki_page  updat
 
 ## Key docs
 
-- https://tajd.github.io/projektor/agents/mcp-connection/        — full connection guide + tool catalog with inputs/outputs
-- AGENTS.md                                                      — contributor conventions and service-layer contract (in the repo)
-- https://tajd.github.io/projektor/architecture/system-design/   — system design: how it works, diagram, layers, request flow
-- https://tajd.github.io/projektor/guides/self-hosting/          — self-host on Cloudflare in five minutes
+- https://tajd.github.io/projektor/agents/mcp-connection/        - full connection guide + tool catalog with inputs/outputs
+- AGENTS.md                                                      - contributor conventions and service-layer contract (in the repo)
+- https://tajd.github.io/projektor/architecture/system-design/   - system design: how it works, diagram, layers, request flow
+- https://tajd.github.io/projektor/guides/self-hosting/          - self-host on Cloudflare in five minutes

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -4,7 +4,7 @@
 #   scripts/build-release.sh <version>
 #
 # Produces dist/projektor-<version>.tar.gz containing everything a consumer needs
-# to deploy with only `wrangler` — no source, no node_modules, no build step:
+# to deploy with only `wrangler` - no source, no node_modules, no build step:
 #
 #   worker.js              bundled, self-contained Worker (deps inlined)
 #   web/                   pre-built Astro frontend (apps/web/dist)

--- a/scripts/check-island-api.sh
+++ b/scripts/check-island-api.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Enforce the island API convention: no raw fetch() or local buildHeaders in islands.
-# See apps/web/src/utils/api-client.ts — islands must use apiFetch from there.
+# See apps/web/src/utils/api-client.ts - islands must use apiFetch from there.
 
 set -euo pipefail
 
@@ -8,7 +8,7 @@ ISLANDS_DIR="apps/web/src/islands"
 ERRORS=0
 
 while IFS= read -r line; do
-  echo "ERROR: local buildHeaders declared in $line — remove it and use buildHeaders from utils/api-client.ts"
+  echo "ERROR: local buildHeaders declared in $line - remove it and use buildHeaders from utils/api-client.ts"
   ERRORS=$((ERRORS + 1))
 done < <(grep -rn --include="*.ts" --include="*.tsx" \
   -E "(function buildHeaders|const buildHeaders)" \
@@ -16,7 +16,7 @@ done < <(grep -rn --include="*.ts" --include="*.tsx" \
 
 while IFS= read -r match; do
   file=$(echo "$match" | cut -d: -f1)
-  echo "ERROR: raw fetch() found in $file — use apiFetch from utils/api-client.ts instead"
+  echo "ERROR: raw fetch() found in $file - use apiFetch from utils/api-client.ts instead"
   ERRORS=$((ERRORS + 1))
 done < <(grep -rn --include="*.ts" --include="*.tsx" \
   -E "(=\s*fetch\(|await fetch\()" \

--- a/scripts/release-assets/wrangler.example.toml
+++ b/scripts/release-assets/wrangler.example.toml
@@ -1,9 +1,9 @@
-# projektor deploy config — copy this to ./wrangler.toml and fill in the REPLACE_ values.
+# projektor deploy config - copy this to ./wrangler.toml and fill in the REPLACE_ values.
 #
 # This file ships inside the release artifact. After you extract the artifact into
 # ./vendor, the paths below (worker.js, web, migrations) resolve relative to your
 # deploy repo root. You own this copy: fill in your Cloudflare resource IDs once;
-# on a version bump, re-extract the artifact — these paths do not change.
+# on a version bump, re-extract the artifact - these paths do not change.
 
 name = "projektor"
 main = "./vendor/worker.js"
@@ -55,5 +55,5 @@ AUTO_JOIN_ROLE = "viewer"
 
 # ─── Secrets (set ONCE; they persist on the Worker across every deploy) ────────
 #   wrangler secret put JWT_SECRET
-# JWT_SECRET — random string used for API token signing. CI does NOT manage this;
+# JWT_SECRET - random string used for API token signing. CI does NOT manage this;
 # set it once and it survives future deploys.


### PR DESCRIPTION
Replaces em dashes (U+2014) with hyphens across all documentation and prose —
README, AGENTS, CONTRIBUTING, SECURITY, the `apps/docs` Starlight content, `llms.txt`
— plus config and scripts (20 files).

Scope is deliberately **non-code**: source `.ts`/`.tsx` files are left untouched to
avoid churn and to keep the diff clear of pre-existing lint/format debt that biome's
`--changed` check would otherwise drag in. (That debt is real and worth fixing — see
the follow-up.)

The tab-title feature that was originally bundled on this branch was dropped: it lives
in `IssueDetail.tsx`, which carries pre-existing a11y lint debt, so it's being re-filed
as its own task rather than forcing unrelated fixes through here.

Verification: pre-commit hooks green (island-api, lint, type-check); pre-push tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
