### PR TITLE
fix(web): harden island fetch check and convert 5 islands to apiFetch (PROJ-228)

### DIFF
--- a/apps/web/src/islands/ApiHealth.tsx
+++ b/apps/web/src/islands/ApiHealth.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "preact/hooks";
+import { apiFetch } from "../utils/api-client";
 
 export default function ApiHealth() {
 	const [status, setStatus] = useState<string>("checking…");
 
 	useEffect(() => {
-		fetch("/api/health")
-			.then((r) => (r.ok ? "ok" : `error ${r.status}`))
+		apiFetch("/api/health")
+			.then(() => "ok")
 			.catch(() => "unreachable")
 			.then(setStatus);
 	}, []);

--- a/apps/web/src/islands/ProjectLanding.tsx
+++ b/apps/web/src/islands/ProjectLanding.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { statusDisplayName } from "../lib/status";
-import { apiFetch, buildHeaders } from "../utils/api-client";
+import { apiFetch } from "../utils/api-client";
 
 interface Project {
 	id: string;
@@ -67,33 +67,28 @@ export default function ProjectLanding({ workspaceSlug }: Props) {
 			setLoading(true);
 			setError(null);
 			try {
-				const headers = buildHeaders(workspaceSlug);
-				const [projRes, issuesRes, wikiRes] = await Promise.all([
-					fetch(`/api/projects/${id}`, { credentials: "include", headers }),
-					fetch(`/api/issues?project=${id}`, { credentials: "include", headers }),
-					fetch(`/api/wiki?projectId=${encodeURIComponent(id)}`, {
-						credentials: "include",
-						headers,
-					}),
+				const [proj, issuesData, wikiData] = await Promise.all([
+					apiFetch<Project>(`/api/projects/${id}`, { workspaceSlug }),
+					apiFetch<{ items: RecentIssue[] }>(`/api/issues?project=${id}`, { workspaceSlug }).catch(
+						() => null
+					),
+					apiFetch<RecentWikiPage[]>(`/api/wiki?projectId=${encodeURIComponent(id)}`, {
+						workspaceSlug,
+					}).catch(() => null),
 				]);
 
-				if (!projRes.ok) throw new Error(`Failed to load project (HTTP ${projRes.status})`);
-
-				const proj = (await projRes.json()) as Project;
 				setProject(proj);
 
-				if (issuesRes.ok) {
-					const data = (await issuesRes.json()) as { items: RecentIssue[] };
-					const sorted = (Array.isArray(data?.items) ? data.items : [])
+				if (issuesData) {
+					const sorted = (Array.isArray(issuesData?.items) ? issuesData.items : [])
 						.slice()
 						.sort((a, b) => b.updated_at - a.updated_at)
 						.slice(0, 5);
 					setRecentIssues(sorted);
 				}
 
-				if (wikiRes.ok) {
-					const wiki = (await wikiRes.json()) as RecentWikiPage[];
-					const sorted = (Array.isArray(wiki) ? wiki : [])
+				if (wikiData) {
+					const sorted = (Array.isArray(wikiData) ? wikiData : [])
 						.slice()
 						.sort((a, b) => b.updated_at - a.updated_at)
 						.slice(0, 5);

--- a/apps/web/src/islands/ProjectNav.tsx
+++ b/apps/web/src/islands/ProjectNav.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "preact/hooks";
-import { buildHeaders } from "../utils/api-client";
+import { apiFetch } from "../utils/api-client";
 
 interface Project {
 	id: string;
@@ -30,25 +30,19 @@ export default function ProjectNav({ workspaceSlug }: Props) {
 		const rawId = params.get("id") || params.get("projectId");
 		const rawProject = params.get("project");
 
-		const headers = buildHeaders(workspaceSlug);
-
 		const resolve = (p: Project) => {
 			setProject(p);
 			localStorage.setItem("projektor-last-project-id", p.id);
 		};
 
 		if (rawId) {
-			fetch(`/api/projects/${encodeURIComponent(rawId)}`, { credentials: "include", headers })
-				.then((r) => (r.ok ? r.json() : null))
-				.then((p) => {
-					if (p) resolve(p as Project);
-				})
+			apiFetch<Project>(`/api/projects/${encodeURIComponent(rawId)}`, { workspaceSlug })
+				.then((p) => resolve(p))
 				.catch(() => {});
 		} else if (rawProject) {
 			// ?project may be a key (e.g. "PROJ") or UUID; fetch list and find by either
-			fetch("/api/projects", { credentials: "include", headers: buildHeaders(workspaceSlug) })
-				.then((r) => (r.ok ? r.json() : []))
-				.then((list: Project[]) => {
+			apiFetch<Project[]>("/api/projects", { workspaceSlug })
+				.then((list) => {
 					if (Array.isArray(list)) {
 						const found = list.find((p) => p.key === rawProject || p.id === rawProject);
 						if (found) resolve(found);
@@ -59,25 +53,18 @@ export default function ProjectNav({ workspaceSlug }: Props) {
 			// No project param in URL — recover from localStorage, then fall back to first project
 			const storedId = localStorage.getItem("projektor-last-project-id");
 			if (storedId) {
-				fetch(`/api/projects/${encodeURIComponent(storedId)}`, { credentials: "include", headers })
-					.then((r) => (r.ok ? r.json() : null))
-					.then((p) => {
-						if (p) {
-							resolve(p as Project);
-						} else {
-							// Stored id is stale — fall back to first project
-							return fetch("/api/projects", { credentials: "include", headers })
-								.then((r) => (r.ok ? r.json() : []))
-								.then((list: Project[]) => {
-									if (Array.isArray(list) && list.length > 0) resolve(list[0]);
-								});
-						}
-					})
+				apiFetch<Project>(`/api/projects/${encodeURIComponent(storedId)}`, { workspaceSlug })
+					.then((p) => resolve(p))
+					.catch(() =>
+						// Stored id is stale (or the request failed) — fall back to first project
+						apiFetch<Project[]>("/api/projects", { workspaceSlug }).then((list) => {
+							if (Array.isArray(list) && list.length > 0) resolve(list[0]);
+						})
+					)
 					.catch(() => {});
 			} else {
-				fetch("/api/projects", { credentials: "include", headers })
-					.then((r) => (r.ok ? r.json() : []))
-					.then((list: Project[]) => {
+				apiFetch<Project[]>("/api/projects", { workspaceSlug })
+					.then((list) => {
 						if (Array.isArray(list) && list.length > 0) resolve(list[0]);
 					})
 					.catch(() => {});

--- a/apps/web/src/islands/ShareView.tsx
+++ b/apps/web/src/islands/ShareView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "preact/hooks";
+import { apiFetch } from "../utils/api-client";
 import { renderMd } from "../utils/markdown";
 
 interface SharedIssue {
@@ -51,17 +52,15 @@ export default function ShareView() {
 			return;
 		}
 		const token = m[1];
-		fetch(`/api/share/${token}`)
-			.then(async (res) => {
-				if (!res.ok) throw new Error(res.status === 404 ? "not_found" : "error");
-				return res.json() as Promise<SharedIssue>;
-			})
+		// Public/unauthenticated endpoint - apiFetch's credentials: "include" and
+		// missing workspace header are both no-ops here since /api/share is open.
+		apiFetch<SharedIssue>(`/api/share/${token}`)
 			.then((data) => {
 				setIssue(data);
 				setLoading(false);
 			})
 			.catch((e) => {
-				setError(String(e.message));
+				setError(String(e.message?.includes("404") ? "not_found" : "error"));
 				setLoading(false);
 			});
 	}, []);

--- a/apps/web/src/islands/SprintManager.tsx
+++ b/apps/web/src/islands/SprintManager.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "preact/hooks";
-import { apiFetch, buildHeaders } from "../utils/api-client";
+import { apiFetch } from "../utils/api-client";
 import { issueUrl } from "../utils/issue-url";
 
 interface Sprint {
@@ -262,20 +262,16 @@ export default function SprintManager({ workspaceSlug }: Props) {
 			setLoading(true);
 			setError(null);
 			try {
-				const headers = buildHeaders(workspaceSlug);
-				const [projRes, sprintRes] = await Promise.all([
-					fetch(`/api/projects/${pid}`, { credentials: "include", headers }),
-					fetch(`/api/sprints?projectId=${encodeURIComponent(pid)}`, {
-						credentials: "include",
-						headers,
-					}),
+				const [proj, sprintData] = await Promise.all([
+					apiFetch<Project>(`/api/projects/${pid}`, { workspaceSlug }),
+					apiFetch<{ items: Sprint[] }>(`/api/sprints?projectId=${encodeURIComponent(pid)}`, {
+						workspaceSlug,
+					}).catch(() => null),
 				]);
-				if (!projRes.ok) throw new Error(`Failed to load project (HTTP ${projRes.status})`);
-				setProject((await projRes.json()) as Project);
+				setProject(proj);
 
-				if (sprintRes.ok) {
-					const data = (await sprintRes.json()) as { items: Sprint[] };
-					setSprints(Array.isArray(data?.items) ? data.items : []);
+				if (sprintData) {
+					setSprints(Array.isArray(sprintData?.items) ? sprintData.items : []);
 				}
 			} catch (e) {
 				setError(String(e));

--- a/scripts/check-island-api.sh
+++ b/scripts/check-island-api.sh
@@ -19,7 +19,7 @@ while IFS= read -r match; do
   echo "ERROR: raw fetch() found in $file - use apiFetch from utils/api-client.ts instead"
   ERRORS=$((ERRORS + 1))
 done < <(grep -rn --include="*.ts" --include="*.tsx" \
-  -E "(=\s*fetch\(|await fetch\()" \
+  -E "[^a-zA-Z0-9_.]fetch\(" \
   "$ISLANDS_DIR")
 
 if [ "$ERRORS" -gt 0 ]; then


### PR DESCRIPTION
## Summary
- `scripts/check-island-api.sh` only matched `= fetch(` / `await fetch(`, missing bare `fetch(` calls (e.g. inside `Promise.all([...])` or `.then()` chains). Broadened the regex to `[^a-zA-Z0-9_.]fetch\(`, which catches any raw fetch call while still excluding `apiFetch(`.
- Converted the 5 offending islands to `apiFetch()`/`buildHeaders()` from `utils/api-client.ts`: `ProjectLanding.tsx`, `ProjectNav.tsx`, `SprintManager.tsx`, `ApiHealth.tsx`, `ShareView.tsx`.
- `ShareView.tsx` hits the public `/api/share/:token` endpoint (registered before auth middleware) — `apiFetch`'s `credentials: "include"` and missing workspace header are both no-ops there, so no exception was needed; converted directly with a comment explaining why.

## Test plan
- [x] `bash scripts/check-island-api.sh` fails before the fix (confirmed 12 raw-fetch errors across the 5 files), passes after conversion.
- [x] `pnpm --filter @projektor/web test` — 244/244 passing.
- [x] `pnpm turbo type-check` — 0 errors.
- [x] `pnpm --filter @projektor/api test` — 515/515 passing (1 unrelated rate-limit test flaked once, passed on immediate re-run and full re-run — not touched by this change).
- [x] pre-commit/pre-push hooks (island-api, lint, type-check, test, test-web) all green on push.

Coordinated via projektor MCP fleet protocol (register_agent/claim_files/post_message).