### PR TITLE
Fix ticket count cap, mobile zoom, editor freeze, and bold auto-wrap

### DIFF
--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -198,13 +198,12 @@ async function addCustomFieldFilter(
 
 // Date-range filters (PROJ-212) — inclusive bounds, index-backed.
 function addDateRangeFilters(conditions: Condition[], filters: ListIssuesFilters): void {
-	const { completedAfter, completedBefore, updatedAfter, updatedBefore, cursor } = filters;
+	const { completedAfter, completedBefore, updatedAfter, updatedBefore } = filters;
 
 	if (completedAfter) conditions.push(gte(schema.issues.completedAt, completedAfter));
 	if (completedBefore) conditions.push(lte(schema.issues.completedAt, completedBefore));
 	if (updatedAfter) conditions.push(gte(schema.issues.updatedAt, updatedAfter));
 	if (updatedBefore) conditions.push(lte(schema.issues.updatedAt, updatedBefore));
-	if (cursor) conditions.push(sql`${schema.issues.createdAt} < ${cursor}`);
 }
 
 async function buildListIssuesConditions(
@@ -228,7 +227,19 @@ export async function listIssues(ctx: ServiceCtx, raw: unknown) {
 
 	const orm = drizzle(ctx.db, { schema });
 
+	// Conditions exclude the pagination cursor, so they represent the full filtered set —
+	// used as-is for the total count, and extended with the cursor below for the page query.
 	const conditions = await buildListIssuesConditions(orm, ctx, filters);
+	const pageConditions = filters.cursor
+		? [...conditions, sql`${schema.issues.createdAt} < ${filters.cursor}`]
+		: conditions;
+
+	const totalRow = await orm
+		.select({ count: sql<number>`count(*)` })
+		.from(schema.issues)
+		.where(and(...conditions))
+		.get();
+	const total = totalRow?.count ?? 0;
 
 	// Select with snake_case aliases to preserve the same response shape as the raw-SQL version.
 	// labels uses a raw SQL expression to return the stored JSON string (bypassing Drizzle's
@@ -267,7 +278,7 @@ export async function listIssues(ctx: ServiceCtx, raw: unknown) {
 		.leftJoin(schema.projects, eq(schema.issues.projectId, schema.projects.id))
 		.leftJoin(schema.taskTypes, eq(schema.issues.typeId, schema.taskTypes.id))
 		.leftJoin(schema.taskStatuses, eq(schema.issues.statusId, schema.taskStatuses.id))
-		.where(and(...conditions))
+		.where(and(...pageConditions))
 		.orderBy(desc(schema.issues.createdAt))
 		.limit(limit + 1);
 
@@ -283,7 +294,7 @@ export async function listIssues(ctx: ServiceCtx, raw: unknown) {
 		customFields: customFieldsByIssue[i.id as string] ?? [],
 	}));
 
-	return { items: itemsWithFields, nextCursor };
+	return { items: itemsWithFields, nextCursor, total };
 }
 
 // Snake-case aliases preserve the existing response contract. The labels raw expression

--- a/apps/api/src/test/issues.test.ts
+++ b/apps/api/src/test/issues.test.ts
@@ -27,7 +27,11 @@ describe("Issues API", () => {
 		({ token, slug, workspaceId, userId, projectId } = await seedProjectFixture({ role: "owner" }));
 	});
 
-	type IssuesPage = { items: Array<Record<string, unknown>>; nextCursor: number | null };
+	type IssuesPage = {
+		items: Array<Record<string, unknown>>;
+		nextCursor: number | null;
+		total: number;
+	};
 
 	async function listIssues(url = "http://localhost/api/issues") {
 		const res = await SELF.fetch(url, { headers: authHeaders(token, slug) });
@@ -300,6 +304,27 @@ describe("Issues API", () => {
 		);
 		expect(second.items).toHaveLength(5);
 		expect(second.nextCursor).toBeNull();
+	});
+
+	it("reports the real total match count, not just the loaded page size (PROJ-303)", async () => {
+		const base = 1_700_000_000;
+		for (let i = 0; i < 35; i++) {
+			await seedIssue(workspaceId, projectId, userId, {
+				title: `Issue ${i}`,
+				createdAt: base + i,
+			});
+		}
+
+		// The first page only loads 30 rows, but `total` must reflect all 35 matches —
+		// this is what the frontend header count relies on instead of items.length.
+		const { page: first } = await listIssues("http://localhost/api/issues");
+		expect(first.items).toHaveLength(30);
+		expect(first.total).toBe(35);
+
+		const { page: second } = await listIssues(
+			`http://localhost/api/issues?cursor=${first.nextCursor}`
+		);
+		expect(second.total).toBe(35);
 	});
 
 	it("projectId filter scopes results to that project only", async () => {

--- a/apps/web/src/islands/IssueList.test.tsx
+++ b/apps/web/src/islands/IssueList.test.tsx
@@ -558,6 +558,30 @@ describe("project filter API contract", () => {
 		expect(String(issueCall?.[0])).toContain("limit=30");
 	});
 
+	it("header count shows the server's real total, not just the loaded page size (PROJ-303)", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation((url: string) => {
+				const s = String(url);
+				if (s.includes("task-statuses"))
+					return Promise.resolve({ ok: true, json: () => Promise.resolve(STATUSES) });
+				if (s.includes("/api/projects"))
+					return Promise.resolve({ ok: true, json: () => Promise.resolve(PROJECTS) });
+				// Server reports 42 matches total even though only the loaded page (2 issues) is returned.
+				return Promise.resolve({
+					ok: true,
+					json: () => Promise.resolve({ items: ISSUES, nextCursor: 999, total: 42 }),
+				});
+			})
+		);
+		render(<IssueList />);
+		await waitForLoaded();
+
+		await waitFor(() => {
+			expect(screen.getByText(/\(of 42\)/)).toBeTruthy();
+		});
+	});
+
 	it("includes project=<id> in issues fetch when ?project=KEY is active", async () => {
 		history.replaceState(null, "", "/?project=PROJ");
 		const mockFetch = setupProjectFetch();

--- a/apps/web/src/islands/MarkdownEditor.test.tsx
+++ b/apps/web/src/islands/MarkdownEditor.test.tsx
@@ -101,6 +101,18 @@ describe("MarkdownEditor", () => {
 		});
 	});
 
+	it("doesn't nest a second auto-overflow scroll container around CodeMirror's own scroller (PROJ-305)", () => {
+		// CodeMirror's `.cm-scroller` already sets `overflow: auto` internally. Wrapping
+		// it in a sibling container that ALSO has `overflow-auto` inside a stretched
+		// flex row caused a real-browser layout thrash (content height change -> flex
+		// re-stretch -> CM re-measures -> height changes again) that froze the page
+		// mid-typing. jsdom has no layout engine so this can't be caught by behavior —
+		// assert directly on the mount container's class instead.
+		const { container } = render(<MarkdownEditor value="" onChange={() => {}} />);
+		const editorPane = container.querySelector(".cm-editor")?.parentElement;
+		expect(editorPane?.className).not.toContain("overflow-auto");
+	});
+
 	it("switches to preview pane when the mobile Preview button is clicked", () => {
 		render(<MarkdownEditor value="" onChange={() => {}} />);
 		const buttons = screen.getAllByRole("button");

--- a/apps/web/src/islands/MarkdownEditor.tsx
+++ b/apps/web/src/islands/MarkdownEditor.tsx
@@ -180,6 +180,13 @@ function useMarkdownEditorView(
 ) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const viewRef = useRef<EditorView | null>(null);
+	// The last doc content WE emitted via onChange. The "sync externally-driven value"
+	// effect below compares the incoming `value` prop against this — not against the
+	// live doc — so a same-tick echo of our own change (however delayed by Preact's
+	// scheduling) is recognized as our own and skipped, instead of being re-dispatched
+	// as if it were an external change and potentially clobbering keystrokes typed since
+	// (PROJ-305: this race was making the editor appear to freeze mid-typing).
+	const lastEmitted = useRef(value);
 
 	useEffect(() => {
 		if (!containerRef.current) return;
@@ -197,7 +204,9 @@ function useMarkdownEditorView(
 				keymap.of([...customKeymap, ...historyKeymap, ...defaultKeymap]),
 				EditorView.updateListener.of((update) => {
 					if (update.docChanged) {
-						onChange(update.state.doc.toString());
+						const next = update.state.doc.toString();
+						lastEmitted.current = next;
+						onChange(next);
 					}
 				}),
 				EditorView.theme({
@@ -227,8 +236,12 @@ function useMarkdownEditorView(
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
-	// Sync externally-driven value changes (e.g. switching issues)
+	// Sync externally-driven value changes (e.g. switching issues). If `value` matches
+	// what we last emitted, this render is just our own change echoing back through
+	// props — nothing to do, regardless of whether the doc has since moved on further.
 	useEffect(() => {
+		if (value === lastEmitted.current) return;
+		lastEmitted.current = value;
 		const view = viewRef.current;
 		if (!view) return;
 		const current = view.state.doc.toString();
@@ -328,7 +341,7 @@ export default function MarkdownEditor({ value, onChange, minHeight = "240px" }:
 
 			<div class="flex flex-1" style={{ minHeight }}>
 				<div
-					class={`flex-1 min-w-0 overflow-auto flex flex-col${mobilePreview ? " max-sm:hidden" : ""}`}
+					class={`flex-1 min-w-0 flex flex-col${mobilePreview ? " max-sm:hidden" : ""}`}
 					ref={containerRef}
 				/>
 				<PreviewPane preview={preview} mobilePreview={mobilePreview} />

--- a/apps/web/src/islands/issue-list/IssueListLayout.tsx
+++ b/apps/web/src/islands/issue-list/IssueListLayout.tsx
@@ -113,7 +113,7 @@ function IssueListTop({
 				view={view}
 				setView={setView}
 				filtered={filtered}
-				totalIssues={data.issues.length}
+				totalIssues={data.total}
 				projectsCount={data.projects.length}
 				openCreateModal={createModal.openCreateModal}
 			/>

--- a/apps/web/src/islands/issue-list/ListSection.tsx
+++ b/apps/web/src/islands/issue-list/ListSection.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "preact/hooks";
 import { formatIssueRef } from "../../lib/issue-ref";
 import { issueUrl } from "../../utils/issue-url";
 import type { Issue, SortKey, TaskStatus } from "../board-utils";
@@ -178,6 +179,23 @@ export default function ListSection({
 	loadingMore,
 	loadMore,
 }: ListSectionProps) {
+	// Auto-paginate on scroll (PROJ-303): load the next page as soon as the sentinel
+	// at the bottom of the list scrolls into view, instead of requiring a manual click.
+	const sentinelRef = useRef<HTMLDivElement>(null);
+	useEffect(() => {
+		if (nextCursor == null) return;
+		const node = sentinelRef.current;
+		if (!node) return;
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries.some((e) => e.isIntersecting)) loadMore();
+			},
+			{ rootMargin: "400px" }
+		);
+		observer.observe(node);
+		return () => observer.disconnect();
+	}, [nextCursor, loadMore]);
+
 	if (issues.length === 0) {
 		return <p class="text-text-base">No issues match the current filters.</p>;
 	}
@@ -205,12 +223,11 @@ export default function ListSection({
 				changePriority={changePriority}
 			/>
 
-			{/* Load more (PROJ-201): visible only while the server has another page */}
+			{/* Auto-load sentinel (PROJ-201/303): fetches the next page once it scrolls
+			    into view; only rendered while the server has another page. */}
 			{nextCursor != null && (
-				<div class="flex justify-center mt-4">
-					<button type="button" class="btn btn-outline" onClick={loadMore} disabled={loadingMore}>
-						{loadingMore ? "Loading…" : "Load more"}
-					</button>
+				<div ref={sentinelRef} class="flex justify-center mt-4 py-2">
+					{loadingMore && <span class="text-sm text-text-muted">Loading more…</span>}
 				</div>
 			)}
 		</>

--- a/apps/web/src/islands/issue-list/useIssueFetching.ts
+++ b/apps/web/src/islands/issue-list/useIssueFetching.ts
@@ -33,9 +33,13 @@ export function useIssueFetching(
 	// response from the most recently issued fetchIssues call is applied.
 	const fetchSeq = useRef(0);
 	const [error, setError] = useState<string | null>(null);
-	// Pagination (PROJ-201): list view loads 30 at a time and appends via "Load more".
+	// Pagination (PROJ-201/303): list view loads 30 at a time and appends automatically
+	// as the user scrolls near the bottom (see useInfiniteScroll / ListSection).
 	const [nextCursor, setNextCursor] = useState<number | null>(null);
 	const [loadingMore, setLoadingMore] = useState(false);
+	// Real total matching the current filters (server-computed), not just how many
+	// have been loaded so far — PROJ-303: the header count must never look capped.
+	const [total, setTotal] = useState(0);
 
 	// Build the filter query params shared by the initial fetch and "Load more"
 	// (everything except limit/cursor, which the callers set).
@@ -68,7 +72,7 @@ export function useIssueFetching(
 		try {
 			const qs = buildFilterParams();
 			qs.set("limit", String(pageSize));
-			const data = await apiFetch<{ items: Issue[]; nextCursor: number | null }>(
+			const data = await apiFetch<{ items: Issue[]; nextCursor: number | null; total: number }>(
 				`/api/issues?${qs.toString()}`,
 				{
 					workspaceSlug,
@@ -77,6 +81,7 @@ export function useIssueFetching(
 			if (seq !== fetchSeq.current) return; // superseded by a newer request
 			setIssues(data.items);
 			setNextCursor(data.nextCursor ?? null);
+			setTotal(data.total ?? data.items.length);
 			hasLoadedOnce.current = true;
 		} catch (e) {
 			if (seq !== fetchSeq.current) return;
@@ -94,7 +99,7 @@ export function useIssueFetching(
 			const qs = buildFilterParams();
 			qs.set("limit", String(pageSize));
 			qs.set("cursor", String(nextCursor));
-			const data = await apiFetch<{ items: Issue[]; nextCursor: number | null }>(
+			const data = await apiFetch<{ items: Issue[]; nextCursor: number | null; total: number }>(
 				`/api/issues?${qs.toString()}`,
 				{
 					workspaceSlug,
@@ -102,6 +107,7 @@ export function useIssueFetching(
 			);
 			setIssues((prev) => [...prev, ...data.items]);
 			setNextCursor(data.nextCursor ?? null);
+			setTotal(data.total ?? 0);
 		} catch (e) {
 			setError(String(e));
 		} finally {
@@ -121,6 +127,7 @@ export function useIssueFetching(
 		error,
 		nextCursor,
 		loadingMore,
+		total,
 		fetchIssues,
 		loadMore,
 	};

--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -426,6 +426,12 @@ const navItems = [
         /* Roomier tap targets inside the drawer */
         .sidebar-link { padding: 0.6875rem 0.75rem; }
         .theme-toggle { padding: 0.5rem 0.625rem; min-height: 44px; }
+
+        /* iOS Safari auto-zooms the page on focus of any form control rendered
+           below 16px; forcing 16px here (PROJ-304) prevents that zoom-in. */
+        input, textarea, select {
+          font-size: 16px;
+        }
       }
 
       /* ── Custom Select (islands) ───────────────────────────────────── */

--- a/apps/web/src/layouts/Base.mobile-viewport.test.ts
+++ b/apps/web/src/layouts/Base.mobile-viewport.test.ts
@@ -1,0 +1,19 @@
+// Base.astro isn't a Preact component, so it can't be rendered with
+// @testing-library/preact — this asserts directly on the source instead.
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(join(__dirname, "Base.astro"), "utf-8");
+
+describe("Base layout — mobile viewport", () => {
+	it("forces 16px form-control font-size on mobile so iOS Safari doesn't auto-zoom on focus (PROJ-304)", () => {
+		const mobileQueryStart = source.lastIndexOf("@media (max-width: 640px)");
+		expect(mobileQueryStart).toBeGreaterThan(-1);
+
+		const mobileQueryEnd = source.indexOf("\n      }", mobileQueryStart);
+		const mobileQuery = source.slice(mobileQueryStart, mobileQueryEnd);
+
+		expect(mobileQuery).toMatch(/input,\s*textarea,\s*select\s*{\s*font-size:\s*16px;/);
+	});
+});


### PR DESCRIPTION
## Summary
- **PROJ-303**: report the server's real filtered total (not just the loaded page size) and auto-paginate the list view on scroll instead of a manual "Load more" click.
- **PROJ-305**: fix a reentrant CodeMirror<->Preact echo loop, and remove a redundant `overflow-auto` container that was fighting CodeMirror's own scroller for layout — this was the actual cause of a real, reproducible hard freeze while typing into a ticket's description.
- **PROJ-306**: bold auto-wrap turned out to be a downstream symptom of the PROJ-305 race; resolved by the same fix and confirmed live in-browser.
- **PROJ-304**: force 16px font-size on mobile form controls so iOS Safari doesn't auto-zoom the page on focus.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm turbo type-check`
- [x] `pnpm --filter @projektor/api test` (571 passed)
- [x] `pnpm --filter @projektor/web test` (255 passed, incl. new regression tests for PROJ-304/305)
- [x] Manually confirmed in a real browser: description editor no longer freezes while typing, and bold auto-wrap no longer occurs.

https://claude.ai/code/session_013Got2KX8D4dWvGJLhpuY7f