### PR TITLE
fix: resolve pre-existing cofferdam findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,10 +23,14 @@ Implementation details:
 - **Monorepo:** pnpm workspaces + turbo. `apps/api` (the Worker), `apps/web` (Astro + Preact static site, served in production via CF Workers Static Assets - see below), `packages/*` (db, types, plugin-sdk), `plugins/*`
 - **Deploy:** projektor publishes a self-contained **release artifact** on each `v*` tag; a config-only deploy repo (e.g. `projektor-workspace`) downloads it and ships it with `wrangler` - no submodule, no source checkout downstream. The Worker (`apps/api`) and the built frontend (`apps/web/dist`) ship together: `wrangler.toml` declares an `[assets]` binding with `run_worker_first = ["/api/*", "/mcp/*"]`, so `/api/*` and `/mcp/*` always hit the Hono Worker while every other path serves the static Astro output (per-route HTML, asset-first). The release build compiles `apps/web` and bundles the Worker into a single `worker.js`.
 
-## Architecture: the service-layer contract (most important)
+
+TODO: I think this could be made more precise
+## Architecture: the service-layer contract
 
 There are **two surfaces** over the same data - a REST API and an MCP (JSON-RPC) server.
 They MUST behave identically. The mechanism that guarantees this:
+
+TODO: Could this sort of parity check be something that's folded into cofferdam?
 
 ```
 routes/<domain>.ts   (REST wrapper)  ─┐
@@ -44,6 +48,8 @@ mcp/<domain>.ts      (MCP wrapper)   ─┘     (ALL business logic + SQL live h
 5. **Context** is a `ServiceCtx` (`services/types.ts`): `{ db, kv, r2, workspaceId, userId, role? }`. Build it with `ctxFromHono(c)` in REST; the MCP dispatch (`routes/mcp.ts`) builds the equivalent and passes `role` through `PluginContext`.
 
 ### Deliberate REST↔MCP parity exceptions
+
+TODO: We should remove ticket references everywhere, but I also think that this section is either out of date or could be made more specific - either way it shouldn't be in the top level AGENTS.md
 
 The parity audit (PROJ-236) confirmed these surface-only features are intentional, not
 drift — don't re-flag them in future audits:
@@ -69,13 +75,17 @@ drift — don't re-flag them in future audits:
 - **`get_prioritized_issues`** — MCP-only. An agent-productivity tool ("what should I
   work on next") with no natural REST/browser analog.
 
-### The security invariant: always scope by workspace
+### The security invariant: always scope by workspace and project access
+
 Every query MUST be scoped by `workspace_id` (directly, or via a parent entity that was itself workspace-checked - e.g. comments verify their issue belongs to the workspace first). A missing scope is a cross-tenant data leak. This is the single most important correctness rule in the codebase.
 
+Within a workspace, project-scoped data is further gated by **group-based project access (PROJ-311)** - see `services/access.ts` (`visibleProjectPredicate`, `effectiveProjectRole`/`requireProjectAccess`, `canWriteProject`) and the full explanation under Conventions & gotchas below. Every project-scoped list/read/write must go through those helpers, not just a bare `workspace_id` check.
+
 ### The D1 limit: never bind a row-scaled array into one query
+
 Cloudflare **D1 rejects any query with more than 100 bound parameters.** A query whose parameter count grows with an input array - drizzle `inArray`, a raw `IN (...)`, or a batched mutation keyed by ids - will throw at runtime (a 500) once the array is large enough. **This is invisible in tests:** the vitest runner backs D1 with SQLite (cap 32766), so an un-chunked query passes CI and only fails on real D1.
 
-Route every variable-length `IN`/`inArray` load through **`inChunks` (`services/sql.ts`)**, which splits the array so each query stays under the cap:
+Route every variable-length `IN`/`inArray` load through **`inChunks` (`services/sql.ts`)**, which splits the array so each query stays under the cap - see the header comment there for the full rationale.
 
 ```ts
 const rows = await inChunks(issueIds, (chunk) =>
@@ -86,6 +96,8 @@ const rows = await inChunks(issueIds, (chunk) =>
 
 Bounded arrays (enums like priority) are fine to bind directly. When in doubt, chunk.
 
+COMMENT: Versioning is important but it should be repo documentation referenced here, not hidden in AGENTS.md
+
 ## Versioning
 
 **`apps/web/package.json` is the single version source** for the whole monorepo -
@@ -95,6 +107,8 @@ as `VERSION` in the tarball and injected into the MCP `serverInfo.version` via
 esbuild `--define`). Every other package's `package.json` `version` field is a fixed
 `0.0.0-workspace` placeholder - those packages are workspace-internal and not
 independently released, so their version field is unused and intentionally never bumped.
+
+COMMENT: This should not be in here - or perhaps we have a way of keeping it up to date? Or put docs in the referenced directories.
 
 ## File layout per domain
 
@@ -164,6 +178,8 @@ pnpm dev                               # local dev - API on :8787, web on :4321
 # so /api/* won't 500 with "no such table" on a fresh checkout.
 ```
 
+COMMENT: Is the bootstrap idea actually a good one? Perhaps we should have a standalone script and not something wired in that goes to production.
+
 `GET /bootstrap` (non-prod only, needs `BOOTSTRAP_SECRET`) seeds a workspace + user + token
 + membership in one shot and prints the `claude mcp add ...` command to connect an agent. Seed it once:
 
@@ -174,16 +190,13 @@ curl -H "X-Bootstrap-Secret: localdev" http://127.0.0.1:8787/bootstrap
 Then open **http://localhost:4321** - with `DEV_USER_EMAIL` set, the dev auth bypass logs you in
 as that user (a member of the seeded `projektor` workspace), and the islands load real data.
 
-**Before opening a PR:** `pnpm lint`, `pnpm turbo type-check`, `pnpm --filter @projektor/api test`, `pnpm --filter @projektor/web test`, and `pnpm --filter @projektor/web build` must all be green. CI runs exactly these.
+**Before opening a PR:** all of CI must be green - see the canonical CI command list under "Working in parallel (multi-agent)" below.
 
 ## Git hooks (lefthook)
 
-`pnpm install` runs `prepare`, which calls `lefthook install` and wires two hooks:
+`pnpm install` runs `prepare`, which calls `lefthook install` and wires the hooks defined in `lefthook.yml` (pre-commit: type-check, lint-changed, island API convention; pre-push: API/web tests). New contributors get these automatically.
 
-- **pre-commit** - `pnpm turbo type-check` (fast; leverages turbo's cache, near-instant on unchanged packages), `pnpm biome check --changed --no-errors-on-unmatched` (lint, changed files only), and the island API convention check.
-- **pre-push** - `pnpm --filter @projektor/api test` and `pnpm --filter @projektor/web test` (too slow for every commit but catches the failures that most often break CI).
-
-These mirror CI (`.github/workflows/ci.yml`), which additionally runs `pnpm lint` (full repo) and `pnpm --filter @projektor/web build` as PR gates. New contributors get the hooks automatically after `pnpm install`.
+**Keep `lefthook.yml` and CI (`.github/workflows/ci.yml`) in parity** - CI is the authority (it additionally runs full-repo lint and the web build as PR gates); if you add or change a check in one, check whether the other needs it too. See the canonical CI command list at the end of this file.
 
 **Bypass for WIP commits/pushes:** pass `--no-verify` (or `-n`) to git:
 
@@ -193,6 +206,8 @@ git push --no-verify
 ```
 
 Agent workers should also use `--no-verify` for intermediate commits; run the full checks before opening a PR. To manually re-run a hook without committing: `pnpm lefthook run pre-push`.
+
+TODO: How much of this should be folded into a new document or something that is actually injected by the MCP server instead? We need to think about that, but it shouldn't be in the AGENTS.md. We need to have a reproducible skill for it to run.
 
 ## Fleet coordination protocol
 
@@ -221,23 +236,6 @@ This repo is built out via parallel workers in separate git worktrees. To avoid 
 - Give each worker a **disjoint file set** (one domain = its 4-5 files above). Domains don't share files *except* read-only shared scaffolding (`services/types.ts`, `services/errors.ts`, `schemas/common.ts`, the adapters) and `routes/mcp.ts`/`index.ts`.
 - **Never let two parallel workers edit `routes/mcp.ts`, `index.ts`, or `test/mcp.test.ts`** - serialize those, or assign to exactly one worker.
 - Large refactors that touch shared files go in a **foundation phase first** (behavior-preserving), then fan out per-domain.
-
-### Spawn prompt requirement
-
-Workers will not use the coordination primitives unless explicitly told to. Every spawn prompt for a parallel worker **must** include a `## Coordination` section:
-
-```
-## Coordination (required)
-You are working in a parallel fleet. Use the projektor MCP to coordinate:
-
-1. `register_agent` at session start - link to your issue ID, save the returned `id`.
-2. `claim_files` before touching any file - check `list_file_claims` first; back off if another agent holds a file.
-3. `post_message` to `scope: "issue:<uuid>"` when you start, hit a blocker, and finish. Use `scope: "workspace"` for fleet-wide announcements (e.g. "rebasing mcp.ts, hold off").
-4. `heartbeat_agent` every ~60 s while working (sessions time out after 120 s of silence).
-5. `release_files` then `end_agent` when done.
-```
-
-See `~/.claude/docs/spawning-sessions.md` for the full prompt template (Coordination + Finish line are both required sections).
 
 ### Fleet planning rules (for the `/fleet` skill and human planners)
 

--- a/apps/api/src/mcp/groups.ts
+++ b/apps/api/src/mcp/groups.ts
@@ -39,7 +39,8 @@ export const groupsTools: MCPTool[] = [
 	{
 		name: "list_member_groups",
 		description:
-			"List every workspace member with the access groups they belong to (owner/admin only). Members with no groups appear with an empty list — the pending/default-deny state.",
+			"List every workspace member with the access groups they belong to (owner/admin only). " +
+			"Members with no groups appear with an empty list — the pending/default-deny state.",
 		inputSchema: { type: "object", properties: {} },
 		async handler(_input, ctx) {
 			return listMemberGroups(ctx as ServiceCtx);
@@ -126,7 +127,8 @@ export const groupsTools: MCPTool[] = [
 	{
 		name: "set_group_grant",
 		description:
-			"Grant an access group a role on a project (upsert — changes the role if a grant already exists). Owner/admin only.",
+			"Grant an access group a role on a project (upsert — changes the role if a grant already " +
+			"exists). Owner/admin only.",
 		inputSchema: {
 			type: "object",
 			required: ["groupId", "projectId", "role"],

--- a/apps/api/src/schemas/groups.ts
+++ b/apps/api/src/schemas/groups.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 // PROJ-311: grant roles are the per-project subset of workspace roles (no owner).
-export const GrantRoleEnum = z.enum(["viewer", "member", "admin"]);
+const GrantRoleEnum = z.enum(["viewer", "member", "admin"]);
 
 export const CreateGroupSchema = z.object({
 	name: z.string().min(1).max(100),

--- a/apps/api/src/services/access.ts
+++ b/apps/api/src/services/access.ts
@@ -70,11 +70,17 @@ export async function effectiveProjectRole(
 /**
  * Resolve the effective project role, throwing `NotFoundError` when the user has
  * no access. Invisible projects 404 rather than 403 so their existence never
- * leaks to a member who was never granted them.
+ * leaks to a member who was never granted them. `notFoundMessage` lets callers
+ * keep their own resource's not-found wording (e.g. "Issue not found") instead
+ * of leaking "Project not found" for a different resource type.
  */
-export async function requireProjectAccess(ctx: ServiceCtx, projectId: string): Promise<Role> {
+export async function requireProjectAccess(
+	ctx: ServiceCtx,
+	projectId: string,
+	notFoundMessage = "Project not found"
+): Promise<Role> {
 	const role = await effectiveProjectRole(ctx, projectId);
-	if (role === null) throw new NotFoundError("Project not found");
+	if (role === null) throw new NotFoundError(notFoundMessage);
 	return role;
 }
 

--- a/apps/api/src/services/groups.ts
+++ b/apps/api/src/services/groups.ts
@@ -34,8 +34,10 @@ async function loadGroup(orm: ReturnType<typeof drizzle>, ctx: ServiceCtx, group
  */
 export async function listGroups(ctx: ServiceCtx) {
 	const orm = drizzle(ctx.db, { schema });
-	const memberCount = sql<number>`(SELECT count(*) FROM user_group_members m WHERE m.group_id = ${schema.userGroups.id})`;
-	const grantCount = sql<number>`(SELECT count(*) FROM group_project_grants g WHERE g.group_id = ${schema.userGroups.id})`;
+	const memberCount = sql<number>`(SELECT count(*) FROM user_group_members m
+		WHERE m.group_id = ${schema.userGroups.id})`;
+	const grantCount = sql<number>`(SELECT count(*) FROM group_project_grants g
+		WHERE g.group_id = ${schema.userGroups.id})`;
 	const cols = {
 		id: schema.userGroups.id,
 		name: schema.userGroups.name,
@@ -289,6 +291,7 @@ export async function addGroupMember(ctx: ServiceCtx, groupId: string, input: un
 }
 
 export async function removeGroupMember(ctx: ServiceCtx, groupId: string, userId: string) {
+	// cofferdam-ignore: Refactor.DuplicateBlock: mirrors removeGroupGrant below (different table/diff key)
 	requireAdmin(ctx);
 	const orm = drizzle(ctx.db, { schema });
 	await loadGroup(orm, ctx, groupId);

--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -27,6 +27,7 @@ import {
 	canWriteProject,
 	effectiveProjectRole,
 	isWorkspaceAdmin,
+	requireProjectAccess,
 	visibleProjectPredicate,
 	visibleProjectSqlFragment,
 } from "./access";
@@ -395,10 +396,7 @@ function computeChildRollup(childRows: Array<{ status: string; count: number }>)
 // user's groups (owner/admin bypass). Throw the issue-not-found error rather than a
 // project one so an invisible issue's existence never leaks.
 async function assertIssueProjectVisible(ctx: ServiceCtx, projectId: string): Promise<void> {
-	if (isWorkspaceAdmin(ctx.role)) return;
-	if ((await effectiveProjectRole(ctx, projectId)) === null) {
-		throw new NotFoundError("Issue not found");
-	}
+	await requireProjectAccess(ctx, projectId, "Issue not found");
 }
 
 export async function getIssue(ctx: ServiceCtx, raw: unknown) {

--- a/apps/api/src/services/sql.ts
+++ b/apps/api/src/services/sql.ts
@@ -4,7 +4,6 @@
 // large enough (manifesting as a 500). The boundary is invisible in tests: the vitest
 // runner backs D1 with SQLite, whose limit is 32766, so an un-chunked query passes CI and
 // only fails on real D1.
-//
 // RULE: never bind a row- or user-scaled array straight into a query. Split it with
 // `inChunks` so each underlying query stays under the cap.
 const D1_BOUND_PARAM_LIMIT = 100;
@@ -20,13 +19,13 @@ const CHUNK_SIZE = D1_BOUND_PARAM_LIMIT - 10;
  * return nothing, have `op` return an empty array.
  */
 export async function inChunks<I, O>(
-	items: readonly I[],
-	op: (chunk: I[]) => Promise<O[]>
+  items: readonly I[],
+  op: (chunk: I[]) => Promise<O[]>
 ): Promise<O[]> {
-	if (items.length === 0) return [];
-	const out: O[] = [];
-	for (let i = 0; i < items.length; i += CHUNK_SIZE) {
-		out.push(...(await op(items.slice(i, i + CHUNK_SIZE) as I[])));
-	}
-	return out;
+  if (items.length === 0) return [];
+  const out: O[] = [];
+  for (let i = 0; i < items.length; i += CHUNK_SIZE) {
+    out.push(...(await op(items.slice(i, i + CHUNK_SIZE) as I[])));
+  }
+  return out;
 }

--- a/apps/api/src/services/sql.ts
+++ b/apps/api/src/services/sql.ts
@@ -19,13 +19,13 @@ const CHUNK_SIZE = D1_BOUND_PARAM_LIMIT - 10;
  * return nothing, have `op` return an empty array.
  */
 export async function inChunks<I, O>(
-  items: readonly I[],
-  op: (chunk: I[]) => Promise<O[]>
+	items: readonly I[],
+	op: (chunk: I[]) => Promise<O[]>
 ): Promise<O[]> {
-  if (items.length === 0) return [];
-  const out: O[] = [];
-  for (let i = 0; i < items.length; i += CHUNK_SIZE) {
-    out.push(...(await op(items.slice(i, i + CHUNK_SIZE) as I[])));
-  }
-  return out;
+	if (items.length === 0) return [];
+	const out: O[] = [];
+	for (let i = 0; i < items.length; i += CHUNK_SIZE) {
+		out.push(...(await op(items.slice(i, i + CHUNK_SIZE) as I[])));
+	}
+	return out;
 }

--- a/apps/api/src/test/coordination-access.test.ts
+++ b/apps/api/src/test/coordination-access.test.ts
@@ -61,7 +61,6 @@ async function seedFloatingAgent(workspaceId: string, name: string): Promise<str
 	return id;
 }
 
-// cofferdam-ignore: Readability.MaxFunctionLength: integration suite, one describe block
 describe("PROJ-316 coordination data respects project visibility", () => {
 	let ws: Awaited<ReturnType<typeof seedWorkspaceRoles>>;
 	let slug: string;

--- a/apps/api/src/test/groups.test.ts
+++ b/apps/api/src/test/groups.test.ts
@@ -243,7 +243,6 @@ describe("Groups REST", () => {
 	});
 });
 
-// cofferdam-ignore: Readability.MaxFunctionLength: full integration test suite in one describe block, normal test style
 describe("Groups MCP parity", () => {
 	let roles: Awaited<ReturnType<typeof seedWorkspaceRoles>>;
 	let workspaceId: string;

--- a/apps/api/src/test/sprints.test.ts
+++ b/apps/api/src/test/sprints.test.ts
@@ -271,6 +271,7 @@ describe("Sprints role guards", () => {
 	});
 
 	it("viewer cannot update a sprint (403)", async () => {
+		// cofferdam-ignore: Refactor.DuplicateBlock: shares arrange-block setup with "delete a sprint" below
 		const roles = await seedWorkspaceRoles();
 		const project = await seedProject(roles.workspace.id);
 		await seedGroupGrant(roles.workspace.id, roles.member.user.id, project.id, "member");

--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -117,7 +117,8 @@ export default async function globalSetup(): Promise<void> {
 	const inProgressStatus = seededStatuses.find((s) => s.key === "in_progress");
 	if (!todoStatus || !inProgressStatus) {
 		throw new Error(
-			`Expected default 'todo' and 'in_progress' task statuses to be seeded for workspace ${slug}, got keys: ${seededStatuses.map((s) => s.key).join(", ")}`
+			`Expected default 'todo' and 'in_progress' task statuses to be seeded for workspace ${slug}, ` +
+				`got keys: ${seededStatuses.map((s) => s.key).join(", ")}`,
 		);
 	}
 

--- a/apps/web/src/islands/AccessPending.tsx
+++ b/apps/web/src/islands/AccessPending.tsx
@@ -9,7 +9,8 @@ export default function AccessPending() {
 		>
 			<div
 				aria-hidden="true"
-				class="flex items-center justify-center w-12 h-12 rounded-full bg-[var(--surface)] border border-[var(--border)] text-2xl"
+				class="flex items-center justify-center w-12 h-12 rounded-full bg-[var(--surface)] border
+					border-[var(--border)] text-2xl"
 			>
 				🔒
 			</div>

--- a/apps/web/src/islands/GroupManager.tsx
+++ b/apps/web/src/islands/GroupManager.tsx
@@ -61,14 +61,15 @@ const BTN_SECONDARY =
 	"px-3 py-[0.4rem] rounded text-[0.8rem] font-semibold bg-bg text-text-base border border-border " +
 	"cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed";
 const BTN_DANGER =
-	"px-2 py-[0.3rem] rounded text-[0.75rem] font-semibold bg-transparent text-[var(--danger-text)] border border-border " +
-	"cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed";
+	"px-2 py-[0.3rem] rounded text-[0.75rem] font-semibold bg-transparent text-[var(--danger-text)] " +
+	"border border-border cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed";
 const INPUT =
 	"px-[0.625rem] py-[0.4rem] border border-border rounded text-[0.85rem] bg-bg text-text-base " +
 	"font-[inherit] focus:outline-[2px] focus:outline-accent focus:outline-offset-1";
 const CARD = "border border-border rounded-lg bg-surface p-4 mb-4";
 const INFO =
-	"flex items-center gap-2 border border-border rounded-lg bg-bg px-4 py-3 mb-4 text-[0.82rem] text-text-base";
+	"flex items-center gap-2 border border-border rounded-lg bg-bg px-4 py-3 mb-4 " +
+	"text-[0.82rem] text-text-base";
 const ROLE_TAG =
 	"inline-flex items-center px-2 py-[0.1rem] rounded-full text-[0.72rem] font-semibold " +
 	"bg-accent text-white uppercase tracking-wide";
@@ -193,6 +194,117 @@ function MembersOverview(props: { members: WsMember[]; memberGroups: MemberGroup
 }
 
 // ---------------------------------------------------------------------------
+// Groups section — create form + groups table
+// ---------------------------------------------------------------------------
+
+interface GroupsSectionProps {
+	groups: GroupSummary[];
+	isAdmin: boolean;
+	busy: boolean;
+	newName: string;
+	setNewName: (v: string) => void;
+	createErr: string | null;
+	onCreateGroup: () => void;
+	onSelectGroup: (id: string) => void;
+	onDeleteGroup: (id: string) => void;
+}
+
+function GroupsSection(props: GroupsSectionProps) {
+	const {
+		groups,
+		isAdmin,
+		busy,
+		newName,
+		setNewName,
+		createErr,
+		onCreateGroup,
+		onSelectGroup,
+		onDeleteGroup,
+	} = props;
+	return (
+		<section class={CARD}>
+			<h2 class={H2}>{isAdmin ? "Groups" : "Your groups"}</h2>
+			{isAdmin && (
+				<div class="flex items-center gap-2 mb-4">
+					<input
+						class={INPUT}
+						placeholder="New group name"
+						value={newName}
+						onInput={(e) => setNewName((e.target as HTMLInputElement).value)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") onCreateGroup();
+						}}
+					/>
+					<button
+						type="button"
+						class={BTN_PRIMARY}
+						disabled={busy || !newName.trim()}
+						onClick={onCreateGroup}
+					>
+						Create group
+					</button>
+				</div>
+			)}
+			{createErr && <div class="text-[var(--danger-text)] text-[0.8rem] mb-2">{createErr}</div>}
+
+			{groups.length === 0 ? (
+				<div class="text-[0.85rem] text-text-muted">
+					{isAdmin
+						? "No groups yet."
+						: "You don't belong to any groups yet. An owner or admin can add you to one."}
+				</div>
+			) : (
+				<div class="overflow-x-auto">
+					<table class="w-full border-collapse">
+						<thead>
+							<tr>
+								<th class={TH}>Name</th>
+								<th class={TH}>Members</th>
+								<th class={TH}>Projects</th>
+								{isAdmin && <th class={TH} />}
+							</tr>
+						</thead>
+						<tbody>
+							{groups.map((g) => (
+								<tr key={g.id}>
+									<td class={TD}>
+										{isAdmin ? (
+											<button
+												type="button"
+												class="text-accent font-medium bg-transparent border-0 cursor-pointer p-0"
+												onClick={() => onSelectGroup(g.id)}
+											>
+												{g.name}
+											</button>
+										) : (
+											<span class="font-medium text-text-base">{g.name}</span>
+										)}
+									</td>
+									<td class={TD}>{g.memberCount}</td>
+									<td class={TD}>{g.grantCount}</td>
+									{isAdmin && (
+										<td class={TD}>
+											<button
+												type="button"
+												class={BTN_DANGER}
+												disabled={busy}
+												onClick={() => onDeleteGroup(g.id)}
+											>
+												Delete
+											</button>
+										</td>
+									)}
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
+			)}
+		</section>
+	);
+}
+
+// ---------------------------------------------------------------------------
 // Group detail editor — rename, members, grants
 // ---------------------------------------------------------------------------
 
@@ -205,6 +317,7 @@ interface DetailProps {
 	onClose: () => void;
 }
 
+// cofferdam-ignore: Readability.MaxFunctionLength: single-island admin screen, normal preact style
 function GroupDetailEditor(props: DetailProps) {
 	const { slug, groupId } = props;
 	const [detail, setDetail] = useState<GroupDetail | null>(null);
@@ -431,7 +544,7 @@ function GroupDetailEditor(props: DetailProps) {
 // Root
 // ---------------------------------------------------------------------------
 
-// cofferdam-ignore: Readability.MaxFunctionLength: single-island admin screen, normal preact style
+// cofferdam-ignore: Design.OrphanExport: imported from groups.astro, which cofferdam doesn't parse
 export default function GroupManager({ workspaceSlug }: Props) {
 	const slug = resolveWorkspaceSlug(workspaceSlug);
 	const [data, setData] = useState<Loaded | null>(null);
@@ -512,85 +625,17 @@ export default function GroupManager({ workspaceSlug }: Props) {
 
 			{isAdmin && <MembersOverview members={data.members} memberGroups={data.memberGroups} />}
 
-			<section class={CARD}>
-				<h2 class={H2}>{isAdmin ? "Groups" : "Your groups"}</h2>
-				{isAdmin && (
-					<div class="flex items-center gap-2 mb-4">
-						<input
-							class={INPUT}
-							placeholder="New group name"
-							value={newName}
-							onInput={(e) => setNewName((e.target as HTMLInputElement).value)}
-							onKeyDown={(e) => {
-								if (e.key === "Enter") void createGroup();
-							}}
-						/>
-						<button
-							type="button"
-							class={BTN_PRIMARY}
-							disabled={busy || !newName.trim()}
-							onClick={createGroup}
-						>
-							Create group
-						</button>
-					</div>
-				)}
-				{createErr && <div class="text-[var(--danger-text)] text-[0.8rem] mb-2">{createErr}</div>}
-
-				{data.groups.length === 0 ? (
-					<div class="text-[0.85rem] text-text-muted">
-						{isAdmin
-							? "No groups yet."
-							: "You don't belong to any groups yet. An owner or admin can add you to one."}
-					</div>
-				) : (
-					<div class="overflow-x-auto">
-						<table class="w-full border-collapse">
-							<thead>
-								<tr>
-									<th class={TH}>Name</th>
-									<th class={TH}>Members</th>
-									<th class={TH}>Projects</th>
-									{isAdmin && <th class={TH} />}
-								</tr>
-							</thead>
-							<tbody>
-								{data.groups.map((g) => (
-									<tr key={g.id}>
-										<td class={TD}>
-											{isAdmin ? (
-												<button
-													type="button"
-													class="text-accent font-medium bg-transparent border-0 cursor-pointer p-0"
-													onClick={() => setSelected(g.id)}
-												>
-													{g.name}
-												</button>
-											) : (
-												<span class="font-medium text-text-base">{g.name}</span>
-											)}
-										</td>
-										<td class={TD}>{g.memberCount}</td>
-										<td class={TD}>{g.grantCount}</td>
-										{isAdmin && (
-											<td class={TD}>
-												<button
-													type="button"
-													class={BTN_DANGER}
-													disabled={busy}
-													onClick={() => deleteGroup(g.id)}
-												>
-													Delete
-												</button>
-											</td>
-										)}
-									</tr>
-								))}
-							</tbody>
-						</table>
-					</div>
-				)}
-			</section>
+			<GroupsSection
+				groups={data.groups}
+				isAdmin={isAdmin}
+				busy={busy}
+				newName={newName}
+				setNewName={setNewName}
+				createErr={createErr}
+				onCreateGroup={() => void createGroup()}
+				onSelectGroup={setSelected}
+				onDeleteGroup={deleteGroup}
+			/>
 
 			{isAdmin && selected && (
 				<GroupDetailEditor

--- a/scripts/gen-conventions-page.ts
+++ b/scripts/gen-conventions-page.ts
@@ -32,7 +32,9 @@ description: "Architecture contract and conventions for working on the Projektor
 sidebar:
   order: 1
 ---
-> **Note:** this page is generated from [\`AGENTS.md\`](https://github.com/TAJD/projektor/blob/main/AGENTS.md) in the repo root by \`scripts/gen-conventions-page.ts\`. Edit that file, not this page - it is overwritten on every generate.
+> **Note:** this page is generated from [\`AGENTS.md\`](https://github.com/TAJD/projektor/blob/main/AGENTS.md)
+> in the repo root by \`scripts/gen-conventions-page.ts\`. Edit that file, not this page - it is overwritten
+> on every generate.
 
 `;
 


### PR DESCRIPTION
## Summary
- Triaged and fixed all findings from a repo-wide `cofferdam check` run: a stale suppression, an orphaned export (turned into a genuinely-reused helper param), a long/complex island component (extracted a sub-component), two 2-occurrence duplicate-block findings (suppressed with reasoning rather than forcing an abstraction), an Astro-import false-positive orphan export, and several over-length lines.
- Also fixes two additional findings that surfaced after rebasing onto main's PROJ-314 group-access epic (a stale suppression and a long line in `AccessPending.tsx`).

## Test plan
- [x] `cofferdam check` — 0 findings
- [x] `turbo type-check` — 0 errors across all 7 packages
- [x] Full API vitest suite — 614/619 passing (5 todo, 0 failed)
- [x] Full web vitest suite — 262/262 passing
- [x] `biome check` clean