### PR TITLE
fix(api): include project_key/project_name in single-issue GET response (PROJ-226)

### DIFF
--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -301,6 +301,8 @@ export async function getIssue(ctx: ServiceCtx, raw: unknown) {
 		created_at: schema.issues.createdAt,
 		updated_at: schema.issues.updatedAt,
 		completed_at: schema.issues.completedAt,
+		project_key: schema.projects.key,
+		project_name: schema.projects.name,
 		type_key: schema.taskTypes.key,
 		type_name: schema.taskTypes.name,
 		status_key: schema.taskStatuses.key,
@@ -314,6 +316,7 @@ export async function getIssue(ctx: ServiceCtx, raw: unknown) {
 			(await orm
 				.select(issueColumns)
 				.from(schema.issues)
+				.leftJoin(schema.projects, eq(schema.issues.projectId, schema.projects.id))
 				.leftJoin(schema.taskTypes, eq(schema.issues.typeId, schema.taskTypes.id))
 				.leftJoin(schema.taskStatuses, eq(schema.issues.statusId, schema.taskStatuses.id))
 				.where(and(eq(schema.issues.id, id), eq(schema.issues.workspaceId, ctx.workspaceId)))

--- a/apps/api/src/services/share.ts
+++ b/apps/api/src/services/share.ts
@@ -1,6 +1,13 @@
 import { NotFoundError } from "./errors";
 import type { ServiceCtx } from "./types";
 
+async function hashToken(token: string): Promise<string> {
+	const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(token));
+	return Array.from(new Uint8Array(buf))
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("");
+}
+
 export async function createShareToken(
 	ctx: ServiceCtx,
 	issueId: string
@@ -18,11 +25,13 @@ export async function createShareToken(
 	const token = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 	const expiresAt = now + 3 * 86400;
 
+	// share_tokens.id stores sha256(token), never the raw token — see PROJ-239
+	const id = await hashToken(token);
 	await ctx.db
 		.prepare(
 			"INSERT INTO share_tokens (id, issue_id, workspace_id, created_by, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?)"
 		)
-		.bind(token, issueId, ctx.workspaceId, ctx.userId, expiresAt, now)
+		.bind(id, issueId, ctx.workspaceId, ctx.userId, expiresAt, now)
 		.run();
 
 	return { token, url: `/share/${token}` };
@@ -33,10 +42,11 @@ export async function getShareToken(
 	token: string
 ): Promise<{ issue_id: string; workspace_id: string }> {
 	const now = Math.floor(Date.now() / 1000);
+	const id = await hashToken(token);
 
 	const row = await db
 		.prepare("SELECT issue_id, workspace_id, expires_at FROM share_tokens WHERE id = ?")
-		.bind(token)
+		.bind(id)
 		.first<{ issue_id: string; workspace_id: string; expires_at: number }>();
 
 	if (!row || row.expires_at <= now) throw new NotFoundError("Share link not found or expired");
@@ -66,6 +76,7 @@ export async function getSharedIssue(
 	}
 > {
 	const now = Math.floor(Date.now() / 1000);
+	const id = await hashToken(token);
 
 	const row = await db
 		.prepare(
@@ -82,14 +93,14 @@ export async function getSharedIssue(
       LEFT JOIN users u ON u.id = i.assignee_id
       WHERE st.id = ? AND st.expires_at > ?`
 		)
-		.bind(token, now)
+		.bind(id, now)
 		.first<SharedIssueRow>();
 
 	if (!row) throw new NotFoundError("Share link not found or expired");
 
 	const tokenMeta = await db
 		.prepare("SELECT issue_id FROM share_tokens WHERE id = ?")
-		.bind(token)
+		.bind(id)
 		.first<{ issue_id: string }>();
 
 	if (!tokenMeta) throw new NotFoundError("Share link not found or expired");

--- a/apps/api/src/test/helpers.ts
+++ b/apps/api/src/test/helpers.ts
@@ -1,6 +1,6 @@
 import { env } from "cloudflare:test";
 
-async function hashToken(token: string): Promise<string> {
+export async function hashToken(token: string): Promise<string> {
 	const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(token));
 	return Array.from(new Uint8Array(buf))
 		.map((b) => b.toString(16).padStart(2, "0"))

--- a/apps/api/src/test/issues.test.ts
+++ b/apps/api/src/test/issues.test.ts
@@ -369,8 +369,20 @@ describe("Issues API", () => {
 			headers: authHeaders(token, slug),
 		});
 		expect(getRes.status).toBe(200);
-		const issue = (await getRes.json()) as { title: string };
+		const issue = (await getRes.json()) as { title: string; project_key: string };
 		expect(issue.title).toBe("Ref issue");
+		expect(issue.project_key).toBe("PROJ");
+	});
+
+	it("GET /api/issues/:id includes project_key (PROJ-226 tab title regression)", async () => {
+		const created = await seedIssue(workspaceId, projectId, userId, { title: "By id" });
+
+		const getRes = await SELF.fetch(`http://localhost/api/issues/${created.id}`, {
+			headers: authHeaders(token, slug),
+		});
+		expect(getRes.status).toBe(200);
+		const issue = (await getRes.json()) as { project_key: string };
+		expect(issue.project_key).toBe("PROJ");
 	});
 
 	it("GET /api/issues/search finds issues by title keyword", async () => {

--- a/apps/api/src/test/share.test.ts
+++ b/apps/api/src/test/share.test.ts
@@ -1,6 +1,6 @@
 import { SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
-import { authHeaders, seedFixture, seedIssue, seedProject } from "./helpers";
+import { authHeaders, hashToken, seedFixture, seedIssue, seedProject } from "./helpers";
 
 describe("Share tokens", () => {
 	let token: string;
@@ -58,11 +58,27 @@ describe("Share tokens", () => {
 		await env.DB.prepare(
 			"INSERT INTO share_tokens (id, issue_id, workspace_id, created_by, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?)"
 		)
-			.bind(expiredToken, issueId, workspaceId, userId, now - 1, now - 86400)
+			.bind(await hashToken(expiredToken), issueId, workspaceId, userId, now - 1, now - 86400)
 			.run();
 
 		const res = await SELF.fetch(`http://localhost/api/share/${expiredToken}`);
 		expect(res.status).toBe(404);
+	});
+
+	it("stores the share token hashed, not in plaintext, in D1", async () => {
+		const createRes = await SELF.fetch(`http://localhost/api/issues/${issueId}/share`, {
+			method: "POST",
+			headers: authHeaders(token, slug),
+		});
+		const { token: shareToken } = (await createRes.json()) as { token: string; url: string };
+
+		const { env } = await import("cloudflare:test");
+		const row = await env.DB.prepare("SELECT id FROM share_tokens WHERE issue_id = ?")
+			.bind(issueId)
+			.first<{ id: string }>();
+
+		expect(row?.id).not.toBe(shareToken);
+		expect(row?.id).toBe(await hashToken(shareToken));
 	});
 
 	it("GET /api/share/<unknown-token> returns 404", async () => {

--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -23,7 +23,6 @@ const navItems = [
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#6366f1" />
     <link rel="apple-touch-icon" href="/icon-192.png" />
     <title>{title}</title>


### PR DESCRIPTION
## Summary
- `getIssue()` (backing `GET /api/issues/:id` and `GET /api/issues/KEY-NUMBER`) never selected `project_key`/`project_name`, unlike the list endpoint.
- `IssueDetail.tsx`'s tab-title effect gates on `issue.project_key`, so the deployed browser tab title never updated to `<REF> - <Title>` on issue pages — it stayed stuck at the static `"Issue — Projektor"`.
- Adds `project_key`/`project_name` to the shared `issueColumns` select and a `leftJoin(schema.projects, ...)` on the by-id lookup path (the by-ref path already joined `projects`).
- Also bundles two prior local commits that hadn't made it past the main-branch ruleset yet: the share-token hashing fix (PROJ-239) and the manifest/CORS console-error fix.

## Test plan
- [x] `pnpm --filter @projektor/api test` — 517 passed (added a regression test asserting `project_key` on both by-id and by-ref lookups)
- [x] `pnpm --filter @projektor/api exec tsc --noEmit` — clean
- [x] Verified live on `projektor.tajdickson.workers.dev` that `document.title` doesn't update on issue pages, confirming this reproduces the bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFvEMc8eTEwDe1oSRCkURb