### PR TITLE
ci: drop push-to-main trigger, keep pull_request as the sole gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   # Allow other workflows (e.g. release.yml) to run these exact checks as a gate.


### PR DESCRIPTION
## Summary
- `ci.yml` ran on both `pull_request` and `push: branches: [main]`. Since merges are squash-merged fast-forwards of already-verified PR code, the push trigger re-ran the identical suite a second time on every merge — a double-run with no new coverage.
- Removed the `push` trigger; `pull_request` remains as the required status check, and `workflow_call` still lets `release.yml` reuse the same job as a gate.

Trade-off: this drops the safety net for the rare case of an admin bypassing the PR ruleset and pushing directly to main. Accepted per discussion — the ruleset already blocks non-admin direct pushes, so this case shouldn't come up in normal flow.

## Test plan
- [x] `pnpm vitest run` — 250 passed
- [ ] After merge, confirm only one CI run appears (the PR's), not a second one on the resulting main push

🤖 Generated with [Claude Code](https://claude.com/claude-code)