### PR TITLE
chore(lint): clear biome lint debt across api + web

### DIFF
--- a/apps/api/src/mcp/agent-messages.ts
+++ b/apps/api/src/mcp/agent-messages.ts
@@ -4,16 +4,21 @@ import { listMessages, postMessage } from "../services/agent-messages";
 export const agentMessagesTools: MCPTool[] = [
 	{
 		name: "post_message",
-		description: "Post a coordination message to a workspace or issue channel so the agent fleet can communicate",
+		description:
+			"Post a coordination message to a workspace or issue channel so the agent fleet can communicate",
 		inputSchema: {
 			type: "object",
 			required: ["scope", "body"],
 			properties: {
 				scope: {
 					type: "string",
-					description: 'Channel scope: "workspace" for the workspace-wide channel, or "issue:<uuid>" for an issue channel',
+					description:
+						'Channel scope: "workspace" for the workspace-wide channel, or "issue:<uuid>" for an issue channel',
 				},
-				agentId: { type: "string", description: "Agent session UUID posting the message (optional)" },
+				agentId: {
+					type: "string",
+					description: "Agent session UUID posting the message (optional)",
+				},
 				body: { type: "string", description: "Message body (1–5000 characters)" },
 			},
 		},
@@ -23,7 +28,8 @@ export const agentMessagesTools: MCPTool[] = [
 	},
 	{
 		name: "list_messages",
-		description: "List coordination messages for a workspace or issue channel, in chronological order",
+		description:
+			"List coordination messages for a workspace or issue channel, in chronological order",
 		inputSchema: {
 			type: "object",
 			required: ["scope"],
@@ -32,7 +38,10 @@ export const agentMessagesTools: MCPTool[] = [
 					type: "string",
 					description: 'Channel scope: "workspace" or "issue:<uuid>"',
 				},
-				cursor: { type: "number", description: "Pagination cursor (created_at of last received item)" },
+				cursor: {
+					type: "number",
+					description: "Pagination cursor (created_at of last received item)",
+				},
 				limit: { type: "number", description: "Max messages to return (1–100, default 50)" },
 			},
 		},

--- a/apps/api/src/mcp/workspaces.ts
+++ b/apps/api/src/mcp/workspaces.ts
@@ -78,7 +78,11 @@ export const workspacesTools: MCPTool[] = [
 		async handler(_input, ctx) {
 			const orm = drizzle(ctx.db, { schema });
 			const ws = await orm
-				.select({ id: schema.workspaces.id, name: schema.workspaces.name, slug: schema.workspaces.slug })
+				.select({
+					id: schema.workspaces.id,
+					name: schema.workspaces.name,
+					slug: schema.workspaces.slug,
+				})
 				.from(schema.workspaces)
 				.where(eq(schema.workspaces.id, ctx.workspaceId))
 				.get();

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -50,7 +50,13 @@ router.get("/", async (c) => {
 		"SELECT id, filename, content_type, size, created_at FROM attachments WHERE workspace_id = ? AND entity_type = ? AND entity_id = ? ORDER BY created_at ASC"
 	)
 		.bind(workspace.id, parsed.data, entityId)
-		.all<{ id: string; filename: string; content_type: string; size: number; created_at: number }>();
+		.all<{
+			id: string;
+			filename: string;
+			content_type: string;
+			size: number;
+			created_at: number;
+		}>();
 
 	return c.json(
 		(rows.results ?? []).map((r) => ({

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -95,9 +95,7 @@ router.delete("/:slug/tokens/:tokenId", async (c) => {
 router.delete("/:slug", async (c) => {
 	const ctx = ctxFromHono(c);
 	try {
-		return c.json(
-			await deleteWorkspace(ctx, c.env.DEFAULT_WORKSPACE_SLUG ?? "projektor")
-		);
+		return c.json(await deleteWorkspace(ctx, c.env.DEFAULT_WORKSPACE_SLUG ?? "projektor"));
 	} catch (e) {
 		return serviceErrToResponse(c, e);
 	}

--- a/apps/api/src/schemas/agent-messages.ts
+++ b/apps/api/src/schemas/agent-messages.ts
@@ -1,10 +1,8 @@
 import { z } from "zod";
 
-const scopeSchema = z
-	.string()
-	.refine((v) => v === "workspace" || /^issue:[0-9a-f-]{36}$/.test(v), {
-		message: 'scope must be "workspace" or "issue:<uuid>"',
-	});
+const scopeSchema = z.string().refine((v) => v === "workspace" || /^issue:[0-9a-f-]{36}$/.test(v), {
+	message: 'scope must be "workspace" or "issue:<uuid>"',
+});
 
 export const PostMessageSchema = z.object({
 	scope: scopeSchema,

--- a/apps/api/src/services/agent-messages.ts
+++ b/apps/api/src/services/agent-messages.ts
@@ -80,7 +80,7 @@ export async function listMessages(ctx: ServiceCtx, raw: unknown) {
 			eq(schema.agentMessages.scope, scope),
 			// Next page: rows strictly after (cursorTime, cursorId) in ASC order
 			// (createdAt > cursorTime) OR (createdAt = cursorTime AND id > cursorId)
-			sql`(${schema.agentMessages.createdAt} > ${cursorTime} OR (${schema.agentMessages.createdAt} = ${cursorTime} AND ${schema.agentMessages.id} > ${cursorId}))`,
+			sql`(${schema.agentMessages.createdAt} > ${cursorTime} OR (${schema.agentMessages.createdAt} = ${cursorTime} AND ${schema.agentMessages.id} > ${cursorId}))`
 		);
 	}
 
@@ -91,8 +91,8 @@ export async function listMessages(ctx: ServiceCtx, raw: unknown) {
 			cursorFilter ??
 				and(
 					eq(schema.agentMessages.workspaceId, ctx.workspaceId),
-					eq(schema.agentMessages.scope, scope),
-				),
+					eq(schema.agentMessages.scope, scope)
+				)
 		)
 		.orderBy(asc(schema.agentMessages.createdAt), asc(schema.agentMessages.id))
 		.limit(limit + 1);

--- a/apps/api/src/services/share.ts
+++ b/apps/api/src/services/share.ts
@@ -60,7 +60,11 @@ interface SharedIssueRow {
 export async function getSharedIssue(
 	db: D1Database,
 	token: string
-): Promise<SharedIssueRow & { customFields: Array<{ key: string; label: string; type: string; value: string }> }> {
+): Promise<
+	SharedIssueRow & {
+		customFields: Array<{ key: string; label: string; type: string; value: string }>;
+	}
+> {
 	const now = Math.floor(Date.now() / 1000);
 
 	const row = await db
@@ -88,6 +92,8 @@ export async function getSharedIssue(
 		.bind(token)
 		.first<{ issue_id: string }>();
 
+	if (!tokenMeta) throw new NotFoundError("Share link not found or expired");
+
 	const cfRows = await db
 		.prepare(
 			`SELECT cfd.key, cfd.label, cfd.type, cfv.value
@@ -95,7 +101,7 @@ export async function getSharedIssue(
        JOIN custom_field_definitions cfd ON cfd.id = cfv.field_id
        WHERE cfv.issue_id = ?`
 		)
-		.bind(tokenMeta!.issue_id)
+		.bind(tokenMeta.issue_id)
 		.all<{ key: string; label: string; type: string; value: string }>();
 
 	return { ...row, customFields: cfRows.results ?? [] };

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -61,7 +61,7 @@ async function validateParentDepth(
 			.prepare("SELECT parent_id FROM wiki_pages WHERE id = ? AND workspace_id = ?")
 			.bind(cur, workspaceId)
 			.first<{ parent_id: string | null }>();
-		if (!row || !row.parent_id) break;
+		if (!row?.parent_id) break;
 		const pid = row.parent_id;
 		if (seen.has(pid)) break;
 		seen.add(pid);

--- a/apps/api/src/services/workspaces.ts
+++ b/apps/api/src/services/workspaces.ts
@@ -275,7 +275,7 @@ export async function deleteWorkspace(
 }
 
 export async function getWorkspaceMcpInfo(
-	ctx: ServiceCtx,
+	_ctx: ServiceCtx,
 	workspace: { id: string; slug: string },
 	origin: string
 ): Promise<{

--- a/apps/api/src/test/agent-messages.test.ts
+++ b/apps/api/src/test/agent-messages.test.ts
@@ -37,11 +37,26 @@ describe("Agent Messages API", () => {
 		});
 	}
 
-	async function mcpCall(method: string, args: Record<string, unknown>, t = token, s = slug, wsId = workspaceId) {
+	async function mcpCall(
+		method: string,
+		args: Record<string, unknown>,
+		t = token,
+		s = slug,
+		wsId = workspaceId
+	) {
 		return SELF.fetch(`http://localhost/mcp/${wsId}`, {
 			method: "POST",
-			headers: { Authorization: `Bearer ${t}`, "X-Workspace-Slug": s, "Content-Type": "application/json" },
-			body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: method, arguments: args } }),
+			headers: {
+				Authorization: `Bearer ${t}`,
+				"X-Workspace-Slug": s,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				jsonrpc: "2.0",
+				id: 1,
+				method: "tools/call",
+				params: { name: method, arguments: args },
+			}),
 		});
 	}
 
@@ -67,7 +82,10 @@ describe("Agent Messages API", () => {
 		// Confirm all 3 messages land in the scope before testing pagination
 		const allRes = await listMessages({ scope }, token2, slug);
 		expect(allRes.status).toBe(200);
-		const all = (await allRes.json()) as { items: Array<{ body: string }>; nextCursor: string | null };
+		const all = (await allRes.json()) as {
+			items: Array<{ body: string }>;
+			nextCursor: string | null;
+		};
 		expect(all.items).toHaveLength(3);
 
 		// token3 for page 1 (fresh budget)
@@ -76,7 +94,10 @@ describe("Agent Messages API", () => {
 		// Page 1: limit=2 — composite cursor is "createdAt:id" for same-second stability
 		const page1Res = await listMessages({ scope, limit: "2" }, token3, slug);
 		expect(page1Res.status).toBe(200);
-		const page1 = (await page1Res.json()) as { items: Array<{ body: string }>; nextCursor: string | null };
+		const page1 = (await page1Res.json()) as {
+			items: Array<{ body: string }>;
+			nextCursor: string | null;
+		};
 		expect(page1.items).toHaveLength(2);
 		expect(page1.items[0].body).toBe("message one");
 		expect(page1.items[1].body).toBe("message two");
@@ -89,7 +110,10 @@ describe("Agent Messages API", () => {
 			slug
 		);
 		expect(page2Res.status).toBe(200);
-		const page2 = (await page2Res.json()) as { items: Array<{ body: string }>; nextCursor: string | null };
+		const page2 = (await page2Res.json()) as {
+			items: Array<{ body: string }>;
+			nextCursor: string | null;
+		};
 		expect(page2.items).toHaveLength(1);
 		expect(page2.items[0].body).toBe("message three");
 		expect(page2.nextCursor).toBeNull();
@@ -99,7 +123,9 @@ describe("Agent Messages API", () => {
 		const mcpRes = await mcpCall("list_messages", { scope }, token4, slug);
 		expect(mcpRes.status).toBe(200);
 		const mcpBody = (await mcpRes.json()) as { result: { content: Array<{ text: string }> } };
-		const mcpData = JSON.parse(mcpBody.result.content[0].text) as { items: Array<{ body: string }> };
+		const mcpData = JSON.parse(mcpBody.result.content[0].text) as {
+			items: Array<{ body: string }>;
+		};
 		expect(mcpData.items).toHaveLength(3);
 	});
 
@@ -154,7 +180,9 @@ describe("Agent Messages API", () => {
 		});
 		expect(claimRes.status).toBe(200);
 		const claimBody = (await claimRes.json()) as { result: { content: Array<{ text: string }> } };
-		expect(JSON.parse(claimBody.result.content[0].text)).toMatchObject({ created: [{ path: "src/coord.ts" }] });
+		expect(JSON.parse(claimBody.result.content[0].text)).toMatchObject({
+			created: [{ path: "src/coord.ts" }],
+		});
 
 		// agent2 tries to claim path A without force — expect conflict
 		const conflictRes = await mcpCall("claim_files", {
@@ -164,7 +192,9 @@ describe("Agent Messages API", () => {
 			force: false,
 		});
 		expect(conflictRes.status).toBe(200);
-		const conflictBody = (await conflictRes.json()) as { error?: { code: number; message: string } };
+		const conflictBody = (await conflictRes.json()) as {
+			error?: { code: number; message: string };
+		};
 		expect(conflictBody.error?.code).toBe(-32000);
 
 		// agent2 posts a message to the issue channel
@@ -181,45 +211,73 @@ describe("Agent Messages API", () => {
 		const readRes = await mcpCall("list_messages", { scope }, token2, slug);
 		expect(readRes.status).toBe(200);
 		const readBody = (await readRes.json()) as { result: { content: Array<{ text: string }> } };
-		const readData = JSON.parse(readBody.result.content[0].text) as { items: Array<{ body: string }> };
+		const readData = JSON.parse(readBody.result.content[0].text) as {
+			items: Array<{ body: string }>;
+		};
 		expect(readData.items.some((m) => m.body.includes("can you release?"))).toBe(true);
 
 		// agent1 releases path A
-		const releaseRes = await mcpCall("release_files", { paths: ["src/coord.ts"], issueId: issue2.id }, token2, slug);
+		const releaseRes = await mcpCall(
+			"release_files",
+			{ paths: ["src/coord.ts"], issueId: issue2.id },
+			token2,
+			slug
+		);
 		expect(releaseRes.status).toBe(200);
 
 		// agent2 re-claims path A successfully
-		const reclaimRes = await mcpCall("claim_files", {
-			issueId: issue2.id,
-			agentId: agent2.id,
-			paths: ["src/coord.ts"],
-		}, token2, slug);
+		const reclaimRes = await mcpCall(
+			"claim_files",
+			{
+				issueId: issue2.id,
+				agentId: agent2.id,
+				paths: ["src/coord.ts"],
+			},
+			token2,
+			slug
+		);
 		expect(reclaimRes.status).toBe(200);
-		const reclaimBody = (await reclaimRes.json()) as { result: { content: Array<{ text: string }> } };
-		const reclaimData = JSON.parse(reclaimBody.result.content[0].text) as { created: Array<{ issueId: string }> };
+		const reclaimBody = (await reclaimRes.json()) as {
+			result: { content: Array<{ text: string }> };
+		};
+		const reclaimData = JSON.parse(reclaimBody.result.content[0].text) as {
+			created: Array<{ issueId: string }>;
+		};
 		expect(reclaimData.created[0].issueId).toBe(issue2.id);
 
 		// agent1 claims path B so agent2 can force-steal it
-		const claimBRes = await mcpCall("claim_files", {
-			issueId: issue2.id,
-			agentId: agent1.id,
-			paths: ["src/forced.ts"],
-		}, token2, slug);
+		const claimBRes = await mcpCall(
+			"claim_files",
+			{
+				issueId: issue2.id,
+				agentId: agent1.id,
+				paths: ["src/forced.ts"],
+			},
+			token2,
+			slug
+		);
 		expect(claimBRes.status).toBe(200);
 
 		// Phase 3 (token3): agent2 force-claims path B; assert override notice in list_messages
 		const token3 = await seedToken(workspaceId, userId);
 		const issue3 = await seedIssue(workspaceId, projectId, userId, { title: "Force Issue" });
 
-		const forceRes = await mcpCall("claim_files", {
-			issueId: issue3.id,
-			agentId: agent2.id,
-			paths: ["src/forced.ts"],
-			force: true,
-		}, token3, slug);
+		const forceRes = await mcpCall(
+			"claim_files",
+			{
+				issueId: issue3.id,
+				agentId: agent2.id,
+				paths: ["src/forced.ts"],
+				force: true,
+			},
+			token3,
+			slug
+		);
 		expect(forceRes.status).toBe(200);
 		const forceBody = (await forceRes.json()) as { result: { content: Array<{ text: string }> } };
-		const forceData = JSON.parse(forceBody.result.content[0].text) as { overridden: Array<unknown> };
+		const forceData = JSON.parse(forceBody.result.content[0].text) as {
+			overridden: Array<unknown>;
+		};
 		expect(forceData.overridden).toHaveLength(1);
 
 		// The force-override notice should appear in the issue3 scope channel (Epic B wiring)
@@ -227,8 +285,14 @@ describe("Agent Messages API", () => {
 		const noticeRes = await mcpCall("list_messages", { scope: noticeScope }, token3, slug);
 		expect(noticeRes.status).toBe(200);
 		const noticeBody = (await noticeRes.json()) as { result: { content: Array<{ text: string }> } };
-		const noticeData = JSON.parse(noticeBody.result.content[0].text) as { items: Array<{ body: string }> };
-		expect(noticeData.items.some((m) => m.body.includes("force-claimed") && m.body.includes("src/forced.ts"))).toBe(true);
+		const noticeData = JSON.parse(noticeBody.result.content[0].text) as {
+			items: Array<{ body: string }>;
+		};
+		expect(
+			noticeData.items.some(
+				(m) => m.body.includes("force-claimed") && m.body.includes("src/forced.ts")
+			)
+		).toBe(true);
 	});
 
 	// C4: workspace isolation; issue-scope isolation; cursor stability
@@ -242,7 +306,9 @@ describe("Agent Messages API", () => {
 		// Workspace Y should not see workspace X's messages
 		const other = await seedFixture();
 		const otherProject = await seedProject(other.workspace.id);
-		const otherIssue = await seedIssue(other.workspace.id, otherProject.id, other.user.id, { title: "Other" });
+		const otherIssue = await seedIssue(other.workspace.id, otherProject.id, other.user.id, {
+			title: "Other",
+		});
 		const otherScope = `issue:${otherIssue.id}`;
 
 		// Post in workspace Y's issue scope

--- a/apps/api/src/test/cache.test.ts
+++ b/apps/api/src/test/cache.test.ts
@@ -124,9 +124,7 @@ describe("KV caching", () => {
 			const firstBody = (await first.json()) as unknown[];
 			expect(firstBody.length).toBeGreaterThan(0);
 
-			await env.DB.prepare("DELETE FROM task_types WHERE workspace_id = ?")
-				.bind(workspaceId)
-				.run();
+			await env.DB.prepare("DELETE FROM task_types WHERE workspace_id = ?").bind(workspaceId).run();
 
 			const second = await SELF.fetch(url, { headers: hdrs });
 			expect(second.status).toBe(200);
@@ -159,9 +157,7 @@ describe("KV caching", () => {
 			expect(first.length).toBeGreaterThan(0);
 
 			// Delete from D1 — cache should serve the next request
-			await env.DB.prepare("DELETE FROM projects WHERE workspace_id = ?")
-				.bind(workspaceId)
-				.run();
+			await env.DB.prepare("DELETE FROM projects WHERE workspace_id = ?").bind(workspaceId).run();
 
 			// Second call — served from KV cache
 			const second = await mcpListProjects();

--- a/apps/api/src/test/files.test.ts
+++ b/apps/api/src/test/files.test.ts
@@ -1,4 +1,4 @@
-import { SELF, env } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
 import { authHeaders, seedFixture } from "./helpers";
 
@@ -61,10 +61,9 @@ describe("Files API", () => {
 	});
 
 	it("GET /api/files returns 400 for missing entityId", async () => {
-		const res = await SELF.fetch(
-			"http://localhost/api/files?entityType=issue",
-			{ headers: authHeaders(token, slug) }
-		);
+		const res = await SELF.fetch("http://localhost/api/files?entityType=issue", {
+			headers: authHeaders(token, slug),
+		});
 		expect(res.status).toBe(400);
 	});
 

--- a/apps/api/src/test/issue-links.test.ts
+++ b/apps/api/src/test/issue-links.test.ts
@@ -201,8 +201,12 @@ describe("Issue Links role guards", () => {
 	it("viewer cannot create a link (403)", async () => {
 		const roles = await seedWorkspaceRoles();
 		const project = await seedProject(roles.workspace.id);
-		const issue1 = await seedIssue(roles.workspace.id, project.id, roles.owner.user.id, { title: "A" });
-		const issue2 = await seedIssue(roles.workspace.id, project.id, roles.owner.user.id, { title: "B" });
+		const issue1 = await seedIssue(roles.workspace.id, project.id, roles.owner.user.id, {
+			title: "A",
+		});
+		const issue2 = await seedIssue(roles.workspace.id, project.id, roles.owner.user.id, {
+			title: "B",
+		});
 
 		const res = await SELF.fetch(`http://localhost/api/issues/${issue1.id}/links`, {
 			method: "POST",
@@ -215,8 +219,12 @@ describe("Issue Links role guards", () => {
 	it("viewer cannot delete a link (403)", async () => {
 		const roles = await seedWorkspaceRoles();
 		const project = await seedProject(roles.workspace.id);
-		const issue1 = await seedIssue(roles.workspace.id, project.id, roles.owner.user.id, { title: "A" });
-		const issue2 = await seedIssue(roles.workspace.id, project.id, roles.owner.user.id, { title: "B" });
+		const issue1 = await seedIssue(roles.workspace.id, project.id, roles.owner.user.id, {
+			title: "A",
+		});
+		const issue2 = await seedIssue(roles.workspace.id, project.id, roles.owner.user.id, {
+			title: "B",
+		});
 
 		const createRes = await SELF.fetch(`http://localhost/api/issues/${issue1.id}/links`, {
 			method: "POST",

--- a/apps/api/src/test/project-activity.test.ts
+++ b/apps/api/src/test/project-activity.test.ts
@@ -15,7 +15,12 @@ async function mcpCall<T>(
 	const res = await SELF.fetch(`http://localhost/mcp/${workspaceId}`, {
 		method: "POST",
 		headers,
-		body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: toolName, arguments: args } }),
+		body: JSON.stringify({
+			jsonrpc: "2.0",
+			id: 1,
+			method: "tools/call",
+			params: { name: toolName, arguments: args },
+		}),
 	});
 	return res.json();
 }
@@ -68,7 +73,17 @@ async function seedWikiPage(
 		`INSERT INTO wiki_pages (id, workspace_id, project_id, slug, title, content, created_by_id, updated_by_id, created_at, updated_at)
      VALUES (?, ?, ?, ?, ?, '', ?, ?, ?, ?)`
 	)
-		.bind(id, workspaceId, projectId, slug, opts.title ?? "Test Page", authorId, authorId, now, updatedAt)
+		.bind(
+			id,
+			workspaceId,
+			projectId,
+			slug,
+			opts.title ?? "Test Page",
+			authorId,
+			authorId,
+			now,
+			updatedAt
+		)
 		.run();
 	return { id, slug };
 }
@@ -93,7 +108,12 @@ describe("list_project_activity MCP tool", () => {
 	});
 
 	it("returns empty array when project has no activity", async () => {
-		const res = await mcpCall<McpContent>(workspaceId, "list_project_activity", { projectId }, headers);
+		const res = await mcpCall<McpContent>(
+			workspaceId,
+			"list_project_activity",
+			{ projectId },
+			headers
+		);
 		const events = parseEvents(res);
 		expect(Array.isArray(events)).toBe(true);
 		expect(events).toHaveLength(0);
@@ -102,8 +122,19 @@ describe("list_project_activity MCP tool", () => {
 	it("returns issue_created events", async () => {
 		await seedIssue(workspaceId, projectId, userId, { title: "My Issue" });
 
-		const res = (await mcpCall<McpContent>(workspaceId, "list_project_activity", { projectId }, headers)) as JsonRpcResult<McpContent>;
-		const events = JSON.parse(res.result.content[0].text) as Array<{ type: string; summary: string; entity_type: string; entity_ref: string; created_at: number }>;
+		const res = (await mcpCall<McpContent>(
+			workspaceId,
+			"list_project_activity",
+			{ projectId },
+			headers
+		)) as JsonRpcResult<McpContent>;
+		const events = JSON.parse(res.result.content[0].text) as Array<{
+			type: string;
+			summary: string;
+			entity_type: string;
+			entity_ref: string;
+			created_at: number;
+		}>;
 
 		const created = events.filter((e) => e.type === "issue_created");
 		expect(created).toHaveLength(1);
@@ -117,8 +148,16 @@ describe("list_project_activity MCP tool", () => {
 		const issue = await seedIssue(workspaceId, projectId, userId);
 		await seedComment(issue.id, userId, "Hello world");
 
-		const res = (await mcpCall<McpContent>(workspaceId, "list_project_activity", { projectId }, headers)) as JsonRpcResult<McpContent>;
-		const events = JSON.parse(res.result.content[0].text) as Array<{ type: string; actor: string | null }>;
+		const res = (await mcpCall<McpContent>(
+			workspaceId,
+			"list_project_activity",
+			{ projectId },
+			headers
+		)) as JsonRpcResult<McpContent>;
+		const events = JSON.parse(res.result.content[0].text) as Array<{
+			type: string;
+			actor: string | null;
+		}>;
 
 		const commented = events.filter((e) => e.type === "issue_commented");
 		expect(commented).toHaveLength(1);
@@ -128,8 +167,18 @@ describe("list_project_activity MCP tool", () => {
 	it("returns wiki_page_created events", async () => {
 		await seedWikiPage(workspaceId, projectId, userId, { title: "Design Doc" });
 
-		const res = (await mcpCall<McpContent>(workspaceId, "list_project_activity", { projectId }, headers)) as JsonRpcResult<McpContent>;
-		const events = JSON.parse(res.result.content[0].text) as Array<{ type: string; entity_type: string; summary: string; entity_ref: string }>;
+		const res = (await mcpCall<McpContent>(
+			workspaceId,
+			"list_project_activity",
+			{ projectId },
+			headers
+		)) as JsonRpcResult<McpContent>;
+		const events = JSON.parse(res.result.content[0].text) as Array<{
+			type: string;
+			entity_type: string;
+			summary: string;
+			entity_ref: string;
+		}>;
 
 		const wikiCreated = events.filter((e) => e.type === "wiki_page_created");
 		expect(wikiCreated).toHaveLength(1);
@@ -139,9 +188,17 @@ describe("list_project_activity MCP tool", () => {
 	});
 
 	it("returns wiki_page_edited events when updated_at differs from created_at", async () => {
-		await seedWikiPage(workspaceId, projectId, userId, { title: "Edited Doc", updatedAt: Math.floor(Date.now() / 1000) + 10 });
+		await seedWikiPage(workspaceId, projectId, userId, {
+			title: "Edited Doc",
+			updatedAt: Math.floor(Date.now() / 1000) + 10,
+		});
 
-		const res = (await mcpCall<McpContent>(workspaceId, "list_project_activity", { projectId }, headers)) as JsonRpcResult<McpContent>;
+		const res = (await mcpCall<McpContent>(
+			workspaceId,
+			"list_project_activity",
+			{ projectId },
+			headers
+		)) as JsonRpcResult<McpContent>;
 		const events = JSON.parse(res.result.content[0].text) as Array<{ type: string }>;
 
 		const edited = events.filter((e) => e.type === "wiki_page_edited");
@@ -151,7 +208,12 @@ describe("list_project_activity MCP tool", () => {
 	it("does not return wiki_page_edited when page was never updated", async () => {
 		await seedWikiPage(workspaceId, projectId, userId, { title: "Untouched" });
 
-		const res = (await mcpCall<McpContent>(workspaceId, "list_project_activity", { projectId }, headers)) as JsonRpcResult<McpContent>;
+		const res = (await mcpCall<McpContent>(
+			workspaceId,
+			"list_project_activity",
+			{ projectId },
+			headers
+		)) as JsonRpcResult<McpContent>;
 		const events = JSON.parse(res.result.content[0].text) as Array<{ type: string }>;
 
 		const edited = events.filter((e) => e.type === "wiki_page_edited");
@@ -160,10 +222,23 @@ describe("list_project_activity MCP tool", () => {
 
 	it("returns sprint_started events for active sprints with a start_date", async () => {
 		const now = Math.floor(Date.now() / 1000);
-		await seedSprint(workspaceId, projectId, { name: "Sprint Alpha", status: "active", startDate: now });
+		await seedSprint(workspaceId, projectId, {
+			name: "Sprint Alpha",
+			status: "active",
+			startDate: now,
+		});
 
-		const res = (await mcpCall<McpContent>(workspaceId, "list_project_activity", { projectId }, headers)) as JsonRpcResult<McpContent>;
-		const events = JSON.parse(res.result.content[0].text) as Array<{ type: string; summary: string; entity_type: string }>;
+		const res = (await mcpCall<McpContent>(
+			workspaceId,
+			"list_project_activity",
+			{ projectId },
+			headers
+		)) as JsonRpcResult<McpContent>;
+		const events = JSON.parse(res.result.content[0].text) as Array<{
+			type: string;
+			summary: string;
+			entity_type: string;
+		}>;
 
 		const started = events.filter((e) => e.type === "sprint_started");
 		expect(started).toHaveLength(1);
@@ -173,10 +248,23 @@ describe("list_project_activity MCP tool", () => {
 
 	it("returns sprint_completed events for completed sprints", async () => {
 		const now = Math.floor(Date.now() / 1000);
-		await seedSprint(workspaceId, projectId, { name: "Sprint Beta", status: "completed", startDate: now - 100, endDate: now });
+		await seedSprint(workspaceId, projectId, {
+			name: "Sprint Beta",
+			status: "completed",
+			startDate: now - 100,
+			endDate: now,
+		});
 
-		const res = (await mcpCall<McpContent>(workspaceId, "list_project_activity", { projectId }, headers)) as JsonRpcResult<McpContent>;
-		const events = JSON.parse(res.result.content[0].text) as Array<{ type: string; summary: string }>;
+		const res = (await mcpCall<McpContent>(
+			workspaceId,
+			"list_project_activity",
+			{ projectId },
+			headers
+		)) as JsonRpcResult<McpContent>;
+		const events = JSON.parse(res.result.content[0].text) as Array<{
+			type: string;
+			summary: string;
+		}>;
 
 		const completed = events.filter((e) => e.type === "sprint_completed");
 		expect(completed).toHaveLength(1);
@@ -191,7 +279,12 @@ describe("list_project_activity MCP tool", () => {
 			await seedIssue(workspaceId, projectId, userId, { title: `Issue ${i}` });
 		}
 
-		const res = (await mcpCall<McpContent>(workspaceId, "list_project_activity", { projectId, limit: 2 }, headers)) as JsonRpcResult<McpContent>;
+		const res = (await mcpCall<McpContent>(
+			workspaceId,
+			"list_project_activity",
+			{ projectId, limit: 2 },
+			headers
+		)) as JsonRpcResult<McpContent>;
 		const events = JSON.parse(res.result.content[0].text) as unknown[];
 		expect(events).toHaveLength(2);
 	});
@@ -201,7 +294,12 @@ describe("list_project_activity MCP tool", () => {
 		await seedIssue(workspaceId, projectId, userId, { title: "Old issue", createdAt: past - 1 });
 		await seedIssue(workspaceId, projectId, userId, { title: "New issue" });
 
-		const res = (await mcpCall<McpContent>(workspaceId, "list_project_activity", { projectId, since: past }, headers)) as JsonRpcResult<McpContent>;
+		const res = (await mcpCall<McpContent>(
+			workspaceId,
+			"list_project_activity",
+			{ projectId, since: past },
+			headers
+		)) as JsonRpcResult<McpContent>;
 		const events = JSON.parse(res.result.content[0].text) as Array<{ summary: string }>;
 
 		const titles = events.map((e) => e.summary);
@@ -214,8 +312,16 @@ describe("list_project_activity MCP tool", () => {
 		await seedIssue(workspaceId, projectId, userId, { title: "Older", createdAt: base });
 		await seedIssue(workspaceId, projectId, userId, { title: "Newer", createdAt: base + 50 });
 
-		const res = (await mcpCall<McpContent>(workspaceId, "list_project_activity", { projectId }, headers)) as JsonRpcResult<McpContent>;
-		const events = JSON.parse(res.result.content[0].text) as Array<{ summary: string; created_at: number }>;
+		const res = (await mcpCall<McpContent>(
+			workspaceId,
+			"list_project_activity",
+			{ projectId },
+			headers
+		)) as JsonRpcResult<McpContent>;
+		const events = JSON.parse(res.result.content[0].text) as Array<{
+			summary: string;
+			created_at: number;
+		}>;
 
 		const created = events.filter((e) => e.summary === "Older" || e.summary === "Newer");
 		expect(created[0].summary).toBe("Newer");
@@ -227,7 +333,12 @@ describe("list_project_activity MCP tool", () => {
 		await seedIssue(workspaceId, other.id, userId, { title: "Other project issue" });
 		await seedIssue(workspaceId, projectId, userId, { title: "This project issue" });
 
-		const res = (await mcpCall<McpContent>(workspaceId, "list_project_activity", { projectId }, headers)) as JsonRpcResult<McpContent>;
+		const res = (await mcpCall<McpContent>(
+			workspaceId,
+			"list_project_activity",
+			{ projectId },
+			headers
+		)) as JsonRpcResult<McpContent>;
 		const events = JSON.parse(res.result.content[0].text) as Array<{ summary: string }>;
 
 		const summaries = events.map((e) => e.summary);
@@ -236,7 +347,12 @@ describe("list_project_activity MCP tool", () => {
 	});
 
 	it("returns error for unknown project", async () => {
-		const res = (await mcpCall(workspaceId, "list_project_activity", { projectId: crypto.randomUUID() }, headers)) as JsonRpcError;
+		const res = (await mcpCall(
+			workspaceId,
+			"list_project_activity",
+			{ projectId: crypto.randomUUID() },
+			headers
+		)) as JsonRpcError;
 		expect(res.error).toBeDefined();
 		expect(res.error.message).toMatch(/not found/i);
 	});
@@ -249,7 +365,12 @@ describe("list_project_activity MCP tool", () => {
 	it("response shape is flat (no nested objects)", async () => {
 		await seedIssue(workspaceId, projectId, userId, { title: "Flat check" });
 
-		const res = (await mcpCall<McpContent>(workspaceId, "list_project_activity", { projectId }, headers)) as JsonRpcResult<McpContent>;
+		const res = (await mcpCall<McpContent>(
+			workspaceId,
+			"list_project_activity",
+			{ projectId },
+			headers
+		)) as JsonRpcResult<McpContent>;
 		const events = JSON.parse(res.result.content[0].text) as Array<Record<string, unknown>>;
 
 		for (const event of events) {

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -209,10 +209,9 @@ describe("Wiki API", () => {
 			body: JSON.stringify({ title: "Workspace Page", content: "global" }),
 		});
 
-		const projectRes = await SELF.fetch(
-			`http://localhost/api/wiki?projectId=${project.id}`,
-			{ headers: authHeaders(token, slug) }
-		);
+		const projectRes = await SELF.fetch(`http://localhost/api/wiki?projectId=${project.id}`, {
+			headers: authHeaders(token, slug),
+		});
 		const projectPages = (await projectRes.json()) as Array<{ title: string }>;
 		expect(projectPages).toHaveLength(1);
 		expect(projectPages[0].title).toBe("Project Page");

--- a/apps/web/src/islands/EpicList.test.tsx
+++ b/apps/web/src/islands/EpicList.test.tsx
@@ -52,9 +52,30 @@ const EPIC_ISSUE: Issue = {
 
 // Fixtures for priority sort tests — created_at descending so the API returns them
 // in LOW → MEDIUM → URGENT order (newest last); clicking Priority sorts differently.
-const URGENT_EPIC: Issue = { ...EPIC_ISSUE, id: "e-urgent", number: 11, title: "Urgent Epic", priority: "urgent", created_at: 3000 };
-const MEDIUM_EPIC: Issue = { ...EPIC_ISSUE, id: "e-medium", number: 12, title: "Medium Epic", priority: "medium", created_at: 2000 };
-const LOW_EPIC:    Issue = { ...EPIC_ISSUE, id: "e-low",    number: 13, title: "Low Epic",    priority: "low",    created_at: 1000 };
+const URGENT_EPIC: Issue = {
+	...EPIC_ISSUE,
+	id: "e-urgent",
+	number: 11,
+	title: "Urgent Epic",
+	priority: "urgent",
+	created_at: 3000,
+};
+const MEDIUM_EPIC: Issue = {
+	...EPIC_ISSUE,
+	id: "e-medium",
+	number: 12,
+	title: "Medium Epic",
+	priority: "medium",
+	created_at: 2000,
+};
+const LOW_EPIC: Issue = {
+	...EPIC_ISSUE,
+	id: "e-low",
+	number: 13,
+	title: "Low Epic",
+	priority: "low",
+	created_at: 1000,
+};
 
 function mockFetchEpics(issues: Issue[] = [EPIC_ISSUE]) {
 	vi.stubGlobal(

--- a/apps/web/src/islands/EpicList.tsx
+++ b/apps/web/src/islands/EpicList.tsx
@@ -3,7 +3,13 @@ import { statusDisplayName } from "../lib/status";
 import { apiFetch } from "../utils/api-client";
 import { issueUrl } from "../utils/issue-url";
 import { PRIORITY_OPTIONS } from "../utils/issue-utils";
-import { CATEGORY_COLORS, categoryColor, type Issue, type SortKey, sortIssues } from "./board-utils";
+import {
+	CATEGORY_COLORS,
+	categoryColor,
+	type Issue,
+	type SortKey,
+	sortIssues,
+} from "./board-utils";
 import Select from "./Select";
 
 interface Props {

--- a/apps/web/src/islands/IssueDetail.test.tsx
+++ b/apps/web/src/islands/IssueDetail.test.tsx
@@ -224,10 +224,14 @@ describe("URL path parsing (pretty-URL fallback)", () => {
 
 		const mockFetch = vi.fn().mockImplementation((url: string) => {
 			const u = String(url);
-			if (u.includes("/comments")) return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
-			if (u.includes("/links")) return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
-			if (u.includes("task-statuses")) return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
-			if (u.includes("?parentId=")) return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [] }) });
+			if (u.includes("/comments"))
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			if (u.includes("/links"))
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			if (u.includes("task-statuses"))
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			if (u.includes("?parentId="))
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [] }) });
 			// Ref lookup: GET /api/issues/PROJ-87 → returns the UUID
 			if (u.endsWith("/api/issues/PROJ-87")) {
 				return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: "plain-1" }) });
@@ -251,10 +255,14 @@ describe("URL path parsing (pretty-URL fallback)", () => {
 
 		const mockFetch = vi.fn().mockImplementation((url: string) => {
 			const u = String(url);
-			if (u.includes("/comments")) return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
-			if (u.includes("/links")) return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
-			if (u.includes("task-statuses")) return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
-			if (u.includes("?parentId=")) return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [] }) });
+			if (u.includes("/comments"))
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			if (u.includes("/links"))
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			if (u.includes("task-statuses"))
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			if (u.includes("?parentId="))
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [] }) });
 			return Promise.resolve({ ok: true, json: () => Promise.resolve(PLAIN_ISSUE_DATA) });
 		});
 		vi.stubGlobal("fetch", mockFetch);
@@ -274,10 +282,13 @@ describe("URL path parsing (pretty-URL fallback)", () => {
 function makeFetchForDetail(issueData: IssueFixture) {
 	return vi.fn().mockImplementation((url: string) => {
 		const u = String(url);
-		if (u.includes("/comments")) return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+		if (u.includes("/comments"))
+			return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
 		if (u.includes("/links")) return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
-		if (u.includes("task-statuses")) return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
-		if (u.includes("?parentId=")) return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [] }) });
+		if (u.includes("task-statuses"))
+			return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+		if (u.includes("?parentId="))
+			return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [] }) });
 		return Promise.resolve({ ok: true, json: () => Promise.resolve(issueData) });
 	});
 }
@@ -296,7 +307,7 @@ describe("workspace-slug header contract (PROJ-98)", () => {
 			([url]) => String(url).includes("/api/issues/plain-1") && !String(url).includes("?")
 		);
 		expect(issueCall).toBeDefined();
-		const headers = (issueCall![1].headers as Record<string, string>) ?? {};
+		const headers = (issueCall?.[1].headers as Record<string, string>) ?? {};
 		expect(headers["X-Workspace-Slug"]).toBe("my-workspace");
 	});
 

--- a/apps/web/src/islands/IssueDetail.tsx
+++ b/apps/web/src/islands/IssueDetail.tsx
@@ -2,12 +2,12 @@ import { useCallback, useEffect, useState } from "preact/hooks";
 import { formatIssueRef, isValidIssueRef, normalizeIssueRef } from "../lib/issue-ref";
 import { parseStoryPoints } from "../lib/story-points";
 import { apiFetch } from "../utils/api-client";
-import { renderMd } from "../utils/markdown";
 import { issueUrl } from "../utils/issue-url";
 import { PRIORITY_OPTIONS } from "../utils/issue-utils";
-import Select from "./Select";
-import MarkdownEditor from "./MarkdownEditor";
+import { renderMd } from "../utils/markdown";
 import { categoryColor } from "./board-utils";
+import MarkdownEditor from "./MarkdownEditor";
+import Select from "./Select";
 
 interface TaskStatus {
 	id: string;
@@ -144,6 +144,7 @@ const PencilIcon = () => (
 		stroke-linecap="round"
 		stroke-linejoin="round"
 	>
+		<title>Edit</title>
 		<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
 		<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
 	</svg>
@@ -171,7 +172,12 @@ function SidebarField({ label, children }: { label: string; children: preact.Com
 	);
 }
 
-export default function IssueDetail({ issueId: issueIdProp, issueNumber, projectSlug, workspaceSlug }: Props) {
+export default function IssueDetail({
+	issueId: issueIdProp,
+	issueNumber,
+	projectSlug,
+	workspaceSlug,
+}: Props) {
 	const [issueId, setIssueId] = useState(issueIdProp ?? "");
 	const [issue, setIssue] = useState<IssueData | null>(null);
 	const [comments, setComments] = useState<Comment[]>([]);
@@ -396,7 +402,9 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 			(async () => {
 				if (!workspaceSlug) return;
 				try {
-					const data = await apiFetch<{ members: Member[] }>(`/api/workspaces/${workspaceSlug}`, { workspaceSlug });
+					const data = await apiFetch<{ members: Member[] }>(`/api/workspaces/${workspaceSlug}`, {
+						workspaceSlug,
+					});
 					if (Array.isArray(data?.members)) setMembers(data.members);
 				} catch {
 					// non-fatal — assignee field falls back to display-only
@@ -424,7 +432,11 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 
 		setUpdatingStatus(true);
 		try {
-			await apiFetch(`/api/issues/${issueId}`, { workspaceSlug, method: "PATCH", body: { statusId } });
+			await apiFetch(`/api/issues/${issueId}`, {
+				workspaceSlug,
+				method: "PATCH",
+				body: { statusId },
+			});
 		} catch {
 			await fetchIssue();
 		} finally {
@@ -439,7 +451,11 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 
 		setUpdatingPriority(true);
 		try {
-			await apiFetch(`/api/issues/${issueId}`, { workspaceSlug, method: "PATCH", body: { priority } });
+			await apiFetch(`/api/issues/${issueId}`, {
+				workspaceSlug,
+				method: "PATCH",
+				body: { priority },
+			});
 		} catch {
 			await fetchIssue();
 		} finally {
@@ -453,7 +469,11 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 
 		setIssue((prev) =>
 			prev
-				? { ...prev, assignee_id: assigneeId || null, assignee_name: member?.name ?? member?.email ?? null }
+				? {
+						...prev,
+						assignee_id: assigneeId || null,
+						assignee_name: member?.name ?? member?.email ?? null,
+					}
 				: prev
 		);
 
@@ -519,7 +539,11 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 		setSavingBody(true);
 		setSaveBodyError(null);
 		try {
-			await apiFetch(`/api/issues/${issueId}`, { workspaceSlug, method: "PATCH", body: { body: editBody } });
+			await apiFetch(`/api/issues/${issueId}`, {
+				workspaceSlug,
+				method: "PATCH",
+				body: { body: editBody },
+			});
 			await fetchIssue();
 			setEditingBody(false);
 		} catch (e) {
@@ -682,7 +706,10 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 	async function doDeleteComment(commentId: string) {
 		if (!window.confirm("Delete this comment?")) return;
 		try {
-			await apiFetch(`/api/issues/${issueId}/comments/${commentId}`, { workspaceSlug, method: "DELETE" });
+			await apiFetch(`/api/issues/${issueId}/comments/${commentId}`, {
+				workspaceSlug,
+				method: "DELETE",
+			});
 			await fetchComments();
 		} catch {
 			// non-fatal
@@ -760,7 +787,10 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 						← Epics
 					</a>
 				) : (
-					<a href={backHref ?? `/issues${issue.project_key ? `?project=${issue.project_key}` : ""}`} class="text-text-muted no-underline">
+					<a
+						href={backHref ?? `/issues${issue.project_key ? `?project=${issue.project_key}` : ""}`}
+						class="text-text-muted no-underline"
+					>
 						← Issues
 					</a>
 				)}
@@ -792,11 +822,31 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 							class="text-text-muted hover:text-text-base transition-colors leading-none"
 						>
 							{copiedRef ? (
-								<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+								<svg
+									width="12"
+									height="12"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2.5"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+								>
+									<title>Copied</title>
 									<polyline points="20 6 9 17 4 12" />
 								</svg>
 							) : (
-								<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+								<svg
+									width="12"
+									height="12"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+								>
+									<title>Copy</title>
 									<rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
 									<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
 								</svg>
@@ -845,7 +895,12 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 					{/* Parent badge */}
 					{parentEpic && (
 						<a
-							href={issueUrl(parentEpic.project_key, parentEpic.number, parentEpic.title, parentEpic.id)}
+							href={issueUrl(
+								parentEpic.project_key,
+								parentEpic.number,
+								parentEpic.title,
+								parentEpic.id
+							)}
 							class={`inline-flex items-center gap-1 px-2 py-[0.125rem] rounded no-underline text-xs font-medium border ${parentEpic.type_key === "epic" ? "bg-[var(--epic-bg)] text-[var(--epic-text)] border-[var(--epic-border)]" : "bg-surface text-text-muted border-border"}`}
 						>
 							<span>{parentEpic.type_key === "epic" ? "⬡" : "↑"}</span>
@@ -877,14 +932,25 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 								if (e.key === "Escape") cancelEditTitle();
 							}}
 							disabled={savingTitle}
+							// biome-ignore lint/a11y/noAutofocus: intentional focus when the inline editor opens
 							autoFocus
 							class="w-full text-2xl font-bold text-text-base bg-bg border border-border rounded-md px-3 py-1.5 mb-2 focus:outline-none focus:ring-1 focus:ring-[var(--accent)]"
 						/>
 						<div class="flex gap-2">
-							<button type="button" onClick={saveTitle} disabled={savingTitle} class="btn btn-primary btn-sm">
+							<button
+								type="button"
+								onClick={saveTitle}
+								disabled={savingTitle}
+								class="btn btn-primary btn-sm"
+							>
 								{savingTitle ? "Saving…" : "Save"}
 							</button>
-							<button type="button" onClick={cancelEditTitle} disabled={savingTitle} class="btn btn-outline btn-sm">
+							<button
+								type="button"
+								onClick={cancelEditTitle}
+								disabled={savingTitle}
+								class="btn btn-outline btn-sm"
+							>
 								Cancel
 							</button>
 						</div>
@@ -894,6 +960,9 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 						<h1
 							class="m-0 text-2xl font-bold text-text-base leading-tight cursor-pointer"
 							onClick={startEditTitle}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") startEditTitle();
+							}}
 							title="Click to edit title"
 						>
 							{issue.title}
@@ -912,10 +981,8 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 
 			{/* Two-column body */}
 			<div class="flex gap-8 items-start max-sm:flex-col">
-
 				{/* ── Main column ── */}
 				<div class="flex-1 min-w-0">
-
 					{/* Description */}
 					<section class="mb-8">
 						<div class="flex items-center gap-3 mb-4">
@@ -947,10 +1014,20 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 									<MarkdownEditor value={editBody} onChange={setEditBody} minHeight="240px" />
 								</div>
 								<div class="flex gap-2">
-									<button type="button" onClick={saveBody} disabled={savingBody} class="btn btn-primary">
+									<button
+										type="button"
+										onClick={saveBody}
+										disabled={savingBody}
+										class="btn btn-primary"
+									>
 										{savingBody ? "Saving…" : "Save"}
 									</button>
-									<button type="button" onClick={cancelEditBody} disabled={savingBody} class="btn btn-outline">
+									<button
+										type="button"
+										onClick={cancelEditBody}
+										disabled={savingBody}
+										class="btn btn-outline"
+									>
 										Cancel
 									</button>
 								</div>
@@ -1032,9 +1109,7 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 					<section class="mb-8">
 						<SectionDivider title={`Relations${links.length > 0 ? ` (${links.length})` : ""}`} />
 
-						{fetchingLinks && links.length === 0 && (
-							<p class="text-text-muted text-sm">Loading…</p>
-						)}
+						{fetchingLinks && links.length === 0 && <p class="text-text-muted text-sm">Loading…</p>}
 
 						{linksByType.length > 0 && (
 							<div class="mb-4">
@@ -1045,14 +1120,22 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 										</p>
 										<div class="flex flex-wrap gap-2">
 											{group.items.map((link) => {
-												const ref = formatIssueRef(link.linkedIssueProjectKey, link.linkedIssueNumber);
+												const ref = formatIssueRef(
+													link.linkedIssueProjectKey,
+													link.linkedIssueNumber
+												);
 												return (
 													<span
 														key={link.id}
 														class="inline-flex items-center gap-[0.375rem] px-2 py-1 border border-border rounded-md bg-surface text-[0.8rem]"
 													>
 														<a
-															href={issueUrl(link.linkedIssueProjectKey, link.linkedIssueNumber, link.linkedIssueTitle, link.linkedIssueId)}
+															href={issueUrl(
+																link.linkedIssueProjectKey,
+																link.linkedIssueNumber,
+																link.linkedIssueTitle,
+																link.linkedIssueId
+															)}
 															class="text-accent no-underline inline-flex items-center gap-[0.375rem]"
 														>
 															<span class="font-mono text-text-muted">{ref}</span>
@@ -1103,13 +1186,23 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 										if (e.key === "Escape") setLinkFormOpen(false);
 									}}
 									placeholder="PROJ-12"
+									// biome-ignore lint/a11y/noAutofocus: intentional focus when the inline editor opens
 									autoFocus
 									class="px-[0.625rem] py-[0.375rem] border border-border rounded text-sm w-28 max-sm:w-full bg-bg text-text-base"
 								/>
-								<button type="button" onClick={addLink} disabled={addingLink} class="btn btn-primary">
+								<button
+									type="button"
+									onClick={addLink}
+									disabled={addingLink}
+									class="btn btn-primary"
+								>
 									{addingLink ? "Adding…" : "Add"}
 								</button>
-								<button type="button" onClick={() => setLinkFormOpen(false)} class="btn btn-outline">
+								<button
+									type="button"
+									onClick={() => setLinkFormOpen(false)}
+									class="btn btn-outline"
+								>
 									Cancel
 								</button>
 								{linkFormError && (
@@ -1132,7 +1225,9 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 
 					{/* Attachments */}
 					<section class="mb-8">
-						<SectionDivider title={`Attachments${attachments.length > 0 ? ` (${attachments.length})` : ""}`} />
+						<SectionDivider
+							title={`Attachments${attachments.length > 0 ? ` (${attachments.length})` : ""}`}
+						/>
 
 						{attachments.length > 0 && (
 							<div class="mb-4 flex flex-col gap-2">
@@ -1151,9 +1246,7 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 											>
 												{a.filename}
 											</a>
-											<span class="text-xs text-text-muted shrink-0">
-												{formatBytes(a.size)}
-											</span>
+											<span class="text-xs text-text-muted shrink-0">{formatBytes(a.size)}</span>
 											<button
 												type="button"
 												onClick={() => deleteAttachment(a.id)}
@@ -1194,7 +1287,11 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 								</button>
 								<button
 									type="button"
-									onClick={() => { setUploadFormOpen(false); setUploadFile(null); setUploadError(null); }}
+									onClick={() => {
+										setUploadFormOpen(false);
+										setUploadFile(null);
+										setUploadError(null);
+									}}
 									class="btn btn-outline"
 								>
 									Cancel
@@ -1219,7 +1316,9 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 
 					{/* Comments */}
 					<section>
-						<SectionDivider title={`Comments${comments.length > 0 ? ` (${comments.length})` : ""}`} />
+						<SectionDivider
+							title={`Comments${comments.length > 0 ? ` (${comments.length})` : ""}`}
+						/>
 
 						{comments.length === 0 ? (
 							<p class="text-text-muted mb-4">No comments yet.</p>
@@ -1238,24 +1337,26 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 												<span class="text-xs text-text-muted" title={formatDate(c.created_at)}>
 													{relativeTime(c.created_at)}
 												</span>
-												{currentUserId && c.author_id === currentUserId && editingCommentId !== c.id && (
-													<>
-														<button
-															type="button"
-															onClick={() => startEditComment(c)}
-															class="btn btn-outline btn-sm"
-														>
-															Edit
-														</button>
-														<button
-															type="button"
-															onClick={() => doDeleteComment(c.id)}
-															class="btn btn-sm bg-transparent border border-[var(--danger-text)] text-[var(--danger-text)]"
-														>
-															Delete
-														</button>
-													</>
-												)}
+												{currentUserId &&
+													c.author_id === currentUserId &&
+													editingCommentId !== c.id && (
+														<>
+															<button
+																type="button"
+																onClick={() => startEditComment(c)}
+																class="btn btn-outline btn-sm"
+															>
+																Edit
+															</button>
+															<button
+																type="button"
+																onClick={() => doDeleteComment(c.id)}
+																class="btn btn-sm bg-transparent border border-[var(--danger-text)] text-[var(--danger-text)]"
+															>
+																Delete
+															</button>
+														</>
+													)}
 											</div>
 										</div>
 										{editingCommentId === c.id ? (
@@ -1267,7 +1368,9 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 												)}
 												<textarea
 													value={editCommentBody}
-													onInput={(e) => setEditCommentBody((e.target as HTMLTextAreaElement).value)}
+													onInput={(e) =>
+														setEditCommentBody((e.target as HTMLTextAreaElement).value)
+													}
 													rows={4}
 													class="w-full px-3 py-2 border border-border rounded text-sm resize-y box-border mb-2 bg-bg text-text-base"
 												/>
@@ -1329,7 +1432,6 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 				{/* ── Sidebar ── */}
 				<div class="w-[240px] shrink-0 max-sm:w-full sticky top-4 self-start">
 					<div class="rounded-lg border border-border bg-surface px-4 py-2 divide-y divide-[var(--border)]">
-
 						{/* Status */}
 						<SidebarField label="Status">
 							{statuses.length > 0 ? (
@@ -1403,6 +1505,7 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 										}}
 										onBlur={savePoints}
 										disabled={savingPoints}
+										// biome-ignore lint/a11y/noAutofocus: intentional focus when the inline editor opens
 										autoFocus
 										class="w-16 px-[0.375rem] py-[0.125rem] border border-border rounded text-[0.8rem] text-center bg-bg text-text-base"
 									/>
@@ -1428,9 +1531,7 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 							<SidebarField label="Project">
 								<span class="text-sm text-text-base">
 									{issue.project_name}
-									{issue.project_key && (
-										<span class="text-text-muted"> ({issue.project_key})</span>
-									)}
+									{issue.project_key && <span class="text-text-muted"> ({issue.project_key})</span>}
 								</span>
 							</SidebarField>
 						)}
@@ -1444,7 +1545,6 @@ export default function IssueDetail({ issueId: issueIdProp, issueNumber, project
 						<SidebarField label="Updated">
 							<span class="text-sm text-text-base">{formatDate(issue.updated_at)}</span>
 						</SidebarField>
-
 					</div>
 				</div>
 			</div>

--- a/apps/web/src/islands/IssueList.test.tsx
+++ b/apps/web/src/islands/IssueList.test.tsx
@@ -555,7 +555,7 @@ describe("project filter API contract", () => {
 		const calls = mockFetch.mock.calls as [string, RequestInit][];
 		const issueCall = calls.find(([url]) => String(url).includes("/api/issues"));
 		expect(issueCall).toBeDefined();
-		expect(String(issueCall![0])).toContain("limit=30");
+		expect(String(issueCall?.[0])).toContain("limit=30");
 	});
 
 	it("includes project=<id> in issues fetch when ?project=KEY is active", async () => {
@@ -571,7 +571,7 @@ describe("project filter API contract", () => {
 		});
 
 		const projectCall = calls.find(([url]) => String(url).includes("project=proj-1"));
-		expect(String(projectCall![0])).toContain("limit=30");
+		expect(String(projectCall?.[0])).toContain("limit=30");
 	});
 
 	it("does not include project param when no project filter is set", async () => {

--- a/apps/web/src/islands/MarkdownEditor.test.tsx
+++ b/apps/web/src/islands/MarkdownEditor.test.tsx
@@ -66,7 +66,8 @@ describe("MarkdownEditor", () => {
 		// The mobile Preview toggle is a button with text 'Preview'
 		const previewToggle = buttons.find((b) => b.textContent === "Preview");
 		expect(previewToggle).toBeDefined();
-		fireEvent.click(previewToggle!);
+		if (!previewToggle) throw new Error("Preview toggle not found");
+		fireEvent.click(previewToggle);
 		// After click the Edit button loses its active styles (class contains bg-transparent)
 		const editToggle = buttons.find((b) => b.textContent === "Edit");
 		expect(editToggle?.className).toContain("border-border");

--- a/apps/web/src/islands/MarkdownEditor.tsx
+++ b/apps/web/src/islands/MarkdownEditor.tsx
@@ -124,7 +124,7 @@ export default function MarkdownEditor({ value, onChange, minHeight = "240px" }:
 		if (viewRef.current) wrapSelection(viewRef.current, "_", "_");
 	}
 	function heading(n: 1 | 2 | 3) {
-		if (viewRef.current) prefixLines(viewRef.current, "#".repeat(n) + " ");
+		if (viewRef.current) prefixLines(viewRef.current, `${"#".repeat(n)} `);
 	}
 	function link() {
 		const view = viewRef.current;
@@ -268,7 +268,6 @@ export default function MarkdownEditor({ value, onChange, minHeight = "240px" }:
 					{preview ? (
 						<div
 							class="flex-1 overflow-auto px-4 py-3 text-sm leading-[1.7] text-text-base prose prose-sm max-w-none"
-							// biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized by DOMPurify in renderMarkdown
 							dangerouslySetInnerHTML={{ __html: preview }}
 						/>
 					) : (

--- a/apps/web/src/islands/MyIssues.tsx
+++ b/apps/web/src/islands/MyIssues.tsx
@@ -91,11 +91,13 @@ export default function MyIssues({ workspaceSlug }: Props) {
 	for (const issue of visible) {
 		const key = issue.project_key ?? "__none__";
 		const name = issue.project_name ?? issue.project_key ?? "No project";
-		if (!byProject.has(key)) {
+		let group = byProject.get(key);
+		if (!group) {
+			group = { name, issues: [] };
+			byProject.set(key, group);
 			projectOrder.push(key);
-			byProject.set(key, { name, issues: [] });
 		}
-		byProject.get(key)!.issues.push(issue);
+		group.issues.push(issue);
 	}
 
 	const hasAny = visible.length > 0;
@@ -129,7 +131,8 @@ export default function MyIssues({ workspaceSlug }: Props) {
 			) : (
 				<div class="flex flex-col gap-8">
 					{projectOrder.map((key) => {
-						const group = byProject.get(key)!;
+						const group = byProject.get(key);
+						if (!group) return null;
 						return (
 							<section key={key}>
 								<h2 class="text-sm font-semibold text-text-muted uppercase tracking-[0.05em] mb-2 pb-1 border-b border-border">
@@ -141,10 +144,18 @@ export default function MyIssues({ workspaceSlug }: Props) {
 									<table class="w-full border-collapse text-[0.9rem]">
 										<thead>
 											<tr class="bg-surface">
-												<th class="text-left px-3 py-2 border-b-2 border-border font-semibold whitespace-nowrap text-text-base">#</th>
-												<th class="text-left px-3 py-2 border-b-2 border-border font-semibold w-full text-text-base">Title</th>
-												<th class="text-left px-3 py-2 border-b-2 border-border font-semibold whitespace-nowrap text-text-base">Priority</th>
-												<th class="text-left px-3 py-2 border-b-2 border-border font-semibold whitespace-nowrap text-text-base">Status</th>
+												<th class="text-left px-3 py-2 border-b-2 border-border font-semibold whitespace-nowrap text-text-base">
+													#
+												</th>
+												<th class="text-left px-3 py-2 border-b-2 border-border font-semibold w-full text-text-base">
+													Title
+												</th>
+												<th class="text-left px-3 py-2 border-b-2 border-border font-semibold whitespace-nowrap text-text-base">
+													Priority
+												</th>
+												<th class="text-left px-3 py-2 border-b-2 border-border font-semibold whitespace-nowrap text-text-base">
+													Status
+												</th>
 											</tr>
 										</thead>
 										<tbody>
@@ -159,7 +170,12 @@ export default function MyIssues({ workspaceSlug }: Props) {
 														</td>
 														<td class="px-3 py-2 align-middle text-text-base">
 															<a
-																href={issueUrl(issue.project_key, issue.number, issue.title, issue.id)}
+																href={issueUrl(
+																	issue.project_key,
+																	issue.number,
+																	issue.title,
+																	issue.id
+																)}
 																class="text-text-base no-underline hover:underline focus:underline"
 															>
 																{issue.title}
@@ -184,12 +200,20 @@ export default function MyIssues({ workspaceSlug }: Props) {
 								{/* Mobile cards */}
 								<div class="hidden max-sm:flex max-sm:flex-col max-sm:gap-3">
 									{group.issues.map((issue) => (
-										<div key={issue.id} class="py-3 px-4 border border-border rounded-md bg-surface">
+										<div
+											key={issue.id}
+											class="py-3 px-4 border border-border rounded-md bg-surface"
+										>
 											<div class="font-mono text-[0.8rem] text-text-muted mb-1">
 												{formatIssueRef(issue.project_key, issue.number)}
 											</div>
-											<a href={issueUrl(issue.project_key, issue.number, issue.title, issue.id)} class="no-underline">
-												<div class="text-[0.9rem] text-text-base font-medium mb-2">{issue.title}</div>
+											<a
+												href={issueUrl(issue.project_key, issue.number, issue.title, issue.id)}
+												class="no-underline"
+											>
+												<div class="text-[0.9rem] text-text-base font-medium mb-2">
+													{issue.title}
+												</div>
 											</a>
 											<div class="flex gap-[0.375rem] flex-wrap items-center">
 												{priorityBadge(issue)}

--- a/apps/web/src/islands/ProjectLanding.test.tsx
+++ b/apps/web/src/islands/ProjectLanding.test.tsx
@@ -29,10 +29,7 @@ const ISSUE = {
 	updated_at: 1000,
 };
 
-function mockFetchProject(
-	issues: typeof ISSUE[] = [ISSUE],
-	wiki: unknown[] = []
-) {
+function mockFetchProject(issues: (typeof ISSUE)[] = [ISSUE], wiki: unknown[] = []) {
 	vi.stubGlobal(
 		"fetch",
 		vi.fn().mockImplementation((url: string) => {
@@ -89,10 +86,7 @@ describe("ProjectLanding", () => {
 
 	it("shows an error message when the project fetch fails", async () => {
 		history.replaceState(null, "", "?id=p1");
-		vi.stubGlobal(
-			"fetch",
-			vi.fn().mockResolvedValue({ ok: false, status: 500 })
-		);
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
 		render(<ProjectLanding />);
 		expect(await screen.findByRole("alert")).toBeTruthy();
 	});

--- a/apps/web/src/islands/ProjectLanding.tsx
+++ b/apps/web/src/islands/ProjectLanding.tsx
@@ -42,7 +42,6 @@ const CATEGORY_COLORS: Record<string, string> = {
 	cancelled: "var(--status-cancelled)",
 };
 
-
 export default function ProjectLanding({ workspaceSlug }: Props) {
 	const [projectId, setProjectId] = useState<string | null>(null);
 	useEffect(() => {
@@ -72,7 +71,10 @@ export default function ProjectLanding({ workspaceSlug }: Props) {
 				const [projRes, issuesRes, wikiRes] = await Promise.all([
 					fetch(`/api/projects/${id}`, { credentials: "include", headers }),
 					fetch(`/api/issues?project=${id}`, { credentials: "include", headers }),
-					fetch(`/api/wiki?projectId=${encodeURIComponent(id)}`, { credentials: "include", headers }),
+					fetch(`/api/wiki?projectId=${encodeURIComponent(id)}`, {
+						credentials: "include",
+						headers,
+					}),
 				]);
 
 				if (!projRes.ok) throw new Error(`Failed to load project (HTTP ${projRes.status})`);
@@ -172,9 +174,7 @@ export default function ProjectLanding({ workspaceSlug }: Props) {
 				</nav>
 
 				<div class="flex items-center gap-3 mb-2">
-					<h1 class="m-0 text-2xl font-bold text-text-base">
-						{project.name}
-					</h1>
+					<h1 class="m-0 text-2xl font-bold text-text-base">{project.name}</h1>
 					<span class="font-mono text-xs font-medium px-2 py-[0.125rem] rounded bg-surface border border-border text-text-muted">
 						{project.key}
 					</span>
@@ -218,6 +218,7 @@ export default function ProjectLanding({ workspaceSlug }: Props) {
 							</div>
 						</div>
 					) : (
+						// biome-ignore lint/a11y/useSemanticElements: div contains block-level <p> content, so a native <button> would be invalid HTML; implemented as a fully-keyboard-accessible ARIA button
 						<div
 							role="button"
 							tabIndex={0}
@@ -234,9 +235,7 @@ export default function ProjectLanding({ workspaceSlug }: Props) {
 									{project.description}
 								</p>
 							) : (
-								<p class="m-0 text-text-muted text-sm italic">
-									Add a description…
-								</p>
+								<p class="m-0 text-text-muted text-sm italic">Add a description…</p>
 							)}
 						</div>
 					)}
@@ -245,7 +244,10 @@ export default function ProjectLanding({ workspaceSlug }: Props) {
 
 			{/* Recent Issues */}
 			<section class="mb-8" aria-labelledby="recent-issues-heading">
-				<h2 id="recent-issues-heading" class="text-xs font-semibold text-text-muted m-0 mb-3 uppercase tracking-[0.05em]">
+				<h2
+					id="recent-issues-heading"
+					class="text-xs font-semibold text-text-muted m-0 mb-3 uppercase tracking-[0.05em]"
+				>
 					Recent Issues
 				</h2>
 				{recentIssues.length === 0 ? (
@@ -258,10 +260,11 @@ export default function ProjectLanding({ workspaceSlug }: Props) {
 								: `#${issue.number}`;
 							const color = CATEGORY_COLORS[issue.status_category ?? ""] ?? "var(--text-muted)";
 							return (
-								<div key={issue.id} class="flex items-baseline gap-2 py-2 border-b border-border last:border-b-0">
-									<span class="font-mono text-xs text-text-muted shrink-0">
-										{ref}
-									</span>
+								<div
+									key={issue.id}
+									class="flex items-baseline gap-2 py-2 border-b border-border last:border-b-0"
+								>
+									<span class="font-mono text-xs text-text-muted shrink-0">{ref}</span>
 									<span class="text-[0.8rem] font-medium shrink-0 min-w-[4rem]" style={{ color }}>
 										{statusDisplayName(issue.status_name, issue.status_key)}
 									</span>
@@ -283,7 +286,10 @@ export default function ProjectLanding({ workspaceSlug }: Props) {
 
 			{/* Recent Wiki Pages */}
 			<section class="mb-8" aria-labelledby="recent-wiki-heading">
-				<h2 id="recent-wiki-heading" class="text-xs font-semibold text-text-muted m-0 mb-3 uppercase tracking-[0.05em]">
+				<h2
+					id="recent-wiki-heading"
+					class="text-xs font-semibold text-text-muted m-0 mb-3 uppercase tracking-[0.05em]"
+				>
 					Recent Wiki Pages
 				</h2>
 				{recentWiki.length === 0 ? (

--- a/apps/web/src/islands/ProjectList.tsx
+++ b/apps/web/src/islands/ProjectList.tsx
@@ -124,7 +124,10 @@ export default function ProjectList({ workspaceSlug }: { workspaceSlug?: string 
 			>
 				<div class="flex gap-3 flex-wrap">
 					<div class="flex-[2_1_160px] min-w-0">
-						<label htmlFor="new-project-name" class="block mb-1 text-xs font-semibold text-[var(--text-muted)]">
+						<label
+							htmlFor="new-project-name"
+							class="block mb-1 text-xs font-semibold text-[var(--text-muted)]"
+						>
 							Name{" "}
 							<span aria-hidden="true" style={{ color: "var(--accent)" }}>
 								*
@@ -143,7 +146,10 @@ export default function ProjectList({ workspaceSlug }: { workspaceSlug?: string 
 						/>
 					</div>
 					<div class="flex-[1_1_100px] min-w-0">
-						<label htmlFor="new-project-key" class="block mb-1 text-xs font-semibold text-[var(--text-muted)]">
+						<label
+							htmlFor="new-project-key"
+							class="block mb-1 text-xs font-semibold text-[var(--text-muted)]"
+						>
 							Key{" "}
 							<span aria-hidden="true" style={{ color: "var(--accent)" }}>
 								*
@@ -164,7 +170,10 @@ export default function ProjectList({ workspaceSlug }: { workspaceSlug?: string 
 						/>
 					</div>
 					<div class="flex-[3_1_220px] min-w-0">
-						<label htmlFor="new-project-desc" class="block mb-1 text-xs font-semibold text-[var(--text-muted)]">
+						<label
+							htmlFor="new-project-desc"
+							class="block mb-1 text-xs font-semibold text-[var(--text-muted)]"
+						>
 							Description
 						</label>
 						<input
@@ -228,11 +237,12 @@ export default function ProjectList({ workspaceSlug }: { workspaceSlug?: string 
 			{formOpen && renderForm()}
 
 			{projects.length === 0 ? (
-				<p class="text-[var(--text-muted)] text-center py-12">
-					No projects yet.
-				</p>
+				<p class="text-[var(--text-muted)] text-center py-12">No projects yet.</p>
 			) : (
-				<div class="grid gap-4" style={{ gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))" }}>
+				<div
+					class="grid gap-4"
+					style={{ gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))" }}
+				>
 					{projects.map((p) => {
 						const count = p.open_issue_count ?? 0;
 						const countLabel =
@@ -245,9 +255,7 @@ export default function ProjectList({ workspaceSlug }: { workspaceSlug?: string 
 								class="flex flex-col gap-2 p-4 bg-[var(--surface)] border border-[var(--border)] rounded-lg no-underline shadow-sm transition-all duration-150 hover:border-[var(--accent)] hover:-translate-y-px"
 							>
 								<div class="flex items-center gap-2">
-									<span class="font-bold text-[var(--text)] text-base">
-										{p.name}
-									</span>
+									<span class="font-bold text-[var(--text)] text-base">{p.name}</span>
 									<span class="font-mono text-[0.7rem] font-medium px-1.5 py-0.5 rounded bg-[var(--surface)] border border-[var(--border)] text-[var(--text-muted)] leading-6">
 										{p.key}
 									</span>
@@ -256,7 +264,11 @@ export default function ProjectList({ workspaceSlug }: { workspaceSlug?: string 
 								{p.description && (
 									<span
 										class="text-sm text-[var(--text-muted)] overflow-hidden"
-										style={{ display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical" }}
+										style={{
+											display: "-webkit-box",
+											WebkitLineClamp: 2,
+											WebkitBoxOrient: "vertical",
+										}}
 									>
 										{p.description}
 									</span>

--- a/apps/web/src/islands/ProjectNav.tsx
+++ b/apps/web/src/islands/ProjectNav.tsx
@@ -11,7 +11,6 @@ interface Props {
 	workspaceSlug?: string;
 }
 
-
 const TABS = [
 	{ label: "Overview", path: "/projects/view" },
 	{ label: "Issues", path: "/issues" },
@@ -106,10 +105,7 @@ export default function ProjectNav({ workspaceSlug }: Props) {
 	return (
 		<div class="border-b border-border bg-[var(--nav-bg)]">
 			<div class="flex items-center gap-2 px-6 pt-3 pb-[0.375rem]">
-				<a
-					href={`/projects/view?id=${encodeURIComponent(project.id)}`}
-					class="no-underline"
-				>
+				<a href={`/projects/view?id=${encodeURIComponent(project.id)}`} class="no-underline">
 					<h2 class="m-0 text-[0.9375rem] font-semibold text-text-base">{project.name}</h2>
 				</a>
 				<span class="font-mono text-[0.72rem] font-medium px-[0.4rem] py-[0.1rem] rounded-[3px] bg-surface border border-border text-text-muted">

--- a/apps/web/src/islands/Select.test.tsx
+++ b/apps/web/src/islands/Select.test.tsx
@@ -14,26 +14,20 @@ const OPTIONS: SelectOption[] = [
 
 describe("Select", () => {
 	it("renders the placeholder (raw value) when no option matches", () => {
-		render(
-			<Select value="" options={OPTIONS} onChange={() => {}} ariaLabel="Status" />
-		);
+		render(<Select value="" options={OPTIONS} onChange={() => {}} ariaLabel="Status" />);
 		// No option has value "", so the trigger falls back to the raw value ("").
 		const button = screen.getByRole("combobox", { name: "Status" });
 		expect(button.textContent).toContain("▾");
 	});
 
 	it("renders the selected option's label when value matches", () => {
-		render(
-			<Select value="done" options={OPTIONS} onChange={() => {}} ariaLabel="Status" />
-		);
+		render(<Select value="done" options={OPTIONS} onChange={() => {}} ariaLabel="Status" />);
 		expect(screen.getByText("Done")).toBeTruthy();
 	});
 
 	it("calls onChange with the option value when an option is clicked", () => {
 		const onChange = vi.fn();
-		render(
-			<Select value="open" options={OPTIONS} onChange={onChange} ariaLabel="Status" />
-		);
+		render(<Select value="open" options={OPTIONS} onChange={onChange} ariaLabel="Status" />);
 		// Open the menu, then click the "Done" option.
 		fireEvent.click(screen.getByRole("combobox", { name: "Status" }));
 		fireEvent.click(screen.getByRole("option", { name: "Done" }));
@@ -42,13 +36,7 @@ describe("Select", () => {
 
 	it("renders a disabled trigger when disabled", () => {
 		render(
-			<Select
-				value="open"
-				options={OPTIONS}
-				onChange={() => {}}
-				ariaLabel="Status"
-				disabled
-			/>
+			<Select value="open" options={OPTIONS} onChange={() => {}} ariaLabel="Status" disabled />
 		);
 		const button = screen.getByRole("combobox", { name: "Status" });
 		// The native `disabled` attribute is what blocks pointer interaction in the

--- a/apps/web/src/islands/ShareView.tsx
+++ b/apps/web/src/islands/ShareView.tsx
@@ -66,7 +66,12 @@ export default function ShareView() {
 			});
 	}, []);
 
-	if (loading) return <p aria-live="polite" style={{ padding: "2rem" }}>Loading…</p>;
+	if (loading)
+		return (
+			<p aria-live="polite" style={{ padding: "2rem" }}>
+				Loading…
+			</p>
+		);
 
 	if (error) {
 		const isExpired = error === "not_found";
@@ -81,7 +86,15 @@ export default function ShareView() {
 						? "This share link may have expired (links are valid for 3 days) or the URL is incorrect."
 						: "Unable to load the shared issue. Please try again later."}
 				</p>
-				<a href="/" style={{ color: "var(--accent)", textDecoration: "none", marginTop: "1.5rem", display: "inline-block" }}>
+				<a
+					href="/"
+					style={{
+						color: "var(--accent)",
+						textDecoration: "none",
+						marginTop: "1.5rem",
+						display: "inline-block",
+					}}
+				>
 					← Go to Projektor
 				</a>
 			</div>
@@ -111,9 +124,7 @@ export default function ShareView() {
 					color: "var(--text-muted)",
 				}}
 			>
-				<span>
-					Shared view · Expires {formatDate(issue.expires_at)}
-				</span>
+				<span>Shared view · Expires {formatDate(issue.expires_at)}</span>
 				<a href="/" style={{ color: "var(--accent)", textDecoration: "none", fontWeight: 500 }}>
 					Sign in to collaborate →
 				</a>
@@ -121,19 +132,28 @@ export default function ShareView() {
 
 			{/* Header */}
 			<header style={{ marginBottom: "1.5rem" }}>
-				<div style={{ display: "flex", alignItems: "center", gap: "0.5rem", marginBottom: "0.75rem", flexWrap: "wrap" }}>
+				<div
+					style={{
+						display: "flex",
+						alignItems: "center",
+						gap: "0.5rem",
+						marginBottom: "0.75rem",
+						flexWrap: "wrap",
+					}}
+				>
 					{/* Priority badge */}
-					<span
-						class="badge"
-						style={{ background: priorityStyle.bg, color: priorityStyle.text }}
-					>
+					<span class="badge" style={{ background: priorityStyle.bg, color: priorityStyle.text }}>
 						{PRIORITY_LABELS[issue.priority] ?? issue.priority}
 					</span>
 					{/* Status badge */}
 					{issue.status_name && (
 						<span
 							class="badge"
-							style={{ background: "var(--surface)", color: "var(--text-muted)", border: "1px solid var(--border)" }}
+							style={{
+								background: "var(--surface)",
+								color: "var(--text-muted)",
+								border: "1px solid var(--border)",
+							}}
 						>
 							{issue.status_name}
 						</span>
@@ -141,14 +161,24 @@ export default function ShareView() {
 					{/* Project */}
 					{issue.project_name && (
 						<span style={{ fontSize: "0.75rem", color: "var(--text-muted)" }}>
-							{issue.project_name}{issue.project_key ? ` (${issue.project_key})` : ""}
+							{issue.project_name}
+							{issue.project_key ? ` (${issue.project_key})` : ""}
 						</span>
 					)}
 				</div>
 				<h1 style={{ margin: 0, fontSize: "1.375rem", fontWeight: 700, lineHeight: 1.3 }}>
 					{issue.title}
 				</h1>
-				<div style={{ marginTop: "0.5rem", fontSize: "0.8rem", color: "var(--text-muted)", display: "flex", gap: "1rem", flexWrap: "wrap" }}>
+				<div
+					style={{
+						marginTop: "0.5rem",
+						fontSize: "0.8rem",
+						color: "var(--text-muted)",
+						display: "flex",
+						gap: "1rem",
+						flexWrap: "wrap",
+					}}
+				>
 					{issue.assignee_name && <span>Assignee: {issue.assignee_name}</span>}
 					<span>Created {formatDate(issue.created_at)}</span>
 				</div>
@@ -162,16 +192,34 @@ export default function ShareView() {
 					style={{ marginBottom: "1.5rem" }}
 				/>
 			) : (
-				<p style={{ color: "var(--text-muted)", fontStyle: "italic", marginBottom: "1.5rem" }}>No description.</p>
+				<p style={{ color: "var(--text-muted)", fontStyle: "italic", marginBottom: "1.5rem" }}>
+					No description.
+				</p>
 			)}
 
 			{/* Custom fields */}
 			{issue.customFields.length > 0 && (
 				<div style={{ borderTop: "1px solid var(--border)", paddingTop: "1rem" }}>
-					<p style={{ fontSize: "0.7rem", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--text-muted)", marginBottom: "0.75rem" }}>
+					<p
+						style={{
+							fontSize: "0.7rem",
+							fontWeight: 600,
+							textTransform: "uppercase",
+							letterSpacing: "0.06em",
+							color: "var(--text-muted)",
+							marginBottom: "0.75rem",
+						}}
+					>
 						Fields
 					</p>
-					<dl style={{ display: "grid", gridTemplateColumns: "max-content 1fr", gap: "0.4rem 1rem", fontSize: "0.8125rem" }}>
+					<dl
+						style={{
+							display: "grid",
+							gridTemplateColumns: "max-content 1fr",
+							gap: "0.4rem 1rem",
+							fontSize: "0.8125rem",
+						}}
+					>
 						{issue.customFields.map((f) => (
 							<>
 								<dt style={{ color: "var(--text-muted)", fontWeight: 500 }}>{f.label}</dt>

--- a/apps/web/src/islands/SprintManager.test.tsx
+++ b/apps/web/src/islands/SprintManager.test.tsx
@@ -110,12 +110,14 @@ describe("SprintManager", () => {
 			target: { value: "Sprint 2" },
 		});
 
-		fireEvent.submit(screen.getByRole("button", { name: /Create sprint/i }).closest("form")!);
+		const form = screen.getByRole("button", { name: /Create sprint/i }).closest("form");
+		if (!form) throw new Error("Create sprint form not found");
+		fireEvent.submit(form);
 
 		await waitFor(() => {
 			const calls = mockFetch.mock.calls as [string, RequestInit][];
-			const postCall = calls.find(([url, init]) =>
-				String(url).includes("/api/sprints") && init?.method === "POST"
+			const postCall = calls.find(
+				([url, init]) => String(url).includes("/api/sprints") && init?.method === "POST"
 			);
 			expect(postCall).toBeDefined();
 		});

--- a/apps/web/src/islands/SprintManager.tsx
+++ b/apps/web/src/islands/SprintManager.tsx
@@ -94,9 +94,7 @@ function CompletionSummaryPanel({
 	return (
 		<div class="mb-6 px-5 py-4 bg-[rgba(22,163,74,0.06)] border border-[rgba(22,163,74,0.3)] rounded-lg">
 			<div class="flex justify-between items-start mb-3">
-				<h3 class="m-0 text-base font-semibold text-text-base">
-					Sprint complete: {sprint.name}
-				</h3>
+				<h3 class="m-0 text-base font-semibold text-text-base">Sprint complete: {sprint.name}</h3>
 				<button
 					type="button"
 					class="text-sm text-text-muted hover:text-text-base"
@@ -120,7 +118,9 @@ function CompletionSummaryPanel({
 				{totalSP > 0 && (
 					<div>
 						<span class="text-text-muted">Story points:</span>{" "}
-						<strong class="text-text-base">{doneSP}/{totalSP}</strong>
+						<strong class="text-text-base">
+							{doneSP}/{totalSP}
+						</strong>
 					</div>
 				)}
 			</div>
@@ -149,13 +149,7 @@ function CompletionSummaryPanel({
 
 const BAR_AREA_PX = 100;
 
-function VelocityChart({
-	data,
-	loading,
-}: {
-	data: SprintVelocity[];
-	loading: boolean;
-}) {
+function VelocityChart({ data, loading }: { data: SprintVelocity[]; loading: boolean }) {
 	const maxPts = Math.max(...data.map((d) => d.pointsTotal), 1);
 
 	return (
@@ -170,10 +164,7 @@ function VelocityChart({
 					<div class="flex items-end gap-2" style={{ height: `${BAR_AREA_PX + 48}px` }}>
 						{data.map(({ sprint, pointsCompleted, pointsTotal }) => {
 							const totalH = Math.round((pointsTotal / maxPts) * BAR_AREA_PX);
-							const doneH =
-								totalH > 0
-									? Math.round((pointsCompleted / pointsTotal) * totalH)
-									: 0;
+							const doneH = totalH > 0 ? Math.round((pointsCompleted / pointsTotal) * totalH) : 0;
 							return (
 								<div
 									key={sprint.id}
@@ -183,9 +174,7 @@ function VelocityChart({
 									<div class="text-[0.7rem] font-semibold text-text-base mb-1">
 										{pointsCompleted}
 										{pointsTotal > 0 && pointsCompleted !== pointsTotal && (
-											<span class="font-normal text-text-muted">
-												/{pointsTotal}
-											</span>
+											<span class="font-normal text-text-muted">/{pointsTotal}</span>
 										)}
 									</div>
 									<div
@@ -432,10 +421,7 @@ export default function SprintManager({ workspaceSlug }: Props) {
 						Projects
 					</a>
 					<span class="mx-[0.375rem]">/</span>
-					<a
-						href={`/projects/view?id=${project.id}`}
-						class="text-text-muted no-underline"
-					>
+					<a href={`/projects/view?id=${project.id}`} class="text-text-muted no-underline">
 						{project.name}
 					</a>
 					<span class="mx-[0.375rem]">/</span>
@@ -445,9 +431,7 @@ export default function SprintManager({ workspaceSlug }: Props) {
 
 			{/* Title */}
 			<div class="flex items-center gap-3 mb-5">
-				<h1 class="m-0 text-2xl font-bold text-text-base">
-					Sprints
-				</h1>
+				<h1 class="m-0 text-2xl font-bold text-text-base">Sprints</h1>
 				{project && (
 					<span class="font-mono text-xs px-2 py-[0.125rem] rounded bg-surface border border-border text-text-muted">
 						{project.key}
@@ -496,14 +480,17 @@ export default function SprintManager({ workspaceSlug }: Props) {
 							role="alert"
 							class="mb-[0.875rem] px-3 py-2 bg-[var(--danger-bg)] border border-[var(--danger-border)] rounded text-[0.8rem] text-[var(--danger-text)]"
 						>
-							A sprint is already active. Only one sprint can be active at a time — the backend
-							will reject activating a second one.
+							A sprint is already active. Only one sprint can be active at a time — the backend will
+							reject activating a second one.
 						</div>
 					)}
 
 					<form onSubmit={handleCreate}>
 						<div class="mb-4">
-							<label class="block text-[0.78rem] font-semibold text-text-muted mb-[0.3rem] uppercase tracking-[0.04em]" for="spr-name">
+							<label
+								class="block text-[0.78rem] font-semibold text-text-muted mb-[0.3rem] uppercase tracking-[0.04em]"
+								for="spr-name"
+							>
 								Name *
 							</label>
 							<input
@@ -519,7 +506,10 @@ export default function SprintManager({ workspaceSlug }: Props) {
 						</div>
 
 						<div class="mb-4">
-							<label class="block text-[0.78rem] font-semibold text-text-muted mb-[0.3rem] uppercase tracking-[0.04em]" for="spr-goal">
+							<label
+								class="block text-[0.78rem] font-semibold text-text-muted mb-[0.3rem] uppercase tracking-[0.04em]"
+								for="spr-goal"
+							>
 								Goal (optional)
 							</label>
 							<input
@@ -535,7 +525,10 @@ export default function SprintManager({ workspaceSlug }: Props) {
 
 						<div class="flex flex-col sm:flex-row gap-4 mb-4">
 							<div class="flex-1">
-								<label class="block text-[0.78rem] font-semibold text-text-muted mb-[0.3rem] uppercase tracking-[0.04em]" for="spr-start">
+								<label
+									class="block text-[0.78rem] font-semibold text-text-muted mb-[0.3rem] uppercase tracking-[0.04em]"
+									for="spr-start"
+								>
 									Start date (optional)
 								</label>
 								<input
@@ -547,7 +540,10 @@ export default function SprintManager({ workspaceSlug }: Props) {
 								/>
 							</div>
 							<div class="flex-1">
-								<label class="block text-[0.78rem] font-semibold text-text-muted mb-[0.3rem] uppercase tracking-[0.04em]" for="spr-end">
+								<label
+									class="block text-[0.78rem] font-semibold text-text-muted mb-[0.3rem] uppercase tracking-[0.04em]"
+									for="spr-end"
+								>
 									End date (optional)
 								</label>
 								<input
@@ -591,14 +587,15 @@ export default function SprintManager({ workspaceSlug }: Props) {
 			{sprints.length === 0 ? (
 				<div class="p-8 text-center text-text-muted bg-surface rounded-lg border border-border">
 					<p class="m-0 mb-2">No sprints yet.</p>
-					<p class="m-0 text-sm">
-						Create a sprint to organise issues into time-boxed iterations.
-					</p>
+					<p class="m-0 text-sm">Create a sprint to organise issues into time-boxed iterations.</p>
 				</div>
 			) : (
 				<div>
 					{sprints.map((sprint) => (
-						<div key={sprint.id} class="px-5 py-4 bg-surface border border-border rounded-lg mb-3 last:mb-0">
+						<div
+							key={sprint.id}
+							class="px-5 py-4 bg-surface border border-border rounded-lg mb-3 last:mb-0"
+						>
 							<div class="flex items-center gap-3 flex-wrap mb-[0.375rem]">
 								<span class="font-semibold text-base text-text-base">{sprint.name}</span>
 								{statusBadge(sprint.status)}
@@ -606,14 +603,10 @@ export default function SprintManager({ workspaceSlug }: Props) {
 							{sprint.goal && <p class="text-sm text-text-muted italic mb-2">{sprint.goal}</p>}
 							<div class="text-[0.8rem] text-text-muted flex gap-4 flex-wrap mb-2">
 								<span>
-									Start:{" "}
-									<strong class="text-text-base">
-										{formatDate(sprint.startDate)}
-									</strong>
+									Start: <strong class="text-text-base">{formatDate(sprint.startDate)}</strong>
 								</span>
 								<span>
-									End:{" "}
-									<strong class="text-text-base">{formatDate(sprint.endDate)}</strong>
+									End: <strong class="text-text-base">{formatDate(sprint.endDate)}</strong>
 								</span>
 							</div>
 							<div class="flex gap-2 items-center flex-wrap">
@@ -624,49 +617,42 @@ export default function SprintManager({ workspaceSlug }: Props) {
 									View issues →
 								</a>
 
-								{sprint.status === "active" && (
-									<>
-										{completeId === sprint.id ? (
-											<span class="inline-flex gap-[0.375rem] items-center">
-												<span class="text-[0.8rem] text-text-muted">
-													Mark complete?
-												</span>
-												<button
-													type="button"
-													class="btn btn-danger btn-sm"
-													disabled={completing}
-													onClick={() => handleComplete(sprint.id)}
-												>
-													{completing ? "…" : "Yes, complete"}
-												</button>
-												<button
-													type="button"
-													class="btn btn-outline btn-sm"
-													disabled={completing}
-													onClick={() => setCompleteId(null)}
-												>
-													Cancel
-												</button>
-												{completeError && (
-													<span class="text-[var(--danger-text)] text-xs">
-														{completeError}
-													</span>
-												)}
-											</span>
-										) : (
+								{sprint.status === "active" &&
+									(completeId === sprint.id ? (
+										<span class="inline-flex gap-[0.375rem] items-center">
+											<span class="text-[0.8rem] text-text-muted">Mark complete?</span>
+											<button
+												type="button"
+												class="btn btn-danger btn-sm"
+												disabled={completing}
+												onClick={() => handleComplete(sprint.id)}
+											>
+												{completing ? "…" : "Yes, complete"}
+											</button>
 											<button
 												type="button"
 												class="btn btn-outline btn-sm"
-												onClick={() => {
-													setCompleteId(sprint.id);
-													setCompleteError(null);
-												}}
+												disabled={completing}
+												onClick={() => setCompleteId(null)}
 											>
-												Complete sprint
+												Cancel
 											</button>
-										)}
-									</>
-								)}
+											{completeError && (
+												<span class="text-[var(--danger-text)] text-xs">{completeError}</span>
+											)}
+										</span>
+									) : (
+										<button
+											type="button"
+											class="btn btn-outline btn-sm"
+											onClick={() => {
+												setCompleteId(sprint.id);
+												setCompleteError(null);
+											}}
+										>
+											Complete sprint
+										</button>
+									))}
 							</div>
 						</div>
 					))}

--- a/apps/web/src/islands/TokenManager.test.tsx
+++ b/apps/web/src/islands/TokenManager.test.tsx
@@ -17,7 +17,7 @@ const TOKEN = {
 	createdAt: 1000,
 };
 
-function mockFetchTokens(tokens: typeof TOKEN[] = [TOKEN]) {
+function mockFetchTokens(tokens: (typeof TOKEN)[] = [TOKEN]) {
 	vi.stubGlobal(
 		"fetch",
 		vi.fn().mockImplementation((url: string) => {
@@ -26,7 +26,10 @@ function mockFetchTokens(tokens: typeof TOKEN[] = [TOKEN]) {
 				return Promise.resolve({ ok: true, json: () => Promise.resolve(tokens) });
 			}
 			if (u.includes("/mcp-info")) {
-				return Promise.resolve({ ok: true, json: () => Promise.resolve({ mcpAddCommandTemplate: null }) });
+				return Promise.resolve({
+					ok: true,
+					json: () => Promise.resolve({ mcpAddCommandTemplate: null }),
+				});
 			}
 			// workspace info
 			return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: "w1" }) });

--- a/apps/web/src/islands/TokenManager.tsx
+++ b/apps/web/src/islands/TokenManager.tsx
@@ -46,7 +46,6 @@ function formatScopes(raw: string): string {
 	return scopes.join(", ") || "—";
 }
 
-
 export default function TokenManager({ workspaceSlug }: Props) {
 	const [tokens, setTokens] = useState<ApiToken[]>([]);
 	const [loading, setLoading] = useState(true);
@@ -78,7 +77,9 @@ export default function TokenManager({ workspaceSlug }: Props) {
 		setError(null);
 		setForbidden(false);
 		try {
-			const data = await apiFetch<ApiToken[]>(`/api/workspaces/${workspaceSlug}/tokens`, { workspaceSlug });
+			const data = await apiFetch<ApiToken[]>(`/api/workspaces/${workspaceSlug}/tokens`, {
+				workspaceSlug,
+			});
 			setTokens(Array.isArray(data) ? data : []);
 		} catch (e) {
 			if (String(e).includes(": 403")) {
@@ -95,13 +96,18 @@ export default function TokenManager({ workspaceSlug }: Props) {
 		(async () => {
 			if (!workspaceSlug) return;
 			try {
-				const data = await apiFetch<{ id: string }>(`/api/workspaces/${workspaceSlug}`, { workspaceSlug });
+				const data = await apiFetch<{ id: string }>(`/api/workspaces/${workspaceSlug}`, {
+					workspaceSlug,
+				});
 				setWorkspaceId(data.id);
 			} catch {
 				// non-fatal
 			}
 			try {
-				const data = await apiFetch<{ mcpAddCommandTemplate: string }>(`/api/workspaces/${workspaceSlug}/mcp-info`, { workspaceSlug });
+				const data = await apiFetch<{ mcpAddCommandTemplate: string }>(
+					`/api/workspaces/${workspaceSlug}/mcp-info`,
+					{ workspaceSlug }
+				);
 				setMcpCommandTemplate(data.mcpAddCommandTemplate);
 			} catch {
 				// non-fatal
@@ -230,13 +236,16 @@ export default function TokenManager({ workspaceSlug }: Props) {
 					{newToken ? (
 						<div class="bg-surface border border-border rounded-md p-4 mt-4">
 							<p class="m-0 mb-2 font-semibold text-[0.9rem] text-text-base">
-								Token created: <span class="font-mono text-[0.8rem] text-text-muted">{newToken.name}</span>
+								Token created:{" "}
+								<span class="font-mono text-[0.8rem] text-text-muted">{newToken.name}</span>
 							</p>
 							<p class="text-[var(--danger-text)] text-[0.8rem] my-1">
 								⚠ Copy this token now — you won't be able to see it again.
 							</p>
 							<div class="flex items-center gap-2 my-2">
-								<code class="flex-1 font-mono text-[0.8rem] px-2 py-[0.375rem] bg-bg border border-border rounded text-text-base break-all">{newToken.token}</code>
+								<code class="flex-1 font-mono text-[0.8rem] px-2 py-[0.375rem] bg-bg border border-border rounded text-text-base break-all">
+									{newToken.token}
+								</code>
 								<button
 									type="button"
 									class="btn btn-outline btn-sm"
@@ -251,7 +260,9 @@ export default function TokenManager({ workspaceSlug }: Props) {
 									<p class="m-0 mb-[0.375rem] text-[0.8rem] font-semibold text-text-muted">
 										Connect to Claude:
 									</p>
-									<div class="font-mono text-xs px-3 py-2 bg-bg border border-border rounded text-text-muted break-all whitespace-pre-wrap leading-[1.6]">{mcpCommand(newToken.token)}</div>
+									<div class="font-mono text-xs px-3 py-2 bg-bg border border-border rounded text-text-muted break-all whitespace-pre-wrap leading-[1.6]">
+										{mcpCommand(newToken.token)}
+									</div>
 									<button
 										type="button"
 										class="btn btn-outline btn-sm mt-2"
@@ -273,9 +284,7 @@ export default function TokenManager({ workspaceSlug }: Props) {
 						</div>
 					) : (
 						<form onSubmit={handleCreate}>
-							<h3 class="m-0 mb-4 text-base font-semibold text-text-base">
-								New API token
-							</h3>
+							<h3 class="m-0 mb-4 text-base font-semibold text-text-base">New API token</h3>
 
 							<div class="flex flex-col gap-1 mb-[0.875rem]">
 								<label class="text-[0.8rem] font-semibold text-text-muted" for="tok-name">
@@ -366,29 +375,43 @@ export default function TokenManager({ workspaceSlug }: Props) {
 			{tokens.length === 0 ? (
 				<div class="p-8 text-center text-text-muted bg-surface rounded-lg border border-border">
 					<p class="m-0 mb-2">No API tokens yet.</p>
-					<p class="m-0 text-sm">
-						Create a token to allow agents and scripts to authenticate.
-					</p>
+					<p class="m-0 text-sm">Create a token to allow agents and scripts to authenticate.</p>
 				</div>
 			) : (
 				<div class="overflow-x-auto">
 					<table class="w-full border-collapse text-[0.9rem]">
 						<thead>
 							<tr>
-								<th class="text-left px-3 py-2 border-b-2 border-border font-semibold text-text-base whitespace-nowrap">Name</th>
-								<th class="text-left px-3 py-2 border-b-2 border-border font-semibold text-text-base whitespace-nowrap">Scope</th>
-								<th class="text-left px-3 py-2 border-b-2 border-border font-semibold text-text-base whitespace-nowrap">Created</th>
-								<th class="text-left px-3 py-2 border-b-2 border-border font-semibold text-text-base whitespace-nowrap">Expires</th>
-								<th class="text-left px-3 py-2 border-b-2 border-border font-semibold text-text-base whitespace-nowrap">Last used</th>
+								<th class="text-left px-3 py-2 border-b-2 border-border font-semibold text-text-base whitespace-nowrap">
+									Name
+								</th>
+								<th class="text-left px-3 py-2 border-b-2 border-border font-semibold text-text-base whitespace-nowrap">
+									Scope
+								</th>
+								<th class="text-left px-3 py-2 border-b-2 border-border font-semibold text-text-base whitespace-nowrap">
+									Created
+								</th>
+								<th class="text-left px-3 py-2 border-b-2 border-border font-semibold text-text-base whitespace-nowrap">
+									Expires
+								</th>
+								<th class="text-left px-3 py-2 border-b-2 border-border font-semibold text-text-base whitespace-nowrap">
+									Last used
+								</th>
 								<th class="text-left px-3 py-2 border-b-2 border-border font-semibold text-text-base whitespace-nowrap"></th>
 							</tr>
 						</thead>
 						<tbody>
 							{tokens.map((tok) => (
 								<tr key={tok.id}>
-									<td class="px-3 py-2 border-b border-border align-middle text-text-base font-medium [tr:last-child_&]:border-b-0">{tok.name}</td>
-									<td class="px-3 py-2 border-b border-border align-middle font-mono text-[0.8rem] text-text-muted [tr:last-child_&]:border-b-0">{formatScopes(tok.scopes)}</td>
-									<td class="px-3 py-2 border-b border-border align-middle font-mono text-[0.8rem] text-text-muted [tr:last-child_&]:border-b-0">{formatDate(tok.createdAt)}</td>
+									<td class="px-3 py-2 border-b border-border align-middle text-text-base font-medium [tr:last-child_&]:border-b-0">
+										{tok.name}
+									</td>
+									<td class="px-3 py-2 border-b border-border align-middle font-mono text-[0.8rem] text-text-muted [tr:last-child_&]:border-b-0">
+										{formatScopes(tok.scopes)}
+									</td>
+									<td class="px-3 py-2 border-b border-border align-middle font-mono text-[0.8rem] text-text-muted [tr:last-child_&]:border-b-0">
+										{formatDate(tok.createdAt)}
+									</td>
 									<td
 										class={`px-3 py-2 border-b border-border align-middle font-mono text-[0.8rem] [tr:last-child_&]:border-b-0 ${
 											tok.expiresAt && tok.expiresAt < Date.now() / 1000
@@ -398,13 +421,13 @@ export default function TokenManager({ workspaceSlug }: Props) {
 									>
 										{tok.expiresAt === null ? "No expiry" : formatDate(tok.expiresAt)}
 									</td>
-									<td class="px-3 py-2 border-b border-border align-middle font-mono text-[0.8rem] text-text-muted [tr:last-child_&]:border-b-0">{formatDate(tok.lastUsedAt)}</td>
+									<td class="px-3 py-2 border-b border-border align-middle font-mono text-[0.8rem] text-text-muted [tr:last-child_&]:border-b-0">
+										{formatDate(tok.lastUsedAt)}
+									</td>
 									<td class="px-3 py-2 border-b border-border align-middle whitespace-nowrap [tr:last-child_&]:border-b-0">
 										{revokeId === tok.id ? (
 											<span class="inline-flex gap-[0.375rem] items-center">
-												<span class="text-[0.8rem] text-text-muted">
-													Revoke?
-												</span>
+												<span class="text-[0.8rem] text-text-muted">Revoke?</span>
 												<button
 													type="button"
 													class="btn btn-danger btn-sm"
@@ -422,9 +445,7 @@ export default function TokenManager({ workspaceSlug }: Props) {
 													No
 												</button>
 												{revokeError && (
-													<span class="text-[var(--danger-text)] text-xs">
-														{revokeError}
-													</span>
+													<span class="text-[var(--danger-text)] text-xs">{revokeError}</span>
 												)}
 											</span>
 										) : (

--- a/apps/web/src/islands/WikiPage.test.tsx
+++ b/apps/web/src/islands/WikiPage.test.tsx
@@ -55,7 +55,10 @@ afterEach(() => {
 
 describe("WikiPage", () => {
 	it("shows 'Select a page' message when no slug in URL", async () => {
-		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([]) }));
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([]) })
+		);
 		render(<WikiPage />);
 		await waitFor(() => {
 			expect(screen.getByText(/Select a page from the sidebar/i)).toBeTruthy();

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -109,9 +109,7 @@ function TreeNodeItem({
 				style={{ paddingLeft: `${0.5 + depth * 1}rem` }}
 				onClick={() => onNavigate(node.slug)}
 			>
-				{depth > 0 && (
-					<span class="text-text-muted mr-1">{"›"}</span>
-				)}
+				{depth > 0 && <span class="text-text-muted mr-1">{"›"}</span>}
 				{node.title}
 			</button>
 			{node.children.length > 0 && (
@@ -130,8 +128,6 @@ function TreeNodeItem({
 		</li>
 	);
 }
-
-
 
 export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Props) {
 	const [slug, setSlug] = useState("");
@@ -240,7 +236,9 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 			setToc([]);
 			setAttachments([]);
 			try {
-				setPage(await apiFetch<WikiPageData>(`/api/wiki/${encodeURIComponent(s)}`, { workspaceSlug }));
+				setPage(
+					await apiFetch<WikiPageData>(`/api/wiki/${encodeURIComponent(s)}`, { workspaceSlug })
+				);
 			} catch (e) {
 				setError(String(e));
 			} finally {
@@ -253,7 +251,10 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 	const fetchRevisions = useCallback(
 		async (s: string) => {
 			try {
-				const data = await apiFetch<WikiRevision[]>(`/api/wiki/${encodeURIComponent(s)}/revisions`, { workspaceSlug });
+				const data = await apiFetch<WikiRevision[]>(
+					`/api/wiki/${encodeURIComponent(s)}/revisions`,
+					{ workspaceSlug }
+				);
 				setRevisions(Array.isArray(data) ? data : []);
 			} catch {
 				// non-fatal
@@ -293,9 +294,7 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 			setToc([]);
 			return;
 		}
-		const headings = Array.from(
-			container.querySelectorAll("h1, h2, h3")
-		) as HTMLElement[];
+		const headings = Array.from(container.querySelectorAll("h1, h2, h3")) as HTMLElement[];
 		headings.forEach((h) => {
 			if (!h.id) {
 				h.id = (h.textContent ?? "")
@@ -306,7 +305,7 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 		});
 		setToc(
 			headings.map((h) => ({
-				level: parseInt(h.tagName[1]),
+				level: parseInt(h.tagName[1], 10),
 				text: h.textContent ?? "",
 				id: h.id,
 			}))
@@ -330,7 +329,9 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 			{ rootMargin: "-10% 0% -70% 0%", threshold: 0 }
 		);
 		const headings = container.querySelectorAll("h1[id], h2[id], h3[id]");
-		headings.forEach((h) => observer.observe(h));
+		headings.forEach((h) => {
+			observer.observe(h);
+		});
 		return () => observer.disconnect();
 	}, [toc]);
 
@@ -546,7 +547,10 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 									<button
 										type="button"
 										class="block w-full text-left py-[0.375rem] px-2 rounded border-none cursor-pointer text-sm bg-transparent text-text-base hover:bg-border focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
-										onClick={() => { setSearchQuery(""); navigateTo(r.slug); }}
+										onClick={() => {
+											setSearchQuery("");
+											navigateTo(r.slug);
+										}}
 									>
 										<span class="font-medium">{r.title}</span>
 										{r.excerpt && (
@@ -570,361 +574,359 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 								onNavigate={navigateTo}
 							/>
 						))}
-						{pageTree.length === 0 && (
-							<li class="text-[0.8rem] text-text-muted">No pages yet</li>
-						)}
+						{pageTree.length === 0 && <li class="text-[0.8rem] text-text-muted">No pages yet</li>}
 					</ul>
 				)}
 			</aside>
 
 			{/* Main */}
 			<main class="flex-1 p-8 min-w-0">
-					{creating ? (
-						<div>
-							<h2 class="mb-6 text-2xl font-bold text-text-base">
-								{createParentTitle ? `New child page under "${createParentTitle}"` : "New page"}
-							</h2>
-							{createError && (
-								<p role="alert" class="text-[var(--danger-text)] mb-3">
-									{createError}
-								</p>
-							)}
-							<div class="mb-4">
-								<label
-									htmlFor="create-title"
-									class="block font-medium text-sm text-text-base mb-1"
-								>
-									Title <span class="text-[var(--danger-text)]">*</span>
-								</label>
-								<input
-									id="create-title"
-									type="text"
-									value={createTitle}
-									onInput={(e) => {
-										const v = (e.target as HTMLInputElement).value;
-										setCreateTitle(v);
-										if (!slugManuallyEdited) setCreateSlug(slugify(v));
-									}}
-									placeholder="Page title"
-									class="w-full px-3 py-2 border border-border rounded text-sm bg-bg text-text-base box-border text-base"
-								/>
-							</div>
-							<div class="mb-4">
-								<label
-									htmlFor="create-slug"
-									class="block font-medium text-sm text-text-base mb-1"
-								>
-									Slug
-								</label>
-								<input
-									id="create-slug"
-									type="text"
-									value={createSlug}
-									onInput={(e) => {
-										setCreateSlug((e.target as HTMLInputElement).value);
-										setSlugManuallyEdited(true);
-									}}
-									placeholder="auto-derived-from-title"
-									class="w-full px-3 py-2 border border-border rounded text-sm bg-bg text-text-base box-border font-mono"
-								/>
-							</div>
-							<div class="mb-5">
-								<label class="block font-medium text-sm text-text-base mb-1">
-									Content (Markdown)
-								</label>
-								<MarkdownEditor
-									value={createContent}
-									onChange={setCreateContent}
-									minHeight="280px"
-								/>
-							</div>
-							<div class="flex gap-2">
-								<button
-									type="button"
-									onClick={submitCreate}
-									disabled={createSaving}
-									class="btn btn-primary"
-								>
-									{createSaving ? "Creating…" : "Create page"}
-								</button>
-								<button
-									type="button"
-									onClick={cancelCreate}
-									disabled={createSaving}
-									class="btn btn-outline"
-								>
-									Cancel
-								</button>
-							</div>
+				{creating ? (
+					<div>
+						<h2 class="mb-6 text-2xl font-bold text-text-base">
+							{createParentTitle ? `New child page under "${createParentTitle}"` : "New page"}
+						</h2>
+						{createError && (
+							<p role="alert" class="text-[var(--danger-text)] mb-3">
+								{createError}
+							</p>
+						)}
+						<div class="mb-4">
+							<label htmlFor="create-title" class="block font-medium text-sm text-text-base mb-1">
+								Title <span class="text-[var(--danger-text)]">*</span>
+							</label>
+							<input
+								id="create-title"
+								type="text"
+								value={createTitle}
+								onInput={(e) => {
+									const v = (e.target as HTMLInputElement).value;
+									setCreateTitle(v);
+									if (!slugManuallyEdited) setCreateSlug(slugify(v));
+								}}
+								placeholder="Page title"
+								class="w-full px-3 py-2 border border-border rounded text-sm bg-bg text-text-base box-border text-base"
+							/>
 						</div>
-					) : !slug ? (
-						<p class="text-text-muted">
-							Select a page from the sidebar or create a new one.
-						</p>
-					) : loading ? (
-						<p aria-live="polite">Loading…</p>
-					) : error ? (
-						<p role="alert" class="text-[var(--danger-text)]">
-							Failed to load page: {error}
-						</p>
-					) : !page ? null : (
-						<div class="flex gap-8 items-start">
-							<article class="flex-1 min-w-0">
-								{/* Breadcrumbs (PROJ-114) */}
-								{breadcrumbs.length > 1 && (
-									<nav class="wiki-breadcrumb text-[0.8rem] text-text-muted mb-3 flex flex-wrap gap-1 items-center" aria-label="Breadcrumb">
-										<button type="button" class="bg-transparent border-none cursor-pointer text-text-muted text-[0.8rem] p-0 underline decoration-transparent hover:text-accent hover:decoration-accent" onClick={() => navigateTo(breadcrumbs[0].slug)}>
-											Home
-										</button>
-										{breadcrumbs.slice(1, -1).map((crumb) => (
-											<>
-												<span>›</span>
-												<button
-													key={crumb.id}
-													type="button"
-													class="bg-transparent border-none cursor-pointer text-text-muted text-[0.8rem] p-0 underline decoration-transparent hover:text-accent hover:decoration-accent"
-													onClick={() => navigateTo(crumb.slug)}
-												>
-													{crumb.title}
-												</button>
-											</>
-										))}
-										<span>›</span>
-										<span class="text-text-base">
-											{breadcrumbs[breadcrumbs.length - 1].title}
-										</span>
-									</nav>
-								)}
+						<div class="mb-4">
+							<label htmlFor="create-slug" class="block font-medium text-sm text-text-base mb-1">
+								Slug
+							</label>
+							<input
+								id="create-slug"
+								type="text"
+								value={createSlug}
+								onInput={(e) => {
+									setCreateSlug((e.target as HTMLInputElement).value);
+									setSlugManuallyEdited(true);
+								}}
+								placeholder="auto-derived-from-title"
+								class="w-full px-3 py-2 border border-border rounded text-sm bg-bg text-text-base box-border font-mono"
+							/>
+						</div>
+						<div class="mb-5">
+							{/* biome-ignore lint/a11y/noLabelWithoutControl: caption for the MarkdownEditor rich-text component, which exposes no associable form control */}
+							<label class="block font-medium text-sm text-text-base mb-1">
+								Content (Markdown)
+							</label>
+							<MarkdownEditor value={createContent} onChange={setCreateContent} minHeight="280px" />
+						</div>
+						<div class="flex gap-2">
+							<button
+								type="button"
+								onClick={submitCreate}
+								disabled={createSaving}
+								class="btn btn-primary"
+							>
+								{createSaving ? "Creating…" : "Create page"}
+							</button>
+							<button
+								type="button"
+								onClick={cancelCreate}
+								disabled={createSaving}
+								class="btn btn-outline"
+							>
+								Cancel
+							</button>
+						</div>
+					</div>
+				) : !slug ? (
+					<p class="text-text-muted">Select a page from the sidebar or create a new one.</p>
+				) : loading ? (
+					<p aria-live="polite">Loading…</p>
+				) : error ? (
+					<p role="alert" class="text-[var(--danger-text)]">
+						Failed to load page: {error}
+					</p>
+				) : !page ? null : (
+					<div class="flex gap-8 items-start">
+						<article class="flex-1 min-w-0">
+							{/* Breadcrumbs (PROJ-114) */}
+							{breadcrumbs.length > 1 && (
+								<nav
+									class="wiki-breadcrumb text-[0.8rem] text-text-muted mb-3 flex flex-wrap gap-1 items-center"
+									aria-label="Breadcrumb"
+								>
+									<button
+										type="button"
+										class="bg-transparent border-none cursor-pointer text-text-muted text-[0.8rem] p-0 underline decoration-transparent hover:text-accent hover:decoration-accent"
+										onClick={() => navigateTo(breadcrumbs[0].slug)}
+									>
+										Home
+									</button>
+									{breadcrumbs.slice(1, -1).map((crumb) => (
+										<>
+											<span>›</span>
+											<button
+												key={crumb.id}
+												type="button"
+												class="bg-transparent border-none cursor-pointer text-text-muted text-[0.8rem] p-0 underline decoration-transparent hover:text-accent hover:decoration-accent"
+												onClick={() => navigateTo(crumb.slug)}
+											>
+												{crumb.title}
+											</button>
+										</>
+									))}
+									<span>›</span>
+									<span class="text-text-base">{breadcrumbs[breadcrumbs.length - 1].title}</span>
+								</nav>
+							)}
 
-								{/* Mobile ToC (PROJ-113) */}
-								{showToc && (
-									<details class="mb-4 max-[900px]:block min-[901px]:hidden">
-										<summary class="cursor-pointer text-[0.8rem] text-text-muted select-none">Contents ({toc.length})</summary>
-										<div class="pt-2">
-											<TocList />
-										</div>
-									</details>
-								)}
-
-								<header class="flex items-start justify-between gap-4 mb-1">
-									{editing ? (
-										<input
-											id="wiki-title"
-											type="text"
-											value={editTitle}
-											onInput={(e) => setEditTitle((e.target as HTMLInputElement).value)}
-											aria-label="Page title"
-											class="flex-1 px-3 py-2 border border-border rounded text-sm bg-bg text-text-base box-border text-2xl font-bold"
-										/>
-									) : (
-										<h1 class="m-0 text-[1.75rem] font-bold text-text-base">
-											{page.title}
-										</h1>
-									)}
-
-									<div class="flex gap-2 shrink-0">
-										{editing ? (
-											<>
-												<button
-													type="button"
-													onClick={save}
-													disabled={saving}
-													class="btn btn-primary"
-												>
-													{saving ? "Saving…" : "Save"}
-												</button>
-												<button
-													type="button"
-													onClick={cancelEdit}
-													disabled={saving}
-													class="btn btn-outline"
-												>
-													Cancel
-												</button>
-											</>
-										) : (
-											<>
-												<button
-													type="button"
-													onClick={() => startCreate(page.id)}
-													class="btn btn-outline btn-sm"
-												>
-													+ Child page
-												</button>
-												<button type="button" onClick={startEdit} class="btn btn-outline">
-													Edit
-												</button>
-												<button type="button" onClick={deletePage} class="btn btn-danger">
-													Delete
-												</button>
-											</>
-										)}
+							{/* Mobile ToC (PROJ-113) */}
+							{showToc && (
+								<details class="mb-4 max-[900px]:block min-[901px]:hidden">
+									<summary class="cursor-pointer text-[0.8rem] text-text-muted select-none">
+										Contents ({toc.length})
+									</summary>
+									<div class="pt-2">
+										<TocList />
 									</div>
-								</header>
+								</details>
+							)}
 
-								{latestRevision && (
-									<p class="text-[0.8rem] text-text-muted mt-1 mb-5">
-										Last edited by{" "}
-										<strong class="text-text-base">
-											{latestRevision.author_name ?? "Unknown"}
-										</strong>{" "}
-										at {new Date(latestRevision.created_at * 1000).toLocaleString()}
-									</p>
-								)}
-
-								{saveError && (
-									<p role="alert" class="text-[var(--danger-text)] mb-3">
-										{saveError}
-									</p>
-								)}
-
+							<header class="flex items-start justify-between gap-4 mb-1">
 								{editing ? (
-									<div class="mb-3">
-										<MarkdownEditor
-											value={editContent}
-											onChange={setEditContent}
-											minHeight="320px"
-										/>
-									</div>
-								) : (
-									<div
-										ref={contentRef}
-										class="prose prose-sm max-w-none"
-										dangerouslySetInnerHTML={{ __html: renderMdWithWikilinks(page.content, wikiPages) }}
+									<input
+										id="wiki-title"
+										type="text"
+										value={editTitle}
+										onInput={(e) => setEditTitle((e.target as HTMLInputElement).value)}
+										aria-label="Page title"
+										class="flex-1 px-3 py-2 border border-border rounded text-sm bg-bg text-text-base box-border text-2xl font-bold"
 									/>
+								) : (
+									<h1 class="m-0 text-[1.75rem] font-bold text-text-base">{page.title}</h1>
 								)}
 
-								{revisions.length > 0 && (
-									<div class="mt-8">
-										<button
-											type="button"
-											onClick={() => setShowHistory((h) => !h)}
-											class="btn btn-outline btn-sm text-text-muted"
-										>
-											{showHistory ? "▲ Hide history" : "▼ History"} ({revisions.length})
-										</button>
-										{showHistory && (
-											<ul class="mt-3 list-none p-0">
-												{revisions.map((r) => (
-													<li
-														key={r.id}
-														class="py-[0.375rem] border-b border-border text-[0.8rem] text-text-muted"
-													>
-														<strong class="text-text-base">
-															{r.author_name ?? "Unknown"}
-														</strong>
-														{" — "}
-														{new Date(r.created_at * 1000).toLocaleString()}
-													</li>
-												))}
-											</ul>
-										)}
-									</div>
-								)}
-
-								{/* Attachments */}
-								<div class="mt-8">
-									<h3 class="text-xs uppercase tracking-[0.05em] text-text-muted font-semibold mb-3 pb-2 border-b border-border">
-										{`Attachments${attachments.length > 0 ? ` (${attachments.length})` : ""}`}
-									</h3>
-
-									{attachments.length > 0 && (
-										<div class="mb-4 flex flex-col gap-2">
-											{attachments.map((a) => {
-												const qs = workspaceSlug ? `?workspace=${workspaceSlug}` : "";
-												return (
-													<div
-														key={a.id}
-														class="flex items-center gap-3 px-3 py-2 border border-border rounded-md bg-surface"
-													>
-														<a
-															href={`/api/files/${a.id}${qs}`}
-															target="_blank"
-															rel="noreferrer"
-															class="text-accent text-sm no-underline hover:underline flex-1 min-w-0 truncate"
-														>
-															{a.filename}
-														</a>
-														<span class="text-xs text-text-muted shrink-0">
-															{formatBytes(a.size)}
-														</span>
-														<button
-															type="button"
-															onClick={() => deleteAttachment(a.id)}
-															aria-label={`Delete ${a.filename}`}
-															class="btn btn-sm bg-transparent border-none text-text-muted px-[0.125rem] leading-none"
-														>
-															×
-														</button>
-													</div>
-												);
-											})}
-										</div>
-									)}
-
-									{uploadFormOpen ? (
-										<div class="flex flex-wrap gap-2 items-center">
-											<label class="relative cursor-pointer">
-												<input
-													type="file"
-													class="sr-only"
-													onChange={(e) => {
-														const f = (e.target as HTMLInputElement).files?.[0] ?? null;
-														setUploadFile(f);
-														setUploadError(null);
-													}}
-												/>
-												<span class="btn btn-outline btn-sm">
-													{uploadFile ? uploadFile.name : "Choose file"}
-												</span>
-											</label>
+								<div class="flex gap-2 shrink-0">
+									{editing ? (
+										<>
 											<button
 												type="button"
-												onClick={uploadAttachment}
-												disabled={!uploadFile || uploading}
+												onClick={save}
+												disabled={saving}
 												class="btn btn-primary"
 											>
-												{uploading ? "Uploading…" : "Upload"}
+												{saving ? "Saving…" : "Save"}
 											</button>
 											<button
 												type="button"
-												onClick={() => { setUploadFormOpen(false); setUploadFile(null); setUploadError(null); }}
+												onClick={cancelEdit}
+												disabled={saving}
 												class="btn btn-outline"
 											>
 												Cancel
 											</button>
-											{uploadError && (
-												<span role="alert" class="text-[0.8rem] text-[var(--danger-text)] self-center">
-													{uploadError}
-												</span>
-											)}
-										</div>
+										</>
 									) : (
-										<button
-											type="button"
-											onClick={() => setUploadFormOpen(true)}
-											class="text-sm text-text-muted hover:text-text-base transition-colors flex items-center gap-1"
-										>
-											<span class="text-base leading-none">+</span>
-											<span>Attach file</span>
-										</button>
+										<>
+											<button
+												type="button"
+												onClick={() => startCreate(page.id)}
+												class="btn btn-outline btn-sm"
+											>
+												+ Child page
+											</button>
+											<button type="button" onClick={startEdit} class="btn btn-outline">
+												Edit
+											</button>
+											<button type="button" onClick={deletePage} class="btn btn-danger">
+												Delete
+											</button>
+										</>
 									)}
 								</div>
+							</header>
 
-								<footer class="mt-8 pt-4 border-t border-border text-xs text-text-muted">
-									Last updated: {new Date(page.updated_at * 1000).toLocaleString()}
-								</footer>
-							</article>
-
-							{/* Sticky ToC sidebar — desktop only (PROJ-113) */}
-							{showToc && (
-								<nav class="w-[190px] shrink-0 sticky top-6 self-start max-h-[calc(100vh-3rem)] overflow-y-auto text-[0.8rem] max-[900px]:hidden" aria-label="Table of contents">
-									<h3 class="m-0 mb-2 text-xs uppercase tracking-[0.05em] text-text-muted font-semibold">Contents</h3>
-									<TocList />
-								</nav>
+							{latestRevision && (
+								<p class="text-[0.8rem] text-text-muted mt-1 mb-5">
+									Last edited by{" "}
+									<strong class="text-text-base">{latestRevision.author_name ?? "Unknown"}</strong>{" "}
+									at {new Date(latestRevision.created_at * 1000).toLocaleString()}
+								</p>
 							)}
-						</div>
-					)}
+
+							{saveError && (
+								<p role="alert" class="text-[var(--danger-text)] mb-3">
+									{saveError}
+								</p>
+							)}
+
+							{editing ? (
+								<div class="mb-3">
+									<MarkdownEditor value={editContent} onChange={setEditContent} minHeight="320px" />
+								</div>
+							) : (
+								<div
+									ref={contentRef}
+									class="prose prose-sm max-w-none"
+									dangerouslySetInnerHTML={{
+										__html: renderMdWithWikilinks(page.content, wikiPages),
+									}}
+								/>
+							)}
+
+							{revisions.length > 0 && (
+								<div class="mt-8">
+									<button
+										type="button"
+										onClick={() => setShowHistory((h) => !h)}
+										class="btn btn-outline btn-sm text-text-muted"
+									>
+										{showHistory ? "▲ Hide history" : "▼ History"} ({revisions.length})
+									</button>
+									{showHistory && (
+										<ul class="mt-3 list-none p-0">
+											{revisions.map((r) => (
+												<li
+													key={r.id}
+													class="py-[0.375rem] border-b border-border text-[0.8rem] text-text-muted"
+												>
+													<strong class="text-text-base">{r.author_name ?? "Unknown"}</strong>
+													{" — "}
+													{new Date(r.created_at * 1000).toLocaleString()}
+												</li>
+											))}
+										</ul>
+									)}
+								</div>
+							)}
+
+							{/* Attachments */}
+							<div class="mt-8">
+								<h3 class="text-xs uppercase tracking-[0.05em] text-text-muted font-semibold mb-3 pb-2 border-b border-border">
+									{`Attachments${attachments.length > 0 ? ` (${attachments.length})` : ""}`}
+								</h3>
+
+								{attachments.length > 0 && (
+									<div class="mb-4 flex flex-col gap-2">
+										{attachments.map((a) => {
+											const qs = workspaceSlug ? `?workspace=${workspaceSlug}` : "";
+											return (
+												<div
+													key={a.id}
+													class="flex items-center gap-3 px-3 py-2 border border-border rounded-md bg-surface"
+												>
+													<a
+														href={`/api/files/${a.id}${qs}`}
+														target="_blank"
+														rel="noreferrer"
+														class="text-accent text-sm no-underline hover:underline flex-1 min-w-0 truncate"
+													>
+														{a.filename}
+													</a>
+													<span class="text-xs text-text-muted shrink-0">
+														{formatBytes(a.size)}
+													</span>
+													<button
+														type="button"
+														onClick={() => deleteAttachment(a.id)}
+														aria-label={`Delete ${a.filename}`}
+														class="btn btn-sm bg-transparent border-none text-text-muted px-[0.125rem] leading-none"
+													>
+														×
+													</button>
+												</div>
+											);
+										})}
+									</div>
+								)}
+
+								{uploadFormOpen ? (
+									<div class="flex flex-wrap gap-2 items-center">
+										<label class="relative cursor-pointer">
+											<input
+												type="file"
+												class="sr-only"
+												onChange={(e) => {
+													const f = (e.target as HTMLInputElement).files?.[0] ?? null;
+													setUploadFile(f);
+													setUploadError(null);
+												}}
+											/>
+											<span class="btn btn-outline btn-sm">
+												{uploadFile ? uploadFile.name : "Choose file"}
+											</span>
+										</label>
+										<button
+											type="button"
+											onClick={uploadAttachment}
+											disabled={!uploadFile || uploading}
+											class="btn btn-primary"
+										>
+											{uploading ? "Uploading…" : "Upload"}
+										</button>
+										<button
+											type="button"
+											onClick={() => {
+												setUploadFormOpen(false);
+												setUploadFile(null);
+												setUploadError(null);
+											}}
+											class="btn btn-outline"
+										>
+											Cancel
+										</button>
+										{uploadError && (
+											<span
+												role="alert"
+												class="text-[0.8rem] text-[var(--danger-text)] self-center"
+											>
+												{uploadError}
+											</span>
+										)}
+									</div>
+								) : (
+									<button
+										type="button"
+										onClick={() => setUploadFormOpen(true)}
+										class="text-sm text-text-muted hover:text-text-base transition-colors flex items-center gap-1"
+									>
+										<span class="text-base leading-none">+</span>
+										<span>Attach file</span>
+									</button>
+								)}
+							</div>
+
+							<footer class="mt-8 pt-4 border-t border-border text-xs text-text-muted">
+								Last updated: {new Date(page.updated_at * 1000).toLocaleString()}
+							</footer>
+						</article>
+
+						{/* Sticky ToC sidebar — desktop only (PROJ-113) */}
+						{showToc && (
+							<nav
+								class="w-[190px] shrink-0 sticky top-6 self-start max-h-[calc(100vh-3rem)] overflow-y-auto text-[0.8rem] max-[900px]:hidden"
+								aria-label="Table of contents"
+							>
+								<h3 class="m-0 mb-2 text-xs uppercase tracking-[0.05em] text-text-muted font-semibold">
+									Contents
+								</h3>
+								<TocList />
+							</nav>
+						)}
+					</div>
+				)}
 			</main>
 		</div>
 	);

--- a/apps/web/src/islands/board-utils.ts
+++ b/apps/web/src/islands/board-utils.ts
@@ -36,7 +36,14 @@ export interface Issue {
 	customFields?: CustomFieldValue[];
 }
 
-export type SortKey = "number" | "priority" | "updated" | "status" | "assignee" | "created_at" | "title";
+export type SortKey =
+	| "number"
+	| "priority"
+	| "updated"
+	| "status"
+	| "assignee"
+	| "created_at"
+	| "title";
 
 export const PRIORITY_ORDER: Record<string, number> = {
 	urgent: 0,
@@ -132,11 +139,7 @@ export function filterIssues(
 }
 
 /** Sorts a copy of an issue list by the given SortKey. */
-export function sortIssues(
-	issues: Issue[],
-	sortBy: SortKey,
-	sortDir: "asc" | "desc"
-): Issue[] {
+export function sortIssues(issues: Issue[], sortBy: SortKey, sortDir: "asc" | "desc"): Issue[] {
 	return [...issues].sort((a, b) => {
 		let diff = 0;
 		if (sortBy === "number") {
@@ -153,8 +156,10 @@ export function sortIssues(
 			diff = (a.assignee_name ?? "").localeCompare(b.assignee_name ?? "");
 		} else if (sortBy === "status") {
 			// backlog issues: status_category=todo, status_key=backlog → order slot 4
-			const aOrder = a.status_key === "backlog" ? 4 : (STATUS_CATEGORY_ORDER[a.status_category ?? ""] ?? 99);
-			const bOrder = b.status_key === "backlog" ? 4 : (STATUS_CATEGORY_ORDER[b.status_category ?? ""] ?? 99);
+			const aOrder =
+				a.status_key === "backlog" ? 4 : (STATUS_CATEGORY_ORDER[a.status_category ?? ""] ?? 99);
+			const bOrder =
+				b.status_key === "backlog" ? 4 : (STATUS_CATEGORY_ORDER[b.status_category ?? ""] ?? 99);
 			diff = aOrder - bOrder;
 		}
 		return sortDir === "asc" ? diff : -diff;

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -14,10 +14,7 @@ import { cleanup } from "@testing-library/preact";
 import { afterEach, beforeEach, vi } from "vitest";
 
 beforeEach(() => {
-	vi.stubGlobal(
-		"fetch",
-		vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })
-	);
+	vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) }));
 });
 
 afterEach(() => {

--- a/apps/web/src/utils/api-client.ts
+++ b/apps/web/src/utils/api-client.ts
@@ -9,7 +9,12 @@ export function buildHeaders(
 
 export async function apiFetch<T = unknown>(
 	path: string,
-	opts: { workspaceSlug?: string; method?: string; body?: unknown; headers?: Record<string, string> } = {}
+	opts: {
+		workspaceSlug?: string;
+		method?: string;
+		body?: unknown;
+		headers?: Record<string, string>;
+	} = {}
 ): Promise<T> {
 	const isFormData = opts.body instanceof FormData;
 	const res = await fetch(path, {
@@ -19,7 +24,9 @@ export async function apiFetch<T = unknown>(
 			...buildHeaders(opts.workspaceSlug, opts.headers),
 			...(opts.body && !isFormData ? { "Content-Type": "application/json" } : {}),
 		},
-		...(opts.body ? { body: isFormData ? (opts.body as FormData) : JSON.stringify(opts.body) } : {}),
+		...(opts.body
+			? { body: isFormData ? (opts.body as FormData) : JSON.stringify(opts.body) }
+			: {}),
 	});
 	if (!res.ok) throw new Error(`API ${opts.method ?? "GET"} ${path} failed: ${res.status}`);
 	return res.json() as Promise<T>;

--- a/apps/web/src/utils/issue-utils.ts
+++ b/apps/web/src/utils/issue-utils.ts
@@ -1,3 +1,4 @@
-export const PRIORITY_OPTIONS = (["urgent", "high", "medium", "low", "none"] as const).map(
-	(p) => ({ value: p, label: p })
-);
+export const PRIORITY_OPTIONS = (["urgent", "high", "medium", "low", "none"] as const).map((p) => ({
+	value: p,
+	label: p,
+}));

--- a/biome.json
+++ b/biome.json
@@ -67,6 +67,18 @@
 					}
 				}
 			}
+		},
+		{
+			"includes": ["apps/web/src/islands/Select.tsx"],
+			"linter": {
+				"rules": {
+					"a11y": {
+						"noNoninteractiveElementToInteractiveRole": "off",
+						"useFocusableInteractive": "off",
+						"useKeyWithClickEvents": "off"
+					}
+				}
+			}
 		}
 	]
 }

--- a/packages/db/src/schema/agent-messages.ts
+++ b/packages/db/src/schema/agent-messages.ts
@@ -1,6 +1,6 @@
 import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
-import { workspaces } from "./core";
 import { agentSessions } from "./agents";
+import { workspaces } from "./core";
 
 export const agentMessages = sqliteTable(
 	"agent_messages",


### PR DESCRIPTION
Clears the standing biome lint debt so `biome check` is green (0 errors, 0 warnings) and can gate cleanly going forward.

## What changed
- **Safe autofix pass** — formatter + import sort across the api/web islands (no behaviour change).
- **Per-case fixes** for the remaining errors:
  - optional chaining (`wiki.ts`), `parseInt` radix, template literals (`MarkdownEditor`), useless-fragment removal (`SprintManager`), block-body `forEach` (`WikiPage`).
  - non-null-assertion narrowing in services and tests (proper guards / optional chaining — test semantics unchanged).
  - unused param (`_ctx`) and unused biome-suppression cleanup.
- **a11y** (improved, not degraded):
  - `<title>` added to three inline SVGs and a keyboard handler on the click-to-edit issue title (`IssueDetail`).
  - Justified suppressions where the lint is a false positive: `Select` implements the WAI-ARIA combobox/`aria-activedescendant` listbox pattern (handled via a `biome.json` override matching the existing `IssueList.tsx` precedent); intentional `autoFocus` on inline editors; the `MarkdownEditor` caption label (no associable control); and the ARIA-button `div` in `ProjectLanding` (contains block `<p>`, so a native `<button>` would be invalid HTML).

## Verification
- `biome check` → 0 errors, 0 warnings
- web tests: 234 passing · api tests: 515 passing
- pre-commit hooks (type-check + lint + island-api) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)