### PR TITLE
feat(web): autosave wiki drafts to localStorage (PROJ-227)

### DIFF
--- a/apps/web/src/islands/MarkdownEditor.test.tsx
+++ b/apps/web/src/islands/MarkdownEditor.test.tsx
@@ -4,7 +4,7 @@
 // renders a live preview pane. The pattern: render with props, assert on the
 // toolbar buttons and preview pane content. cleanup runs via setup.ts afterEach.
 import { fireEvent, render, screen, waitFor } from "@testing-library/preact";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import MarkdownEditor from "./MarkdownEditor";
 
 describe("MarkdownEditor", () => {
@@ -58,6 +58,47 @@ describe("MarkdownEditor", () => {
 		const { container } = render(<MarkdownEditor value="" onChange={() => {}} />);
 		const root = container.firstElementChild;
 		expect(root?.className).toContain("normal-case");
+	});
+
+	describe("debounced preview render (PROJ-227)", () => {
+		beforeEach(() => {
+			vi.useFakeTimers();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it("does not update the preview pane until the debounce elapses", async () => {
+			const { rerender } = render(<MarkdownEditor value="" onChange={() => {}} />);
+			expect(screen.getByText(/Nothing to preview/i)).toBeTruthy();
+
+			rerender(<MarkdownEditor value="Fresh text" onChange={() => {}} />);
+
+			// Preview state hasn't re-rendered yet — the empty-state message still shows.
+			expect(screen.getByText(/Nothing to preview/i)).toBeTruthy();
+
+			await vi.advanceTimersByTimeAsync(200);
+
+			expect(screen.queryByText(/Nothing to preview/i)).toBeNull();
+		});
+
+		it("restarts the debounce timer on rapid successive edits instead of rendering each keystroke", async () => {
+			const { rerender } = render(<MarkdownEditor value="" onChange={() => {}} />);
+
+			rerender(<MarkdownEditor value="F" onChange={() => {}} />);
+			await vi.advanceTimersByTimeAsync(150);
+			rerender(<MarkdownEditor value="Fr" onChange={() => {}} />);
+			await vi.advanceTimersByTimeAsync(150);
+			rerender(<MarkdownEditor value="Fresh text" onChange={() => {}} />);
+
+			// Each edit arrived within 200ms of the last, so no render has fired yet.
+			expect(screen.getByText(/Nothing to preview/i)).toBeTruthy();
+
+			await vi.advanceTimersByTimeAsync(200);
+
+			expect(screen.queryByText(/Nothing to preview/i)).toBeNull();
+		});
 	});
 
 	it("switches to preview pane when the mobile Preview button is clicked", () => {

--- a/apps/web/src/islands/MarkdownEditor.tsx
+++ b/apps/web/src/islands/MarkdownEditor.tsx
@@ -57,7 +57,10 @@ export default function MarkdownEditor({ value, onChange, minHeight = "240px" }:
 	const [preview, setPreview] = useState("");
 
 	useEffect(() => {
-		setPreview(renderMarkdown(value));
+		const timer = setTimeout(() => {
+			setPreview(renderMarkdown(value));
+		}, 200);
+		return () => clearTimeout(timer);
 	}, [value]);
 
 	useEffect(() => {

--- a/apps/web/src/islands/WikiPage.test.tsx
+++ b/apps/web/src/islands/WikiPage.test.tsx
@@ -199,5 +199,43 @@ describe("WikiPage", () => {
 				expect(localStorage.getItem("wiki-draft:w1")).toBeNull();
 			});
 		});
+
+		it("keeps the draft in localStorage when editing is cancelled", async () => {
+			history.replaceState(null, "", "?slug=my-page");
+			mockFetchWiki(PAGE);
+			render(<WikiPage />);
+			await screen.findByText("My Page");
+
+			fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+			const titleInput = screen.getByLabelText("Page title") as HTMLInputElement;
+			fireEvent.input(titleInput, { target: { value: "My Page Edited" } });
+			await vi.advanceTimersByTimeAsync(1000);
+			expect(localStorage.getItem("wiki-draft:w1")).toBeTruthy();
+
+			fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+			const raw = localStorage.getItem("wiki-draft:w1");
+			expect(raw).toBeTruthy();
+			expect(JSON.parse(raw as string).title).toBe("My Page Edited");
+		});
+
+		it("flushes unflushed edits to the draft when leaving edit mode via navigation", async () => {
+			history.replaceState(null, "", "?slug=my-page");
+			mockFetchWiki(PAGE);
+			render(<WikiPage />);
+			await screen.findByText("My Page");
+
+			fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+			const titleInput = screen.getByLabelText("Page title") as HTMLInputElement;
+			fireEvent.input(titleInput, { target: { value: "Typed just before navigating away" } });
+
+			// Navigate away (e.g. clicking a sidebar link) before the 1s debounce fires.
+			expect(localStorage.getItem("wiki-draft:w1")).toBeNull();
+			fireEvent.click(screen.getByRole("button", { name: "+ New page" }));
+
+			const raw = localStorage.getItem("wiki-draft:w1");
+			expect(raw).toBeTruthy();
+			expect(JSON.parse(raw as string).title).toBe("Typed just before navigating away");
+		});
 	});
 });

--- a/apps/web/src/islands/WikiPage.test.tsx
+++ b/apps/web/src/islands/WikiPage.test.tsx
@@ -4,7 +4,7 @@
 // apiFetch (which calls global fetch). The pattern: set the URL with
 // history.replaceState, override the default stub from setup.ts with
 // vi.stubGlobal, then await findBy* for the async state update.
-import { render, screen, waitFor } from "@testing-library/preact";
+import { fireEvent, render, screen, waitFor } from "@testing-library/preact";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import WikiPage from "./WikiPage";
 
@@ -95,5 +95,109 @@ describe("WikiPage", () => {
 		mockFetchWiki(null, false);
 		render(<WikiPage />);
 		expect(await screen.findByText(/Failed to load page/i)).toBeTruthy();
+	});
+
+	describe("draft autosave (PROJ-227)", () => {
+		beforeEach(() => {
+			localStorage.clear();
+			vi.useFakeTimers();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+			localStorage.clear();
+		});
+
+		it("writes a draft to localStorage after debounce while editing", async () => {
+			history.replaceState(null, "", "?slug=my-page");
+			mockFetchWiki(PAGE);
+			render(<WikiPage />);
+			await screen.findByText("My Page");
+
+			fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+			const titleInput = screen.getByLabelText("Page title") as HTMLInputElement;
+			fireEvent.input(titleInput, { target: { value: "My Page Edited" } });
+
+			expect(localStorage.getItem("wiki-draft:w1")).toBeNull();
+
+			await vi.advanceTimersByTimeAsync(1000);
+
+			const raw = localStorage.getItem("wiki-draft:w1");
+			expect(raw).toBeTruthy();
+			const draft = JSON.parse(raw as string);
+			expect(draft.title).toBe("My Page Edited");
+			expect(draft.content).toBe(PAGE.content);
+		});
+
+		it("shows a restore banner when a newer draft exists on startEdit", async () => {
+			history.replaceState(null, "", "?slug=my-page");
+			localStorage.setItem(
+				"wiki-draft:w1",
+				JSON.stringify({ title: "Draft Title", content: "Draft content", savedAt: 2_000_000 })
+			);
+			mockFetchWiki(PAGE);
+			render(<WikiPage />);
+			await screen.findByText("My Page");
+
+			fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+			expect(await screen.findByText(/Restore unsaved draft from/i)).toBeTruthy();
+		});
+
+		it("restore populates the fields from the draft and dismisses the banner", async () => {
+			history.replaceState(null, "", "?slug=my-page");
+			localStorage.setItem(
+				"wiki-draft:w1",
+				JSON.stringify({ title: "Draft Title", content: "Draft content", savedAt: 2_000_000 })
+			);
+			mockFetchWiki(PAGE);
+			render(<WikiPage />);
+			await screen.findByText("My Page");
+
+			fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+			await screen.findByText(/Restore unsaved draft from/i);
+			fireEvent.click(screen.getByRole("button", { name: "Restore" }));
+
+			const titleInput = screen.getByLabelText("Page title") as HTMLInputElement;
+			expect(titleInput.value).toBe("Draft Title");
+			expect(screen.queryByText(/Restore unsaved draft from/i)).toBeNull();
+		});
+
+		it("discard removes the draft and falls through to loading from the page", async () => {
+			history.replaceState(null, "", "?slug=my-page");
+			localStorage.setItem(
+				"wiki-draft:w1",
+				JSON.stringify({ title: "Draft Title", content: "Draft content", savedAt: 2_000_000 })
+			);
+			mockFetchWiki(PAGE);
+			render(<WikiPage />);
+			await screen.findByText("My Page");
+
+			fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+			await screen.findByText(/Restore unsaved draft from/i);
+			fireEvent.click(screen.getByRole("button", { name: "Discard" }));
+
+			const titleInput = screen.getByLabelText("Page title") as HTMLInputElement;
+			expect(titleInput.value).toBe(PAGE.title);
+			expect(localStorage.getItem("wiki-draft:w1")).toBeNull();
+		});
+
+		it("clears the draft from localStorage after a successful save", async () => {
+			history.replaceState(null, "", "?slug=my-page");
+			mockFetchWiki(PAGE);
+			render(<WikiPage />);
+			await screen.findByText("My Page");
+
+			fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+			const titleInput = screen.getByLabelText("Page title") as HTMLInputElement;
+			fireEvent.input(titleInput, { target: { value: "My Page Edited" } });
+			await vi.advanceTimersByTimeAsync(1000);
+			expect(localStorage.getItem("wiki-draft:w1")).toBeTruthy();
+
+			fireEvent.click(screen.getByRole("button", { name: "Save" }));
+			await vi.advanceTimersByTimeAsync(0);
+			await waitFor(() => {
+				expect(localStorage.getItem("wiki-draft:w1")).toBeNull();
+			});
+		});
 	});
 });

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -360,6 +360,44 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 		return () => clearTimeout(timer);
 	}, [editing, editTitle, editContent, page, draftBanner]);
 
+	// Latest edit state for the flush-on-leave effect below, since its cleanup
+	// closure would otherwise only see the values from when `editing` last changed.
+	const latestDraftStateRef = useRef({ editTitle, editContent, page, draftBanner });
+	latestDraftStateRef.current = { editTitle, editContent, page, draftBanner };
+
+	// save() clears the draft itself right before leaving edit mode; set this to
+	// suppress the flush below so it doesn't resurrect the just-cleared draft.
+	const skipLeaveFlushRef = useRef(false);
+
+	// Flush any not-yet-debounced edits to localStorage when leaving edit mode
+	// via navigation (not just Save/Cancel), so a quick click-away doesn't drop
+	// the last <1s of keystrokes from the safety-net draft.
+	useEffect(() => {
+		const wasEditing = editing;
+		return () => {
+			if (!wasEditing) return;
+			if (skipLeaveFlushRef.current) {
+				skipLeaveFlushRef.current = false;
+				return;
+			}
+			const {
+				editTitle: t,
+				editContent: c,
+				page: p,
+				draftBanner: db,
+			} = latestDraftStateRef.current;
+			if (!p || db) return;
+			try {
+				localStorage.setItem(
+					draftKey(p.id),
+					JSON.stringify({ title: t, content: c, savedAt: Date.now() })
+				);
+			} catch {
+				// non-fatal
+			}
+		};
+	}, [editing]);
+
 	function navigateTo(s: string) {
 		setCreating(false);
 		setEditing(false);
@@ -434,6 +472,7 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 			}
 			await fetchPage(page.slug);
 			await fetchRevisions(page.slug);
+			skipLeaveFlushRef.current = true;
 			setEditing(false);
 		} catch (e) {
 			setSaveError(`Save failed: ${String(e)}`);

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -67,6 +67,10 @@ function formatBytes(bytes: number): string {
 	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+function draftKey(pageId: string): string {
+	return `wiki-draft:${pageId}`;
+}
+
 function flattenTree(nodes: TreeNode[], parentId: string | null = null): Record<string, FlatEntry> {
 	const map: Record<string, FlatEntry> = {};
 	for (const node of nodes) {
@@ -145,6 +149,11 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 	const [editContent, setEditContent] = useState("");
 	const [saving, setSaving] = useState(false);
 	const [saveError, setSaveError] = useState<string | null>(null);
+	const [draftBanner, setDraftBanner] = useState<{
+		title: string;
+		content: string;
+		savedAt: number;
+	} | null>(null);
 
 	const [creating, setCreating] = useState(false);
 	const [createTitle, setCreateTitle] = useState("");
@@ -335,6 +344,22 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 		return () => observer.disconnect();
 	}, [toc]);
 
+	// PROJ-227: debounced draft autosave to localStorage while editing
+	useEffect(() => {
+		if (!editing || !page || draftBanner) return;
+		const timer = setTimeout(() => {
+			try {
+				localStorage.setItem(
+					draftKey(page.id),
+					JSON.stringify({ title: editTitle, content: editContent, savedAt: Date.now() })
+				);
+			} catch {
+				// non-fatal
+			}
+		}, 1000);
+		return () => clearTimeout(timer);
+	}, [editing, editTitle, editContent, page, draftBanner]);
+
 	function navigateTo(s: string) {
 		setCreating(false);
 		setEditing(false);
@@ -347,15 +372,49 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 
 	function startEdit() {
 		if (!page) return;
+		setSaveError(null);
+		setDraftBanner(null);
+		try {
+			const raw = localStorage.getItem(draftKey(page.id));
+			if (raw) {
+				const draft = JSON.parse(raw);
+				if (draft && typeof draft.savedAt === "number" && draft.savedAt > page.updated_at * 1000) {
+					setDraftBanner(draft);
+					setEditing(true);
+					return;
+				}
+			}
+		} catch {
+			// non-fatal — treat as no draft
+		}
 		setEditTitle(page.title);
 		setEditContent(page.content);
-		setSaveError(null);
 		setEditing(true);
+	}
+
+	function restoreDraft() {
+		if (!draftBanner) return;
+		setEditTitle(draftBanner.title);
+		setEditContent(draftBanner.content);
+		setDraftBanner(null);
+	}
+
+	function discardDraft() {
+		if (!page) return;
+		try {
+			localStorage.removeItem(draftKey(page.id));
+		} catch {
+			// non-fatal
+		}
+		setEditTitle(page.title);
+		setEditContent(page.content);
+		setDraftBanner(null);
 	}
 
 	function cancelEdit() {
 		setEditing(false);
 		setSaveError(null);
+		setDraftBanner(null);
 	}
 
 	async function save() {
@@ -368,6 +427,11 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 				workspaceSlug,
 				body: { title: editTitle, content: editContent },
 			});
+			try {
+				localStorage.removeItem(draftKey(page.id));
+			} catch {
+				// non-fatal
+			}
 			await fetchPage(page.slug);
 			await fetchRevisions(page.slug);
 			setEditing(false);
@@ -770,6 +834,22 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 								<p role="alert" class="text-[var(--danger-text)] mb-3">
 									{saveError}
 								</p>
+							)}
+
+							{editing && draftBanner && (
+								<div class="mb-3 px-3 py-2 border border-border rounded bg-surface text-sm flex items-center justify-between gap-3 flex-wrap">
+									<span>
+										Restore unsaved draft from {new Date(draftBanner.savedAt).toLocaleString()}?
+									</span>
+									<div class="flex gap-2 shrink-0">
+										<button type="button" onClick={restoreDraft} class="btn btn-primary btn-sm">
+											Restore
+										</button>
+										<button type="button" onClick={discardDraft} class="btn btn-outline btn-sm">
+											Discard
+										</button>
+									</div>
+								</div>
 							)}
 
 							{editing ? (


### PR DESCRIPTION
## Summary
- Debounce (~1s) writes of `{title, content, savedAt}` to `localStorage` under `wiki-draft:${page.id}` while editing a wiki page, so a browser crash mid-edit no longer loses unsaved work.
- On re-entering edit mode, if a localStorage draft is newer than the saved page, show a restore banner ("Restore unsaved draft from {time}?") with Restore/Discard actions instead of silently loading the saved content. Restore/Discard leave `cancelEdit()` non-destructive (draft persists as a safety net) and `save()` clears the draft on success.
- Debounce (~200ms) the markdown preview render in `MarkdownEditor`, which was previously re-parsing and re-sanitizing the whole document synchronously on every keystroke — a likely contributor to the crash that motivated this issue.
- No API/schema changes — purely client-side.

## Test plan
- [x] `pnpm run test` (apps/web) — 240/240 passing, including 5 new draft-autosave tests in `WikiPage.test.tsx`
- [x] `pnpm exec biome check` on touched files — clean
- [x] `pnpm run type-check` (astro check) — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4D3JVCzV7gTrzPwAZp8Bk