### PR TITLE
chore(web): bump version to 0.2.11 for release

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@projektor/web",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": true,
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
## Summary
- Bump apps/web version to 0.2.11 ahead of tagging the v0.2.11 release.

## Test plan
- [x] CI (type-check + tests) passes