### PR TITLE
fix(web): populate wiki editor from saved content when a stale draft exists

### DIFF
--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -421,21 +421,19 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 		if (!page) return;
 		setSaveError(null);
 		setDraftBanner(null);
+		setEditTitle(page.title);
+		setEditContent(page.content);
 		try {
 			const raw = localStorage.getItem(draftKey(page.id));
 			if (raw) {
 				const draft = JSON.parse(raw);
 				if (draft && typeof draft.savedAt === "number" && draft.savedAt > page.updated_at * 1000) {
 					setDraftBanner(draft);
-					setEditing(true);
-					return;
 				}
 			}
 		} catch {
 			// non-fatal — treat as no draft
 		}
-		setEditTitle(page.title);
-		setEditContent(page.content);
 		setEditing(true);
 	}
 


### PR DESCRIPTION
## Summary
- `startEdit()` in `WikiPage.tsx` returned early whenever a newer localStorage draft existed for the page, skipping the `setEditTitle`/`setEditContent` calls that seed the editor from the saved page.
- Result: opening **Edit** on a wiki page with a stale/newer autosaved draft showed a completely blank title and content, with only a small "Restore unsaved draft?" banner as a clue — easy to mistake for the page crashing / losing content while typing.
- Fix: always seed `editTitle`/`editContent` from `page` first, then layer the draft-restore banner on top so Restore/Discard both behave correctly against a populated baseline.

## Test plan
- [x] `pnpm vitest run src/islands/WikiPage.test.tsx` — 12/12 passing
- [x] Full `test` + `test-web` suites passing (ran via pre-push hook)
- [x] Manually reproduced in a local dev instance (astro dev + wrangler dev): planted a stale draft in localStorage, confirmed editor opened blank before the fix, and now opens populated with the saved content plus the restore banner after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWnhDPe1iMvA3BCvXHetRD