### PR TITLE
Post-review hardening: workflow gates, auth, metrics & CI (PROJ-286)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'   # apps/docs' astro 7 requires Node >= 22.12
+          node-version: '22.12.0'   # pinned; apps/docs' astro 7 requires Node >= 22.12
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - name: Generated docs are fresh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"   # astro 7 requires Node >= 22.12
+          node-version: "22.12.0"   # pinned; astro 7 requires Node >= 22.12
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       # Generate the tool catalog + contributor-conventions mirror before building, so the site is fresh.

--- a/apps/api/src/middleware/workspace.ts
+++ b/apps/api/src/middleware/workspace.ts
@@ -1,18 +1,57 @@
 import type { HonoEnv } from "@projektor/types";
 import type { Context, Next } from "hono";
 
+// PROJ-296: accept common truthy spellings so operators don't silently
+// disable subdomain routing with e.g. "1", "yes", or a non-"true" TOML bool.
+export function subdomainRoutingEnabled(v: string | undefined): boolean {
+	return ["true", "1", "yes"].includes(v?.trim().toLowerCase() ?? "");
+}
+
+// PROJ-295: the leading label of a Host header, but only when it plausibly
+// names a tenant subdomain (3+ labels, not localhost/an IP) rather than a
+// bare apex or a CDN/proxy artifact.
+function subdomainCandidate(host: string | undefined): string | undefined {
+	if (!host) return undefined;
+	const hostname = host.split(":")[0];
+	if (hostname === "localhost" || /^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) return undefined;
+	const labels = hostname.split(".");
+	if (labels.length < 3) return undefined;
+	return labels[0];
+}
+
+// PROJ-295: warn (but keep failing closed) when a would-be-valid subdomain is being
+// ignored because the flag is off — this catches the silent per-tenant outage an
+// upgrade could otherwise cause.
+async function warnIfIgnoredSubdomain(
+	c: Context<HonoEnv>,
+	headerSlug: string | undefined,
+	routingEnabled: boolean
+): Promise<void> {
+	if (headerSlug || routingEnabled) return;
+	const candidateSlug = subdomainCandidate(c.req.header("host"));
+	if (!candidateSlug) return;
+	const resolvable = await c.env.DB.prepare("SELECT id FROM workspaces WHERE slug = ?")
+		.bind(candidateSlug)
+		.first<{ id: string }>();
+	if (resolvable) {
+		console.warn(
+			`workspace subdomain "${candidateSlug}" would resolve but WORKSPACE_SUBDOMAIN_ROUTING is off; rejecting request`
+		);
+	}
+}
+
 export async function workspaceMiddleware(c: Context<HonoEnv>, next: Next) {
 	// Workspace resolved from the X-Workspace-Slug header, or (opt-in) the Host header's
 	// subdomain. See WORKSPACE_SUBDOMAIN_ROUTING in packages/types/src/env.ts. (PROJ-267)
 	const headerSlug = c.req.header("X-Workspace-Slug");
-	const subdomainRoutingEnabled = c.env.WORKSPACE_SUBDOMAIN_ROUTING === "true";
-	const slug =
-		headerSlug ?? (subdomainRoutingEnabled ? c.req.header("host")?.split(".")[0] : undefined);
+	const routingEnabled = subdomainRoutingEnabled(c.env.WORKSPACE_SUBDOMAIN_ROUTING);
+	const slug = headerSlug ?? (routingEnabled ? c.req.header("host")?.split(".")[0] : undefined);
 
 	if (!slug) {
+		await warnIfIgnoredSubdomain(c, headerSlug, routingEnabled);
 		return c.json(
 			{
-				error: subdomainRoutingEnabled
+				error: routingEnabled
 					? "Workspace not specified"
 					: "Workspace not specified: missing X-Workspace-Slug header",
 			},

--- a/apps/api/src/schemas/issues.ts
+++ b/apps/api/src/schemas/issues.ts
@@ -18,7 +18,7 @@ export const CreateIssueSchema = z.object({
 
 // PROJ-254: completion report an agent (or human) submits when entering review /
 // before an issue can be marked done.
-export const CompletionReportSchema = z.object({
+const CompletionReportSchema = z.object({
 	summary: z.string().min(1),
 	verification: z.string().min(1),
 	prLink: z.string().url().optional(),

--- a/apps/api/src/services/definition-of-ready.ts
+++ b/apps/api/src/services/definition-of-ready.ts
@@ -1,4 +1,4 @@
-// Heuristic definition-of-ready check (PROJ-253, spec: docs/design/agentic-workflow.md
+// Heuristic definition-of-ready check (PROJ-253/291, spec: docs/design/agentic-workflow.md
 // Phase 3). Deliberately a text heuristic over the existing body field, not a new
 // structured schema — the epic's own child issues are already written this way, and a
 // schema change would break every existing issue's readiness overnight.
@@ -8,18 +8,45 @@ export interface ReadinessCheck {
 	missing: string[];
 }
 
-// Does the line at `idx` in `lines` introduce a new section (so the section started at
-// an earlier line has ended)? Matches a markdown heading or a bolded label line.
+// Does the line introduce a new section (so a section started earlier has ended)?
 function isSectionBoundary(line: string): boolean {
 	return /^#{1,6}\s/.test(line) || /^\*\*[A-Za-z][^*]*\*\*:?\s*$/.test(line);
 }
 
-// A section is "present" when its label line exists AND at least one non-blank line of
-// real content follows before the next section boundary or the body ends.
-function sectionHasContent(body: string, labelPattern: RegExp): boolean {
+function ci(source: string, flags: string): RegExp {
+	return new RegExp(source, flags.includes("i") ? "i" : "");
+}
+
+// Is `line` a STRUCTURAL label line for `label` — a heading, a bold label, or a
+// "Label:"-prefixed line — rather than prose that merely mentions the phrase
+// (PROJ-291)? "## Scope / files", "**Acceptance criteria**", "Verification:" pass;
+// "acceptance criteria are unclear" does not.
+function isLabelLine(line: string, label: RegExp): boolean {
+	const t = line.trim();
+	const word = ci(`\\b(?:${label.source})\\b`, label.flags);
+
+	const isHeading = /^#{1,6}\s+/.test(t);
+	const isBold = /^\*\*[^*]+\*\*:?\s*$/.test(t) || /^[-*]\s+\*\*[^*]+\*\*/.test(t);
+	if (isHeading || isBold) return word.test(t);
+
+	// A plain line only counts when the label is a "Label:" prefix, not mid-sentence.
+	const stripped = t.replace(/^[-*]\s+/, "");
+	return ci(`^\\s*(?:${label.source})\\b[^:]*:`, label.flags).test(stripped);
+}
+
+// Non-empty content for `label`'s section: inline after a "Label:" or on a following
+// non-blank line before the next section boundary.
+function sectionHasContent(body: string, label: RegExp): boolean {
 	const lines = body.split(/\r?\n/);
-	const idx = lines.findIndex((l) => labelPattern.test(l));
+	const idx = lines.findIndex((l) => isLabelLine(l, label));
 	if (idx === -1) return false;
+
+	const inline = lines[idx]
+		.replace(/^[#\-*\s]+/, "")
+		.replace(/\*\*/g, "")
+		.replace(/`/g, "");
+	const afterColon = inline.includes(":") ? inline.slice(inline.indexOf(":") + 1).trim() : "";
+	if (afterColon !== "") return true;
 
 	for (let i = idx + 1; i < lines.length; i++) {
 		const line = lines[i].trim();
@@ -30,16 +57,26 @@ function sectionHasContent(body: string, labelPattern: RegExp): boolean {
 	return false;
 }
 
+// A path-shaped token inside an inline code span: contains a directory separator or a
+// filename.ext. A lone span like `true` no longer satisfies "scope/files" (PROJ-291).
+function hasFilePathToken(body: string): boolean {
+	const spans = body.match(/`[^`\n]+`/g);
+	if (!spans) return false;
+	return spans.some((s) => {
+		const inner = s.slice(1, -1).trim();
+		return inner.includes("/") || /[\w-]+\.[a-z]{1,5}\b/i.test(inner);
+	});
+}
+
 export function checkDefinitionOfReady(body: string): ReadinessCheck {
 	const missing: string[] = [];
 
-	if (!sectionHasContent(body, /acceptance criteria/i)) {
+	if (!sectionHasContent(body, /acceptance criteria|\bAC\b/i)) {
 		missing.push("acceptance criteria");
 	}
 
-	const hasScopeSection = sectionHasContent(body, /\b(scope|files?)\b/i);
-	const hasInlineFilePath = /`[^`\n]+`/.test(body);
-	if (!hasScopeSection && !hasInlineFilePath) {
+	const hasScopeSection = sectionHasContent(body, /scope|files?/i);
+	if (!hasScopeSection && !hasFilePathToken(body)) {
 		missing.push("scope/files");
 	}
 

--- a/apps/api/src/services/flow-metrics.ts
+++ b/apps/api/src/services/flow-metrics.ts
@@ -1,5 +1,5 @@
 import { drizzle, schema } from "@projektor/db";
-import { and, eq, gte, lte } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { GetFlowMetricsSchema } from "../schemas/flow-metrics";
 import { NotFoundError, ValidationError } from "./errors";
 import type { ServiceCtx } from "./types";
@@ -97,13 +97,9 @@ export async function getFlowMetrics(ctx: ServiceCtx, raw: unknown) {
 
 	const orm = drizzle(ctx.db, { schema });
 
-	const conditions = [
-		eq(schema.issues.workspaceId, ctx.workspaceId),
-		eq(schema.issues.projectId, projectId),
-	];
-	if (since !== undefined) conditions.push(gte(schema.issues.createdAt, since));
-	if (until !== undefined) conditions.push(lte(schema.issues.createdAt, until));
-
+	// Scope by project only, not created_at: since/until describe an activity window
+	// (claimed/done), and an issue created before the window but active inside it must
+	// still count (e.g. WIP). Row count stays bounded by project size.
 	const issues = await orm
 		.select({
 			id: schema.issues.id,
@@ -112,14 +108,19 @@ export async function getFlowMetrics(ctx: ServiceCtx, raw: unknown) {
 			doneAt: schema.issues.doneAt,
 		})
 		.from(schema.issues)
-		.where(and(...conditions));
+		.where(
+			and(eq(schema.issues.workspaceId, ctx.workspaceId), eq(schema.issues.projectId, projectId))
+		);
+
+	const inWindow = (t: number) =>
+		(since === undefined || t >= since) && (until === undefined || t <= until);
 
 	const leadTimes = issues
-		.filter((i) => i.readyAt !== null && i.doneAt !== null)
+		.filter((i) => i.readyAt !== null && i.doneAt !== null && inWindow(i.doneAt))
 		// biome-ignore lint/style/noNonNullAssertion: filtered above
 		.map((i) => i.doneAt! - i.readyAt!);
 	const cycleTimes = issues
-		.filter((i) => i.claimedAt !== null && i.doneAt !== null)
+		.filter((i) => i.claimedAt !== null && i.doneAt !== null && inWindow(i.doneAt))
 		// biome-ignore lint/style/noNonNullAssertion: filtered above
 		.map((i) => i.doneAt! - i.claimedAt!);
 
@@ -128,7 +129,8 @@ export async function getFlowMetrics(ctx: ServiceCtx, raw: unknown) {
 	const wipUntil = until ?? now;
 	const wipOverTime = buildWipOverTime(issues, wipSince, wipUntil);
 
-	const agentVsHuman = await computeAgentVsHuman(ctx, orm, issues);
+	const cycleWindowIssues = issues.filter((i) => i.doneAt === null || inWindow(i.doneAt));
+	const agentVsHuman = await computeAgentVsHuman(ctx, orm, cycleWindowIssues);
 
 	return {
 		leadTime: summarize(leadTimes),

--- a/apps/api/src/services/issue-leases.ts
+++ b/apps/api/src/services/issue-leases.ts
@@ -33,21 +33,28 @@ async function assertIssueExists(
 	return { projectId: issue.projectId };
 }
 
-// Live (session-active, non-released) leases on issues in this project, capped by
-// the project's agent_wip_limit (falling back to DEFAULT_AGENT_WIP_LIMIT).
-async function assertWipCapacity(
+// The project's agent WIP cap (its own agent_wip_limit, else the default).
+async function fetchAgentWipCap(
 	orm: ReturnType<typeof drizzle>,
 	ctx: ServiceCtx,
-	projectId: string,
-	cutoff: number
-): Promise<void> {
+	projectId: string
+): Promise<number> {
 	const project = await orm
 		.select({ agentWipLimit: schema.projects.agentWipLimit })
 		.from(schema.projects)
 		.where(and(eq(schema.projects.id, projectId), eq(schema.projects.workspaceId, ctx.workspaceId)))
 		.get();
-	const cap = project?.agentWipLimit ?? DEFAULT_AGENT_WIP_LIMIT;
+	return project?.agentWipLimit ?? DEFAULT_AGENT_WIP_LIMIT;
+}
 
+// The issue ids currently held by a live lease in this project — only used to build
+// a helpful error when a claim is rejected for hitting the cap.
+async function liveLeaseHoldersForProject(
+	orm: ReturnType<typeof drizzle>,
+	ctx: ServiceCtx,
+	projectId: string,
+	cutoff: number
+): Promise<string[]> {
 	const live = await orm
 		.select({ issueId: schema.issueLeases.issueId })
 		.from(schema.issueLeases)
@@ -62,12 +69,7 @@ async function assertWipCapacity(
 				gt(schema.agentSessions.lastHeartbeatAt, cutoff)
 			)
 		);
-
-	if (live.length >= cap) {
-		throw new ConflictError(
-			`Project agent WIP limit reached (${cap}); currently held: ${live.map((l) => l.issueId).join(", ")}`
-		);
-	}
+	return live.map((l) => l.issueId);
 }
 
 // The claiming session must itself be live — a dead agent can't hold a lease.
@@ -139,11 +141,17 @@ async function reclaimStaleLeaseOrThrow(
 }
 
 /**
- * Claim an issue for an agent session. Atomic: the partial UNIQUE index on
- * (workspace_id, issue_id) WHERE released_at IS NULL guarantees at most one
- * active lease per issue, so two concurrent claims can't both succeed — the
- * loser hits the constraint and is reported as a conflict. A lease whose owning
- * session has gone stale (stopped heartbeating) is reclaimed transparently.
+ * Claim an issue for an agent session. Two independent atomicity guards, both
+ * enforced inside a single INSERT so concurrent claims can't race (PROJ-290 —
+ * D1 has no interactive transactions, and a read-then-insert let two claims each
+ * see cap-1 and both proceed):
+ *   1. Per-issue: the partial UNIQUE index on (workspace_id, issue_id) WHERE
+ *      released_at IS NULL — at most one active lease per issue.
+ *   2. Per-project WIP cap: the INSERT ... SELECT ... WHERE (live-lease count) <
+ *      cap subquery is evaluated as part of the write statement (SQLite holds the
+ *      db write lock), so a concurrent claim sees the other's just-inserted row
+ *      and the count can't be undercounted.
+ * A lease whose owning session has gone stale is reclaimed transparently first.
  */
 export async function claimIssue(ctx: ServiceCtx, raw: unknown) {
 	const result = ClaimIssueSchema.safeParse(raw);
@@ -155,29 +163,43 @@ export async function claimIssue(ctx: ServiceCtx, raw: unknown) {
 
 	const { projectId } = await assertIssueExists(orm, ctx, issueId);
 	await assertAgentSessionLive(orm, ctx, agentId, cutoff);
-	await assertWipCapacity(orm, ctx, projectId, cutoff);
+	const cap = await fetchAgentWipCap(orm, ctx, projectId);
 
 	const now = Math.floor(Date.now() / 1000);
 	await reclaimStaleLeaseOrThrow(orm, ctx, issueId, cutoff, now);
 
 	const id = crypto.randomUUID();
+	let res: D1Result;
 	try {
-		await orm.insert(schema.issueLeases).values({
-			id,
-			workspaceId: ctx.workspaceId,
-			issueId,
-			agentSessionId: agentId,
-			claimedAt: now,
-			releasedAt: null,
-			releaseReason: null,
-		});
+		res = await ctx.db
+			.prepare(
+				`INSERT INTO issue_leases (id, workspace_id, issue_id, agent_session_id, claimed_at, released_at, release_reason)
+				 SELECT ?, ?, ?, ?, ?, NULL, NULL
+				 WHERE (
+				   SELECT COUNT(*) FROM issue_leases il
+				   JOIN issues i ON i.id = il.issue_id
+				   JOIN agent_sessions s ON s.id = il.agent_session_id
+				   WHERE il.workspace_id = ? AND il.released_at IS NULL
+				     AND i.project_id = ? AND s.status = 'active' AND s.last_heartbeat_at > ?
+				 ) < ?`
+			)
+			.bind(id, ctx.workspaceId, issueId, agentId, now, ctx.workspaceId, projectId, cutoff, cap)
+			.run();
 	} catch (e) {
-		// Lost a genuine race: another claim inserted the active lease first and
-		// the partial UNIQUE index rejected ours.
+		// Lost a genuine race: another claim inserted the active lease for THIS
+		// issue first and the partial UNIQUE index rejected ours.
 		if (e instanceof Error && /UNIQUE constraint failed/i.test(e.message)) {
 			throw new ConflictError("Issue was just leased by another agent");
 		}
 		throw e;
+	}
+
+	// No row inserted and no UNIQUE violation ⇒ the WIP-cap guard subquery held.
+	if (res.meta.changes === 0) {
+		const held = await liveLeaseHoldersForProject(orm, ctx, projectId, cutoff);
+		throw new ConflictError(
+			`Project agent WIP limit reached (${cap}); currently held: ${held.join(", ")}`
+		);
 	}
 
 	const row = await orm
@@ -256,6 +278,56 @@ export async function liveLeasedIssueIds(ctx: ServiceCtx): Promise<Set<string>> 
 			)
 		);
 	return new Set(rows.map((r) => r.issueId));
+}
+
+/**
+ * Is there a LIVE lease held by an AGENT-kind session on this issue? This is the
+ * authoritative "an agent is actively working this issue" signal used by the
+ * review/done gate (PROJ-287), replacing the spoofable caller-supplied
+ * agentSessionId/kind — a caller cannot omit a field or self-declare kind:"human"
+ * to escape it while genuinely holding an agent lease.
+ */
+export async function issueHasLiveAgentLease(ctx: ServiceCtx, issueId: string): Promise<boolean> {
+	const orm = drizzle(ctx.db, { schema });
+	const row = await orm
+		.select({ id: schema.issueLeases.id })
+		.from(schema.issueLeases)
+		.innerJoin(schema.agentSessions, eq(schema.issueLeases.agentSessionId, schema.agentSessions.id))
+		.where(
+			and(
+				eq(schema.issueLeases.workspaceId, ctx.workspaceId),
+				eq(schema.issueLeases.issueId, issueId),
+				isNull(schema.issueLeases.releasedAt),
+				eq(schema.agentSessions.kind, "agent"),
+				eq(schema.agentSessions.status, "active"),
+				gt(schema.agentSessions.lastHeartbeatAt, liveCutoff())
+			)
+		)
+		.get();
+	return row != null;
+}
+
+/**
+ * Has this issue EVER been leased by an agent-kind session (live, released, or
+ * stale)? Scopes the human-done completion-report requirement to agent-worked
+ * issues (PROJ-289) so closing ordinary human/duplicate/won't-fix issues isn't
+ * blocked for a report no agent was ever going to write.
+ */
+export async function issueEverHadAgentLease(ctx: ServiceCtx, issueId: string): Promise<boolean> {
+	const orm = drizzle(ctx.db, { schema });
+	const row = await orm
+		.select({ id: schema.issueLeases.id })
+		.from(schema.issueLeases)
+		.innerJoin(schema.agentSessions, eq(schema.issueLeases.agentSessionId, schema.agentSessions.id))
+		.where(
+			and(
+				eq(schema.issueLeases.workspaceId, ctx.workspaceId),
+				eq(schema.issueLeases.issueId, issueId),
+				eq(schema.agentSessions.kind, "agent")
+			)
+		)
+		.get();
+	return row != null;
 }
 
 /**

--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -32,7 +32,7 @@ import {
 } from "./custom-fields";
 import { checkDefinitionOfReady } from "./definition-of-ready";
 import { ForbiddenError, NotFoundError, ValidationError } from "./errors";
-import { liveLeasedIssueIds } from "./issue-leases";
+import { issueEverHadAgentLease, issueHasLiveAgentLease, liveLeasedIssueIds } from "./issue-leases";
 import { listLinksForIssue } from "./issue-links";
 import { inChunks } from "./sql";
 import { resolveStatus } from "./task-statuses";
@@ -654,6 +654,17 @@ function applyCompletedAtTransition(
 // on re-entry — so lead/cycle time still reflects rework after a reopen. "Ready" isn't
 // its own status_category (backlog and todo share category 'todo'), so it's detected
 // from the legacy `status` key instead: any status other than 'backlog'.
+function isClaimedState(
+	category: string | null | undefined,
+	key: string | null | undefined
+): boolean {
+	return category === "in_progress" || key === "in_progress" || key === "in_review";
+}
+
+function isDoneState(category: string | null | undefined, key: string | null | undefined): boolean {
+	return category === "done" || key === "done";
+}
+
 function applyFlowTimestampTransitions(
 	setValues: SetValues,
 	existing: ExistingIssue,
@@ -661,44 +672,17 @@ function applyFlowTimestampTransitions(
 	newStatusCategory: string | undefined
 ): void {
 	const wasReady = existing.status !== "backlog";
-	const isReady = resolvedStatusKey !== "backlog";
-	if (isReady && !wasReady && existing.readyAt == null) setValues.readyAt = now();
+	if (resolvedStatusKey !== "backlog" && !wasReady && existing.readyAt == null) {
+		setValues.readyAt = now();
+	}
 
-	const wasClaimed =
-		existing.statusCategory === "in_progress" ||
-		existing.status === "in_progress" ||
-		existing.status === "in_review";
-	const isClaimed =
-		newStatusCategory === "in_progress" ||
-		resolvedStatusKey === "in_progress" ||
-		resolvedStatusKey === "in_review";
+	const wasClaimed = isClaimedState(existing.statusCategory, existing.status);
+	const isClaimed = isClaimedState(newStatusCategory, resolvedStatusKey);
 	if (isClaimed && !wasClaimed && existing.claimedAt == null) setValues.claimedAt = now();
 
-	const wasDone = existing.statusCategory === "done" || existing.status === "done";
-	const isDone = newStatusCategory === "done" || resolvedStatusKey === "done";
+	const wasDone = isDoneState(existing.statusCategory, existing.status);
+	const isDone = isDoneState(newStatusCategory, resolvedStatusKey);
 	if (isDone && !wasDone && existing.doneAt == null) setValues.doneAt = now();
-}
-
-// PROJ-254: an agentSessionId identifies the session doing this update. No id (a
-// human via the browser, or any call that omits it) means "human" for gating purposes.
-async function resolveAgentKind(
-	orm: ReturnType<typeof drizzle>,
-	ctx: ServiceCtx,
-	agentSessionId: string | undefined
-): Promise<"agent" | "human" | null> {
-	if (!agentSessionId) return null;
-	const session = await orm
-		.select({ kind: schema.agentSessions.kind })
-		.from(schema.agentSessions)
-		.where(
-			and(
-				eq(schema.agentSessions.id, agentSessionId),
-				eq(schema.agentSessions.workspaceId, ctx.workspaceId)
-			)
-		)
-		.get();
-	if (!session) throw new NotFoundError("Agent session not found");
-	return session.kind;
 }
 
 function assertCompletionReportPresent(data: UpdateIssueData): void {
@@ -714,37 +698,62 @@ function assertCompletionReportPresent(data: UpdateIssueData): void {
 	}
 }
 
-// PROJ-254: entering in_review as an agent requires a completion report in the same
-// call; entering done always requires a human, and requires a completion report to
-// already be on record (or supplied in this same call).
-async function assertReviewGate(
-	orm: ReturnType<typeof drizzle>,
-	ctx: ServiceCtx,
-	data: UpdateIssueData,
+// PROJ-292: a review step is identified by its status key naming a review, NOT by a
+// dedicated category — there is no 'in_review' category (the default review status is
+// category 'in_progress'), and keying on the single literal "in_review" let a
+// workspace's custom review status (e.g. "code-review", "peer_review") slip the gate.
+function isReviewStatusKey(key: string | undefined): boolean {
+	return key != null && /review/i.test(key);
+}
+
+// Pure classification of what this status change is entering, shared by the gate
+// (what to enforce) and the completion-report stamp (PROJ-293 — stamp/post only on a
+// real transition, not on any update that happens to carry a completionReport).
+function classifyStatusTransition(
 	existing: ExistingIssue,
 	resolvedStatusKey: string,
 	newStatusCategory: string | undefined
-): Promise<void> {
-	const agentKind = await resolveAgentKind(orm, ctx, data.agentSessionId);
-
-	const wasInReview = existing.status === "in_review";
-	const enteringInReview = resolvedStatusKey === "in_review" && !wasInReview;
-	if (enteringInReview && agentKind === "agent") {
-		assertCompletionReportPresent(data);
-	}
+): { enteringInReview: boolean; enteringDone: boolean } {
+	const wasInReview = isReviewStatusKey(existing.status);
+	const enteringInReview = isReviewStatusKey(resolvedStatusKey) && !wasInReview;
 
 	const wasDone = existing.statusCategory === "done" || existing.status === "done";
 	const enteringDone = (newStatusCategory === "done" || resolvedStatusKey === "done") && !wasDone;
+	return { enteringInReview, enteringDone };
+}
+
+// PROJ-254/287/289/292: the gate is bound to the issue's LIVE AGENT LEASE — the one
+// signal an agent can't spoof by omitting agentSessionId or self-declaring
+// kind:"human". Entering review while an agent holds a live lease requires a
+// completion report; an agent (live lease) can never mark done; and the done-report
+// requirement applies only to issues an agent has actually worked, so ordinary human
+// closes (duplicates, won't-fix, chores) aren't blocked.
+async function assertReviewGate(
+	ctx: ServiceCtx,
+	data: UpdateIssueData,
+	existing: ExistingIssue,
+	transition: { enteringInReview: boolean; enteringDone: boolean }
+): Promise<void> {
+	const { enteringInReview, enteringDone } = transition;
+	if (!enteringInReview && !enteringDone) return;
+
+	const hasLiveAgentLease = await issueHasLiveAgentLease(ctx, existing.id);
+
+	if (enteringInReview && hasLiveAgentLease) {
+		assertCompletionReportPresent(data);
+	}
+
 	if (enteringDone) {
-		if (agentKind === "agent") {
+		if (hasLiveAgentLease) {
 			throw new ForbiddenError(
 				"An agent cannot mark an issue done — a human must approve (PROJ-254)"
 			);
 		}
-		if (existing.completionReportAt == null && !data.completionReport) {
+		const everAgentWorked = await issueEverHadAgentLease(ctx, existing.id);
+		if (everAgentWorked && existing.completionReportAt == null && !data.completionReport) {
 			throw new ValidationError({
 				formErrors: [
-					"A completion report is required before an issue can be marked done (PROJ-254)",
+					"A completion report is required before an agent-worked issue can be marked done (PROJ-254)",
 				],
 				fieldErrors: {},
 			});
@@ -758,8 +767,8 @@ async function applyStatusFields(
 	setValues: SetValues,
 	data: UpdateIssueData,
 	existing: ExistingIssue
-): Promise<void> {
-	if (data.status === undefined && !("statusId" in data)) return;
+): Promise<boolean> {
+	if (data.status === undefined && !("statusId" in data)) return false;
 
 	const { id: resolvedStatusId, key: resolvedStatusKey } = await resolveStatus(
 		ctx,
@@ -768,7 +777,8 @@ async function applyStatusFields(
 	);
 
 	const newStatusCategory = await fetchStatusCategory(orm, resolvedStatusId);
-	await assertReviewGate(orm, ctx, data, existing, resolvedStatusKey, newStatusCategory);
+	const transition = classifyStatusTransition(existing, resolvedStatusKey, newStatusCategory);
+	await assertReviewGate(ctx, data, existing, transition);
 
 	setValues.status = resolvedStatusKey;
 	setValues.statusId = resolvedStatusId;
@@ -776,6 +786,8 @@ async function applyStatusFields(
 
 	applyCompletedAtTransition(setValues, existing, resolvedStatusKey, newStatusCategory);
 	applyFlowTimestampTransitions(setValues, existing, resolvedStatusKey, newStatusCategory);
+
+	return transition.enteringInReview || transition.enteringDone;
 }
 
 function now(): number {
@@ -803,17 +815,21 @@ async function buildUpdateSetValues(
 	orm: ReturnType<typeof drizzle>,
 	data: UpdateIssueData,
 	existing: ExistingIssue
-): Promise<SetValues> {
+): Promise<{ setValues: SetValues; recordCompletionReport: boolean }> {
 	const setValues: SetValues = { updatedAt: now() };
 	applySimpleFields(setValues, data);
-	await applyStatusFields(ctx, orm, setValues, data, existing);
+	const reviewOrDoneTransition = await applyStatusFields(ctx, orm, setValues, data, existing);
 	if ("typeId" in data) {
 		setValues.typeId = await resolveTypeId(ctx, data.typeId);
 	}
-	if (data.completionReport) {
+	// PROJ-293: only stamp/post the report when the issue actually transitions into
+	// review or done — a title-only update carrying a completionReport must not
+	// pre-stamp completion_report_at (which would later satisfy the human-done gate).
+	const recordCompletionReport = Boolean(data.completionReport) && reviewOrDoneTransition;
+	if (recordCompletionReport) {
 		setValues.completionReportAt = now();
 	}
-	return setValues;
+	return { setValues, recordCompletionReport };
 }
 
 async function reindexIssueFts(
@@ -917,14 +933,19 @@ export async function updateIssue(ctx: ServiceCtx, id: string, raw: unknown) {
 		.get();
 	if (!existing) throw new NotFoundError("Issue not found");
 
-	const setValues = await buildUpdateSetValues(ctx, orm, data, existing);
+	const { setValues, recordCompletionReport } = await buildUpdateSetValues(
+		ctx,
+		orm,
+		data,
+		existing
+	);
 
 	await orm
 		.update(schema.issues)
 		.set(setValues)
 		.where(and(eq(schema.issues.id, id), eq(schema.issues.workspaceId, ctx.workspaceId)));
 
-	if (data.completionReport) {
+	if (recordCompletionReport && data.completionReport) {
 		await addComment(ctx, {
 			issueId: id,
 			body: formatCompletionReportComment(data.completionReport),
@@ -1156,9 +1177,13 @@ export async function getPrioritizedIssues(ctx: ServiceCtx, raw: unknown) {
 		const { ready, missing } = checkDefinitionOfReady(body ?? "");
 		return ready ? issue : { ...issue, needsGrooming: true, missingCriteria: missing };
 	});
+	// PROJ-291: don't SILENTLY drop not-ready issues — a caller seeing an empty list
+	// otherwise concludes "no work" when a differently-worded backlog exists. Surface
+	// the count so the caller knows to groom (or re-query with includeNotReady).
+	const droppedNotReady = annotated.filter((i) => "needsGrooming" in i).length;
 	const ready = includeNotReady ? annotated : annotated.filter((i) => !("needsGrooming" in i));
 
-	return { issues: ready.slice(0, limit) };
+	return { issues: ready.slice(0, limit), droppedNotReady: includeNotReady ? 0 : droppedNotReady };
 }
 
 function sanitizeFtsQuery(q: string): string {

--- a/apps/api/src/test/auth.test.ts
+++ b/apps/api/src/test/auth.test.ts
@@ -315,6 +315,39 @@ describe("PROJ-274: read-scoped token is denied write on every request", () => {
 		const body = (await res.json()) as { error: string };
 		expect(body.error).toMatch(/scope/i);
 	});
+
+	it("read-only token gets a JSON-RPC scope error calling a write MCP tool, never a cached bypass", async () => {
+		const fixture = await seedFixture();
+		const readOnlyToken = await seedToken(fixture.workspace.id, fixture.user.id, {
+			scopes: ["read"],
+		});
+
+		const res = await SELF.fetch(`http://localhost/mcp/${fixture.workspace.id}`, {
+			method: "POST",
+			headers: authHeaders(readOnlyToken, fixture.workspace.slug),
+			body: JSON.stringify({
+				jsonrpc: "2.0",
+				id: 1,
+				method: "tools/call",
+				params: { name: "create_project", arguments: { name: "Blocked", key: "BLK" } },
+			}),
+		});
+		const body = (await res.json()) as { error?: { code: number; message: string } };
+		expect(body.error).toBeDefined();
+		expect(body.error?.code).toBe(-32003);
+		expect(body.error?.message).toMatch(/scope/i);
+	});
+
+	it("workspace-scoped token used against a different member workspace returns 403 (PROJ-16 confinement)", async () => {
+		const fixture = await seedFixture();
+		const otherWs = await seedWorkspace(`ws2-${crypto.randomUUID().slice(0, 8)}`);
+		await seedMember(otherWs.id, fixture.user.id, "member");
+
+		const res = await SELF.fetch("http://localhost/api/issues", {
+			headers: authHeaders(fixture.token, otherWs.slug),
+		});
+		expect(res.status).toBe(403);
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/test/definition-of-ready.test.ts
+++ b/apps/api/src/test/definition-of-ready.test.ts
@@ -55,4 +55,42 @@ describe("checkDefinitionOfReady (PROJ-253)", () => {
 			missing: ["acceptance criteria", "scope/files", "verification"],
 		});
 	});
+
+	it("rejects a lone non-path backtick as the scope signal (PROJ-291)", () => {
+		const body = [
+			"## Acceptance criteria",
+			"- Does the thing",
+			"",
+			"Set it to `true`.",
+			"",
+			"## Verification",
+			"runs `pnpm test`",
+		].join("\n");
+		const result = checkDefinitionOfReady(body);
+		expect(result.ready).toBe(false);
+		expect(result.missing).toContain("scope/files");
+	});
+
+	it("does not treat prose that merely mentions a section label as present (PROJ-291)", () => {
+		const body = [
+			"Acceptance criteria are unclear right now.",
+			"We should figure them out.",
+			"",
+			"## Scope",
+			"`src/x.ts`",
+			"",
+			"## Verification",
+			"`pnpm test x`",
+		].join("\n");
+		expect(checkDefinitionOfReady(body).missing).toContain("acceptance criteria");
+	});
+
+	it("recognises colon-prefixed labels (PROJ-291)", () => {
+		const body = [
+			"Acceptance criteria: does the thing",
+			"Scope: `src/x.ts`",
+			"Verification: `pnpm test`",
+		].join("\n");
+		expect(checkDefinitionOfReady(body)).toEqual({ ready: true, missing: [] });
+	});
 });

--- a/apps/api/src/test/flow-metrics.test.ts
+++ b/apps/api/src/test/flow-metrics.test.ts
@@ -18,6 +18,7 @@ interface FlowMetrics {
 	agentVsHuman: { agent: Distribution; human: Distribution };
 }
 
+// cofferdam-ignore: Readability.MaxFunctionLength: one describe block, normal test style
 describe("Flow metrics (PROJ-252)", () => {
 	let token: string;
 	let slug: string;
@@ -121,5 +122,54 @@ describe("Flow metrics (PROJ-252)", () => {
 			headers: authHeaders(token, slug),
 		});
 		expect(res.status).toBe(404);
+	});
+
+	it("includes an issue created before the window but claimed+done inside it (PROJ-294)", async () => {
+		const DAY = 86400;
+		const now = Math.floor(Date.now() / 1000);
+		const since = now - 3 * DAY;
+		const until = now;
+
+		const oldIssue = await seedIssue(workspaceId, projectId, userId, {
+			title: "Created before window",
+			createdAt: now - 10 * DAY,
+		});
+		await stampFlowTimestamps(oldIssue.id, {
+			readyAt: now - 10 * DAY,
+			claimedAt: now - 2 * DAY,
+			doneAt: now - 1 * DAY,
+		});
+
+		const res = await SELF.fetch(
+			`http://localhost/api/projects/${projectId}/flow-metrics?since=${since}&until=${until}`,
+			{ headers: authHeaders(token, slug) }
+		);
+		expect(res.status).toBe(200);
+		const metrics = (await res.json()) as FlowMetrics;
+
+		expect(metrics.cycleTime.count).toBe(1);
+		expect(metrics.cycleTime.avg).toBeCloseTo(DAY, 0);
+		expect(metrics.wipOverTime.some((b) => b.count >= 1)).toBe(true);
+	});
+
+	it("returns non-empty lead/cycle metrics for issues with backfilled done_at (PROJ-288)", async () => {
+		const now = Math.floor(Date.now() / 1000);
+		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Pre-migration done" });
+		// Simulates the 0026 backfill outcome: done_at populated from completed_at
+		// for an issue that finished before flow-timestamp stamping existed.
+		await stampFlowTimestamps(issue.id, {
+			readyAt: now - 300,
+			claimedAt: now - 200,
+			doneAt: now - 50,
+		});
+
+		const res = await SELF.fetch(`http://localhost/api/projects/${projectId}/flow-metrics`, {
+			headers: authHeaders(token, slug),
+		});
+		expect(res.status).toBe(200);
+		const metrics = (await res.json()) as FlowMetrics;
+
+		expect(metrics.leadTime.count).toBe(1);
+		expect(metrics.cycleTime.count).toBe(1);
 	});
 });

--- a/apps/api/src/test/helpers.ts
+++ b/apps/api/src/test/helpers.ts
@@ -245,6 +245,55 @@ export async function seedCustomFieldValue(issueId: string, fieldId: string, val
 		.run();
 }
 
+/**
+ * Seed an agent (or human) session plus an active issue lease directly, bypassing the
+ * claim flow. `live: true` (default) means an active session heartbeating within the
+ * TTL (a live lease); `live: false` means an ended session with a stale heartbeat (the
+ * issue was agent-worked but no lease is currently live).
+ */
+export async function seedAgentLease(
+	workspaceId: string,
+	issueId: string,
+	opts?: { kind?: "agent" | "human"; live?: boolean; name?: string }
+): Promise<{ agentSessionId: string; leaseId: string }> {
+	const now = Math.floor(Date.now() / 1000);
+	const live = opts?.live ?? true;
+	const agentSessionId = crypto.randomUUID();
+	await env.DB.prepare(
+		`INSERT INTO agent_sessions
+       (id, workspace_id, issue_id, token_id, name, kind, status, started_at, last_heartbeat_at, ended_at)
+     VALUES (?, ?, ?, NULL, ?, ?, ?, ?, ?, ?)`
+	)
+		.bind(
+			agentSessionId,
+			workspaceId,
+			issueId,
+			opts?.name ?? "seed-agent",
+			opts?.kind ?? "agent",
+			live ? "active" : "ended",
+			now,
+			live ? now : now - 1000,
+			live ? null : now
+		)
+		.run();
+	const leaseId = crypto.randomUUID();
+	await env.DB.prepare(
+		`INSERT INTO issue_leases (id, workspace_id, issue_id, agent_session_id, claimed_at, released_at, release_reason)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`
+	)
+		.bind(
+			leaseId,
+			workspaceId,
+			issueId,
+			agentSessionId,
+			now,
+			live ? null : now,
+			live ? null : "agent_ended"
+		)
+		.run();
+	return { agentSessionId, leaseId };
+}
+
 /** Seed a complete workspace + user + member + token in one call */
 export async function seedFixture(opts?: { slug?: string; email?: string; role?: string }) {
 	const workspace = await seedWorkspace(opts?.slug ?? `ws-${crypto.randomUUID().slice(0, 8)}`);

--- a/apps/api/src/test/issue-leases.test.ts
+++ b/apps/api/src/test/issue-leases.test.ts
@@ -259,6 +259,29 @@ describe("claim_issue agent WIP limit (PROJ-253)", () => {
 		expect(JSON.stringify(body)).toMatch(/WIP limit/i);
 	});
 
+	it("TOCTOU: N concurrent claims never push a project over the cap (PROJ-290)", async () => {
+		const agent = await registerAgent("worker");
+		const issues = await Promise.all(
+			Array.from({ length: 8 }, (_, i) =>
+				seedIssue(workspaceId, projectId, userId, { title: `C${i}` })
+			)
+		);
+
+		// Fire all claims at once: the read-then-insert bug let several each see cap-1
+		// and all proceed. The guarded INSERT must let at most `cap` (default 3) win.
+		const results = await Promise.all(issues.map((iss) => claim(iss.id, agent)));
+		const granted = results.filter((r) => r.status === 201).length;
+		expect(granted).toBeLessThanOrEqual(3);
+
+		const row = await env.DB.prepare(
+			`SELECT COUNT(*) AS n FROM issue_leases il JOIN issues i ON i.id = il.issue_id
+			 WHERE il.released_at IS NULL AND i.project_id = ?`
+		)
+			.bind(projectId)
+			.first<{ n: number }>();
+		expect(row!.n).toBeLessThanOrEqual(3);
+	});
+
 	it("respects a project's own agent_wip_limit override", async () => {
 		const patchRes = await SELF.fetch(`http://localhost/api/projects/${projectId}`, {
 			method: "PATCH",

--- a/apps/api/src/test/issues.test.ts
+++ b/apps/api/src/test/issues.test.ts
@@ -1358,6 +1358,7 @@ describe("Issues role guards", () => {
 	});
 });
 
+// cofferdam-ignore: Readability.MaxFunctionLength: one describe block, normal test style
 describe("get_prioritized_issues MCP tool", () => {
 	let token: string;
 	let slug: string;
@@ -1479,20 +1480,31 @@ describe("get_prioritized_issues MCP tool", () => {
 		const ready = await seedIssue(workspaceId, projectId, userId, { title: "Ready" });
 		await env.DB.prepare("UPDATE issues SET body = ? WHERE id = ?")
 			.bind(
-				["## Acceptance criteria", "- Does the thing", "", "## Verification", "`pnpm test`"].join(
-					"\n"
-				),
+				[
+					"## Acceptance criteria",
+					"- Does the thing",
+					"",
+					"## Scope",
+					"`src/thing.ts`",
+					"",
+					"## Verification",
+					"`pnpm test`",
+				].join("\n"),
 				ready.id
 			)
 			.run();
 		await seedIssue(workspaceId, projectId, userId, { title: "Not ready" });
 
 		const defaultBody = await callPrioritized();
-		const defaultTitles = (
-			JSON.parse(defaultBody.result!.content[0].text) as { issues: Array<{ title: string }> }
-		).issues.map((i) => i.title);
+		const defaultParsed = JSON.parse(defaultBody.result!.content[0].text) as {
+			issues: Array<{ title: string }>;
+			droppedNotReady: number;
+		};
+		const defaultTitles = defaultParsed.issues.map((i) => i.title);
 		expect(defaultTitles).toContain("Ready");
 		expect(defaultTitles).not.toContain("Not ready");
+		// PROJ-291: dropped not-ready issues are surfaced as a count, not silently gone.
+		expect(defaultParsed.droppedNotReady).toBeGreaterThanOrEqual(1);
 
 		const withNotReady = await callPrioritized({ includeNotReady: true });
 		const data = JSON.parse(withNotReady.result!.content[0].text) as {

--- a/apps/api/src/test/review-gating.test.ts
+++ b/apps/api/src/test/review-gating.test.ts
@@ -1,8 +1,20 @@
 import { env, SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
-import { authHeaders, seedIssue, seedProjectFixture } from "./helpers";
+import {
+	authHeaders,
+	seedAgentLease,
+	seedIssue,
+	seedProjectFixture,
+	seedTaskStatus,
+} from "./helpers";
 
-describe("Review gating (PROJ-254)", () => {
+// PROJ-254 gate, hardened by PROJ-287/289/292/293: the review/done gate is bound to
+// the issue's LIVE AGENT LEASE (an agent can't spoof it by omitting agentSessionId or
+// self-declaring kind:"human"), the done-report requirement is scoped to agent-worked
+// issues, review is keyed on any review-like status, and the report is only stamped on
+// a real transition.
+// cofferdam-ignore: Readability.MaxFunctionLength: one describe block, normal test style
+describe("Review gating (PROJ-254/287/289/292/293)", () => {
 	let token: string;
 	let slug: string;
 	let workspaceId: string;
@@ -12,16 +24,6 @@ describe("Review gating (PROJ-254)", () => {
 	beforeEach(async () => {
 		({ token, slug, workspaceId, userId, projectId } = await seedProjectFixture({ role: "owner" }));
 	});
-
-	async function registerAgent(kind?: "agent" | "human"): Promise<string> {
-		const res = await SELF.fetch("http://localhost/api/agents", {
-			method: "POST",
-			headers: authHeaders(token, slug),
-			body: JSON.stringify({ name: "gate-test", kind }),
-		});
-		const session = (await res.json()) as { id: string };
-		return session.id;
-	}
 
 	function patch(id: string, body: Record<string, unknown>) {
 		return SELF.fetch(`http://localhost/api/issues/${id}`, {
@@ -38,88 +40,144 @@ describe("Review gating (PROJ-254)", () => {
 		return row?.completion_report_at ?? null;
 	}
 
+	async function commentBodies(id: string): Promise<string[]> {
+		const res = await SELF.fetch(`http://localhost/api/issues/${id}/comments`, {
+			headers: authHeaders(token, slug),
+		});
+		const comments = (await res.json()) as Array<{ body: string }>;
+		return comments.map((c) => c.body);
+	}
+
 	const report = { summary: "Did the thing", verification: "pnpm test" };
 
-	it("rejects an agent entering in_review without a completion report", async () => {
-		const issue = await seedIssue(workspaceId, projectId, userId, { title: "No report" });
-		const agentId = await registerAgent();
+	// --- Agent path (live agent lease present) ---
 
-		const res = await patch(issue.id, { status: "in_review", agentSessionId: agentId });
+	it("rejects an agent (live lease) entering in_review without a completion report", async () => {
+		const issue = await seedIssue(workspaceId, projectId, userId, { title: "No report" });
+		await seedAgentLease(workspaceId, issue.id);
+
+		const res = await patch(issue.id, { status: "in_review" });
 		expect(res.status).toBe(400);
 	});
 
-	it("accepts an agent entering in_review with a completion report, and posts it as a comment", async () => {
+	it("accepts an agent (live lease) entering in_review with a report, and posts it", async () => {
 		const issue = await seedIssue(workspaceId, projectId, userId, { title: "With report" });
-		const agentId = await registerAgent();
+		await seedAgentLease(workspaceId, issue.id);
 
-		const res = await patch(issue.id, {
-			status: "in_review",
-			agentSessionId: agentId,
-			completionReport: report,
-		});
+		const res = await patch(issue.id, { status: "in_review", completionReport: report });
 		expect(res.status).toBe(200);
 		expect(await completionReportAtOf(issue.id)).toEqual(expect.any(Number));
-
-		const commentsRes = await SELF.fetch(`http://localhost/api/issues/${issue.id}/comments`, {
-			headers: authHeaders(token, slug),
-		});
-		const comments = (await commentsRes.json()) as Array<{ body: string }>;
-		expect(comments.some((c) => c.body.includes("Did the thing"))).toBe(true);
+		expect((await commentBodies(issue.id)).some((b) => b.includes("Did the thing"))).toBe(true);
 	});
 
-	it("never lets an agent transition an issue to done, report or not", async () => {
+	it("never lets an agent (live lease) transition an issue to done, report or not", async () => {
 		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Agent tries done" });
-		const agentId = await registerAgent();
+		await seedAgentLease(workspaceId, issue.id);
+
+		const res = await patch(issue.id, { status: "done", completionReport: report });
+		expect(res.status).toBe(403);
+	});
+
+	// --- Regression: the closed bypasses (PROJ-287) ---
+
+	it("REGRESSION: omitting agentSessionId does not let an agent-leased issue skip the done gate", async () => {
+		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Omit bypass" });
+		await seedAgentLease(workspaceId, issue.id);
+
+		// No agentSessionId at all — previously treated as human and allowed straight to done.
+		const res = await patch(issue.id, { status: "done", completionReport: report });
+		expect(res.status).toBe(403);
+	});
+
+	it("REGRESSION: a self-declared kind:human session cannot escape a live agent lease", async () => {
+		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Human spoof" });
+		await seedAgentLease(workspaceId, issue.id, { kind: "agent" });
+		// Attach a human-kind session too; it must not downgrade the live agent lease.
+		const human = await seedAgentLease(workspaceId, issue.id, { kind: "human", live: false });
 
 		const res = await patch(issue.id, {
 			status: "done",
-			agentSessionId: agentId,
+			agentSessionId: human.agentSessionId,
 			completionReport: report,
 		});
 		expect(res.status).toBe(403);
 	});
 
-	it("blocks a human done transition until a completion report is on record", async () => {
-		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Human, no report" });
-
-		const res = await patch(issue.id, { status: "done" });
-		expect(res.status).toBe(400);
-	});
-
-	it("allows a human done transition once a completion report already exists", async () => {
-		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Agent reviewed" });
-		const agentId = await registerAgent();
-
-		expect(
-			(
-				await patch(issue.id, {
-					status: "in_review",
-					agentSessionId: agentId,
-					completionReport: report,
-				})
-			).status
-		).toBe(200);
-
-		const res = await patch(issue.id, { status: "done" });
-		expect(res.status).toBe(200);
-	});
-
-	it("allows a human to supply the completion report in the same call that marks done", async () => {
-		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Straight to done" });
-
-		const res = await patch(issue.id, { status: "done", completionReport: report });
-		expect(res.status).toBe(200);
-	});
-
-	it("a human-kind agent session is treated as human, not agent", async () => {
-		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Human session" });
-		const humanSessionId = await registerAgent("human");
+	it("REGRESSION: a stale/ended agentSessionId no longer hard-404s a valid update", async () => {
+		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Stale session" });
 
 		const res = await patch(issue.id, {
-			status: "done",
-			agentSessionId: humanSessionId,
-			completionReport: report,
+			status: "todo",
+			agentSessionId: crypto.randomUUID(), // never existed
 		});
 		expect(res.status).toBe(200);
+	});
+
+	// --- Human path scoped to agent-worked issues (PROJ-289) ---
+
+	it("lets a human close a never-agent-leased issue with no report", async () => {
+		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Plain human close" });
+
+		const res = await patch(issue.id, { status: "done" });
+		expect(res.status).toBe(200);
+	});
+
+	it("still requires a report to close an agent-worked issue (lease no longer live)", async () => {
+		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Agent worked" });
+		await seedAgentLease(workspaceId, issue.id, { live: false });
+
+		expect((await patch(issue.id, { status: "done" })).status).toBe(400);
+		expect((await patch(issue.id, { status: "done", completionReport: report })).status).toBe(200);
+	});
+
+	// --- Custom review status keyed on the word, not the literal (PROJ-292) ---
+
+	it("gates a custom review status (category in_progress) the same as in_review", async () => {
+		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Custom review" });
+		await seedAgentLease(workspaceId, issue.id);
+		const custom = await seedTaskStatus(workspaceId, {
+			key: "code-review",
+			name: "Code Review",
+			category: "in_progress",
+		});
+
+		expect((await patch(issue.id, { statusId: custom.id })).status).toBe(400);
+		expect((await patch(issue.id, { statusId: custom.id, completionReport: report })).status).toBe(
+			200
+		);
+	});
+
+	// --- REST/MCP parity (PROJ-301) ---
+
+	it("MCP parity: update_issue enforces the done gate on an agent-leased issue", async () => {
+		const issue = await seedIssue(workspaceId, projectId, userId, { title: "MCP done" });
+		await seedAgentLease(workspaceId, issue.id);
+
+		const res = await SELF.fetch(`http://localhost/mcp/${workspaceId}`, {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({
+				jsonrpc: "2.0",
+				id: 1,
+				method: "tools/call",
+				params: {
+					name: "update_issue",
+					arguments: { id: issue.id, status: "done", completionReport: report },
+				},
+			}),
+		});
+		// Agent holds a live lease → an agent cannot mark done; surfaced as a tool error.
+		expect(JSON.stringify(await res.json())).toMatch(/agent cannot mark/i);
+	});
+
+	// --- Report stamped only on a real transition (PROJ-293) ---
+
+	it("does not stamp/post a completionReport on a title-only update", async () => {
+		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Pre-stamp attempt" });
+
+		const res = await patch(issue.id, { title: "Renamed", completionReport: report });
+		expect(res.status).toBe(200);
+		expect(await completionReportAtOf(issue.id)).toBeNull();
+		expect((await commentBodies(issue.id)).some((b) => b.includes("Did the thing"))).toBe(false);
 	});
 });

--- a/apps/api/src/test/workspace-subdomain-routing.test.ts
+++ b/apps/api/src/test/workspace-subdomain-routing.test.ts
@@ -1,6 +1,17 @@
 import { env, SELF } from "cloudflare:test";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { subdomainRoutingEnabled } from "../middleware/workspace";
 import { seedFixture } from "./helpers";
+
+describe("subdomainRoutingEnabled", () => {
+	it.each(["true", "1", "yes", "TRUE", "Yes", " true ", "1 "])("accepts %j", (v) => {
+		expect(subdomainRoutingEnabled(v)).toBe(true);
+	});
+
+	it.each([undefined, "", "false", "0", "no", "on"])("rejects %j", (v) => {
+		expect(subdomainRoutingEnabled(v)).toBe(false);
+	});
+});
 
 // PROJ-267 (epic PROJ-261, C2): Host-header subdomain routing is opt-in via
 // WORKSPACE_SUBDOMAIN_ROUTING and off by default.
@@ -52,5 +63,38 @@ describe("workspace subdomain routing (WORKSPACE_SUBDOMAIN_ROUTING)", () => {
 			body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
 		});
 		expect(res.status).toBe(200);
+	});
+
+	it('flag "1" (truthy, non-"true") + no header + matching Host subdomain resolves', async () => {
+		const fixture = await seedFixture();
+		env.WORKSPACE_SUBDOMAIN_ROUTING = "1";
+		const res = await SELF.fetch(`http://localhost/mcp/${fixture.workspace.id}`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${fixture.token}`,
+				Host: `${fixture.workspace.slug}.example.com`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
+		});
+		expect(res.status).toBe(200);
+	});
+
+	it("flag off + no header + a resolvable subdomain warns before the 400", async () => {
+		const fixture = await seedFixture();
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const res = await SELF.fetch(`http://localhost/mcp/${fixture.workspace.id}`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${fixture.token}`,
+				Host: `${fixture.workspace.slug}.example.com`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
+		});
+		expect(res.status).toBe(400);
+		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(fixture.workspace.slug));
+		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("WORKSPACE_SUBDOMAIN_ROUTING"));
+		warnSpy.mockRestore();
 	});
 });

--- a/apps/api/src/version.d.ts
+++ b/apps/api/src/version.d.ts
@@ -2,4 +2,4 @@
  * Injected by esbuild's `--define` at release-build time (scripts/build-release.sh).
  * Undefined in local `wrangler dev` and in tests - callers must guard with `typeof`.
  */
-declare const __PROJEKTOR_VERSION__: string;
+declare const __PROJEKTOR_VERSION__: string | undefined;

--- a/apps/docs/src/content/docs/guides/deploying.md
+++ b/apps/docs/src/content/docs/guides/deploying.md
@@ -168,6 +168,12 @@ wrangler deploy                                       # upload worker + assets
 Your `wrangler.toml` points `main`, `[assets].directory`, and `migrations_dir` at
 `./vendor/...`, which the extract step populates. `vendor/` is gitignored.
 
+## Upgrade notes
+
+**Subdomain-based workspace routing is now opt-in.** Set `WORKSPACE_SUBDOMAIN_ROUTING=true`
+if you rely on subdomain-based tenant routing; otherwise clients must send the
+`X-Workspace-Slug` header.
+
 ## Cutting a release (maintainers)
 
 Releases are tag-driven. From the `projektor` repo:

--- a/apps/web/tailwind.config.mjs
+++ b/apps/web/tailwind.config.mjs
@@ -1,3 +1,5 @@
+import typography from '@tailwindcss/typography';
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./src/**/*.{astro,tsx,ts,js}'],
@@ -33,5 +35,5 @@ export default {
       }),
     },
   },
-  plugins: [require('@tailwindcss/typography')],
+  plugins: [typography],
 };

--- a/cofferdam.toml
+++ b/cofferdam.toml
@@ -11,14 +11,18 @@
 # limit = 120
 # severity = "low"
 
-# Vitest integration tests legitimately run 60-100+ line linear
-# arrange-act-assert bodies (multi-step API setup, several assertions per
-# scenario) — that's normal test style, not a code smell the way a
-# 90-line production function is. There's no per-path override in
-# cofferdam yet, so this raises the ceiling project-wide instead.
+# Gating (medium) so long PRODUCTION functions fail CI again (PROJ-300).
+# cofferdam.toml has no per-path/per-glob override (only `limit`/`severity`
+# per check, applied project-wide). Vitest integration tests legitimately run
+# 60-100+ line linear arrange-act-assert bodies (multi-step API setup, several
+# assertions per scenario) — normal test style, not a code smell the way a
+# 90-line production function is. The few existing over-long test describe
+# blocks carry an inline `// cofferdam-ignore: Readability.MaxFunctionLength`
+# so the baseline stays empty; any new long function (test or source) still
+# surfaces as a finding and fails CI.
 [checks."Readability.MaxFunctionLength"]
 limit = 100
-severity = "low"
+severity = "medium"
 
 # [checks."Design.MaxParameters"]
 # limit = 5

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "onlyBuiltDependencies": ["esbuild", "workerd", "sharp", "@cofferdam/cofferdam"]
   },
   "engines": {
-    "node": ">=20",
+    "node": ">=22.12",
     "pnpm": ">=9"
   }
 }

--- a/packages/db/migrations/0026_backfill_flow_timestamps.sql
+++ b/packages/db/migrations/0026_backfill_flow_timestamps.sql
@@ -1,0 +1,20 @@
+-- Backfill flow-metric timestamps (PROJ-288). Migration 0023 only stamps
+-- ready_at/claimed_at/done_at on FUTURE transitions, so issues that were
+-- already done before that migration ran never pick up done_at (they never
+-- transition again) and are silently excluded from lead/cycle metrics.
+
+-- done_at: completed_at (0022) already records when the issue entered done,
+-- so reuse it directly rather than approximating further.
+UPDATE issues SET done_at = completed_at
+  WHERE completed_at IS NOT NULL AND done_at IS NULL;
+
+-- ready_at: best-effort floor, not an exact value — an issue that is past
+-- backlog was ready no later than when it was created.
+UPDATE issues SET ready_at = created_at
+  WHERE ready_at IS NULL AND status != 'backlog';
+
+-- claimed_at: best-effort floor — anything that reached in-progress-or-beyond
+-- (including issues already done) was claimed no later than when it was created.
+UPDATE issues SET claimed_at = created_at
+  WHERE claimed_at IS NULL
+    AND (status_category = 'in_progress' OR status IN ('in_progress', 'in_review') OR done_at IS NOT NULL);

--- a/packages/types/src/env.ts
+++ b/packages/types/src/env.ts
@@ -39,7 +39,8 @@ export interface Env {
 	// is absent (e.g. team.example.com -> slug "team"). Off by default: most deployments
 	// sit behind a single Cloudflare Workers hostname, where the leading label is a
 	// CDN/proxy artifact, not a real tenant signal. Set "true" only when workspace
-	// subdomains are actually provisioned in DNS. (PROJ-267)
+	// subdomains are actually provisioned in DNS. Honored truthy values (case-
+	// insensitive, whitespace-trimmed): "true", "1", "yes". (PROJ-267, PROJ-296)
 	WORKSPACE_SUBDOMAIN_ROUTING?: string;
 }
 

--- a/scripts/release-assets/wrangler.example.toml
+++ b/scripts/release-assets/wrangler.example.toml
@@ -57,6 +57,9 @@ AUTO_JOIN_ROLE = "viewer"
 # Set to "true" only if you've provisioned real workspace subdomains in DNS
 # (team.example.com -> slug "team") - otherwise the Host header's leading label
 # is just a CDN/proxy artifact, not a real tenant signal.
+# Upgrade note: this used to be effectively always-on for hosts with a
+# subdomain; if you relied on that, set this explicitly or switch clients to
+# send X-Workspace-Slug.
 # WORKSPACE_SUBDOMAIN_ROUTING = "true"
 
 # ─── Secrets (set ONCE; they persist on the Worker across every deploy) ────────


### PR DESCRIPTION
Epic **PROJ-286** — post-review follow-ups on PROJ-250 (agentic workflow gates) and PROJ-261 (auth/docs), plus swept-in deploy/CI bugs.

## Workflow gates
- **PROJ-287/289** — bind the review/done gate to the issue's **live agent lease** rather than caller-supplied `agentSessionId`/`kind`. Omitting the id or self-declaring `kind:"human"` no longer bypasses it; an agent holding a live lease can never mark an issue `done`, and the done-report requirement is scoped to issues that were actually agent-worked (a plain human close of a never-agent issue needs no report).
- **PROJ-290** — atomic WIP cap via a guarded `INSERT ... SELECT ... WHERE (live-count) < cap`, closing the check-then-insert TOCTOU race (SQLite serializes the write). Regression test fires 8 concurrent claims against a cap of 3.
- **PROJ-291** — hardened Definition-of-Ready heuristics (structural label / file-path-token detection instead of prose matches) and **stop silently dropping** not-ready issues from the prioritized list — `get_prioritized_issues` now returns `{ issues, droppedNotReady }`.
- **PROJ-292** — review detection keyed on a `/review/i` **status key**, not a category (there is no `in_review` category; the default review status has category `in_progress`, so custom review statuses like `code-review` were slipping the gate). See "Decisions" below.
- **PROJ-293** — stamp `completion_report_at` / post the report **only on a real review/done transition**, not on any update that happens to carry a `completionReport`.

## Flow metrics
- **PROJ-288/294** — new `0026_backfill_flow_timestamps` migration (best-effort floors from `completed_at`/`created_at`) and window lead/cycle/agent-vs-human on `done_at` instead of filtering by `created_at`.

## Auth / routing
- **PROJ-295/296** — `WORKSPACE_SUBDOMAIN_ROUTING` accepts `true`/`1`/`yes` and **warns (fails closed)** when an otherwise-resolvable subdomain is ignored because the flag is off — catching the silent per-tenant outage an upgrade could cause. Opt-in documented in the deploy guide + example wrangler config.
- **PROJ-297** — broadened the C1 workspace-confinement auth regression test.

## CI / deps / hygiene
- **PROJ-298** — `engines.node >= 22.12`; CI Node pinned to `22.12.0` (ci + docs).
- **PROJ-299** — typed `__PROJEKTOR_VERSION__` as `string | undefined`.
- **PROJ-300** — restored `Readability.MaxFunctionLength` as a **gating (medium)** check; existing long test `describe` blocks carry inline `cofferdam-ignore` so the baseline stays empty. Also reduced `workspaceMiddleware` + `applyFlowTimestampTransitions` complexity and dropped a stale orphan export that re-enabling the gate surfaced.

## Verification
- `pnpm --filter @projektor/api test` — **570 passed, 5 todo, 1 skipped**.
- `pnpm turbo type-check`, `pnpm biome check .`, `pnpm cofferdam` — all green.

## Decisions / follow-ups
- **PROJ-292** interim: review is matched on a `/review/i` key because the schema has no `in_review` category. A cleaner long-term fix is a dedicated `is_review` status flag (or category) — worth a follow-up ticket.
- **PROJ-287** nuance: a human marking an issue `done` while an agent's lease is still live (within its ~120s heartbeat window) is treated as the agent → 403. The workflow expects the agent to release/end its lease on handoff; flagging in case that window needs tightening.
- **apps/web astro 5→7** upgrade deferred to its own PR (major frontend + Tailwind v4 migration; out of scope for this hardening PR).
- External-repo tickets (projektor-deploy-example, GitHub Pages setup) are not actionable from this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)