### PR TITLE
fix(web): render mermaid diagrams in wiki markdown

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "astro": "^5.0.0",
     "dompurify": "^3.2.0",
     "marked": "^15.0.0",
+    "mermaid": "^11.0.0",
     "preact": "^10.25.0"
   },
   "devDependencies": {

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { slugify } from "../lib/slugify";
 import { apiFetch } from "../utils/api-client";
-import { renderMdWithWikilinks } from "../utils/markdown";
+import { renderMdWithWikilinks, renderMermaidDiagrams } from "../utils/markdown";
 import MarkdownEditor from "./MarkdownEditor";
 
 interface SearchResult {
@@ -321,6 +321,15 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 		);
 	}, [page?.content]);
 
+	// Hydrate ```mermaid code blocks into rendered diagrams
+	useEffect(() => {
+		const container = contentRef.current;
+		if (!container || !page) return;
+		renderMermaidDiagrams(container).catch(() => {
+			// non-fatal — leave the raw code block visible
+		});
+	}, [page?.content]);
+
 	// PROJ-113: IntersectionObserver for active heading
 	useEffect(() => {
 		if (toc.length < 3) return;
@@ -617,6 +626,8 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 				.wiki-link-broken { color: var(--text-muted); text-decoration: underline; text-decoration-style: dashed; text-underline-offset: 2px; }
 				.wiki-link-broken a { font-size: 0.8em; margin-left: 0.2em; color: var(--text-muted); text-decoration: none; border: 1px solid var(--border); border-radius: 3px; padding: 0 3px; }
 				.wiki-link-broken a:hover { color: var(--accent); border-color: var(--accent); }
+				.prose pre.mermaid { display: flex; justify-content: center; background: none; padding: 0; }
+				.prose pre.mermaid svg { max-width: 100%; width: auto; height: auto; }
 				@media (max-width: 640px) {
 					.wiki-breadcrumb button { max-width: 8rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 				}

--- a/apps/web/src/utils/markdown.test.ts
+++ b/apps/web/src/utils/markdown.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { renderMd } from "./markdown";
 
 describe("renderMd — XSS sanitization", () => {
@@ -64,5 +64,66 @@ describe("renderMd — legitimate markdown still renders", () => {
 		expect(html).toContain("<ul>");
 		expect(html).toContain("<li>one</li>");
 		expect(html).toContain("<li>two</li>");
+	});
+});
+
+describe("renderMd — mermaid code blocks", () => {
+	it('renders a ```mermaid fence as a <pre class="mermaid"> placeholder', () => {
+		const html = renderMd("```mermaid\ngraph TD\n    A --> B\n```");
+		expect(html).toContain('<pre class="mermaid">');
+		expect(html).toContain("graph TD");
+		expect(html).toContain("A --&gt; B");
+	});
+
+	it("does not treat other languages as mermaid", () => {
+		const html = renderMd("```js\nconst x = 1;\n```");
+		expect(html).not.toContain('class="mermaid"');
+		expect(html).toContain("<code");
+	});
+
+	it("survives DOMPurify sanitization intact", () => {
+		const html = renderMd("```mermaid\ngraph TD\n    A[<script>alert(1)</script>] --> B\n```");
+		expect(html).toContain('<pre class="mermaid">');
+		expect(html).not.toContain("<script");
+	});
+});
+
+describe("renderMermaidDiagrams", () => {
+	it("hydrates pre.mermaid nodes via mermaid.run", async () => {
+		const run = vi.fn().mockResolvedValue(undefined);
+		const initialize = vi.fn();
+		vi.doMock("mermaid", () => ({ default: { initialize, run } }));
+		vi.resetModules();
+		const { renderMermaidDiagrams: renderWithMock } = await import("./markdown");
+
+		const container = document.createElement("div");
+		container.innerHTML = '<pre class="mermaid">graph TD\nA --> B</pre>';
+		document.body.appendChild(container);
+
+		await renderWithMock(container);
+
+		expect(initialize).toHaveBeenCalled();
+		expect(run).toHaveBeenCalledWith({ nodes: expect.anything() });
+		expect(run.mock.calls[0][0].nodes).toHaveLength(1);
+
+		vi.doUnmock("mermaid");
+		vi.resetModules();
+	});
+
+	it("does nothing (no import) when there are no mermaid blocks", async () => {
+		const run = vi.fn();
+		vi.doMock("mermaid", () => ({ default: { initialize: vi.fn(), run } }));
+		vi.resetModules();
+		const { renderMermaidDiagrams: renderWithMock } = await import("./markdown");
+
+		const container = document.createElement("div");
+		container.innerHTML = "<p>no diagrams here</p>";
+
+		await renderWithMock(container);
+
+		expect(run).not.toHaveBeenCalled();
+
+		vi.doUnmock("mermaid");
+		vi.resetModules();
 	});
 });

--- a/apps/web/src/utils/markdown.ts
+++ b/apps/web/src/utils/markdown.ts
@@ -1,5 +1,21 @@
 import DOMPurify from "dompurify";
-import { marked } from "marked";
+import { marked, type Tokens } from "marked";
+
+function escapeHtml(s: string): string {
+	return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+// Fenced ```mermaid blocks render as a `<pre class="mermaid">` placeholder that
+// renderMermaidDiagrams() below hydrates into an SVG after the sanitized HTML
+// is mounted in the DOM (marked/DOMPurify have no notion of mermaid).
+const renderer = new marked.Renderer();
+const defaultCode = renderer.code.bind(renderer);
+renderer.code = (token: Tokens.Code) => {
+	if (token.lang === "mermaid") {
+		return `<pre class="mermaid">${escapeHtml(token.text)}</pre>`;
+	}
+	return defaultCode(token);
+};
 
 /**
  * Render untrusted markdown to sanitized HTML.
@@ -13,15 +29,23 @@ import { marked } from "marked";
  */
 export function renderMd(markdown: string): string {
 	if (typeof window === "undefined") return "";
-	return DOMPurify.sanitize(marked.parse(markdown) as string, {
+	return DOMPurify.sanitize(marked.parse(markdown, { renderer }) as string, {
 		USE_PROFILES: { html: true },
 	});
 }
 
 export const renderMarkdown = renderMd;
 
-function escapeHtml(s: string): string {
-	return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+/**
+ * Hydrate any `<pre class="mermaid">` placeholders inside `container` into
+ * rendered SVG diagrams. Call after the sanitized HTML has been mounted.
+ */
+export async function renderMermaidDiagrams(container: Element): Promise<void> {
+	const nodes = container.querySelectorAll<HTMLElement>("pre.mermaid");
+	if (nodes.length === 0) return;
+	const { default: mermaid } = await import("mermaid");
+	mermaid.initialize({ startOnLoad: false, theme: "neutral" });
+	await mermaid.run({ nodes });
 }
 
 function resolveWikilinks(
@@ -57,7 +81,7 @@ export function renderMdWithWikilinks(
 ): string {
 	if (typeof window === "undefined") return "";
 	const resolved = resolveWikilinks(markdown, pages);
-	return DOMPurify.sanitize(marked.parse(resolved) as string, {
+	return DOMPurify.sanitize(marked.parse(resolved, { renderer }) as string, {
 		USE_PROFILES: { html: true },
 	});
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       marked:
         specifier: ^15.0.0
         version: 15.0.12
+      mermaid:
+        specifier: ^11.0.0
+        version: 11.16.0
       preact:
         specifier: ^10.25.0
         version: 10.29.2


### PR DESCRIPTION
## Summary
- Fenced ` ```mermaid ` blocks in wiki (and issue/comment) markdown were never rendered as diagrams — there was no `mermaid` dependency or hydration path in `apps/web` at all, so they just showed up as plain code-block text.
- `marked` now tags mermaid-lang fences as `<pre class="mermaid">` placeholders (verified these survive DOMPurify sanitization unchanged); `renderMermaidDiagrams()` dynamically imports `mermaid` and hydrates those placeholders into SVG after the sanitized HTML mounts.
- Wired hydration into `WikiPage.tsx`'s content-render effect, and added CSS so the diagram renders centered at its natural size instead of stretching to fill the full content width.

## Test plan
- [x] `pnpm vitest run` in `apps/web` — 250 passed, including new coverage in `markdown.test.ts` for the mermaid-fence renderer and the hydration hook
- [x] `pnpm type-check` in `apps/web` — 0 errors
- [x] `pnpm biome check` on changed files — clean
- [x] Manually verified locally: ran `apps/api` (wrangler dev) + `apps/web` (astro dev), created a wiki page with a mermaid flowchart via the API, confirmed the diagram renders and is centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)