### PR TITLE
refactor(api): extract services/user-tokens.ts from routes/auth.ts (PROJ-233)

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,18 +1,10 @@
 import type { HonoEnv } from "@projektor/types";
 import { Hono } from "hono";
-import { z } from "zod";
-import { ScopeSchema } from "../auth/scopes";
+import { serviceErrToResponse } from "../http/error-adapter";
 import { authMiddleware } from "../middleware/auth";
+import { createUserToken, deleteUserToken, getUserWorkspaces } from "../services/user-tokens";
 
 const router = new Hono<HonoEnv>();
-
-const TokenSchema = z.object({
-	name: z.string().min(1).max(100),
-	// Optional: omit for a user-scoped token (works across all the user's workspaces)
-	workspaceId: z.string().uuid().optional(),
-	scopes: z.array(ScopeSchema).min(1),
-	expiresAt: z.number().int().positive().optional(),
-});
 
 router.get("/login", (c) => {
 	const redirectUrl = c.req.query("redirect_url") ?? "/";
@@ -24,74 +16,25 @@ router.get("/login", (c) => {
 
 router.get("/me", authMiddleware, async (c) => {
 	const user = c.get("user") as { id: string; email: string; name: string };
-
-	const { results: workspaces } = await c.env.DB.prepare(
-		`SELECT w.id, w.name, w.slug, wm.role
-     FROM workspaces w
-     JOIN workspace_members wm ON wm.workspace_id = w.id
-     WHERE wm.user_id = ?`
-	)
-		.bind(user.id)
-		.all();
-
+	const workspaces = await getUserWorkspaces({ db: c.env.DB, userId: user.id });
 	return c.json({ user, workspaces });
 });
 
 router.post("/tokens", authMiddleware, async (c) => {
 	const user = c.get("user") as { id: string };
-	const raw = await c.req.json();
-	const result = TokenSchema.safeParse(raw);
-	if (!result.success) return c.json({ error: result.error.flatten() }, 400);
-
-	const { name, workspaceId, scopes, expiresAt } = result.data;
-
-	// PROJ-17: when minting a workspace-scoped token, the caller must be a member
-	// of that workspace. Omitting workspaceId mints a user-scoped token (NULL in DB),
-	// which is valid across all workspaces the user is a member of.
-	if (workspaceId !== undefined) {
-		const member = await c.env.DB.prepare(
-			"SELECT 1 FROM workspace_members WHERE workspace_id = ? AND user_id = ?"
-		)
-			.bind(workspaceId, user.id)
-			.first();
-		if (!member) return c.json({ error: "Forbidden" }, 403);
+	try {
+		const result = await createUserToken({ db: c.env.DB, userId: user.id }, await c.req.json());
+		return c.json(result, 201);
+	} catch (e) {
+		return serviceErrToResponse(c, e);
 	}
-
-	const rawToken = crypto.randomUUID() + crypto.randomUUID();
-	const hash = await hashToken(rawToken);
-
-	await c.env.DB.prepare(
-		`INSERT INTO api_tokens (id, workspace_id, user_id, name, token_hash, scopes, expires_at, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
-	)
-		.bind(
-			crypto.randomUUID(),
-			workspaceId ?? null,
-			user.id,
-			name,
-			hash,
-			JSON.stringify(scopes),
-			expiresAt ?? null,
-			Math.floor(Date.now() / 1000)
-		)
-		.run();
-
-	return c.json({ token: rawToken }, 201);
 });
 
 router.delete("/tokens/:id", authMiddleware, async (c) => {
 	const user = c.get("user") as { id: string };
-	await c.env.DB.prepare("DELETE FROM api_tokens WHERE id = ? AND user_id = ?")
-		.bind(c.req.param("id"), user.id)
-		.run();
-	return c.json({ ok: true });
+	const id = c.req.param("id") ?? "";
+	const result = await deleteUserToken({ db: c.env.DB, userId: user.id }, id);
+	return c.json(result);
 });
-
-async function hashToken(token: string): Promise<string> {
-	const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(token));
-	return Array.from(new Uint8Array(buf))
-		.map((b) => b.toString(16).padStart(2, "0"))
-		.join("");
-}
 
 export { router as authRouter };

--- a/apps/api/src/schemas/user-tokens.ts
+++ b/apps/api/src/schemas/user-tokens.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+import { ScopeSchema } from "../auth/scopes";
+
+export const CreateUserTokenSchema = z.object({
+	name: z.string().min(1).max(100),
+	// Optional: omit for a user-scoped token (works across all the user's workspaces)
+	workspaceId: z.string().uuid().optional(),
+	scopes: z.array(ScopeSchema).min(1),
+	expiresAt: z.number().int().positive().optional(),
+});

--- a/apps/api/src/services/user-tokens.ts
+++ b/apps/api/src/services/user-tokens.ts
@@ -1,0 +1,77 @@
+import { CreateUserTokenSchema } from "../schemas/user-tokens";
+import { ForbiddenError, ValidationError } from "./errors";
+
+// These handlers run pre-workspace-context (login/token minting are user-scoped,
+// not workspace-scoped), so they take a narrower ctx than ServiceCtx.
+export interface UserCtx {
+	db: D1Database;
+	userId: string;
+}
+
+async function hashToken(token: string): Promise<string> {
+	const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(token));
+	return Array.from(new Uint8Array(buf))
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("");
+}
+
+export async function getUserWorkspaces(ctx: UserCtx) {
+	const { results } = await ctx.db
+		.prepare(
+			`SELECT w.id, w.name, w.slug, wm.role
+     FROM workspaces w
+     JOIN workspace_members wm ON wm.workspace_id = w.id
+     WHERE wm.user_id = ?`
+		)
+		.bind(ctx.userId)
+		.all();
+	return results;
+}
+
+export async function createUserToken(ctx: UserCtx, raw: unknown) {
+	const result = CreateUserTokenSchema.safeParse(raw);
+	if (!result.success) throw new ValidationError(result.error.flatten());
+
+	const { name, workspaceId, scopes, expiresAt } = result.data;
+
+	// PROJ-17: when minting a workspace-scoped token, the caller must be a member
+	// of that workspace. Omitting workspaceId mints a user-scoped token (NULL in DB),
+	// which is valid across all workspaces the user is a member of.
+	if (workspaceId !== undefined) {
+		const member = await ctx.db
+			.prepare("SELECT 1 FROM workspace_members WHERE workspace_id = ? AND user_id = ?")
+			.bind(workspaceId, ctx.userId)
+			.first();
+		if (!member) throw new ForbiddenError();
+	}
+
+	const rawToken = crypto.randomUUID() + crypto.randomUUID();
+	const hash = await hashToken(rawToken);
+
+	await ctx.db
+		.prepare(
+			`INSERT INTO api_tokens (id, workspace_id, user_id, name, token_hash, scopes, expires_at, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+		)
+		.bind(
+			crypto.randomUUID(),
+			workspaceId ?? null,
+			ctx.userId,
+			name,
+			hash,
+			JSON.stringify(scopes),
+			expiresAt ?? null,
+			Math.floor(Date.now() / 1000)
+		)
+		.run();
+
+	return { token: rawToken };
+}
+
+export async function deleteUserToken(ctx: UserCtx, id: string) {
+	await ctx.db
+		.prepare("DELETE FROM api_tokens WHERE id = ? AND user_id = ?")
+		.bind(id, ctx.userId)
+		.run();
+	return { ok: true };
+}


### PR DESCRIPTION
## Summary
- Moves the raw SQL for `/auth/me`, `POST /auth/tokens`, and `DELETE /auth/tokens/:id` out of `routes/auth.ts` into a new `services/user-tokens.ts`, matching the service-layer contract in AGENTS.md.
- Adds `schemas/user-tokens.ts` (Zod schema, reusing `ScopeSchema`) as the single source of truth for token-minting validation.
- Routes are now thin wrappers: build a narrow `UserCtx` (`{ db, userId }`) since these handlers run pre-workspace-context, call the service, and adapt errors via `http/error-adapter.ts`.
- Behaviour-preserving: SHA-256 token hashing, workspace-membership check, response shapes (`{ token }`, `{ ok: true }`), and status codes (400/403/201/200) are unchanged.
- Confirmed AGENTS.md already documents the deliberate REST-only parity exception for auth token minting/revocation (added in PROJ-236) — no MCP tools added, per the ticket's instruction.
- `apps/api/src/test/user-tokens.test.ts` already covers user-scoped token behavior via HTTP; `auth.test.ts` (token CRUD + auth middleware) still passes unmodified.

## Test plan
- [x] `pnpm turbo type-check`
- [x] `pnpm --filter @projektor/api test` (515 passed)
- [x] `pnpm lint` (biome check, clean)
- [x] `pnpm --filter @projektor/web test` (250 passed, after `pnpm install` to pick up an unrelated dependency added by a rebased main commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011taWxA5HVMF6M3H6QxzjPM