### PR TITLE
Docs: one-step deploy callout + splash-page nav (PROJ-281, PROJ-282)

### DIFF
--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -38,3 +38,18 @@ import backlogScreenshot from '../../assets/backlog.png';
     Projektor's own roadmap is tracked inside Projektor. The docs you're reading are generated from the same repo.
   </Card>
 </CardGrid>
+
+## One-step deploy
+
+Clone the [deploy repo](https://github.com/TAJD/projektor-deploy-example) and run the
+zero-config script - wrangler auto-provisions D1, KV, and R2, applies migrations, and deploys:
+
+```bash
+PROJEKTOR_REPO=you/projektor ADMIN_EMAILS=you@example.com ./deploy-auto.sh
+```
+
+Or hand the repo to an AI agent - *"deploy projektor to my Cloudflare account"* - and let it
+run the same flow. Full walkthrough: [self-hosting guide](/projektor/guides/self-hosting/).
+
+Curious why Projektor looks like this? Read [where Projektor fits](/projektor/philosophy/where-projektor-fits/)
+in the agentic dev-tools stack.


### PR DESCRIPTION
## Summary
- Adds a "One-step deploy" section to the docs splash page reproducing the `deploy-auto.sh` one-command flow and the AI-agent deploy prompt, linking to the full self-hosting guide (PROJ-282).
- Adds a link from the splash page into the philosophy section, giving readers a path into the docs beyond the three hero action buttons (PROJ-281).

## Test plan
- [x] `pnpm --filter @projektor/docs build` — succeeds, starlight-links-validator confirms all new links resolve
- [x] pre-commit/pre-push hooks (lint, type-check, unit tests) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)