### PR TITLE
fix(mcp): strip em-dashes from tool descriptions to unstick CI

### DIFF
--- a/apps/api/src/mcp/issues.ts
+++ b/apps/api/src/mcp/issues.ts
@@ -109,7 +109,7 @@ export const issuesTools: MCPTool[] = [
 	},
 	{
 		name: "update_issue",
-		description: "Update an issue — status, priority, title, body, assignee, or labels",
+		description: "Update an issue - status, priority, title, body, assignee, or labels",
 		inputSchema: {
 			type: "object",
 			required: ["id"],

--- a/apps/api/src/mcp/project-activity.ts
+++ b/apps/api/src/mcp/project-activity.ts
@@ -14,7 +14,7 @@ export const projectActivityTools: MCPTool[] = [
 				projectId: { type: "string", description: "The project UUID to fetch activity for" },
 				since: {
 					type: "number",
-					description: "Unix timestamp — only return events created at or after this time",
+					description: "Unix timestamp - only return events created at or after this time",
 				},
 				limit: {
 					type: "number",

--- a/apps/api/src/mcp/sprints.ts
+++ b/apps/api/src/mcp/sprints.ts
@@ -63,7 +63,7 @@ export const sprintsTools: MCPTool[] = [
 	},
 	{
 		name: "update_sprint",
-		description: "Update sprint fields — name, goal, status, start/end dates",
+		description: "Update sprint fields - name, goal, status, start/end dates",
 		inputSchema: {
 			type: "object",
 			required: ["id"],


### PR DESCRIPTION
## Why CI was failing
Every CI run (main + all PRs) failed at the **"MCP catalog is fresh"** step, which runs `pnpm --filter @projektor/api gen:catalog` and `git diff --exit-code` on the generated `apps/docs/src/content/docs/agents/tool-catalog.md`.

The em-dash strip (#16) replaced `—` with `-` in the **generated** catalog file, but not in the **source** MCP tool `description` strings the catalog is generated from. So the generator kept re-emitting em-dashes for `update_issue` and `update_sprint`, and the diff check failed on every run.

## Fix
Strip the em-dashes at the source (`apps/api/src/mcp/{issues,sprints}.ts`), so the regenerated catalog matches the committed file. Also removed a leftover em-dash in the `project-activity` `since` param description (cosmetic — params aren't listed in the catalog, so it didn't affect CI).

Verified locally: `gen:catalog` + `git diff --exit-code` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)