### PR TITLE
fix: tab title shows project name, whole ref chip copies link (PROJ-277)

### DIFF
--- a/apps/web/src/islands/IssueDetailParts.tsx
+++ b/apps/web/src/islands/IssueDetailParts.tsx
@@ -74,49 +74,46 @@ export function RefChip({ issueRef, copyUrl }: { issueRef: string; copyUrl: stri
 	}
 
 	return (
-		<span
+		<button
+			type="button"
+			onClick={copyLink}
+			title={copiedRef ? "Copied!" : "Copy link"}
 			class="font-mono text-xs font-semibold px-2 py-[0.2rem] rounded bg-surface border
-				border-border text-text-muted inline-flex items-center gap-1.5"
+				border-border text-text-muted inline-flex items-center gap-1.5 cursor-pointer
+				hover:text-text-base transition-colors"
 		>
 			{issueRef}
-			<button
-				type="button"
-				onClick={copyLink}
-				title={copiedRef ? "Copied!" : "Copy link"}
-				class="text-text-muted hover:text-text-base transition-colors leading-none"
-			>
-				{copiedRef ? (
-					<svg
-						width="12"
-						height="12"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2.5"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<title>Copied</title>
-						<polyline points="20 6 9 17 4 12" />
-					</svg>
-				) : (
-					<svg
-						width="12"
-						height="12"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<title>Copy</title>
-						<rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-						<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-					</svg>
-				)}
-			</button>
-		</span>
+			{copiedRef ? (
+				<svg
+					width="12"
+					height="12"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2.5"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				>
+					<title>Copied</title>
+					<polyline points="20 6 9 17 4 12" />
+				</svg>
+			) : (
+				<svg
+					width="12"
+					height="12"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				>
+					<title>Copy</title>
+					<rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+					<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+				</svg>
+			)}
+		</button>
 	);
 }
 

--- a/apps/web/src/islands/ProjectNav.test.tsx
+++ b/apps/web/src/islands/ProjectNav.test.tsx
@@ -46,4 +46,21 @@ describe("ProjectNav", () => {
 		const wikiTab = screen.getByRole("link", { name: "Wiki" });
 		expect(wikiTab.getAttribute("aria-current")).toBeNull();
 	});
+
+	it("sets the document title to '<pageLabel> — <project name>' once resolved", async () => {
+		window.history.pushState({}, "", "/epics?id=p1");
+		mockFetchProject(PROJECT);
+		render(<ProjectNav pageLabel="Epics" />);
+		await screen.findByText("Projektor");
+		expect(document.title).toBe("Epics — Projektor");
+	});
+
+	it("leaves the document title untouched when no pageLabel is given", async () => {
+		document.title = "unchanged";
+		window.history.pushState({}, "", "/issues?id=p1");
+		mockFetchProject(PROJECT);
+		render(<ProjectNav />);
+		await screen.findByText("Projektor");
+		expect(document.title).toBe("unchanged");
+	});
 });

--- a/apps/web/src/islands/ProjectNav.tsx
+++ b/apps/web/src/islands/ProjectNav.tsx
@@ -9,6 +9,7 @@ interface Project {
 
 interface Props {
 	workspaceSlug?: string;
+	pageLabel?: string;
 }
 
 const TABS = [
@@ -35,7 +36,7 @@ function tabClass(active: boolean): string {
 	}`;
 }
 
-export default function ProjectNav({ workspaceSlug }: Props) {
+export default function ProjectNav({ workspaceSlug, pageLabel }: Props) {
 	const [project, setProject] = useState<Project | null>(null);
 	const [activePath, setActivePath] = useState("");
 
@@ -49,6 +50,7 @@ export default function ProjectNav({ workspaceSlug }: Props) {
 		const resolve = (p: Project) => {
 			setProject(p);
 			localStorage.setItem("projektor-last-project-id", p.id);
+			if (pageLabel) document.title = `${pageLabel} — ${p.name}`;
 		};
 
 		if (rawId) {

--- a/apps/web/src/pages/epics.astro
+++ b/apps/web/src/pages/epics.astro
@@ -6,7 +6,7 @@ import EpicList from '../islands/EpicList';
 const workspaceSlug = import.meta.env.PUBLIC_WORKSPACE_SLUG as string | undefined;
 ---
 <Base title="Epics — Projektor">
-  <ProjectNav client:load workspaceSlug={workspaceSlug} />
+  <ProjectNav client:load workspaceSlug={workspaceSlug} pageLabel="Epics" />
   <div class="page-container">
     <header style="margin-bottom: 1.5rem;">
       <h1 style="margin: 0; font-size: 1.5rem; font-weight: 700; color: var(--text);">Epics</h1>

--- a/apps/web/src/pages/issues.astro
+++ b/apps/web/src/pages/issues.astro
@@ -6,7 +6,7 @@ import IssueList from '../islands/IssueList';
 const workspaceSlug = import.meta.env.PUBLIC_WORKSPACE_SLUG as string | undefined;
 ---
 <Base title="Issues — Projektor">
-  <ProjectNav client:load workspaceSlug={workspaceSlug} />
+  <ProjectNav client:load workspaceSlug={workspaceSlug} pageLabel="Issues" />
   <div class="page-container">
     <IssueList client:load workspaceSlug={workspaceSlug} />
   </div>

--- a/apps/web/src/pages/projects/view.astro
+++ b/apps/web/src/pages/projects/view.astro
@@ -6,7 +6,7 @@ import ProjectLanding from '../../islands/ProjectLanding';
 const workspaceSlug = import.meta.env.PUBLIC_WORKSPACE_SLUG as string | undefined;
 ---
 <Base title="Project — Projektor">
-  <ProjectNav client:load workspaceSlug={workspaceSlug} />
+  <ProjectNav client:load workspaceSlug={workspaceSlug} pageLabel="Overview" />
   <div class="page-container">
     <ProjectLanding client:load workspaceSlug={workspaceSlug} />
   </div>

--- a/apps/web/src/pages/sprints.astro
+++ b/apps/web/src/pages/sprints.astro
@@ -6,7 +6,7 @@ import SprintManager from '../islands/SprintManager';
 const workspaceSlug = import.meta.env.PUBLIC_WORKSPACE_SLUG as string | undefined;
 ---
 <Base title="Sprints — Projektor">
-  <ProjectNav client:load workspaceSlug={workspaceSlug} />
+  <ProjectNav client:load workspaceSlug={workspaceSlug} pageLabel="Sprints" />
   <div class="page-container">
     <SprintManager client:load workspaceSlug={workspaceSlug} />
   </div>

--- a/apps/web/src/pages/wiki.astro
+++ b/apps/web/src/pages/wiki.astro
@@ -6,6 +6,6 @@ import WikiPage from '../islands/WikiPage';
 const workspaceSlug = import.meta.env.PUBLIC_WORKSPACE_SLUG as string | undefined;
 ---
 <Base title="Wiki — Projektor">
-  <ProjectNav client:load workspaceSlug={workspaceSlug} />
+  <ProjectNav client:load workspaceSlug={workspaceSlug} pageLabel="Wiki" />
   <WikiPage client:load workspaceSlug={workspaceSlug} />
 </Base>


### PR DESCRIPTION
## Summary
- Browser tab title on project-scoped pages (Epics, Issues, Sprints, Wiki, Overview) now shows the active project's name (e.g. "Epics — Cofferdam") instead of a generic "— Projektor" suffix. `ProjectNav` gains a `pageLabel` prop and sets `document.title` once the project resolves client-side.
- The issue ref chip's whole button (not just the small copy icon) now copies the issue link when clicked, widening the click target.

Closes PROJ-277.

## Test plan
- [x] `pnpm run test` in `apps/web` — 252 tests pass, including new ProjectNav title-setting tests
- [x] `pnpm run type-check` — 0 errors
- [x] `pnpm biome check` on touched files — clean
- [x] pre-push hook (lint + full api/web suites) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNTmhAixQKXSrET7KP9go2