### PR TITLE
ci: add biome lint and web build gates (PROJ-230, PROJ-231)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,11 @@ jobs:
           pnpm --filter @projektor/api gen:catalog
           git diff --exit-code -- apps/docs/src/content/docs/agents/tool-catalog.md \
             || { echo "::error::MCP tool catalog is stale. Run 'pnpm --filter @projektor/api gen:catalog' and commit the result."; exit 1; }
+      - run: pnpm lint
       - run: pnpm turbo type-check
       - run: pnpm --filter @projektor/api test
       - run: pnpm --filter @projektor/web test
+      - run: pnpm --filter @projektor/web build
       - name: Island API convention
         run: bash scripts/check-island-api.sh
 # E2E tests: run manually with 'pnpm --filter @projektor/web test:e2e'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,16 +137,16 @@ curl -H "X-Bootstrap-Secret: localdev" http://127.0.0.1:8787/bootstrap
 Then open **http://localhost:4321** - with `DEV_USER_EMAIL` set, the dev auth bypass logs you in
 as that user (a member of the seeded `projektor` workspace), and the islands load real data.
 
-**Before opening a PR:** `pnpm turbo type-check` and `pnpm --filter @projektor/api test` must both be green. CI runs exactly these.
+**Before opening a PR:** `pnpm lint`, `pnpm turbo type-check`, `pnpm --filter @projektor/api test`, `pnpm --filter @projektor/web test`, and `pnpm --filter @projektor/web build` must all be green. CI runs exactly these.
 
 ## Git hooks (lefthook)
 
 `pnpm install` runs `prepare`, which calls `lefthook install` and wires two hooks:
 
-- **pre-commit** - `pnpm turbo type-check` (fast; leverages turbo's cache, near-instant on unchanged packages).
-- **pre-push** - `pnpm --filter @projektor/api test` (the ~8s vitest suite; too slow for every commit but catches the failures that most often break CI).
+- **pre-commit** - `pnpm turbo type-check` (fast; leverages turbo's cache, near-instant on unchanged packages), `pnpm biome check --changed --no-errors-on-unmatched` (lint, changed files only), and the island API convention check.
+- **pre-push** - `pnpm --filter @projektor/api test` and `pnpm --filter @projektor/web test` (too slow for every commit but catches the failures that most often break CI).
 
-These mirror CI (`.github/workflows/ci.yml`) exactly. New contributors get them automatically after `pnpm install`.
+These mirror CI (`.github/workflows/ci.yml`), which additionally runs `pnpm lint` (full repo) and `pnpm --filter @projektor/web build` as PR gates. New contributors get the hooks automatically after `pnpm install`.
 
 **Bypass for WIP commits/pushes:** pass `--no-verify` (or `-n`) to git:
 
@@ -266,10 +266,13 @@ own the same island file. Assign each island to exactly one agent per batch.
 builds the artifact and the config-only deploy repo (`projektor-workspace`) picks
 it up. See the [deploy guide](https://tajd.github.io/projektor/guides/deploying/).
 
-**CI commands** (must both pass before opening a PR):
+**CI commands** (must all pass before opening a PR):
 ```bash
+pnpm lint
 pnpm turbo type-check
 pnpm --filter @projektor/api test
+pnpm --filter @projektor/web test
+pnpm --filter @projektor/web build
 ```
 
 **Merge ordering rule:** if two agents both touch the same frontend file (e.g.

--- a/apps/web/src/islands/EpicList.test.tsx
+++ b/apps/web/src/islands/EpicList.test.tsx
@@ -148,7 +148,10 @@ describe("EpicList", () => {
 					});
 				}
 				if (u.includes("/api/issues")) {
-					return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [EPIC_ISSUE] }) });
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve({ items: [EPIC_ISSUE] }),
+					});
 				}
 				return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
 			})


### PR DESCRIPTION
## Summary
- PROJ-230: `pnpm lint` (biome) is defined but was never gated in CI — adds a lint step to ci.yml. No violations found, so no mechanical fix commit was needed — the gate starts green.
- PROJ-231: adds `pnpm --filter @projektor/web build` to ci.yml so Astro build breakage (config, content collections, build-only import errors) is caught on PRs instead of at release-tag time.
- Updated AGENTS.md's git hooks / CI docs, which were stale: lefthook pre-commit already runs `biome check --changed` (not documented before), and the "before opening a PR" / "CI commands" sections now list lint, both test suites, and the build.

## Notes
- lefthook.yml already had a `lint` pre-commit command wired up (`biome check --changed --no-errors-on-unmatched`) — that part of PROJ-230 was already done, just undocumented.
- turbo.json already caches the `build` task (`outputs: ["dist/**", ".wrangler/**"]`), so this stays fast on unchanged web code.
- release.yml calls ci.yml as a reusable workflow, so releases will double-build @projektor/web; acceptable per the ticket (correctness over speed).
- **This PR should merge LAST in the current batch.** It's the only agent touching `.github/workflows/ci.yml` this round, but other agents are lint-fixing claimed frontend files in parallel — expect a rebase before merge.
- Coordination via projektor MCP: registered agent, claimed `.github/workflows/ci.yml` / `lefthook.yml` / `AGENTS.md`, posted start message to the issue channel.

## Test plan
- [x] `pnpm lint` — clean, no violations
- [x] `pnpm turbo type-check` — 7/7 tasks pass (cached)
- [x] `pnpm --filter @projektor/api test` — 515 passed, 5 todo
- [x] `pnpm --filter @projektor/web test` — 244 passed
- [x] `pnpm --filter @projektor/web build` — succeeds, turbo cache confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHQavDjFGFaj3QKusAQg3u