### PR TITLE
fix(web): validate stored project id before use in EpicList (PROJ-229)

### DIFF
--- a/apps/web/src/islands/EpicList.test.tsx
+++ b/apps/web/src/islands/EpicList.test.tsx
@@ -101,10 +101,12 @@ function mockFetchEpics(issues: Issue[] = [EPIC_ISSUE]) {
 
 beforeEach(() => {
 	history.replaceState(null, "", "/");
+	localStorage.clear();
 });
 
 afterEach(() => {
 	history.replaceState(null, "", "/");
+	localStorage.clear();
 });
 
 describe("EpicList", () => {
@@ -122,6 +124,47 @@ describe("EpicList", () => {
 		render(<EpicList />);
 		// No projectId → fetchEpics sets loading=false and returns early → empty state
 		expect(await screen.findByText(/No epics found/i)).toBeTruthy();
+	});
+
+	it("ignores a stale localStorage project id not present in the project list", async () => {
+		// No projectId in the URL; localStorage points at a project that no longer exists.
+		localStorage.setItem("projektor-last-project-id", "stale-deleted-project");
+		const calledUrls: string[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation((url: string) => {
+				const u = String(url);
+				calledUrls.push(u);
+				if (u.includes("/api/task-types")) {
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve([{ id: "tt1", key: "epic", name: "Epic" }]),
+					});
+				}
+				if (u.includes("/api/projects")) {
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve([{ id: "p1", key: "PROJ", name: "Projektor" }]),
+					});
+				}
+				if (u.includes("/api/issues")) {
+					return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [EPIC_ISSUE] }) });
+				}
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+			})
+		);
+
+		render(<EpicList />);
+
+		// Sensible default rendered: falls back to the first project and loads its epics.
+		expect(await screen.findByText("Big Epic")).toBeTruthy();
+
+		// The stale id never reached an API call.
+		expect(calledUrls.some((u) => u.includes("stale-deleted-project"))).toBe(false);
+		expect(calledUrls.some((u) => u.includes("/api/issues") && u.includes("project=p1"))).toBe(
+			true
+		);
+		expect(localStorage.getItem("projektor-last-project-id")).toBe("p1");
 	});
 
 	it("renders epic rows after fetch resolves", async () => {

--- a/apps/web/src/islands/EpicList.tsx
+++ b/apps/web/src/islands/EpicList.tsx
@@ -51,6 +51,8 @@ export default function EpicList({ workspaceSlug }: Props) {
 	const [filterPriorities, setFilterPriorities] = useState<string[]>([]);
 	const [showFiltersPopover, setShowFiltersPopover] = useState(false);
 
+	const storedProjectIdRef = useRef<string | null>(null);
+
 	const filtersContainerRef = useRef<HTMLDivElement>(null);
 	const filtersPopoverRef = useRef<HTMLDivElement>(null);
 	const filtersButtonRef = useRef<HTMLButtonElement>(null);
@@ -73,22 +75,20 @@ export default function EpicList({ workspaceSlug }: Props) {
 		if (s) setFilterStatuses(s.split(",").filter(Boolean));
 		if (p) setFilterPriorities(p.split(",").filter(Boolean));
 
-		// Resolve projectId: URL param → localStorage → defer to projects fetch
+		// Resolve projectId: URL param (trusted) → localStorage (validated against the
+		// fetched project list in the projects effect below) → defer to projects fetch.
 		const fromUrl = params.get("projectId");
 		if (fromUrl) {
 			setProjectId(fromUrl);
+			// safe-ls: remembers the last-viewed project id so a future visit without a
+			// URL param can skip re-selection. Never trusted directly — the projects
+			// effect below validates it against the fetched project list and falls back
+			// to the first project if it's missing (e.g. the project was deleted).
 			localStorage.setItem("projektor-last-project-id", fromUrl);
 			setProjectIdReady(true);
 		} else {
-			const stored = localStorage.getItem("projektor-last-project-id");
-			if (stored) {
-				setProjectId(stored);
-				const newParams = new URLSearchParams(window.location.search);
-				newParams.set("projectId", stored);
-				history.replaceState(null, "", `?${newParams.toString()}`);
-				setProjectIdReady(true);
-			}
-			// else: projects fetch effect will set projectId and mark ready
+			storedProjectIdRef.current = localStorage.getItem("projektor-last-project-id");
+			// projects fetch effect validates the stored id (if any) and marks ready
 		}
 	}, []);
 
@@ -119,14 +119,19 @@ export default function EpicList({ workspaceSlug }: Props) {
 					setProjects(data);
 					setProjectId((prev) => {
 						if (prev) return prev;
-						const first = data[0]?.id ?? null;
-						if (first) {
-							localStorage.setItem("projektor-last-project-id", first);
+						const stored = storedProjectIdRef.current;
+						const validated = stored && data.some((p) => p.id === stored) ? stored : null;
+						const resolved = validated ?? data[0]?.id ?? null;
+						if (resolved) {
+							// safe-ls: resolved id is either the stored value (just confirmed to
+							// exist in the fetched project list) or the first project — never a
+							// stale reference, so it can't cause an API 4xx.
+							localStorage.setItem("projektor-last-project-id", resolved);
 							const p = new URLSearchParams(window.location.search);
-							p.set("projectId", first);
+							p.set("projectId", resolved);
 							history.replaceState(null, "", `?${p.toString()}`);
 						}
-						return first;
+						return resolved;
 					});
 				}
 			} catch {


### PR DESCRIPTION
## Summary
- `EpicList.tsx` stored the last-used `projektor-last-project-id` in localStorage and trusted it directly on reload — a deleted/renamed project left a stale id that silently drove a failing API request, violating the localStorage policy in AGENTS.md.
- The stored value is now only ever used after confirming it exists in the freshly-fetched project list (in the projects effect); otherwise it falls back to the first available project. Both localStorage writes are marked with `// safe-ls:` comments explaining why they're safe, matching the pattern in `IssueList.tsx`.
- Added a unit test covering the stale-ID case: a stored id absent from the fetched project list never reaches an API call, and the component falls back to the first project.

## Test plan
- [x] `pnpm turbo type-check` — 0 errors
- [x] `pnpm --filter @projektor/api test` — 515 passed
- [x] `pnpm --filter @projektor/web test` — 245 passed, including new `EpicList.test.tsx` stale-ID case

Coordination: used the projektor MCP fleet primitives (register_agent, claim_files, post_message) for `apps/web/src/components/EpicList.tsx` / `EpicList.test.tsx` (actual paths: `apps/web/src/islands/`). No other islands touched, per fleet scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YK62nLZ97J6yDmxs4HqGmK