### PR TITLE
fix(web): resolve workspace slug at runtime for group/token pages

### DIFF
--- a/apps/web/src/islands/GroupManager.tsx
+++ b/apps/web/src/islands/GroupManager.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "preact/hooks";
 import { apiFetch } from "../utils/api-client";
+import { resolveWorkspaceSlug } from "../utils/workspace";
 
 type GrantRole = "viewer" | "member" | "admin";
 
@@ -398,7 +399,7 @@ function GroupDetailEditor(props: DetailProps) {
 
 // cofferdam-ignore: Readability.MaxFunctionLength: single-island admin screen, normal preact style
 export default function GroupManager({ workspaceSlug }: Props) {
-	const slug = workspaceSlug ?? "";
+	const slug = resolveWorkspaceSlug(workspaceSlug);
 	const [data, setData] = useState<Loaded | null>(null);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);

--- a/apps/web/src/islands/TokenManager.tsx
+++ b/apps/web/src/islands/TokenManager.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { apiFetch } from "../utils/api-client";
+import { resolveWorkspaceSlug } from "../utils/workspace";
 
 interface ApiToken {
 	id: string;
@@ -686,7 +687,8 @@ function useWorkspaceMcpMeta(workspaceSlug: string | undefined) {
 	return { mcpCommandTemplate, mcpUrl };
 }
 
-export default function TokenManager({ workspaceSlug }: Props) {
+export default function TokenManager({ workspaceSlug: propWorkspaceSlug }: Props) {
+	const workspaceSlug = resolveWorkspaceSlug(propWorkspaceSlug);
 	const [tokens, setTokens] = useState<ApiToken[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);

--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -534,6 +534,9 @@ const navItems = [
               {item.label === 'My Issues' && (
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg>
               )}
+              {item.label === 'Groups' && (
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+              )}
               {item.label === 'Tokens' && (
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
               )}

--- a/apps/web/src/utils/workspace.test.ts
+++ b/apps/web/src/utils/workspace.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveWorkspaceSlug } from "./workspace";
+
+function stubHost(hostname: string) {
+	vi.stubGlobal("location", { hostname } as Location);
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("resolveWorkspaceSlug", () => {
+	it("prefers an explicit build-time slug over the hostname", () => {
+		stubHost("projektor.example.workers.dev");
+		expect(resolveWorkspaceSlug("acme")).toBe("acme");
+	});
+
+	it("falls back to the hostname's first label when no slug is baked in", () => {
+		stubHost("projektor.tajdickson.workers.dev");
+		expect(resolveWorkspaceSlug(undefined)).toBe("projektor");
+	});
+
+	it("returns '' for hosts with no tenant subdomain", () => {
+		for (const h of ["localhost", "127.0.0.1", "example"]) {
+			stubHost(h);
+			expect(resolveWorkspaceSlug(undefined)).toBe("");
+		}
+	});
+});

--- a/apps/web/src/utils/workspace.ts
+++ b/apps/web/src/utils/workspace.ts
@@ -1,0 +1,18 @@
+// Resolve the active workspace slug on the client.
+//
+// Prefer the build-time PUBLIC_WORKSPACE_SLUG (set for local dev / single-tenant
+// custom-domain builds). The generic release artifact never bakes it and instead
+// relies on WORKSPACE_SUBDOMAIN_ROUTING, so fall back to the hostname's first label
+// — the same rule the Worker uses to resolve the tenant from the Host header.
+//
+// Slug-less endpoints (/api/projects, /api/issues) resolve the workspace server-side
+// and don't need this; endpoints that embed the slug in their path (groups, tokens)
+// do. Returns "" during SSR (no `location`) and for host shapes with no tenant
+// subdomain (localhost, bare IPs, single-label hosts).
+export function resolveWorkspaceSlug(propSlug?: string): string {
+	if (propSlug) return propSlug;
+	if (typeof location === "undefined") return "";
+	const host = location.hostname;
+	if (host === "localhost" || /^[\d.]+$/.test(host) || host.split(".").length < 2) return "";
+	return host.split(".")[0];
+}


### PR DESCRIPTION
## Problem

The **Groups** (new in v0.3.0) and **API Tokens** settings pages render **"No workspace configured."** and never load on the deployed dogfood instance.

Both call slug-in-path endpoints (`/api/workspaces/:slug/...`) and hard-guard on an empty slug. They read the slug from the build-time `PUBLIC_WORKSPACE_SLUG` — but the generic release artifact **never bakes it** (by design; the deploy config comment says so and sets `WORKSPACE_SUBDOMAIN_ROUTING=true` instead). So on an artifact deploy the client slug is always empty → both pages dead-end. This affected Tokens already; PROJ-311's Groups page inherited the same broken pattern.

## Fix

Resolve the workspace slug on the client (`resolveWorkspaceSlug`):
1. Prefer `PUBLIC_WORKSPACE_SLUG` (local dev / single-tenant custom-domain builds).
2. Otherwise fall back to the **hostname's first label** — the exact rule the Worker uses to resolve the tenant from the `Host` header under subdomain routing.

Slug-less endpoints (`/api/projects`, `/api/issues`) already resolve the workspace server-side and are unaffected. `IssueDetail` embeds *project keys* (not the workspace slug) and passes `workspaceSlug` only as an optional header, so it's fine too.

Also adds the missing **Groups nav icon** (it rendered iconless next to Projects / My Issues / Tokens — the "no emoji" report).

## Changes
- New `apps/web/src/utils/workspace.ts` (`resolveWorkspaceSlug`) + unit tests.
- Wired into `GroupManager` and `TokenManager` (fixes the pre-existing Tokens break too).
- Groups SVG icon in `Base.astro`.

## Verification
- `pnpm --filter @projektor/web test` — 258 passed (+3 new).
- `pnpm turbo type-check` 7/7, lint clean (pre-commit hooks green).

Post-merge this needs a patch release (0.3.1) to reach the dogfood; will verify on the live instance after deploy.

Honest note: this class of bug is exactly what deploying-and-clicking-through before merge would have caught. Adjusting the workflow accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)