### PR TITLE
chore(web): bump version to 0.2.12 for release

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@projektor/web",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "private": true,
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
## Summary
- Bumps the web nav version ahead of cutting the v0.2.12 release, which includes the mermaid wiki-rendering fix (#31).

🤖 Generated with [Claude Code](https://claude.com/claude-code)