### PR TITLE
fix(web,api): stop serving stale cached issue data

### DIFF
--- a/apps/api/src/services/issue-links.ts
+++ b/apps/api/src/services/issue-links.ts
@@ -5,6 +5,7 @@ import {
 	DeleteIssueLinkSchema,
 	ListIssueLinksSchema,
 } from "../schemas/issues";
+import * as cache from "./cache";
 import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from "./errors";
 import { inChunks } from "./sql";
 import type { ServiceCtx } from "./types";
@@ -102,6 +103,9 @@ export async function createLink(ctx: ServiceCtx, raw: unknown) {
 		createdAt: now,
 	});
 
+	await cache.invalidate(ctx.kv, `issue:${ctx.workspaceId}:${canon.source}`);
+	await cache.invalidate(ctx.kv, `issue:${ctx.workspaceId}:${canon.target}`);
+
 	return { id };
 }
 
@@ -113,7 +117,11 @@ export async function deleteLink(ctx: ServiceCtx, raw: unknown) {
 
 	const orm = drizzle(ctx.db, { schema });
 	const existing = await orm
-		.select({ id: schema.issueLinks.id })
+		.select({
+			id: schema.issueLinks.id,
+			sourceIssueId: schema.issueLinks.sourceIssueId,
+			targetIssueId: schema.issueLinks.targetIssueId,
+		})
 		.from(schema.issueLinks)
 		.where(and(eq(schema.issueLinks.id, id), eq(schema.issueLinks.workspaceId, ctx.workspaceId)))
 		.get();
@@ -122,6 +130,9 @@ export async function deleteLink(ctx: ServiceCtx, raw: unknown) {
 	await orm
 		.delete(schema.issueLinks)
 		.where(and(eq(schema.issueLinks.id, id), eq(schema.issueLinks.workspaceId, ctx.workspaceId)));
+
+	await cache.invalidate(ctx.kv, `issue:${ctx.workspaceId}:${existing.sourceIssueId}`);
+	await cache.invalidate(ctx.kv, `issue:${ctx.workspaceId}:${existing.targetIssueId}`);
 
 	return { ok: true };
 }

--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -20,10 +20,7 @@ export default defineConfig({
         runtimeCaching: [
           {
             urlPattern: /^\/(?:api|mcp)\//,
-            handler: 'NetworkFirst',
-            options: {
-              cacheName: 'api-cache',
-            },
+            handler: 'NetworkOnly',
           },
         ],
       },

--- a/apps/web/src/islands/IssueList.tsx
+++ b/apps/web/src/islands/IssueList.tsx
@@ -102,6 +102,9 @@ export default function IssueList({ workspaceSlug }: Props) {
 	const [epics, setEpics] = useState<Issue[]>([]);
 	const [loading, setLoading] = useState(true);
 	const hasLoadedOnce = useRef(false);
+	// Guards against out-of-order responses when filters change rapidly: only the
+	// response from the most recently issued fetchIssues call is applied.
+	const fetchSeq = useRef(0);
 	const [error, setError] = useState<string | null>(null);
 
 	// Pagination (PROJ-201): list view loads 30 at a time and appends via "Load more".
@@ -235,6 +238,7 @@ export default function IssueList({ workspaceSlug }: Props) {
 	const pageSize = view === "list" ? 30 : 100;
 
 	const fetchIssues = useCallback(async () => {
+		const seq = ++fetchSeq.current;
 		setLoading(true);
 		setError(null);
 		try {
@@ -244,13 +248,15 @@ export default function IssueList({ workspaceSlug }: Props) {
 				`/api/issues?${qs.toString()}`,
 				{ workspaceSlug }
 			);
+			if (seq !== fetchSeq.current) return; // superseded by a newer request
 			setIssues(data.items);
 			setNextCursor(data.nextCursor ?? null);
 			hasLoadedOnce.current = true;
 		} catch (e) {
+			if (seq !== fetchSeq.current) return;
 			setError(String(e));
 		} finally {
-			setLoading(false);
+			if (seq === fetchSeq.current) setLoading(false);
 		}
 	}, [workspaceSlug, buildFilterParams, pageSize]);
 


### PR DESCRIPTION
## Summary
- Service worker cached `/api` and `/mcp` GET responses with `NetworkFirst` and no expiration, so a single dropped request could leave a stale issue list cached indefinitely — switched to `NetworkOnly`.
- `createLink`/`deleteLink` never invalidated the per-issue KV cache, so a linked issue's `links` array could be stale for up to 5 minutes.
- `IssueList`'s `fetchIssues` had no protection against out-of-order responses when filters changed rapidly; an older in-flight request could overwrite a newer one. Guarded with a request sequence number.

## Test plan
- [x] `pnpm --filter @projektor/api type-check`
- [x] `pnpm --filter @projektor/web type-check`
- [x] `pnpm --filter @projektor/api test` (full suite, 515 passed)
- [x] `pnpm --filter @projektor/web build` (service worker generates cleanly with `NetworkOnly`)
- [x] `pnpm biome check` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDv995qNAs5atxvwQikVm2