### PR TITLE
Expose canonical web UI url on issues and wiki pages (PROJ-307)

### DIFF
--- a/apps/api/src/lib/urls.ts
+++ b/apps/api/src/lib/urls.ts
@@ -1,0 +1,22 @@
+function slugifyForUrl(text: string): string {
+	return text
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-|-$/g, "");
+}
+
+/**
+ * Canonical web UI path for an issue (PROJ-307). The web app's route only resolves
+ * on project key + number — the trailing slug is cosmetic and doesn't need to match
+ * exactly, so it's safe to (re)compute here independently of the client.
+ */
+export function issuePath(projectKey: string, number: number, title: string): string {
+	return `/projects/${projectKey}/issues/${number}/${slugifyForUrl(title)}`;
+}
+
+/** Canonical web UI path for a wiki page (PROJ-307). */
+export function wikiPagePath(slug: string, projectId: string | null): string {
+	const qs = new URLSearchParams({ slug });
+	if (projectId) qs.set("projectId", projectId);
+	return `/wiki?${qs.toString()}`;
+}

--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -14,6 +14,7 @@ import {
 	sql,
 } from "drizzle-orm";
 import type { z } from "zod";
+import { issuePath } from "../lib/urls";
 import { IdSchema } from "../schemas/common";
 import {
 	CreateIssueSchema,
@@ -281,6 +282,9 @@ export async function listIssues(ctx: ServiceCtx, raw: unknown) {
 	const itemsWithFields = (items as Array<Record<string, unknown>>).map((i) => ({
 		...i,
 		customFields: customFieldsByIssue[i.id as string] ?? [],
+		url: i.project_key
+			? issuePath(i.project_key as string, i.number as number, i.title as string)
+			: null,
 	}));
 
 	return { items: itemsWithFields, nextCursor };
@@ -405,11 +409,19 @@ export async function getIssue(ctx: ServiceCtx, raw: unknown) {
 	const customFieldsByIssue = await batchLoadCustomFields(ctx.db, ctx.workspaceId, [issueId]);
 	const customFields = customFieldsByIssue[issueId] ?? [];
 
+	const issueRecord = issue as Record<string, unknown>;
 	const fullIssue = {
-		...(issue as Record<string, unknown>),
+		...issueRecord,
 		rollup,
 		links,
 		customFields,
+		url: issueRecord.project_key
+			? issuePath(
+					issueRecord.project_key as string,
+					issueRecord.number as number,
+					issueRecord.title as string
+				)
+			: null,
 	};
 
 	await cache.set(ctx.kv, `issue:${ctx.workspaceId}:${issueId}`, fullIssue, ISSUE_TTL);

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -1,5 +1,6 @@
 import { drizzle, schema } from "@projektor/db";
 import { and, asc, desc, eq, or } from "drizzle-orm";
+import { wikiPagePath } from "../lib/urls";
 import { IdSchema } from "../schemas/common";
 import {
 	CreatePageSchema,
@@ -11,7 +12,7 @@ import { recordActivity } from "./activity";
 import { ForbiddenError, NotFoundError, ValidationError } from "./errors";
 import type { ServiceCtx } from "./types";
 
-type TreeNode = { id: string; slug: string; title: string; children: TreeNode[] };
+type TreeNode = { id: string; slug: string; title: string; url: string; children: TreeNode[] };
 
 function slugify(title: string): string {
 	return title
@@ -24,11 +25,12 @@ async function resolvePageByIdOrSlug(
 	db: D1Database,
 	idOrSlug: string,
 	workspaceId: string
-): Promise<{ id: string; content: string; projectId: string | null }> {
+): Promise<{ id: string; slug: string; content: string; projectId: string | null }> {
 	const orm = drizzle(db, { schema });
 	const page = await orm
 		.select({
 			id: schema.wikiPages.id,
+			slug: schema.wikiPages.slug,
 			content: schema.wikiPages.content,
 			projectId: schema.wikiPages.projectId,
 		})
@@ -171,7 +173,7 @@ export async function listWikiPages(ctx: ServiceCtx, input: unknown) {
 		conditions.push(eq(schema.wikiPages.projectId, parsed.data.projectId));
 	}
 
-	return orm
+	const rows = await orm
 		.select({
 			id: schema.wikiPages.id,
 			slug: schema.wikiPages.slug,
@@ -186,6 +188,8 @@ export async function listWikiPages(ctx: ServiceCtx, input: unknown) {
 		.from(schema.wikiPages)
 		.where(and(...conditions))
 		.orderBy(asc(schema.wikiPages.title));
+
+	return rows.map((r) => ({ ...r, url: wikiPagePath(r.slug, r.project_id) }));
 }
 
 export async function searchWiki(ctx: ServiceCtx, input: unknown) {
@@ -241,7 +245,7 @@ export async function getWikiPage(ctx: ServiceCtx, slugOrId: string) {
 		)
 		.get();
 	if (!page) throw new NotFoundError("Wiki page not found");
-	return page;
+	return { ...page, url: wikiPagePath(page.slug, page.project_id) };
 }
 
 export async function createWikiPage(ctx: ServiceCtx, input: unknown) {
@@ -273,7 +277,7 @@ export async function createWikiPage(ctx: ServiceCtx, input: unknown) {
 		updatedAt: now,
 	});
 	await recordActivity(ctx, { entityType: "wiki_page", entityId: id, action: "created" });
-	return { id, slug, projectId: projectId ?? null };
+	return { id, slug, projectId: projectId ?? null, url: wikiPagePath(slug, projectId ?? null) };
 }
 
 export async function updateWikiPage(ctx: ServiceCtx, idOrSlug: string, input: unknown) {
@@ -313,7 +317,7 @@ export async function updateWikiPage(ctx: ServiceCtx, idOrSlug: string, input: u
 		diff: buildWikiPageUpdateDiff({ title, content }),
 	});
 
-	return { ok: true };
+	return { ok: true, url: wikiPagePath(page.slug, page.projectId) };
 }
 
 export async function deleteWikiPage(ctx: ServiceCtx, slug: string) {
@@ -344,6 +348,7 @@ export async function getWikiTree(ctx: ServiceCtx, projectId?: string): Promise<
 			slug: schema.wikiPages.slug,
 			title: schema.wikiPages.title,
 			parentId: schema.wikiPages.parentId,
+			projectId: schema.wikiPages.projectId,
 		})
 		.from(schema.wikiPages)
 		.where(and(...conditions))
@@ -351,7 +356,13 @@ export async function getWikiTree(ctx: ServiceCtx, projectId?: string): Promise<
 
 	const map = new Map<string, TreeNode>();
 	for (const p of rows) {
-		map.set(p.id, { id: p.id, slug: p.slug, title: p.title, children: [] });
+		map.set(p.id, {
+			id: p.id,
+			slug: p.slug,
+			title: p.title,
+			url: wikiPagePath(p.slug, p.projectId),
+			children: [],
+		});
 	}
 
 	const roots: TreeNode[] = [];

--- a/apps/api/src/test/issues.test.ts
+++ b/apps/api/src/test/issues.test.ts
@@ -65,6 +65,24 @@ describe("Issues API", () => {
 		expect(page.items[0].title).toBe("Visible issue");
 	});
 
+	it("exposes a resolvable url on list items and single-issue fetches (PROJ-307)", async () => {
+		const createRes = await SELF.fetch("http://localhost/api/issues", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ projectId, title: "Wiki full-text search" }),
+		});
+		const created = (await createRes.json()) as { id: string; number: number };
+
+		const { page } = await listIssues();
+		expect(page.items[0].url).toBe(`/projects/PROJ/issues/${created.number}/wiki-full-text-search`);
+
+		const getRes = await SELF.fetch(`http://localhost/api/issues/${created.id}`, {
+			headers: authHeaders(token, slug),
+		});
+		const fetched = (await getRes.json()) as { url: string };
+		expect(fetched.url).toBe(`/projects/PROJ/issues/${created.number}/wiki-full-text-search`);
+	});
+
 	it("auto-increments issue number per project", async () => {
 		for (const title of ["Issue A", "Issue B", "Issue C"]) {
 			await SELF.fetch("http://localhost/api/issues", {

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -6,11 +6,13 @@ import { authHeaders, seedFixture, seedProject, seedWorkspaceRoles } from "./hel
 describe("Wiki API", () => {
 	let token: string;
 	let slug: string;
+	let workspaceId: string;
 
 	beforeEach(async () => {
 		const fixture = await seedFixture();
 		token = fixture.token;
 		slug = fixture.workspace.slug;
+		workspaceId = fixture.workspace.id;
 	});
 
 	it("GET /api/wiki returns empty list initially", async () => {
@@ -30,6 +32,55 @@ describe("Wiki API", () => {
 		expect(res.status).toBe(201);
 		const body = (await res.json()) as { id: string; slug: string };
 		expect(body.slug).toBe("getting-started");
+	});
+
+	describe("canonical page url (PROJ-307)", () => {
+		it("create/get/update/list/tree all expose a resolvable url", async () => {
+			const createRes = await SELF.fetch("http://localhost/api/wiki", {
+				method: "POST",
+				headers: authHeaders(token, slug),
+				body: JSON.stringify({ title: "Weekly Updates", content: "index" }),
+			});
+			const created = (await createRes.json()) as { url: string };
+			expect(created.url).toBe("/wiki?slug=weekly-updates");
+
+			const getRes = await SELF.fetch("http://localhost/api/wiki/weekly-updates", {
+				headers: authHeaders(token, slug),
+			});
+			const fetched = (await getRes.json()) as { url: string };
+			expect(fetched.url).toBe("/wiki?slug=weekly-updates");
+
+			const updateRes = await SELF.fetch("http://localhost/api/wiki/weekly-updates", {
+				method: "PUT",
+				headers: authHeaders(token, slug),
+				body: JSON.stringify({ content: "index v2" }),
+			});
+			const updated = (await updateRes.json()) as { url: string };
+			expect(updated.url).toBe("/wiki?slug=weekly-updates");
+
+			const listRes = await SELF.fetch("http://localhost/api/wiki", {
+				headers: authHeaders(token, slug),
+			});
+			const list = (await listRes.json()) as Array<{ slug: string; url: string }>;
+			expect(list.find((p) => p.slug === "weekly-updates")?.url).toBe("/wiki?slug=weekly-updates");
+
+			const treeRes = await SELF.fetch("http://localhost/api/wiki/tree", {
+				headers: authHeaders(token, slug),
+			});
+			const tree = (await treeRes.json()) as Array<{ slug: string; url: string }>;
+			expect(tree.find((p) => p.slug === "weekly-updates")?.url).toBe("/wiki?slug=weekly-updates");
+		});
+
+		it("includes projectId in the url when the page is scoped to a project", async () => {
+			const project = await seedProject(workspaceId);
+			const createRes = await SELF.fetch("http://localhost/api/wiki", {
+				method: "POST",
+				headers: authHeaders(token, slug),
+				body: JSON.stringify({ title: "Project Notes", content: "notes", projectId: project.id }),
+			});
+			const created = (await createRes.json()) as { url: string };
+			expect(created.url).toBe(`/wiki?slug=project-notes&projectId=${project.id}`);
+		});
 	});
 
 	it("GET /api/wiki/:slug retrieves a page by slug", async () => {


### PR DESCRIPTION
## Summary
Wiki content authored via MCP had no way to link to an issue or another wiki page — neither `get_issue`/`list_issues` nor the wiki endpoints exposed a resolvable URL, so authors fell back to plain-text references (e.g. "ROVI-145") instead of clickable links.

- Adds a `url` field (relative path) to `listIssues` items and `getIssue`'s response.
- Adds a `url` field to `listWikiPages`, `getWikiPage`, `createWikiPage`, `updateWikiPage`, and `wiki_tree`.
- The issue URL's trailing slug is cosmetic — the web route resolves on project key + number alone — so it's safe to recompute server-side without needing to match the client's own slugify exactly.

Closes PROJ-307.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm turbo type-check`
- [x] `pnpm --filter @projektor/api test` (574 passed, incl. 3 new PROJ-307 tests covering create/get/update/list/tree url exposure and project-scoped wiki urls)
- [x] `pnpm --filter @projektor/web test` (252 passed, unaffected)

https://claude.ai/code/session_013Got2KX8D4dWvGJLhpuY7f