### PR TITLE
feat(web): rename groups from the group detail editor

### DIFF
--- a/apps/web/src/islands/GroupManager.test.tsx
+++ b/apps/web/src/islands/GroupManager.test.tsx
@@ -1,0 +1,93 @@
+// GroupManager island — mock-fetch tests for the group rename control.
+//
+// The detail editor is admin-only, so the workspace stub reports currentUserRole
+// "owner". Clicking the group name in the table opens the editor; the name input
+// is seeded from the fetched detail.
+import { fireEvent, render, screen } from "@testing-library/preact";
+import { describe, expect, it, vi } from "vitest";
+import GroupManager from "./GroupManager";
+
+const GROUP = {
+	id: "g1",
+	name: "Engineering",
+	description: null,
+	memberCount: 1,
+	grantCount: 1,
+};
+
+const DETAIL = {
+	...GROUP,
+	members: [{ userId: "u1", email: "alice@example.com", name: "Alice" }],
+	grants: [{ projectId: "p1", projectName: "Apollo", projectKey: "APO", role: "member" }],
+};
+
+function mockFetch() {
+	const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+		const u = String(url);
+		const json = (body: unknown) =>
+			Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+
+		if (u.includes("/groups/g1")) {
+			if (init?.method === "PATCH") return json({ ...DETAIL, name: "Platform" });
+			return json(DETAIL);
+		}
+		if (u.includes("/member-groups")) return json([]);
+		if (u.includes("/groups")) return json([GROUP]);
+		if (u.includes("/api/projects")) return json([{ id: "p1", name: "Apollo", key: "APO" }]);
+		return json({ currentUserRole: "owner", members: [] });
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	return fetchMock;
+}
+
+async function openEditor() {
+	fireEvent.click(await screen.findByRole("button", { name: "Engineering" }));
+	return (await screen.findByLabelText(/Group name/i)) as HTMLInputElement;
+}
+
+describe("GroupManager rename", () => {
+	it("seeds the name input from the loaded group detail", async () => {
+		mockFetch();
+		render(<GroupManager workspaceSlug="my-ws" />);
+		expect((await openEditor()).value).toBe("Engineering");
+	});
+
+	it("disables Rename until the name actually changes", async () => {
+		mockFetch();
+		render(<GroupManager workspaceSlug="my-ws" />);
+		const input = await openEditor();
+		const button = screen.getByRole("button", { name: /^Rename$/ }) as HTMLButtonElement;
+		expect(button.disabled).toBe(true);
+
+		fireEvent.input(input, { target: { value: "Platform" } });
+		expect(button.disabled).toBe(false);
+	});
+
+	it("keeps Rename disabled for a blank or whitespace-only name", async () => {
+		mockFetch();
+		render(<GroupManager workspaceSlug="my-ws" />);
+		const input = await openEditor();
+		fireEvent.input(input, { target: { value: "   " } });
+		expect((screen.getByRole("button", { name: /^Rename$/ }) as HTMLButtonElement).disabled).toBe(
+			true
+		);
+	});
+
+	it("PATCHes the group with the trimmed name", async () => {
+		const fetchMock = mockFetch();
+		render(<GroupManager workspaceSlug="my-ws" />);
+		const input = await openEditor();
+
+		fireEvent.input(input, { target: { value: "  Platform  " } });
+		fireEvent.click(screen.getByRole("button", { name: /^Rename$/ }));
+
+		await vi.waitFor(() => {
+			const patch = fetchMock.mock.calls.find(
+				([, init]) => (init as RequestInit | undefined)?.method === "PATCH"
+			);
+			expect(patch).toBeTruthy();
+			expect(String(patch?.[0])).toContain("/groups/g1");
+			expect(JSON.parse(String((patch?.[1] as RequestInit).body))).toEqual({ name: "Platform" });
+		});
+	});
+});

--- a/apps/web/src/islands/GroupManager.tsx
+++ b/apps/web/src/islands/GroupManager.tsx
@@ -210,6 +210,7 @@ function GroupDetailEditor(props: DetailProps) {
 	const [detail, setDetail] = useState<GroupDetail | null>(null);
 	const [err, setErr] = useState<string | null>(null);
 	const [busy, setBusy] = useState(false);
+	const [nameDraft, setNameDraft] = useState("");
 	const [addUserId, setAddUserId] = useState("");
 	const [grantProjectId, setGrantProjectId] = useState("");
 	const [grantRole, setGrantRole] = useState<GrantRole>("member");
@@ -220,6 +221,7 @@ function GroupDetailEditor(props: DetailProps) {
 				workspaceSlug: slug,
 			});
 			setDetail(d);
+			setNameDraft(d.name);
 		} catch (e) {
 			setErr(String(e));
 		}
@@ -257,13 +259,37 @@ function GroupDetailEditor(props: DetailProps) {
 	);
 	const grantedIds = new Set(detail.grants.map((g) => g.projectId));
 	const grantable = props.projects.filter((p) => !grantedIds.has(p.id));
+	const trimmedName = nameDraft.trim();
 
 	return (
 		<section class={CARD}>
-			<div class="flex items-center justify-between mb-3">
-				<h2 class={H2} style="margin-bottom:0;">
-					{detail.name}
-				</h2>
+			<div class="flex items-center gap-2 mb-3">
+				<label class="sr-only" for="group-name">
+					Group name
+				</label>
+				<input
+					id="group-name"
+					class={`${INPUT} flex-1 font-semibold`}
+					value={nameDraft}
+					disabled={busy}
+					onInput={(e) => setNameDraft((e.target as HTMLInputElement).value)}
+				/>
+				<button
+					type="button"
+					class={BTN_PRIMARY}
+					disabled={busy || trimmedName === "" || trimmedName === detail.name}
+					onClick={() =>
+						run(async () => {
+							await apiFetch(`/api/workspaces/${slug}/groups/${groupId}`, {
+								method: "PATCH",
+								workspaceSlug: slug,
+								body: { name: trimmedName },
+							});
+						})
+					}
+				>
+					Rename
+				</button>
 				<button type="button" class={BTN_SECONDARY} onClick={props.onClose}>
 					Close
 				</button>


### PR DESCRIPTION
## Why

Renaming a group was already fully supported by the backend — `PATCH /api/workspaces/:slug/groups/:groupId` (`updateGroup`) enforces the admin gate, validates the name, and rejects clashes with a 409, and the `update_group` MCP tool exposes the same thing. It even has test coverage (`groups.test.ts:96`, "rename group and reject clashing rename").

The web UI never shipped a control for it. `GroupManager.tsx` rendered the group name as a static `<h2>`, so the capability was unreachable from the browser. The section comment above the editor claimed "rename, members, grants", which is likely why the gap went unnoticed.

## What

UI-only change to the group detail editor:

- The static heading becomes a labelled input, seeded from the fetched group detail.
- A **Rename** button PATCHes the trimmed name.
- The button is disabled while the name is unchanged or blank — the service rejects an empty patch with `"Nothing to update"`, so a no-op never reaches it.
- On success the existing `run()` helper refetches, updating both the editor and the groups table. On failure the draft is preserved and the error surfaces on the editor's existing error line, so a 409 name clash is recoverable without retyping.

No permission work was needed: the detail editor is only rendered for owners/admins, matching `requireAdmin` on the service. Members keep their read-only view.

## Tests

Adds `GroupManager.test.tsx` (no test file existed for this island): seeded input value, disabled state for unchanged and whitespace-only names, and that the PATCH carries the trimmed name.

- `pnpm --filter @projektor/web test` — 266 passing (24 files)
- `pnpm lint` — clean
- `pnpm turbo type-check` — 7/7 packages

## Out of scope

`UpdateGroupSchema` also accepts `description`, but editing it is deliberately left out — this PR does names only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
