### PR TITLE
PROJ-226: set browser tab title to issue ref + title

### DIFF
--- a/apps/web/src/islands/IssueDetail.test.tsx
+++ b/apps/web/src/islands/IssueDetail.test.tsx
@@ -293,6 +293,19 @@ function makeFetchForDetail(issueData: IssueFixture) {
 	});
 }
 
+// ─── PROJ-226: tab title reflects the loaded issue ────────────────────────────
+
+describe("document title (PROJ-226)", () => {
+	it("sets the tab title to '<ref> - <title>' once the issue loads", async () => {
+		setupFetch(PLAIN_ISSUE_DATA);
+		render(<IssueDetail issueId="plain-1" />);
+
+		await waitFor(() => {
+			expect(document.title).toBe("PROJ-7 - Plain Task");
+		});
+	});
+});
+
 describe("workspace-slug header contract (PROJ-98)", () => {
 	it("includes X-Workspace-Slug header when workspaceSlug prop is passed", async () => {
 		const mockFetch = makeFetchForDetail(PLAIN_ISSUE_DATA);

--- a/apps/web/src/islands/IssueDetail.tsx
+++ b/apps/web/src/islands/IssueDetail.tsx
@@ -348,6 +348,7 @@ export default function IssueDetail({
 		if (issue.project_key) {
 			const canonical = issueUrl(issue.project_key, issue.number, issue.title, issue.id);
 			history.replaceState(null, "", canonical);
+			document.title = `${formatIssueRef(issue.project_key, issue.number)} - ${issue.title}`;
 		}
 
 		// Fetch parent issue (any type — not just epics)


### PR DESCRIPTION
## Summary
- Sets `document.title` to `"<ISSUE-REF> - <title>"` (e.g. `PROJ-42 - Fix the thing`) once an issue loads in `IssueDetail.tsx`, so the browser tab shows the issue ref and title when multiple issues are open in tabs.
- Added to the existing effect keyed on `[issue, workspaceSlug]` alongside the canonical-URL rewrite, guarded on `issue.project_key`.

## Test plan
- [x] `node_modules/.bin/biome check --max-diagnostics=none` on changed files — 0 errors
- [x] Added a test in `IssueDetail.test.tsx` asserting `document.title` is `"PROJ-7 - Plain Task"` after the issue loads
- [x] `pnpm --filter @projektor/web test` — 235/235 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)