### PR TITLE
chore(web): bump version to 0.2.10 so nav shows the real version (PROJ-225)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@projektor/web",
-  "version": "0.0.1",
+  "version": "0.2.10",
   "private": true,
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
Follow-up to #20. The sidebar version reads `apps/web/package.json`, which was stale at `0.0.1`. Bump it to `0.2.10` (the release line) so the nav shows the correct version.

The package.json version is the single source of truth for the displayed version; keep it in step with the release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)