### PR TITLE
chore(web): bump version to 0.2.17 for release

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@projektor/web",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "private": true,
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
Version bump for the **v0.2.17** release. The nav/footer version reads `apps/web/package.json`, so this must match the tag before `v0.2.17` is pushed.

Release contents: the PROJ-286 post-review hardening epic (#49) — agent workflow gate binding to live leases (closes the gate-bypass), atomic WIP cap, DoR hardening, flow-metrics backfill/windowing, subdomain-routing env hardening, and CI/deps/tooling cleanup.

Once merged, `v0.2.17` will be tagged on `main` to trigger `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)