### PR TITLE
ci: automate release cutting (bump PR + tag-on-merge)

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -13,18 +13,19 @@ on:
         options: [patch, minor, major]
         default: patch
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   prepare:
     name: Bump version and open PR
     runs-on: ubuntu-latest
     steps:
+      # A PR opened with the default GITHUB_TOKEN doesn't trigger ci.yml's
+      # `pull_request` gate (GitHub suppresses that to avoid recursive runs),
+      # so the bump PR would sit with no CI status. Use WORKSPACE_PAT instead
+      # (same one release-tag.yml and release.yml's dispatch step use).
       - uses: actions/checkout@v4
         with:
           ref: main
+          token: ${{ secrets.WORKSPACE_PAT }}
 
       - name: Bump version
         id: bump
@@ -35,7 +36,7 @@ jobs:
 
       - name: Open release PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.WORKSPACE_PAT }}
         run: |
           VERSION="${{ steps.bump.outputs.version }}"
           BRANCH="chore/release-v$VERSION"

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,53 @@
+name: Prepare release
+
+# Manually triggered: bumps apps/web/package.json (the nav version) and opens a PR.
+# main is ruleset-protected (PR + passing CI required), so this can't commit directly
+# to main. Once the PR merges, release-tag.yml tags it, which fires release.yml.
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options: [patch, minor, major]
+        default: patch
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    name: Bump version and open PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Bump version
+        id: bump
+        working-directory: apps/web
+        run: |
+          NEW_VERSION=$(npm version "${{ inputs.bump }}" --no-git-tag-version | sed 's/^v//')
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Open release PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.bump.outputs.version }}"
+          BRANCH="chore/release-v$VERSION"
+          git checkout -b "$BRANCH"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add apps/web/package.json
+          git commit -m "chore(web): bump version to $VERSION for release"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "chore(web): bump version to $VERSION for release" \
+            --body "Automated version bump ahead of cutting v$VERSION. Merging this will trigger release-tag.yml to tag and publish the release." \
+            --label release \
+            --base main \
+            --head "$BRANCH"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,42 @@
+name: Tag release
+
+# Fires when a release-prepare PR (labeled "release") merges to main. Reads the
+# now-merged apps/web/package.json version, tags it, and pushes the tag — which
+# triggers release.yml (CI gate, build artifact, GitHub Release).
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create and push release tag
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Determine version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./apps/web/package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Tag and push
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q "$TAG"; then
+            echo "::error::Tag $TAG already exists — skipping to avoid re-triggering release.yml."
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git push origin "$TAG"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -8,18 +8,20 @@ on:
     types: [closed]
     branches: [main]
 
-permissions:
-  contents: write
-
 jobs:
   tag:
     name: Create and push release tag
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     steps:
+      # Tags pushed with the default GITHUB_TOKEN don't trigger other workflows
+      # (GitHub suppresses that to avoid runaway loops), so release.yml's
+      # `on: push: tags: ['v*']` would never fire. Use the same WORKSPACE_PAT
+      # release.yml already relies on for its cross-repo dispatch step.
       - uses: actions/checkout@v4
         with:
           ref: main
+          token: ${{ secrets.WORKSPACE_PAT }}
 
       - name: Determine version
         id: version
@@ -28,8 +30,6 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Tag and push
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           TAG="v${{ steps.version.outputs.version }}"
           if git ls-remote --tags origin "refs/tags/$TAG" | grep -q "$TAG"; then


### PR DESCRIPTION
## Summary
- Adds `release-prepare.yml`: manual `workflow_dispatch` (choose patch/minor/major) that bumps `apps/web/package.json` and opens a PR labeled `release`.
- Adds `release-tag.yml`: fires when a `release`-labeled PR merges to `main`; reads the merged version, tags it (`vX.Y.Z`), and pushes the tag — which triggers the existing `release.yml` (CI gate → build artifact → GitHub Release).
- Created the `release` label used to identify these PRs.

`main` stays PR-protected throughout: the workflow can't push directly to `main` (ruleset requires a PR + passing CI), so it opens a PR like a human would. Only the tag push itself skips a PR, since tags aren't covered by the branch ruleset.

## Test plan
- [ ] Run `Prepare release` via Actions → workflow_dispatch with `bump: patch`, confirm it opens a PR bumping the version and labeled `release`
- [ ] Merge that PR, confirm `release-tag.yml` fires and pushes the matching tag
- [ ] Confirm `release.yml` then runs CI + publishes the GitHub Release from that tag
- [ ] Confirm re-running `release-tag.yml` against an existing tag fails loudly instead of silently no-oping

🤖 Generated with [Claude Code](https://claude.com/claude-code)