### PR TITLE
Complete group-based access control epic (PROJ-314: 315/316/317/318/319/313)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,6 +264,7 @@ These are the constraints the fleet skill reads to plan batches. Keep them curre
 | custom-fields | `services/custom-fields.ts` | `schemas/custom-fields.ts` | `routes/custom-fields.ts` | `mcp/custom-fields.ts` | `test/custom-fields.test.ts` |
 | workflow | `services/workflow.ts` | — (no input) | `routes/workflow.ts` | `mcp/workflow.ts` | `test/workflow.test.ts` |
 | flow-metrics | `services/flow-metrics.ts` | `schemas/flow-metrics.ts` | `routes/flow-metrics.ts` | `mcp/flow-metrics.ts` | `test/flow-metrics.test.ts` |
+| groups | `services/groups.ts` | `schemas/groups.ts` | `routes/groups.ts` | `mcp/groups.ts` | `test/groups.test.ts` |
 
 Frontend islands are **not** domain-locked in the same way, but two agents must never
 own the same island file. Assign each island to exactly one agent per batch.

--- a/apps/api/src/services/access.ts
+++ b/apps/api/src/services/access.ts
@@ -109,12 +109,21 @@ export function visibleProjectPredicate(
  * its bind params, or `null` for owner/admin (no filter needed).
  *
  * `projectColExpr` is inlined verbatim, so it MUST be a trusted column reference
- * (e.g. `"i.project_id"`), never user input.
+ * (e.g. `"i.project_id"`), never user input. It is validated as a bare or
+ * table-qualified identifier and throws otherwise, so a future caller can't turn
+ * this into an injection vector by passing something dynamic.
  */
+const COLUMN_EXPR = /^[a-z_][a-z0-9_]*(\.[a-z_][a-z0-9_]*)?$/;
+
 export function visibleProjectSqlFragment(
 	ctx: ServiceCtx,
 	projectColExpr: string
 ): { sql: string; params: unknown[] } | null {
+	if (!COLUMN_EXPR.test(projectColExpr)) {
+		throw new Error(
+			`visibleProjectSqlFragment: projectColExpr must be a column identifier, got ${JSON.stringify(projectColExpr)}`
+		);
+	}
 	if (isWorkspaceAdmin(ctx.role)) return null;
 	return {
 		sql: `EXISTS (SELECT 1 FROM user_group_members ugm

--- a/apps/api/src/services/agents.ts
+++ b/apps/api/src/services/agents.ts
@@ -1,11 +1,12 @@
 import { drizzle, schema } from "@projektor/db";
-import { and, desc, eq, gt } from "drizzle-orm";
+import { and, desc, eq, gt, isNull, or, sql } from "drizzle-orm";
 import {
 	EndAgentSchema,
 	HeartbeatAgentSchema,
 	ListActiveAgentsSchema,
 	RegisterAgentSchema,
 } from "../schemas/agents";
+import { visibleProjectPredicate } from "./access";
 import { NotFoundError, ValidationError } from "./errors";
 import { releaseClaimsForAgent } from "./file-claims";
 import { releaseLeasesForAgent } from "./issue-leases";
@@ -144,6 +145,18 @@ export async function listActiveAgents(ctx: ServiceCtx, raw: unknown) {
 
 	if (issueId) {
 		conditions.push(eq(schema.agentSessions.issueId, issueId));
+	}
+
+	// PROJ-316: a non-admin member only sees agents working an issue in a project
+	// they can access. Agents not tied to any issue carry no project, so they stay
+	// workspace-visible. Owner/admin (predicate undefined) see every agent.
+	const vis = visibleProjectPredicate(
+		ctx,
+		sql`(SELECT i.project_id FROM issues i WHERE i.id = ${schema.agentSessions.issueId})`
+	);
+	if (vis) {
+		const visibleOrUnpinned = or(isNull(schema.agentSessions.issueId), vis);
+		if (visibleOrUnpinned) conditions.push(visibleOrUnpinned);
 	}
 
 	const items = await orm

--- a/apps/api/src/services/file-claims.ts
+++ b/apps/api/src/services/file-claims.ts
@@ -1,6 +1,7 @@
 import { drizzle, schema } from "@projektor/db";
-import { and, eq, inArray, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import { ClaimFilesSchema, ListFileClaimsSchema, ReleaseFilesSchema } from "../schemas/file-claims";
+import { visibleProjectPredicate } from "./access";
 import { postMessage } from "./agent-messages";
 import { ConflictError, NotFoundError, ValidationError } from "./errors";
 import { inChunks } from "./sql";
@@ -246,6 +247,14 @@ export async function listFileClaims(ctx: ServiceCtx, raw: unknown) {
 	if (path) {
 		conditions.push(eq(schema.issueFileClaims.path, path));
 	}
+
+	// PROJ-316: a non-admin member only sees claims on issues whose project they
+	// can access; owner/admin (predicate undefined) see every claim.
+	const vis = visibleProjectPredicate(
+		ctx,
+		sql`(SELECT i.project_id FROM issues i WHERE i.id = ${schema.issueFileClaims.issueId})`
+	);
+	if (vis) conditions.push(vis);
 
 	const items = await orm
 		.select()

--- a/apps/api/src/services/issue-leases.ts
+++ b/apps/api/src/services/issue-leases.ts
@@ -1,10 +1,11 @@
 import { drizzle, schema } from "@projektor/db";
-import { and, eq, gt, isNull } from "drizzle-orm";
+import { and, eq, gt, isNull, sql } from "drizzle-orm";
 import {
 	ClaimIssueSchema,
 	ListIssueLeasesSchema,
 	ReleaseIssueSchema,
 } from "../schemas/issue-leases";
+import { visibleProjectPredicate } from "./access";
 import { ConflictError, NotFoundError, ValidationError } from "./errors";
 import type { ServiceCtx } from "./types";
 
@@ -349,6 +350,14 @@ export async function listIssueLeases(ctx: ServiceCtx, raw: unknown) {
 	];
 	if (issueId) conditions.push(eq(schema.issueLeases.issueId, issueId));
 	if (agentId) conditions.push(eq(schema.issueLeases.agentSessionId, agentId));
+
+	// PROJ-316: a non-admin member only sees leases on issues whose project they
+	// can access; owner/admin (predicate undefined) see every lease.
+	const vis = visibleProjectPredicate(
+		ctx,
+		sql`(SELECT i.project_id FROM issues i WHERE i.id = ${schema.issueLeases.issueId})`
+	);
+	if (vis) conditions.push(vis);
 
 	const rows = await orm
 		.select({

--- a/apps/api/src/test/access-admin-bypass.test.ts
+++ b/apps/api/src/test/access-admin-bypass.test.ts
@@ -1,0 +1,87 @@
+import { SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { authHeaders, seedGroupGrant, seedIssue, seedProject, seedWorkspaceRoles } from "./helpers";
+
+// PROJ-319: pin the admin-bypass path through the hand-written SQL callers of
+// visibleProjectSqlFragment (search) and the effectiveProjectRole/isWorkspaceAdmin
+// bypass used by flow-metrics, contrasted against a non-admin member who is
+// default-deny until granted.
+
+async function search(token: string, slug: string, q: string) {
+	const res = await SELF.fetch(`http://localhost/api/issues/search?q=${encodeURIComponent(q)}`, {
+		headers: authHeaders(token, slug),
+	});
+	return { status: res.status, body: (await res.json()) as Array<{ project_id: string }> };
+}
+
+// seedIssue() inserts directly into `issues`, bypassing the FTS index (which is
+// populated by the create-issue service, not a DB trigger); go through the REST
+// route so search can actually find these issues.
+async function createIssue(token: string, slug: string, projectId: string, title: string) {
+	const res = await SELF.fetch("http://localhost/api/issues", {
+		method: "POST",
+		headers: authHeaders(token, slug),
+		body: JSON.stringify({ projectId, title }),
+	});
+	expect(res.status).toBe(201);
+}
+
+describe("PROJ-319 admin bypass pinning", () => {
+	it("owner's search sees issues across projects they hold no group grant on", async () => {
+		const roles = await seedWorkspaceRoles();
+		const slug = roles.workspace.slug;
+		const p1 = await seedProject(roles.workspace.id, "P1");
+		const p2 = await seedProject(roles.workspace.id, "P2");
+		await createIssue(roles.owner.token, slug, p1.id, "sentinel-bypass-token");
+		await createIssue(roles.owner.token, slug, p2.id, "sentinel-bypass-token");
+
+		const result = await search(roles.owner.token, slug, "sentinel-bypass-token");
+		expect(result.status).toBe(200);
+		const projectIds = result.body.map((i) => i.project_id).sort();
+		expect(projectIds).toEqual([p1.id, p2.id].sort());
+	});
+
+	it("owner's get_flow_metrics returns real data for an ungranted project", async () => {
+		const roles = await seedWorkspaceRoles();
+		const slug = roles.workspace.slug;
+		const project = await seedProject(roles.workspace.id, "UNGRANTED");
+		await seedIssue(roles.workspace.id, project.id, roles.owner.user.id, {
+			title: "Metrics issue",
+		});
+
+		const res = await SELF.fetch(`http://localhost/api/projects/${project.id}/flow-metrics`, {
+			headers: authHeaders(roles.owner.token, slug),
+		});
+		expect(res.status).toBe(200);
+		const metrics = (await res.json()) as { leadTime: { count: number } };
+		expect(metrics.leadTime).toBeDefined();
+	});
+
+	it("a non-admin member granted only P1 sees only P1 in search (contrast)", async () => {
+		const roles = await seedWorkspaceRoles();
+		const slug = roles.workspace.slug;
+		const p1 = await seedProject(roles.workspace.id, "MP1");
+		const p2 = await seedProject(roles.workspace.id, "MP2");
+		await createIssue(roles.owner.token, slug, p1.id, "sentinel-scoped-token");
+		await createIssue(roles.owner.token, slug, p2.id, "sentinel-scoped-token");
+		await seedGroupGrant(roles.workspace.id, roles.member.user.id, p1.id, "member");
+
+		const result = await search(roles.member.token, slug, "sentinel-scoped-token");
+		expect(result.status).toBe(200);
+		expect(result.body.map((i) => i.project_id)).toEqual([p1.id]);
+	});
+
+	it("get_flow_metrics 404s for a non-admin member with no grant on the project", async () => {
+		const roles = await seedWorkspaceRoles();
+		const slug = roles.workspace.slug;
+		const project = await seedProject(roles.workspace.id, "MUNGRANTED");
+		await seedIssue(roles.workspace.id, project.id, roles.owner.user.id, {
+			title: "Hidden metrics",
+		});
+
+		const res = await SELF.fetch(`http://localhost/api/projects/${project.id}/flow-metrics`, {
+			headers: authHeaders(roles.member.token, slug),
+		});
+		expect(res.status).toBe(404);
+	});
+});

--- a/apps/api/src/test/access-fragment.test.ts
+++ b/apps/api/src/test/access-fragment.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { visibleProjectSqlFragment } from "../services/access";
+import type { ServiceCtx } from "../services/types";
+
+// PROJ-317: visibleProjectSqlFragment inlines its column expression verbatim into
+// raw SQL, so it must reject anything that isn't a bare/qualified column identifier
+// before it can become an injection vector.
+
+const memberCtx = { role: "member", userId: "u1" } as unknown as ServiceCtx;
+const ownerCtx = { role: "owner", userId: "u1" } as unknown as ServiceCtx;
+
+describe("visibleProjectSqlFragment column-expression guard", () => {
+	it("accepts a bare or table-qualified column identifier", () => {
+		expect(visibleProjectSqlFragment(memberCtx, "project_id")).not.toBeNull();
+		const frag = visibleProjectSqlFragment(memberCtx, "i.project_id");
+		expect(frag?.params).toEqual(["u1"]);
+		expect(frag?.sql).toContain("gpg.project_id = i.project_id");
+	});
+
+	it("returns null for owner/admin (no filter) but still validates the expression", () => {
+		expect(visibleProjectSqlFragment(ownerCtx, "i.project_id")).toBeNull();
+		expect(() => visibleProjectSqlFragment(ownerCtx, "i.project_id; DROP TABLE issues")).toThrow();
+	});
+
+	it("throws on anything that is not a column identifier", () => {
+		for (const bad of [
+			"i.project_id; DROP TABLE issues",
+			"(SELECT 1)",
+			"i.project_id OR 1=1",
+			"i.project_id, name",
+			"",
+			"1",
+		]) {
+			expect(() => visibleProjectSqlFragment(memberCtx, bad)).toThrow(/column identifier/);
+		}
+	});
+});

--- a/apps/api/src/test/coordination-access.test.ts
+++ b/apps/api/src/test/coordination-access.test.ts
@@ -1,0 +1,129 @@
+import { env, SELF } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	authHeaders,
+	seedAgentLease,
+	seedGroupGrant,
+	seedIssue,
+	seedProject,
+	seedWorkspaceRoles,
+} from "./helpers";
+
+// PROJ-316: the fleet-coordination list surfaces (issue-leases, file-claims,
+// agents) must respect the same default-deny project visibility as issues — a
+// non-admin member with no grant on a project must not be able to enumerate its
+// issue IDs, file paths, or agent activity. Owner/admin bypass groups.
+
+type ListResult = { items: Array<Record<string, unknown>> };
+
+async function mcpList(
+	tool: string,
+	token: string,
+	slug: string,
+	workspaceId: string
+): Promise<ListResult> {
+	const res = await SELF.fetch(`http://localhost/mcp/${workspaceId}`, {
+		method: "POST",
+		headers: authHeaders(token, slug),
+		body: JSON.stringify({
+			jsonrpc: "2.0",
+			id: 1,
+			method: "tools/call",
+			params: { name: tool, arguments: {} },
+		}),
+	});
+	const body = (await res.json()) as {
+		result: { content: Array<{ text: string }> };
+	};
+	return JSON.parse(body.result.content[0].text) as ListResult;
+}
+
+async function seedFileClaim(workspaceId: string, issueId: string, path: string) {
+	const now = Math.floor(Date.now() / 1000);
+	await env.DB.prepare(
+		`INSERT INTO issue_file_claims (id, workspace_id, issue_id, agent_id, path, claimed_at, released_at)
+		 VALUES (?, ?, ?, NULL, ?, ?, NULL)`
+	)
+		.bind(crypto.randomUUID(), workspaceId, issueId, path, now)
+		.run();
+}
+
+async function seedFloatingAgent(workspaceId: string, name: string): Promise<string> {
+	const id = crypto.randomUUID();
+	const now = Math.floor(Date.now() / 1000);
+	await env.DB.prepare(
+		`INSERT INTO agent_sessions
+		   (id, workspace_id, issue_id, token_id, name, kind, status, started_at, last_heartbeat_at, ended_at)
+		 VALUES (?, ?, NULL, NULL, ?, 'agent', 'active', ?, ?, NULL)`
+	)
+		.bind(id, workspaceId, name, now, now)
+		.run();
+	return id;
+}
+
+// cofferdam-ignore: Readability.MaxFunctionLength: integration suite, one describe block
+describe("PROJ-316 coordination data respects project visibility", () => {
+	let ws: Awaited<ReturnType<typeof seedWorkspaceRoles>>;
+	let slug: string;
+	let issueA: string;
+	let issueB: string;
+
+	beforeEach(async () => {
+		ws = await seedWorkspaceRoles();
+		slug = ws.workspace.slug;
+		const projectA = await seedProject(ws.workspace.id, "AAA");
+		const projectB = await seedProject(ws.workspace.id, "BBB");
+		// The member can see project A only.
+		await seedGroupGrant(ws.workspace.id, ws.member.user.id, projectA.id, "member");
+
+		issueA = (await seedIssue(ws.workspace.id, projectA.id, ws.owner.user.id, { title: "A" })).id;
+		issueB = (await seedIssue(ws.workspace.id, projectB.id, ws.owner.user.id, { title: "B" })).id;
+
+		// A live lease + agent on each issue, a file claim on each, and one agent
+		// pinned to no issue (workspace-level coordination).
+		await seedAgentLease(ws.workspace.id, issueA, { name: "agent-A" });
+		await seedAgentLease(ws.workspace.id, issueB, { name: "agent-B" });
+		await seedFileClaim(ws.workspace.id, issueA, "a/only.ts");
+		await seedFileClaim(ws.workspace.id, issueB, "b/secret.ts");
+		await seedFloatingAgent(ws.workspace.id, "floating");
+	});
+
+	it("owner sees leases/claims/agents across every project", async () => {
+		const t = ws.owner.token;
+		const leases = await mcpList("list_issue_leases", t, slug, ws.workspace.id);
+		expect(leases.items.map((l) => l.issueId).sort()).toEqual([issueA, issueB].sort());
+
+		const claims = await mcpList("list_file_claims", t, slug, ws.workspace.id);
+		expect(claims.items.map((c) => c.path).sort()).toEqual(["a/only.ts", "b/secret.ts"]);
+
+		const agents = await mcpList("list_active_agents", t, slug, ws.workspace.id);
+		expect(agents.items.map((a) => a.name).sort()).toEqual(["agent-A", "agent-B", "floating"]);
+	});
+
+	it("a member sees only the granted project's leases and file claims", async () => {
+		const t = ws.member.token;
+		const leases = await mcpList("list_issue_leases", t, slug, ws.workspace.id);
+		expect(leases.items.map((l) => l.issueId)).toEqual([issueA]);
+
+		const claims = await mcpList("list_file_claims", t, slug, ws.workspace.id);
+		expect(claims.items.map((c) => c.path)).toEqual(["a/only.ts"]);
+	});
+
+	it("a member sees agents on granted projects plus issue-less agents, never hidden-project agents", async () => {
+		const agents = await mcpList("list_active_agents", ws.member.token, slug, ws.workspace.id);
+		const names = agents.items.map((a) => a.name).sort();
+		expect(names).toEqual(["agent-A", "floating"]);
+		expect(names).not.toContain("agent-B");
+	});
+
+	it("a member with no grants at all sees none of another project's coordination data", async () => {
+		const t = ws.viewer.token; // viewer has no group grant
+		const leases = await mcpList("list_issue_leases", t, slug, ws.workspace.id);
+		expect(leases.items).toHaveLength(0);
+		const claims = await mcpList("list_file_claims", t, slug, ws.workspace.id);
+		expect(claims.items).toHaveLength(0);
+		const agents = await mcpList("list_active_agents", t, slug, ws.workspace.id);
+		// only the issue-less floating agent leaks nothing about a hidden project
+		expect(agents.items.map((a) => a.name)).toEqual(["floating"]);
+	});
+});

--- a/apps/api/src/test/groups.test.ts
+++ b/apps/api/src/test/groups.test.ts
@@ -273,6 +273,43 @@ describe("Groups MCP parity", () => {
 		expect((res as JsonRpcError).error.code).toBe(-32000);
 	});
 
+	it("list_groups via MCP: member sees only their own groups; owner sees all (PROJ-319)", async () => {
+		const g1 = mcpData<{ id: string }>(
+			(await mcpCall(workspaceId, "create_group", { name: "G1" }, ownerHeaders)) as JsonRpcResult<{
+				content: Array<{ text: string }>;
+			}>
+		);
+		await mcpCall(workspaceId, "create_group", { name: "G2" }, ownerHeaders);
+		await mcpCall(
+			workspaceId,
+			"add_group_member",
+			{ groupId: g1.id, userId: roles.member.user.id },
+			ownerHeaders
+		);
+
+		const memberList = (await mcpCall(
+			workspaceId,
+			"list_groups",
+			{},
+			memberHeaders
+		)) as JsonRpcResult<{
+			content: Array<{ text: string }>;
+		}>;
+		const memberGroups = mcpData<Array<{ name: string }>>(memberList);
+		expect(memberGroups.map((g) => g.name)).toEqual(["G1"]);
+
+		const ownerList = (await mcpCall(
+			workspaceId,
+			"list_groups",
+			{},
+			ownerHeaders
+		)) as JsonRpcResult<{
+			content: Array<{ text: string }>;
+		}>;
+		const ownerGroups = mcpData<Array<{ name: string }>>(ownerList);
+		expect(ownerGroups.map((g) => g.name).sort()).toEqual(["G1", "G2"]);
+	});
+
 	it("full admin loop over MCP: group -> grant -> member", async () => {
 		const project = await seedProject(workspaceId, "LOOP");
 		const created = mcpData<{ id: string }>(

--- a/apps/api/src/test/migration-0028.test.ts
+++ b/apps/api/src/test/migration-0028.test.ts
@@ -1,0 +1,141 @@
+import { env } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import m0028 from "../../../../packages/db/migrations/0028_downgrade_viewer_grants.sql?raw";
+import { seedMember, seedProject, seedUser, seedWorkspace } from "./helpers";
+
+// PROJ-318: 0028 splits the 0027 all-projects backfill so a pre-existing workspace
+// viewer keeps a read-only grant instead of being silently promoted to member.
+
+function splitStatements(sql: string): string[] {
+	return sql
+		.replace(/--[^\n]*/g, "")
+		.split(";")
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+}
+
+async function runMigration0028() {
+	for (const stmt of splitStatements(m0028)) {
+		await env.DB.prepare(stmt).run();
+	}
+}
+
+// Recreate the post-0027 backfill state for a fresh workspace: an 'all-projects'
+// group granting `member` on every project, enrolling both members and viewers.
+async function seed0027Backfill() {
+	const ws = await seedWorkspace();
+	const memberGroupId = `grp-allproj-${ws.id}`;
+	const pX = await seedProject(ws.id, "X");
+	const pY = await seedProject(ws.id, "Y");
+	const viewer = await seedUser(`v-${crypto.randomUUID().slice(0, 8)}@example.com`);
+	const member = await seedUser(`m-${crypto.randomUUID().slice(0, 8)}@example.com`);
+	await seedMember(ws.id, viewer.id, "viewer");
+	await seedMember(ws.id, member.id, "member");
+
+	const now = Math.floor(Date.now() / 1000);
+	await env.DB.prepare(
+		"INSERT INTO user_groups (id, workspace_id, name, description, created_at) VALUES (?, ?, 'all-projects', NULL, ?)"
+	)
+		.bind(memberGroupId, ws.id, now)
+		.run();
+	for (const p of [pX, pY]) {
+		await env.DB.prepare(
+			"INSERT INTO group_project_grants (group_id, project_id, role) VALUES (?, ?, 'member')"
+		)
+			.bind(memberGroupId, p.id)
+			.run();
+	}
+	for (const u of [viewer, member]) {
+		await env.DB.prepare(
+			"INSERT INTO user_group_members (group_id, user_id, added_by, added_at) VALUES (?, ?, ?, ?)"
+		)
+			.bind(memberGroupId, u.id, u.id, now)
+			.run();
+	}
+	return { ws, memberGroupId, viewersGroupId: `grp-allproj-viewers-${ws.id}`, viewer, member };
+}
+
+async function memberCount(groupId: string, userId: string): Promise<number> {
+	const row = await env.DB.prepare(
+		"SELECT COUNT(*) AS n FROM user_group_members WHERE group_id = ? AND user_id = ?"
+	)
+		.bind(groupId, userId)
+		.first<{ n: number }>();
+	return row?.n ?? 0;
+}
+
+describe("0028 viewer-preserving migration", () => {
+	let ctx: Awaited<ReturnType<typeof seed0027Backfill>>;
+
+	beforeEach(async () => {
+		ctx = await seed0027Backfill();
+		await runMigration0028();
+	});
+
+	it("gives the viewer a read-only grant on the same projects", async () => {
+		const grants = await env.DB.prepare("SELECT role FROM group_project_grants WHERE group_id = ?")
+			.bind(ctx.viewersGroupId)
+			.all<{ role: string }>();
+		expect(grants.results).toHaveLength(2);
+		expect(grants.results.every((g) => g.role === "viewer")).toBe(true);
+	});
+
+	it("moves the viewer out of the member group into the read-only group", async () => {
+		expect(await memberCount(ctx.viewersGroupId, ctx.viewer.id)).toBe(1);
+		expect(await memberCount(ctx.memberGroupId, ctx.viewer.id)).toBe(0);
+	});
+
+	it("leaves the member untouched (member group, member grant)", async () => {
+		expect(await memberCount(ctx.memberGroupId, ctx.member.id)).toBe(1);
+		expect(await memberCount(ctx.viewersGroupId, ctx.member.id)).toBe(0);
+		const memberGrants = await env.DB.prepare(
+			"SELECT DISTINCT role FROM group_project_grants WHERE group_id = ?"
+		)
+			.bind(ctx.memberGroupId)
+			.all<{ role: string }>();
+		expect(memberGrants.results.map((r) => r.role)).toEqual(["member"]);
+	});
+
+	it("is idempotent — re-running changes nothing", async () => {
+		await runMigration0028();
+		expect(await memberCount(ctx.viewersGroupId, ctx.viewer.id)).toBe(1);
+		expect(await memberCount(ctx.memberGroupId, ctx.viewer.id)).toBe(0);
+		const grants = await env.DB.prepare(
+			"SELECT COUNT(*) AS n FROM group_project_grants WHERE group_id = ?"
+		)
+			.bind(ctx.viewersGroupId)
+			.first<{ n: number }>();
+		expect(grants?.n).toBe(2);
+	});
+
+	it("creates no viewers group for a workspace that has no viewers", async () => {
+		const ws = await seedWorkspace();
+		const groupId = `grp-allproj-${ws.id}`;
+		const p = await seedProject(ws.id, "Z");
+		const member = await seedUser(`m2-${crypto.randomUUID().slice(0, 8)}@example.com`);
+		await seedMember(ws.id, member.id, "member");
+		const now = Math.floor(Date.now() / 1000);
+		await env.DB.prepare(
+			"INSERT INTO user_groups (id, workspace_id, name, description, created_at) VALUES (?, ?, 'all-projects', NULL, ?)"
+		)
+			.bind(groupId, ws.id, now)
+			.run();
+		await env.DB.prepare(
+			"INSERT INTO group_project_grants (group_id, project_id, role) VALUES (?, ?, 'member')"
+		)
+			.bind(groupId, p.id)
+			.run();
+		await env.DB.prepare(
+			"INSERT INTO user_group_members (group_id, user_id, added_by, added_at) VALUES (?, ?, ?, ?)"
+		)
+			.bind(groupId, member.id, member.id, now)
+			.run();
+
+		await runMigration0028();
+
+		const vg = await env.DB.prepare("SELECT COUNT(*) AS n FROM user_groups WHERE id = ?")
+			.bind(`grp-allproj-viewers-${ws.id}`)
+			.first<{ n: number }>();
+		expect(vg?.n).toBe(0);
+	});
+});

--- a/apps/api/src/test/migrations.ts
+++ b/apps/api/src/test/migrations.ts
@@ -28,6 +28,7 @@ import m0024 from "../../../../packages/db/migrations/0024_project_agent_wip_lim
 import m0025 from "../../../../packages/db/migrations/0025_issue_completion_report.sql?raw";
 import m0026 from "../../../../packages/db/migrations/0026_backfill_flow_timestamps.sql?raw";
 import m0027 from "../../../../packages/db/migrations/0027_user_groups.sql?raw";
+import m0028 from "../../../../packages/db/migrations/0028_downgrade_viewer_grants.sql?raw";
 
 export const MIGRATIONS = [
 	m0000,
@@ -58,4 +59,5 @@ export const MIGRATIONS = [
 	m0025,
 	m0026,
 	m0027,
+	m0028,
 ];

--- a/apps/docs/src/content/docs/contributing/conventions.md
+++ b/apps/docs/src/content/docs/contributing/conventions.md
@@ -270,6 +270,7 @@ These are the constraints the fleet skill reads to plan batches. Keep them curre
 | custom-fields | `services/custom-fields.ts` | `schemas/custom-fields.ts` | `routes/custom-fields.ts` | `mcp/custom-fields.ts` | `test/custom-fields.test.ts` |
 | workflow | `services/workflow.ts` | — (no input) | `routes/workflow.ts` | `mcp/workflow.ts` | `test/workflow.test.ts` |
 | flow-metrics | `services/flow-metrics.ts` | `schemas/flow-metrics.ts` | `routes/flow-metrics.ts` | `mcp/flow-metrics.ts` | `test/flow-metrics.test.ts` |
+| groups | `services/groups.ts` | `schemas/groups.ts` | `routes/groups.ts` | `mcp/groups.ts` | `test/groups.test.ts` |
 
 Frontend islands are **not** domain-locked in the same way, but two agents must never
 own the same island file. Assign each island to exactly one agent per batch.

--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -77,6 +77,30 @@ schedule against a dev deployment.
 | Variable | Required | Description |
 |---|---|---|
 | `E2E_BASE_URL` | **Yes** | Root URL of the dev deployment. API must be at `<url>/api/*`. |
+| `E2E_MEMBER_EMAIL` | No | Email invited as a `member` into the ephemeral e2e workspace during `globalSetup`. Defaults to `e2e-member-<slug>@example.com`. Required (alongside `E2E_MEMBER_TOKEN`) to run `confinement.spec.ts`. |
+| `E2E_MEMBER_TOKEN` | No | A real, workspace-scoped API token owned by `E2E_MEMBER_EMAIL`. Required to run `confinement.spec.ts`. |
+
+---
+
+## Two-user group-access model (PROJ-313)
+
+`board.spec.ts`, `groups-flow.spec.ts`, and the admin parts of the suite run
+entirely as the dev-bypass admin — every unauthenticated request against the
+target deployment is auto-authenticated as the workspace owner. `globalSetup`
+uses this identity to additionally provision a **group-access fixture**: a
+second ("ungranted") project, a member invited into the workspace, a group
+that grants the member `member`-role access to the first project only, and
+that member added to the group.
+
+Testing *member*-eyes confinement (does the member actually see only the
+granted project?) requires authenticating as that member, and dev-bypass
+can't do that — it always resolves to the owner. Workspace-scoped API tokens
+also can't be auto-minted for the member: minting a token requires already
+being authenticated as its owner, and that owner identity isn't available to
+`globalSetup`. So `confinement.spec.ts` is **skipped unless `E2E_BASE_URL`,
+`E2E_MEMBER_EMAIL`, and `E2E_MEMBER_TOKEN` are all set** — the member token
+must be minted out-of-band (e.g. by logging in as `E2E_MEMBER_EMAIL` once and
+creating a workspace API token) and passed in via env.
 
 ---
 
@@ -91,9 +115,16 @@ deployment:
 2. `POST /api/task-statuses` → **Todo** (category: `todo`) and **In Progress** (category: `in_progress`)
 3. `POST /api/projects` → project **E2E** (key `E2E`)
 4. `POST /api/issues` × 2 → two issues seeded in the Todo status
+5. `POST /api/projects` → project **E2E Ungranted** (key `E2EU`), granted to nobody
+6. `POST /api/workspaces/<slug>/members` → invites `E2E_MEMBER_EMAIL` (or a
+   generated default) as a `member`
+7. `POST /api/workspaces/<slug>/groups` → group **E2E Access Group**
+8. `PUT .../groups/<id>/grants` → grants the group `member` role on the E2E project only
+9. `POST .../groups/<id>/members` → adds the invited member to the group
 
-The workspace slug, status IDs, and drag-target issue ID are written to
-`e2e/.e2e-ctx.json` (gitignored) for the spec to read.
+The workspace slug, status IDs, drag-target issue ID, both project IDs/keys,
+the group ID/name, and the member's email/userId are written to
+`e2e/.e2e-ctx.json` (gitignored) for specs to read.
 
 ### Global teardown (`e2e/global-teardown.ts`)
 
@@ -126,6 +157,29 @@ The `onDragStart` handler in IssueList.tsx calls `e.preventDefault()` when
 2. Performs `dragTo` on a card.
 3. Asserts the Todo column still has all its cards (nothing moved).
 4. Asserts `patches.length === 0` (no PATCH was fired).
+
+### Test: Groups flow — admin (`groups-flow.spec.ts`)
+
+API-driven, using Playwright's `request` fixture (inherits the admin headers
+from `playwright.config.ts`):
+
+1. Reads back the seeded group and asserts its grant covers the granted
+   project with role `member`, and the invited member is in its member list.
+2. Creates a new group, grants it a project, reads the group back, and
+   asserts the grant persisted (full create → grant → verify loop).
+3. One `page`-based test navigates to `/settings/groups` (the deployment's
+   **default** workspace, not the ephemeral one) and asserts the page
+   renders — a render smoke of the group-manager surface.
+
+### Test: Group-access confinement — member (`confinement.spec.ts`)
+
+Env-gated (see "Two-user group-access model" above). Builds a dedicated
+member-scoped `APIRequestContext` and asserts:
+
+1. `GET /api/projects` includes the granted project and excludes the
+   ungranted one.
+2. `GET /api/projects/<ungrantedProjectId>` returns `404` (existence is
+   hidden from members without a grant).
 
 ---
 

--- a/apps/web/e2e/confinement.spec.ts
+++ b/apps/web/e2e/confinement.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * PROJ-313: two-user confinement check for group-access (PROJ-311).
+ *
+ * Verifies that a member scoped to a group (granted one project only) cannot
+ * see or reach an ungranted project. Requires a real, workspace-scoped member
+ * API token: dev-bypass authenticates every request as the workspace owner,
+ * and workspace-scoped tokens can only be minted by their owner against a
+ * workspace they already belong to — they can't be auto-minted for the
+ * invited member in the ephemeral e2e workspace. So this suite is env-gated
+ * and skipped unless a real member token is supplied out-of-band.
+ *
+ * Prerequisites: globalSetup must have written e2e/.e2e-ctx.json.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { type APIRequestContext, expect, test } from "@playwright/test";
+import type { E2EContext } from "./global-setup";
+
+function readCtx(): E2EContext {
+	const file = path.resolve(process.cwd(), "e2e", ".e2e-ctx.json");
+	if (!fs.existsSync(file)) {
+		throw new Error(
+			"e2e/.e2e-ctx.json not found — did globalSetup succeed?\n" +
+				"Run with E2E_BASE_URL set to a dev deployment."
+		);
+	}
+	return JSON.parse(fs.readFileSync(file, "utf-8")) as E2EContext;
+}
+
+const SKIP_REASON =
+	"E2E_BASE_URL, E2E_MEMBER_TOKEN, and E2E_MEMBER_EMAIL are all required — a real, " +
+	"workspace-scoped member API token for the invited member is needed and cannot be " +
+	"auto-minted for the ephemeral e2e workspace.";
+
+test.describe("Group-access confinement (member)", () => {
+	let memberRequest: APIRequestContext;
+
+	test.beforeAll(async ({ playwright }) => {
+		if (!process.env.E2E_BASE_URL || !process.env.E2E_MEMBER_TOKEN || !process.env.E2E_MEMBER_EMAIL)
+			return;
+
+		const ctx = readCtx();
+		memberRequest = await playwright.request.newContext({
+			baseURL: process.env.E2E_BASE_URL,
+			extraHTTPHeaders: {
+				Authorization: `Bearer ${process.env.E2E_MEMBER_TOKEN}`,
+				"X-Workspace-Slug": ctx.workspaceSlug,
+			},
+		});
+	});
+
+	test.afterAll(async () => {
+		await memberRequest?.dispose();
+	});
+
+	test("member sees only the granted project", async () => {
+		test.skip(
+			!process.env.E2E_BASE_URL || !process.env.E2E_MEMBER_TOKEN || !process.env.E2E_MEMBER_EMAIL,
+			SKIP_REASON
+		);
+
+		const ctx = readCtx();
+		const res = await memberRequest.get("/api/projects");
+		expect(res.ok()).toBe(true);
+		const projects = (await res.json()) as Array<{ id: string }>;
+
+		expect(projects.some((p) => p.id === ctx.grantedProjectId)).toBe(true);
+		expect(projects.some((p) => p.id === ctx.ungrantedProjectId)).toBe(false);
+	});
+
+	test("member 404s on an ungranted project", async () => {
+		test.skip(
+			!process.env.E2E_BASE_URL || !process.env.E2E_MEMBER_TOKEN || !process.env.E2E_MEMBER_EMAIL,
+			SKIP_REASON
+		);
+
+		const ctx = readCtx();
+		const res = await memberRequest.get(`/api/projects/${ctx.ungrantedProjectId}`);
+		expect(res.status()).toBe(404);
+	});
+});

--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -21,6 +21,14 @@ export interface E2EContext {
 	todoStatusId: string;
 	inProgressStatusId: string;
 	testIssueId: string;
+	grantedProjectId: string;
+	grantedProjectKey: string;
+	ungrantedProjectId: string;
+	ungrantedProjectKey: string;
+	groupId: string;
+	groupName: string;
+	memberEmail: string;
+	memberUserId: string;
 }
 
 // Resolved at runtime relative to the playwright config file's cwd (apps/web/).
@@ -55,6 +63,22 @@ async function wsPost(url: string, slug: string, body: unknown): Promise<unknown
 	return res.json();
 }
 
+async function wsPut(url: string, slug: string, body: unknown): Promise<unknown> {
+	const res = await fetch(url, {
+		method: "PUT",
+		headers: {
+			"Content-Type": "application/json",
+			"X-Workspace-Slug": slug,
+		},
+		body: JSON.stringify(body),
+	});
+	if (!res.ok) {
+		const text = await res.text();
+		throw new Error(`PUT ${url} (ws=${slug}) → ${res.status}: ${text}`);
+	}
+	return res.json();
+}
+
 async function wsGet(url: string, slug: string): Promise<unknown> {
 	const res = await fetch(url, { headers: { "X-Workspace-Slug": slug } });
 	if (!res.ok) {
@@ -71,7 +95,7 @@ export default async function globalSetup(): Promise<void> {
 		throw new Error(
 			"E2E_BASE_URL is required.\n" +
 				"Point it at a dev deployment (ENVIRONMENT=development, DEV_USER_EMAIL set).\n" +
-				"Example: E2E_BASE_URL=https://dev.your-instance.workers.dev pnpm --filter @projektor/web exec playwright test",
+				"Example: E2E_BASE_URL=https://dev.your-instance.workers.dev pnpm --filter @projektor/web exec playwright test"
 		);
 	}
 
@@ -93,7 +117,7 @@ export default async function globalSetup(): Promise<void> {
 	const inProgressStatus = seededStatuses.find((s) => s.key === "in_progress");
 	if (!todoStatus || !inProgressStatus) {
 		throw new Error(
-			`Expected default 'todo' and 'in_progress' task statuses to be seeded for workspace ${slug}, got keys: ${seededStatuses.map((s) => s.key).join(", ")}`,
+			`Expected default 'todo' and 'in_progress' task statuses to be seeded for workspace ${slug}, got keys: ${seededStatuses.map((s) => s.key).join(", ")}`
 		);
 	}
 
@@ -101,7 +125,7 @@ export default async function globalSetup(): Promise<void> {
 	const project = (await wsPost(`${base}/api/projects`, slug, {
 		name: "E2E Project",
 		key: "E2E",
-	})) as { id: string };
+	})) as { id: string; key: string };
 
 	// 4. Create the issue we'll drag in the desktop test
 	const dragIssue = (await wsPost(`${base}/api/issues`, slug, {
@@ -119,11 +143,55 @@ export default async function globalSetup(): Promise<void> {
 		priority: "low",
 	});
 
+	// 6. PROJ-313: group-access fixture — a second (ungranted) project, a member
+	// invited into the workspace, and a group that grants the member access to
+	// the first project only.
+	// cofferdam-ignore: Warning.NoConsoleLog: CI-visible e2e setup progress, not a debug leftover
+	console.log("[e2e setup] Provisioning group-access fixture");
+
+	const ungrantedProject = (await wsPost(`${base}/api/projects`, slug, {
+		name: "E2E Ungranted",
+		key: "E2EU",
+	})) as { id: string; key: string };
+
+	const memberEmail = process.env.E2E_MEMBER_EMAIL ?? `e2e-member-${slug}@example.com`;
+	await wsPost(`${base}/api/workspaces/${slug}/members`, slug, {
+		email: memberEmail,
+		role: "member",
+	});
+	const workspaceDetail = (await wsGet(`${base}/api/workspaces/${slug}`, slug)) as {
+		members: Array<{ id: string; email: string }>;
+	};
+	const memberRecord = workspaceDetail.members.find((m) => m.email === memberEmail);
+	if (!memberRecord) {
+		throw new Error(`Expected invited member ${memberEmail} in workspace members list`);
+	}
+
+	const group = (await wsPost(`${base}/api/workspaces/${slug}/groups`, slug, {
+		name: "E2E Access Group",
+	})) as { id: string; name: string };
+
+	await wsPut(`${base}/api/workspaces/${slug}/groups/${group.id}/grants`, slug, {
+		projectId: project.id,
+		role: "member",
+	});
+	await wsPost(`${base}/api/workspaces/${slug}/groups/${group.id}/members`, slug, {
+		userId: memberRecord.id,
+	});
+
 	const ctx: E2EContext = {
 		workspaceSlug: slug,
 		todoStatusId: todoStatus.id,
 		inProgressStatusId: inProgressStatus.id,
 		testIssueId: dragIssue.id,
+		grantedProjectId: project.id,
+		grantedProjectKey: project.key,
+		ungrantedProjectId: ungrantedProject.id,
+		ungrantedProjectKey: ungrantedProject.key,
+		groupId: group.id,
+		groupName: group.name,
+		memberEmail,
+		memberUserId: memberRecord.id,
 	};
 
 	fs.writeFileSync(CTX_FILE, JSON.stringify(ctx, null, 2));

--- a/apps/web/e2e/groups-flow.spec.ts
+++ b/apps/web/e2e/groups-flow.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * PROJ-313: API-driven E2E for the group-access feature (PROJ-311).
+ *
+ * These tests exercise the groups REST surface directly via Playwright's
+ * `request` fixture rather than the browser: the ephemeral e2e workspace
+ * (created in globalSetup) is only reachable with the admin dev-bypass
+ * identity, and the browser's injected headers target the deployment's
+ * default workspace (see playwright.config.ts). Only the render-smoke test
+ * below uses `page`, and it deliberately targets the default workspace.
+ *
+ * Prerequisites: globalSetup must have written e2e/.e2e-ctx.json.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { expect, test } from "@playwright/test";
+import type { E2EContext } from "./global-setup";
+
+function readCtx(): E2EContext {
+	const file = path.resolve(process.cwd(), "e2e", ".e2e-ctx.json");
+	if (!fs.existsSync(file)) {
+		throw new Error(
+			"e2e/.e2e-ctx.json not found — did globalSetup succeed?\n" +
+				"Run with E2E_BASE_URL set to a dev deployment."
+		);
+	}
+	return JSON.parse(fs.readFileSync(file, "utf-8")) as E2EContext;
+}
+
+interface GroupDetail {
+	id: string;
+	name: string;
+	members: Array<{ userId: string; email: string; name: string }>;
+	grants: Array<{ projectId: string; projectName: string; projectKey: string; role: string }>;
+}
+
+test.describe("Groups flow (admin)", () => {
+	test("admin sees the seeded group with its grant and member", async ({ request }) => {
+		test.skip(!process.env.E2E_BASE_URL, "E2E_BASE_URL not set — skipping live deployment test");
+
+		const ctx = readCtx();
+
+		const res = await request.get(`/api/workspaces/${ctx.workspaceSlug}/groups/${ctx.groupId}`);
+		expect(res.ok()).toBe(true);
+		const detail = (await res.json()) as GroupDetail;
+
+		expect(detail.id).toBe(ctx.groupId);
+		expect(detail.name).toBe(ctx.groupName);
+
+		const grant = detail.grants.find((g) => g.projectId === ctx.grantedProjectId);
+		expect(grant).toBeTruthy();
+		expect(grant?.role).toBe("member");
+		expect(detail.grants.some((g) => g.projectId === ctx.ungrantedProjectId)).toBe(false);
+
+		expect(detail.members.some((m) => m.userId === ctx.memberUserId)).toBe(true);
+	});
+
+	test("admin can create a new group, grant a project, and read it back", async ({ request }) => {
+		test.skip(!process.env.E2E_BASE_URL, "E2E_BASE_URL not set — skipping live deployment test");
+
+		const ctx = readCtx();
+		const groupName = `E2E Ad-hoc Group ${Date.now()}`;
+
+		const createRes = await request.post(`/api/workspaces/${ctx.workspaceSlug}/groups`, {
+			data: { name: groupName },
+		});
+		expect(createRes.status()).toBe(201);
+		const created = (await createRes.json()) as { id: string; name: string };
+		expect(created.name).toBe(groupName);
+
+		const grantRes = await request.put(
+			`/api/workspaces/${ctx.workspaceSlug}/groups/${created.id}/grants`,
+			{ data: { projectId: ctx.grantedProjectId, role: "viewer" } }
+		);
+		expect(grantRes.ok()).toBe(true);
+
+		const detailRes = await request.get(
+			`/api/workspaces/${ctx.workspaceSlug}/groups/${created.id}`
+		);
+		expect(detailRes.ok()).toBe(true);
+		const detail = (await detailRes.json()) as GroupDetail;
+
+		const grant = detail.grants.find((g) => g.projectId === ctx.grantedProjectId);
+		expect(grant).toBeTruthy();
+		expect(grant?.role).toBe("viewer");
+	});
+
+	test("groups settings page renders the group manager UI", async ({ page }) => {
+		test.skip(!process.env.E2E_BASE_URL, "E2E_BASE_URL not set — skipping live deployment test");
+
+		// Targets the deployment's DEFAULT workspace (config's X-Workspace-Slug),
+		// not the ephemeral e2e workspace — this is a render smoke of the surface.
+		await page.goto("/settings/groups");
+		await expect(page.getByRole("heading", { name: "Groups" })).toBeVisible({ timeout: 15_000 });
+	});
+});

--- a/apps/web/src/islands/AccessPending.test.tsx
+++ b/apps/web/src/islands/AccessPending.test.tsx
@@ -1,0 +1,62 @@
+// PROJ-315: the access-pending gate. A non-admin caller whose visible-project
+// set is empty should see the "access pending" panel instead of a bare empty
+// list; an admin of an empty workspace keeps the normal empty state; anyone with
+// projects sees the list. useAccessGate drives all three surfaces, so exercising
+// it through ProjectList covers the shared behaviour.
+import { render, screen } from "@testing-library/preact";
+import { describe, expect, it, vi } from "vitest";
+import AccessPending from "./AccessPending";
+import ProjectList from "./ProjectList";
+
+function routeFetch(routes: Record<string, unknown>) {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn((url: string) => {
+			const path = new URL(url, "http://localhost").pathname;
+			const body = path in routes ? routes[path] : {};
+			return Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+		})
+	);
+}
+
+const PROJECT = {
+	id: "p1",
+	name: "Projektor",
+	key: "PROJ",
+	description: null,
+	workspace_id: "w1",
+	workspace_name: "WS",
+	workspace_slug: "ws",
+	open_issue_count: 0,
+	created_at: 0,
+	updated_at: 0,
+};
+
+describe("AccessPending", () => {
+	it("renders the pending panel", () => {
+		render(<AccessPending />);
+		expect(screen.getByText(/Access pending/i)).toBeTruthy();
+	});
+});
+
+describe("useAccessGate via ProjectList", () => {
+	it("shows the pending panel for a non-admin with no visible projects", async () => {
+		routeFetch({ "/api/projects": [], "/api/workspaces/ws": { currentUserRole: "member" } });
+		render(<ProjectList workspaceSlug="ws" />);
+		expect(await screen.findByText(/Access pending/i)).toBeTruthy();
+	});
+
+	it("keeps the normal empty state for an admin of an empty workspace", async () => {
+		routeFetch({ "/api/projects": [], "/api/workspaces/ws": { currentUserRole: "owner" } });
+		render(<ProjectList workspaceSlug="ws" />);
+		expect(await screen.findByText(/No projects yet/i)).toBeTruthy();
+		expect(screen.queryByText(/Access pending/i)).toBeNull();
+	});
+
+	it("does not gate a non-admin who has visible projects", async () => {
+		routeFetch({ "/api/projects": [PROJECT], "/api/workspaces/ws": { currentUserRole: "member" } });
+		render(<ProjectList workspaceSlug="ws" />);
+		expect(await screen.findByText("Projektor")).toBeTruthy();
+		expect(screen.queryByText(/Access pending/i)).toBeNull();
+	});
+});

--- a/apps/web/src/islands/AccessPending.tsx
+++ b/apps/web/src/islands/AccessPending.tsx
@@ -1,0 +1,23 @@
+// PROJ-315: shared empty-state shown when a non-admin caller has no project
+// access yet. Rendered by ProjectList, IssueList, and WikiPage in place of their
+// normal empty list so the surface reads as "waiting on an admin", not "empty".
+export default function AccessPending() {
+	return (
+		<div
+			role="status"
+			class="flex flex-col items-center gap-3 text-center max-w-md mx-auto py-16 px-6"
+		>
+			<div
+				aria-hidden="true"
+				class="flex items-center justify-center w-12 h-12 rounded-full bg-[var(--surface)] border border-[var(--border)] text-2xl"
+			>
+				🔒
+			</div>
+			<h2 class="m-0 text-lg font-semibold text-[var(--text)]">Access pending</h2>
+			<p class="m-0 text-sm text-[var(--text-muted)]">
+				You’re not a member of any project group yet. Once a workspace admin adds you to a group,
+				the projects, issues, and wiki pages you can access will appear here.
+			</p>
+		</div>
+	);
+}

--- a/apps/web/src/islands/IssueList.tsx
+++ b/apps/web/src/islands/IssueList.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from "preact/hooks";
+import { useAccessGate } from "../utils/access-gate";
+import AccessPending from "./AccessPending";
 import { sortIssues } from "./board-utils";
 import { deriveProjectDescription } from "./issue-list/derive";
 import IssueListLayout from "./issue-list/IssueListLayout";
@@ -28,6 +30,7 @@ export default function IssueList({ workspaceSlug }: Props) {
 		localStorage.setItem("issues-view", view);
 	}, [view]);
 
+	const gate = useAccessGate(workspaceSlug);
 	const filters = useIssueFilters();
 	const search = useIssueSearch(workspaceSlug);
 	const data = useIssueListData(workspaceSlug, view, {
@@ -57,6 +60,7 @@ export default function IssueList({ workspaceSlug }: Props) {
 	// still page-local — tracked separately as a follow-up.)
 	const filtered = sortIssues(data.issues, filters.sortBy, filters.sortDir);
 
+	if (gate.pending) return <AccessPending />;
 	if (data.loading && !data.hasLoadedOnce.current) return <p aria-live="polite">Loading issues…</p>;
 	if (data.error) {
 		return (

--- a/apps/web/src/islands/ProjectList.tsx
+++ b/apps/web/src/islands/ProjectList.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from "preact/hooks";
+import { useAccessGate } from "../utils/access-gate";
 import { apiFetch } from "../utils/api-client";
+import AccessPending from "./AccessPending";
 
 interface Project {
 	id: string;
@@ -316,10 +318,13 @@ export default function ProjectList({ workspaceSlug }: { workspaceSlug?: string 
 			.finally(() => setLoading(false));
 	}, [workspaceSlug]);
 
+	const gate = useAccessGate(workspaceSlug);
+
 	const createForm = useProjectCreateForm(workspaceSlug, (p) =>
 		setProjects((prev) => [...prev, p])
 	);
 
+	if (gate.pending) return <AccessPending />;
 	if (loading) return <p aria-live="polite">Loading projects…</p>;
 	if (error)
 		return (

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -1,8 +1,10 @@
 import type { RefObject } from "preact";
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { slugify } from "../lib/slugify";
+import { useAccessGate } from "../utils/access-gate";
 import { apiFetch } from "../utils/api-client";
 import { renderMdWithWikilinks, renderMermaidDiagrams } from "../utils/markdown";
+import AccessPending from "./AccessPending";
 import MarkdownEditor from "./MarkdownEditor";
 
 interface SearchResult {
@@ -1734,6 +1736,7 @@ function buildArticleProps(article: {
 }
 
 export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Props) {
+	const gate = useAccessGate(workspaceSlug);
 	const { slug, setSlug, projectId } = useWikiUrlState(projectIdProp);
 	const { pageTree, pageMap, treeLoading, fetchTree } = useWikiTree(workspaceSlug, projectId);
 	const { searchQuery, setSearchQuery, searchResults, searchLoading } = useWikiSearch(
@@ -1813,6 +1816,8 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 		attach,
 		workspaceSlug,
 	});
+
+	if (gate.pending) return <AccessPending />;
 
 	return (
 		<WikiPageShell

--- a/apps/web/src/utils/access-gate.ts
+++ b/apps/web/src/utils/access-gate.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "preact/hooks";
+import { apiFetch } from "./api-client";
+import { resolveWorkspaceSlug } from "./workspace";
+
+// PROJ-315: a non-admin member with no group grants sees an empty list on every
+// project-scoped surface (projects, issues, board, wiki). Rather than render a
+// bare "nothing here" that reads like an empty workspace, detect the pending
+// state — a non-admin caller whose visible-project set is empty — and let the
+// surface swap in a friendly "access pending" panel. Admins of a genuinely empty
+// workspace keep the normal empty state.
+export interface AccessGate {
+	loading: boolean;
+	pending: boolean;
+}
+
+export function useAccessGate(workspaceSlug?: string): AccessGate {
+	const [state, setState] = useState<AccessGate>({ loading: true, pending: false });
+
+	useEffect(() => {
+		let cancelled = false;
+		const slug = resolveWorkspaceSlug(workspaceSlug);
+
+		Promise.all([
+			apiFetch<unknown[]>("/api/projects", { workspaceSlug }),
+			slug
+				? apiFetch<{ currentUserRole?: string }>(`/api/workspaces/${slug}`, {
+						workspaceSlug: slug,
+					})
+				: Promise.resolve({ currentUserRole: undefined }),
+		])
+			.then(([projects, ws]) => {
+				if (cancelled) return;
+				const role = ws?.currentUserRole;
+				const isAdmin = role === "owner" || role === "admin";
+				const noProjects = Array.isArray(projects) && projects.length === 0;
+				// Only claim "pending" when we positively know a non-admin role: an
+				// unresolved role (missing slug, request failure) fails open to the
+				// surface's own empty state rather than a misleading pending panel.
+				setState({ loading: false, pending: !!role && !isAdmin && noProjects });
+			})
+			.catch(() => {
+				if (!cancelled) setState({ loading: false, pending: false });
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [workspaceSlug]);
+
+	return state;
+}

--- a/packages/db/migrations/0028_downgrade_viewer_grants.sql
+++ b/packages/db/migrations/0028_downgrade_viewer_grants.sql
@@ -1,0 +1,55 @@
+-- PROJ-318: viewer-preserving downgrade for the 0027 all-projects backfill.
+--
+-- 0027 enrolled every pre-existing member AND viewer into one 'all-projects' group
+-- that grants 'member' on every project, silently giving a workspace viewer write
+-- access. Grants are group-level, so one user's role can't be lowered in place:
+-- split the viewers into their own read-only sibling group that grants 'viewer' on
+-- the same projects, then move them out of the member group. Idempotent; only ever
+-- touches the deterministic backfilled groups ('grp-allproj-<ws>' and its viewers
+-- sibling), never admin-created groups or grants.
+
+-- 1. One read-only sibling group per workspace whose backfilled all-projects group
+--    actually contains a viewer.
+INSERT OR IGNORE INTO user_groups (id, workspace_id, name, description, created_at)
+SELECT 'grp-allproj-viewers-' || w.id, w.id, 'all-projects (viewers)',
+       'Migrated: read-only access to all projects that existed before group-based access control.',
+       strftime('%s', 'now')
+FROM workspaces w
+WHERE EXISTS (
+  SELECT 1 FROM user_group_members m
+  JOIN workspace_members wm ON wm.user_id = m.user_id AND wm.workspace_id = w.id
+  WHERE m.group_id = 'grp-allproj-' || w.id AND wm.role = 'viewer'
+);
+
+-- 2. Grant viewer on exactly the projects the member all-projects group covers.
+INSERT OR IGNORE INTO group_project_grants (group_id, project_id, role)
+SELECT 'grp-allproj-viewers-' || w.id, gpg.project_id, 'viewer'
+FROM workspaces w
+JOIN group_project_grants gpg ON gpg.group_id = 'grp-allproj-' || w.id
+WHERE EXISTS (SELECT 1 FROM user_groups vg WHERE vg.id = 'grp-allproj-viewers-' || w.id);
+
+-- 3. Enroll the workspace viewers who were backfilled into the member group.
+INSERT OR IGNORE INTO user_group_members (group_id, user_id, added_by, added_at)
+SELECT 'grp-allproj-viewers-' || wm.workspace_id, wm.user_id, wm.user_id, strftime('%s', 'now')
+FROM workspace_members wm
+WHERE wm.role = 'viewer'
+  AND EXISTS (SELECT 1 FROM user_groups vg WHERE vg.id = 'grp-allproj-viewers-' || wm.workspace_id)
+  AND EXISTS (SELECT 1 FROM user_group_members m
+              WHERE m.group_id = 'grp-allproj-' || wm.workspace_id AND m.user_id = wm.user_id);
+
+-- 4. Remove those viewers from the member all-projects group, but only once they are
+--    safely in the read-only group (so re-runs and partial states never orphan them).
+DELETE FROM user_group_members
+WHERE group_id LIKE 'grp-allproj-%'
+  AND group_id NOT LIKE 'grp-allproj-viewers-%'
+  AND EXISTS (
+    SELECT 1 FROM workspace_members wm
+    WHERE wm.user_id = user_group_members.user_id
+      AND wm.workspace_id = substr(user_group_members.group_id, 13)
+      AND wm.role = 'viewer'
+  )
+  AND EXISTS (
+    SELECT 1 FROM user_group_members vm
+    WHERE vm.user_id = user_group_members.user_id
+      AND vm.group_id = 'grp-allproj-viewers-' || substr(user_group_members.group_id, 13)
+  );


### PR DESCRIPTION
Completes the PROJ-314 group-based access-control epic. Builds on PROJ-320 (#59, caller role + group admin gating) already on main.

## Tickets

- **PROJ-317** — Harden `visibleProjectSqlFragment` against injection. It inlines its column expression into raw SQL, so add a validate-first guard that rejects anything that isn't a bare/qualified column identifier (throws before it can become an injection vector), even for the admin no-filter path. (+3 unit tests)
- **PROJ-316** — Gate the fleet-coordination list surfaces (issue-leases, file-claims, active-agents) by the same default-deny project visibility as issues, via a correlated scalar subquery on each row's issue → project. Issue-less (floating) agents stay workspace-visible. (+4 MCP integration tests)
- **PROJ-318** — Viewer-preserving migration `0028`. The 0027 all-projects backfill enrolled pre-existing viewers into the member-level group, silently granting write. Grants are group-level, so 0028 splits viewers into a read-only sibling group granting `viewer` on the same projects and moves them out of the member group. Idempotent; only touches the deterministic backfilled groups. (+5 migration tests)
- **PROJ-319** — Regression tests pinning admin raw-SQL bypass (owner/admin see search + flow metrics across ungranted projects) and member `list_groups` scoping. (+5 tests)
- **PROJ-315** — Access-pending empty state. A non-admin member with no group grants gets an empty project set on every project-scoped surface. Add a shared `useAccessGate` hook + `AccessPending` panel, wired into the projects, issues/board, and wiki islands. Admins of a genuinely empty workspace keep the normal "no projects yet" state; the gate fails open when the role can't be resolved. (+4 web tests)
- **PROJ-313** — Two-user E2E harness. Extend Playwright global-setup to provision the group-access fixture (ungranted project + invited member + group granting one project). Add an API-driven groups-flow spec (admin lifecycle against the deployed Worker + a `/settings/groups` render smoke) and an env-gated confinement spec (member sees only the granted project, 404s on the ungranted one).

## Verification

- `pnpm turbo type-check` — clean across all packages.
- `pnpm biome check .` — clean.
- API suite: 613 pass (one pre-existing D1-chunking test can time out under full-suite CPU load; passes in isolation — unrelated to this change).
- Web suite: 262 pass.
- `playwright test --list` parses the 5 new e2e tests; confinement skips cleanly without a member identity.

## Notes

- The E2E confinement spec is env-gated (`E2E_MEMBER_TOKEN` + `E2E_MEMBER_EMAIL`): API-minted tokens are workspace-scoped and can't be auto-minted for the ephemeral e2e workspace, so a real member identity must be supplied out-of-band. Member confinement is otherwise proven by the 316/319 API integration tests.
- Pre-existing: `board.spec.ts` injects `localStorage["workspace-slug"]`, but no current code reads that key (islands resolve the slug from prop/hostname). Left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: https://claude.ai/code/session_01Qo2F4CN9sbAPXD71uPLSM1