### PR TITLE
ci: gate release/deploy on CI passing (reusable workflow)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Allow other workflows (e.g. release.yml) to run these exact checks as a gate.
+  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,16 @@ permissions:
   contents: write   # create the GitHub Release
 
 jobs:
+  # Run the full CI suite (tests, type-check, catalog freshness, island API) as a
+  # gate. Reuses ci.yml so the checks never drift from the branch/PR CI. The
+  # release job below won't start unless this passes.
+  ci:
+    name: CI checks
+    uses: ./.github/workflows/ci.yml
+
   release:
     name: Build & publish release artifact
+    needs: ci
     runs-on: ubuntu-latest
     env:
       VERSION: ${{ github.event.inputs.version || github.ref_name }}


### PR DESCRIPTION
Closes the gap where a `v*` tag push released and deployed regardless of CI (and `release.yml` never re-ran the checks itself — so a red `main` still shipped, e.g. the stale MCP catalog).

## Approach (option A, no step duplication)
- `ci.yml` gains `workflow_call:` so it can be invoked by other workflows.
- `release.yml` adds a `ci` job (`uses: ./.github/workflows/ci.yml`) and the publish job now `needs: ci`.

The release reuses the **exact same** CI checks — one source of truth, no copy-pasted steps. If a check changes in `ci.yml`, the release gate picks it up automatically. A tag won't build/publish/deploy unless tests, type-check, catalog freshness, and the island-API check all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)