### PR TITLE
feat(web): per-project Metrics dashboard (throughput, lead/cycle time, WIP)

### DIFF
--- a/apps/api/src/mcp/flow-metrics.ts
+++ b/apps/api/src/mcp/flow-metrics.ts
@@ -5,8 +5,9 @@ export const flowMetricsTools: MCPTool[] = [
 	{
 		name: "get_flow_metrics",
 		description:
-			"Lead time (ready→done), cycle time (claimed→done), WIP over time, and agent-vs-human cycle " +
-			"time for a project, computed from indexed transition timestamps. Measure flow before tuning WIP limits.",
+			"Lead time (ready→done), cycle time (claimed→done), WIP over time, throughput over time, and " +
+			"agent-vs-human cycle time for a project, computed from indexed transition timestamps. Measure " +
+			"flow before tuning WIP limits.",
 		inputSchema: {
 			type: "object",
 			required: ["projectId"],

--- a/apps/api/src/mcp/flow-metrics.ts
+++ b/apps/api/src/mcp/flow-metrics.ts
@@ -15,11 +15,11 @@ export const flowMetricsTools: MCPTool[] = [
 				projectId: { type: "string", description: "Project UUID" },
 				since: {
 					type: "number",
-					description: "Only issues created at/after this epoch-seconds time",
+					description: "Only issues completed/active at/after this epoch-seconds time",
 				},
 				until: {
 					type: "number",
-					description: "Only issues created at/before this epoch-seconds time",
+					description: "Only issues completed/active at/before this epoch-seconds time",
 				},
 			},
 		},

--- a/apps/api/src/services/flow-metrics.ts
+++ b/apps/api/src/services/flow-metrics.ts
@@ -58,6 +58,24 @@ function buildWipOverTime(
 	return buckets;
 }
 
+function buildThroughputOverTime(
+	issues: FlowIssueRow[],
+	since: number,
+	until: number
+): Array<{ weekStart: string; count: number }> {
+	const DAY = 86400;
+	const WEEK = 7 * DAY;
+	const buckets: Array<{ weekStart: string; count: number }> = [];
+	for (let t = since - (since % WEEK); t <= until; t += WEEK) {
+		const bucketEnd = t + WEEK;
+		const count = issues.filter(
+			(i) => i.doneAt !== null && i.doneAt >= t && i.doneAt < bucketEnd
+		).length;
+		buckets.push({ weekStart: new Date(t * 1000).toISOString().slice(0, 10), count });
+	}
+	return buckets;
+}
+
 async function computeAgentVsHuman(
 	ctx: ServiceCtx,
 	orm: ReturnType<typeof drizzle>,
@@ -134,6 +152,10 @@ export async function getFlowMetrics(ctx: ServiceCtx, raw: unknown) {
 	const wipUntil = until ?? now;
 	const wipOverTime = buildWipOverTime(issues, wipSince, wipUntil);
 
+	const throughputSince = since ?? now - 12 * 7 * 86400;
+	const throughputUntil = until ?? now;
+	const throughputOverTime = buildThroughputOverTime(issues, throughputSince, throughputUntil);
+
 	const cycleWindowIssues = issues.filter((i) => i.doneAt === null || inWindow(i.doneAt));
 	const agentVsHuman = await computeAgentVsHuman(ctx, orm, cycleWindowIssues);
 
@@ -141,6 +163,7 @@ export async function getFlowMetrics(ctx: ServiceCtx, raw: unknown) {
 		leadTime: summarize(leadTimes),
 		cycleTime: summarize(cycleTimes),
 		wipOverTime,
+		throughputOverTime,
 		agentVsHuman,
 	};
 }

--- a/apps/api/src/services/flow-metrics.ts
+++ b/apps/api/src/services/flow-metrics.ts
@@ -58,18 +58,30 @@ function buildWipOverTime(
 	return buckets;
 }
 
+// Unix epoch day 0 (1970-01-01) was a Thursday; align to the preceding Monday so
+// week boundaries read as conventional (ISO) weeks rather than landing on Thursdays.
+function mondayAtOrBefore(t: number): number {
+	const DAY = 86400;
+	const dayIndex = Math.floor(t / DAY);
+	const daysSinceMonday = ((dayIndex % 7) + 7 - 4) % 7; // day 0 (Thu) is 4 days after Monday
+	return (dayIndex - daysSinceMonday) * DAY;
+}
+
 function buildThroughputOverTime(
 	issues: FlowIssueRow[],
 	since: number,
 	until: number
 ): Array<{ weekStart: string; count: number }> {
-	const DAY = 86400;
-	const WEEK = 7 * DAY;
+	const WEEK = 7 * 86400;
 	const buckets: Array<{ weekStart: string; count: number }> = [];
-	for (let t = since - (since % WEEK); t <= until; t += WEEK) {
+	for (let t = mondayAtOrBefore(since); t <= until; t += WEEK) {
 		const bucketEnd = t + WEEK;
+		// Clamp each bucket to the requested window so edge weeks don't pull in
+		// completions from just outside [since, until], matching leadTime/cycleTime.
+		const clampedStart = Math.max(t, since);
+		const clampedEnd = Math.min(bucketEnd, until + 1);
 		const count = issues.filter(
-			(i) => i.doneAt !== null && i.doneAt >= t && i.doneAt < bucketEnd
+			(i) => i.doneAt !== null && i.doneAt >= clampedStart && i.doneAt < clampedEnd
 		).length;
 		buckets.push({ weekStart: new Date(t * 1000).toISOString().slice(0, 10), count });
 	}

--- a/apps/api/src/test/flow-metrics.test.ts
+++ b/apps/api/src/test/flow-metrics.test.ts
@@ -15,6 +15,7 @@ interface FlowMetrics {
 	leadTime: Distribution;
 	cycleTime: Distribution;
 	wipOverTime: Array<{ date: string; count: number }>;
+	throughputOverTime: Array<{ weekStart: string; count: number }>;
 	agentVsHuman: { agent: Distribution; human: Distribution };
 }
 
@@ -171,5 +172,60 @@ describe("Flow metrics (PROJ-252)", () => {
 
 		expect(metrics.leadTime.count).toBe(1);
 		expect(metrics.cycleTime.count).toBe(1);
+	});
+
+	it("buckets throughput weekly and excludes issues outside the window", async () => {
+		const WEEK = 7 * 86400;
+		const now = Math.floor(Date.now() / 1000);
+		const since = now - 3 * WEEK;
+		const until = now;
+
+		const thisWeekIssue = await seedIssue(workspaceId, projectId, userId, { title: "This week" });
+		await stampFlowTimestamps(thisWeekIssue.id, {
+			readyAt: now - 100,
+			claimedAt: now - 50,
+			doneAt: now,
+		});
+
+		const lastWeekIssue = await seedIssue(workspaceId, projectId, userId, { title: "Last week" });
+		await stampFlowTimestamps(lastWeekIssue.id, {
+			readyAt: now - WEEK - 100,
+			claimedAt: now - WEEK - 50,
+			doneAt: now - WEEK,
+		});
+
+		const outsideWindowIssue = await seedIssue(workspaceId, projectId, userId, {
+			title: "Too old",
+		});
+		await stampFlowTimestamps(outsideWindowIssue.id, {
+			readyAt: now - 10 * WEEK,
+			claimedAt: now - 10 * WEEK + 50,
+			doneAt: now - 10 * WEEK + 100,
+		});
+
+		const res = await SELF.fetch(
+			`http://localhost/api/projects/${projectId}/flow-metrics?since=${since}&until=${until}`,
+			{ headers: authHeaders(token, slug) }
+		);
+		expect(res.status).toBe(200);
+		const metrics = (await res.json()) as FlowMetrics;
+
+		const totalCounted = metrics.throughputOverTime.reduce((sum, b) => sum + b.count, 0);
+		expect(totalCounted).toBe(2);
+		expect(metrics.throughputOverTime.length).toBeGreaterThan(0);
+		for (const bucket of metrics.throughputOverTime) {
+			expect(bucket.weekStart).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+		}
+	});
+
+	it("returns an empty throughput series for a project with no completed issues", async () => {
+		const res = await SELF.fetch(`http://localhost/api/projects/${projectId}/flow-metrics`, {
+			headers: authHeaders(token, slug),
+		});
+		expect(res.status).toBe(200);
+		const metrics = (await res.json()) as FlowMetrics;
+
+		expect(Array.isArray(metrics.throughputOverTime)).toBe(true);
+		expect(metrics.throughputOverTime.every((b) => b.count === 0)).toBe(true);
 	});
 });

--- a/apps/api/src/test/flow-metrics.test.ts
+++ b/apps/api/src/test/flow-metrics.test.ts
@@ -218,6 +218,55 @@ describe("Flow metrics (PROJ-252)", () => {
 		}
 	});
 
+	it("excludes an issue completed just before `since` even though it falls in the aligned first bucket", async () => {
+		const WEEK = 7 * 86400;
+		const now = Math.floor(Date.now() / 1000);
+		const since = now - 2 * WEEK;
+		const until = now;
+
+		const justInsideIssue = await seedIssue(workspaceId, projectId, userId, {
+			title: "Just inside since",
+		});
+		await stampFlowTimestamps(justInsideIssue.id, {
+			readyAt: since - 100,
+			claimedAt: since - 50,
+			doneAt: since + 10,
+		});
+
+		const justOutsideIssue = await seedIssue(workspaceId, projectId, userId, {
+			title: "Just before since, same aligned bucket",
+		});
+		await stampFlowTimestamps(justOutsideIssue.id, {
+			readyAt: since - 200,
+			claimedAt: since - 150,
+			doneAt: since - 10,
+		});
+
+		const res = await SELF.fetch(
+			`http://localhost/api/projects/${projectId}/flow-metrics?since=${since}&until=${until}`,
+			{ headers: authHeaders(token, slug) }
+		);
+		expect(res.status).toBe(200);
+		const metrics = (await res.json()) as FlowMetrics;
+
+		const totalCounted = metrics.throughputOverTime.reduce((sum, b) => sum + b.count, 0);
+		expect(totalCounted).toBe(1);
+	});
+
+	it("aligns weekStart labels to Monday", async () => {
+		const res = await SELF.fetch(
+			`http://localhost/api/projects/${projectId}/flow-metrics?since=${Math.floor(Date.now() / 1000) - 4 * 7 * 86400}`,
+			{ headers: authHeaders(token, slug) }
+		);
+		expect(res.status).toBe(200);
+		const metrics = (await res.json()) as FlowMetrics;
+
+		for (const bucket of metrics.throughputOverTime) {
+			const weekday = new Date(`${bucket.weekStart}T00:00:00Z`).getUTCDay();
+			expect(weekday).toBe(1); // 1 === Monday
+		}
+	});
+
 	it("returns an empty throughput series for a project with no completed issues", async () => {
 		const res = await SELF.fetch(`http://localhost/api/projects/${projectId}/flow-metrics`, {
 			headers: authHeaders(token, slug),

--- a/apps/docs/src/content/docs/agents/tool-catalog.md
+++ b/apps/docs/src/content/docs/agents/tool-catalog.md
@@ -184,6 +184,6 @@ running server.
 
 | Tool | Description |
 |------|-------------|
-| `get_flow_metrics` | Lead time (ready→done), cycle time (claimed→done), WIP over time, and agent-vs-human cycle time for a project, computed from indexed transition timestamps. Measure flow before tuning WIP limits. |
+| `get_flow_metrics` | Lead time (ready→done), cycle time (claimed→done), WIP over time, throughput over time, and agent-vs-human cycle time for a project, computed from indexed transition timestamps. Measure flow before tuning WIP limits. |
 
 <!-- gen-mcp-catalog:end -->

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,7 +21,8 @@
     "dompurify": "^3.2.0",
     "marked": "^15.0.0",
     "mermaid": "^11.0.0",
-    "preact": "^10.25.0"
+    "preact": "^10.25.0",
+    "uplot": "^1.6.32"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.0",

--- a/apps/web/src/islands/MetricsDashboard.test.tsx
+++ b/apps/web/src/islands/MetricsDashboard.test.tsx
@@ -17,6 +17,25 @@ const EMPTY_METRICS = {
 	},
 };
 
+// The real API always returns a fixed-size bucket window, even with zero completions —
+// it never returns [] for an active project. This is the actual "no data" shape.
+const ZERO_BUCKET_METRICS = {
+	leadTime: { count: 0, avg: null, p50: null, p90: null },
+	cycleTime: { count: 0, avg: null, p50: null, p90: null },
+	wipOverTime: [
+		{ date: "2026-06-01", count: 0 },
+		{ date: "2026-06-02", count: 0 },
+	],
+	throughputOverTime: [
+		{ weekStart: "2026-05-25", count: 0 },
+		{ weekStart: "2026-06-01", count: 0 },
+	],
+	agentVsHuman: {
+		agent: { count: 0, avg: null, p50: null, p90: null },
+		human: { count: 0, avg: null, p50: null, p90: null },
+	},
+};
+
 const FULL_METRICS = {
 	leadTime: { count: 4, avg: 86400 * 2.3, p50: 86400 * 2, p90: 86400 * 4 },
 	cycleTime: { count: 4, avg: 3600 * 5, p50: 3600 * 4, p90: 3600 * 9 },
@@ -81,6 +100,16 @@ describe("MetricsDashboard", () => {
 	it("does not crash on an empty-metrics response", async () => {
 		history.replaceState(null, "", "?projectId=p1");
 		mockFetchMetrics(EMPTY_METRICS);
+		render(<MetricsDashboard />);
+
+		expect(await screen.findByText("Throughput")).toBeTruthy();
+		expect(screen.getByText(/No completed issues yet/i)).toBeTruthy();
+		expect(screen.getByText(/No WIP data yet/i)).toBeTruthy();
+	});
+
+	it("shows empty-chart states for a fixed-size all-zero bucket window (real API shape)", async () => {
+		history.replaceState(null, "", "?projectId=p1");
+		mockFetchMetrics(ZERO_BUCKET_METRICS);
 		render(<MetricsDashboard />);
 
 		expect(await screen.findByText("Throughput")).toBeTruthy();

--- a/apps/web/src/islands/MetricsDashboard.test.tsx
+++ b/apps/web/src/islands/MetricsDashboard.test.tsx
@@ -84,8 +84,8 @@ describe("MetricsDashboard", () => {
 		render(<MetricsDashboard />);
 
 		expect(await screen.findByText("Throughput")).toBeTruthy();
-		expect(screen.getByText(/No completed issues in this window yet/i)).toBeTruthy();
-		expect(screen.getByText(/No WIP data in this window yet/i)).toBeTruthy();
+		expect(screen.getByText(/No completed issues yet/i)).toBeTruthy();
+		expect(screen.getByText(/No WIP data yet/i)).toBeTruthy();
 	});
 
 	it("shows a message when no project is specified", async () => {

--- a/apps/web/src/islands/MetricsDashboard.test.tsx
+++ b/apps/web/src/islands/MetricsDashboard.test.tsx
@@ -1,0 +1,95 @@
+// MetricsDashboard island — mock-fetch tests.
+//
+// Follows the SprintManager.test.tsx pattern: reads ?projectId= from the URL, then fetches
+// /api/projects/:id/flow-metrics via raw fetch + buildHeaders. loading starts as true.
+import { render, screen } from "@testing-library/preact";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import MetricsDashboard from "./MetricsDashboard";
+
+const EMPTY_METRICS = {
+	leadTime: { count: 0, avg: null, p50: null, p90: null },
+	cycleTime: { count: 0, avg: null, p50: null, p90: null },
+	wipOverTime: [],
+	throughputOverTime: [],
+	agentVsHuman: {
+		agent: { count: 0, avg: null, p50: null, p90: null },
+		human: { count: 0, avg: null, p50: null, p90: null },
+	},
+};
+
+const FULL_METRICS = {
+	leadTime: { count: 4, avg: 86400 * 2.3, p50: 86400 * 2, p90: 86400 * 4 },
+	cycleTime: { count: 4, avg: 3600 * 5, p50: 3600 * 4, p90: 3600 * 9 },
+	wipOverTime: [
+		{ date: "2026-06-01", count: 2 },
+		{ date: "2026-06-02", count: 3 },
+	],
+	throughputOverTime: [
+		{ weekStart: "2026-05-25", count: 1 },
+		{ weekStart: "2026-06-01", count: 3 },
+	],
+	agentVsHuman: {
+		agent: { count: 2, avg: 3600 * 3, p50: 3600 * 2, p90: 3600 * 6 },
+		human: { count: 2, avg: 3600 * 7, p50: 3600 * 6, p90: 3600 * 12 },
+	},
+};
+
+function mockFetchMetrics(metrics: unknown) {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn().mockImplementation((url: string) => {
+			const u = String(url);
+			if (u.includes("/flow-metrics")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve(metrics) });
+			}
+			return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+		})
+	);
+}
+
+beforeEach(() => {
+	history.replaceState(null, "", "/");
+});
+
+afterEach(() => {
+	history.replaceState(null, "", "/");
+});
+
+describe("MetricsDashboard", () => {
+	it("renders loading state initially", () => {
+		history.replaceState(null, "", "?projectId=p1");
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation(() => new Promise(() => {}))
+		);
+		render(<MetricsDashboard />);
+		expect(screen.getByText(/Loading metrics/i)).toBeTruthy();
+	});
+
+	it("renders throughput, lead/cycle tiles, and agent-vs-human after fetch resolves", async () => {
+		history.replaceState(null, "", "?projectId=p1");
+		mockFetchMetrics(FULL_METRICS);
+		render(<MetricsDashboard />);
+
+		expect(await screen.findByText("Throughput")).toBeTruthy();
+		expect(screen.getByText("Lead time")).toBeTruthy();
+		expect(screen.getByText("Cycle time")).toBeTruthy();
+		expect(screen.getByText("WIP over time")).toBeTruthy();
+		expect(screen.getByText("Agent vs human")).toBeTruthy();
+	});
+
+	it("does not crash on an empty-metrics response", async () => {
+		history.replaceState(null, "", "?projectId=p1");
+		mockFetchMetrics(EMPTY_METRICS);
+		render(<MetricsDashboard />);
+
+		expect(await screen.findByText("Throughput")).toBeTruthy();
+		expect(screen.getByText(/No completed issues in this window yet/i)).toBeTruthy();
+		expect(screen.getByText(/No WIP data in this window yet/i)).toBeTruthy();
+	});
+
+	it("shows a message when no project is specified", async () => {
+		render(<MetricsDashboard />);
+		expect(await screen.findByText(/No project specified/i)).toBeTruthy();
+	});
+});

--- a/apps/web/src/islands/MetricsDashboard.tsx
+++ b/apps/web/src/islands/MetricsDashboard.tsx
@@ -176,7 +176,7 @@ function ThroughputChart({ data }: { data: FlowMetrics["throughputOverTime"] }) 
 		};
 	}, [labels]);
 
-	if (data.length === 0) {
+	if (data.length === 0 || data.every((d) => d.count === 0)) {
 		return <EmptyChartState message="No completed issues yet" />;
 	}
 
@@ -224,7 +224,7 @@ function WipChart({ data }: { data: FlowMetrics["wipOverTime"] }) {
 		};
 	}, []);
 
-	if (data.length === 0) {
+	if (data.length === 0 || data.every((d) => d.count === 0)) {
 		return <EmptyChartState message="No WIP data yet" />;
 	}
 

--- a/apps/web/src/islands/MetricsDashboard.tsx
+++ b/apps/web/src/islands/MetricsDashboard.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useState } from "preact/hooks";
+import uPlot from "uplot";
+import { apiFetch } from "../utils/api-client";
+import UplotChart from "./charts/UplotChart";
+
+interface Distribution {
+	count: number;
+	avg: number | null;
+	p50: number | null;
+	p90: number | null;
+}
+
+interface FlowMetrics {
+	leadTime: Distribution;
+	cycleTime: Distribution;
+	wipOverTime: Array<{ date: string; count: number }>;
+	throughputOverTime: Array<{ weekStart: string; count: number }>;
+	agentVsHuman: { agent: Distribution; human: Distribution };
+}
+
+interface Props {
+	workspaceSlug?: string;
+}
+
+function formatDuration(seconds: number | null): string {
+	if (seconds === null) return "—";
+	const abs = Math.abs(seconds);
+	if (abs < 60) return `${Math.round(seconds)}s`;
+	if (abs < 3600) return `${(seconds / 60).toFixed(1)}m`;
+	if (abs < 86400) return `${(seconds / 3600).toFixed(1)}h`;
+	return `${(seconds / 86400).toFixed(1)}d`;
+}
+
+function useFlowMetrics(workspaceSlug: string | undefined) {
+	const [projectId, setProjectId] = useState<string | null>(null);
+	const [metrics, setMetrics] = useState<FlowMetrics | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		const id = new URLSearchParams(window.location.search).get("projectId");
+		setProjectId(id);
+	}, []);
+
+	useEffect(() => {
+		if (!projectId) {
+			setLoading(false);
+			return;
+		}
+		setLoading(true);
+		setError(null);
+		apiFetch<FlowMetrics>(`/api/projects/${encodeURIComponent(projectId)}/flow-metrics`, {
+			workspaceSlug,
+		})
+			.then((data) => setMetrics(data))
+			.catch((e) => setError(String(e)))
+			.finally(() => setLoading(false));
+	}, [projectId, workspaceSlug]);
+
+	return { projectId, metrics, loading, error };
+}
+
+function StatTile({ label, value }: { label: string; value: string }) {
+	return (
+		<div class="px-4 py-3 bg-surface border border-border rounded-lg min-w-0">
+			<p class="m-0 mb-1 text-[0.72rem] font-semibold text-text-muted uppercase tracking-[0.04em]">
+				{label}
+			</p>
+			<p class="m-0 text-lg font-semibold text-text-base">{value}</p>
+		</div>
+	);
+}
+
+function DistributionTiles({ title, dist }: { title: string; dist: Distribution }) {
+	return (
+		<div class="mb-8">
+			<h2 class="m-0 mb-3 text-base font-semibold text-text-base">{title}</h2>
+			<div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+				<StatTile label="Count" value={String(dist.count)} />
+				<StatTile label="Avg" value={formatDuration(dist.avg)} />
+				<StatTile label="p50" value={formatDuration(dist.p50)} />
+				<StatTile label="p90" value={formatDuration(dist.p90)} />
+			</div>
+		</div>
+	);
+}
+
+function ThroughputChart({ data }: { data: FlowMetrics["throughputOverTime"] }) {
+	if (data.length === 0) {
+		return <p class="text-sm text-text-muted m-0">No completed issues in this window yet.</p>;
+	}
+
+	const labels = data.map((d) => d.weekStart);
+	const xs = data.map((_, i) => i);
+	const ys = data.map((d) => d.count);
+
+	return (
+		<UplotChart
+			data={[xs, ys]}
+			options={{
+				width: 600,
+				height: 220,
+				scales: { x: { time: false } },
+				series: [
+					{},
+					{
+						label: "Issues completed",
+						stroke: "rgba(37,99,235,0.8)",
+						fill: "rgba(37,99,235,0.25)",
+						paths: uPlot.paths.bars?.(),
+					},
+				],
+				axes: [
+					{
+						values: (_u, splits) => splits.map((s) => labels[s] ?? ""),
+					},
+					{},
+				],
+			}}
+		/>
+	);
+}
+
+function WipChart({ data }: { data: FlowMetrics["wipOverTime"] }) {
+	if (data.length === 0) {
+		return <p class="text-sm text-text-muted m-0">No WIP data in this window yet.</p>;
+	}
+
+	const xs = data.map((d) => Math.floor(new Date(d.date).getTime() / 1000));
+	const ys = data.map((d) => d.count);
+
+	return (
+		<UplotChart
+			data={[xs, ys]}
+			options={{
+				width: 600,
+				height: 220,
+				scales: { x: { time: true } },
+				series: [{}, { label: "WIP", stroke: "rgba(22,163,74,0.8)", width: 2 }],
+			}}
+		/>
+	);
+}
+
+function AgentVsHumanTiles({ agentVsHuman }: { agentVsHuman: FlowMetrics["agentVsHuman"] }) {
+	return (
+		<div class="mb-8">
+			<h2 class="m-0 mb-3 text-base font-semibold text-text-base">Agent vs human</h2>
+			<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+				<div class="px-4 py-3 bg-surface border border-border rounded-lg">
+					<p class="m-0 mb-2 text-[0.72rem] font-semibold text-text-muted uppercase tracking-[0.04em]">
+						Agent
+					</p>
+					<div class="grid grid-cols-3 gap-2 text-sm">
+						<span>Count: {agentVsHuman.agent.count}</span>
+						<span>Avg: {formatDuration(agentVsHuman.agent.avg)}</span>
+						<span>p90: {formatDuration(agentVsHuman.agent.p90)}</span>
+					</div>
+				</div>
+				<div class="px-4 py-3 bg-surface border border-border rounded-lg">
+					<p class="m-0 mb-2 text-[0.72rem] font-semibold text-text-muted uppercase tracking-[0.04em]">
+						Human
+					</p>
+					<div class="grid grid-cols-3 gap-2 text-sm">
+						<span>Count: {agentVsHuman.human.count}</span>
+						<span>Avg: {formatDuration(agentVsHuman.human.avg)}</span>
+						<span>p90: {formatDuration(agentVsHuman.human.p90)}</span>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export default function MetricsDashboard({ workspaceSlug }: Props) {
+	const { projectId, metrics, loading, error } = useFlowMetrics(workspaceSlug);
+
+	if (!projectId && !loading) {
+		return <p class="text-text-muted">No project specified. Add ?projectId= to the URL.</p>;
+	}
+
+	if (loading) return <p aria-live="polite">Loading metrics…</p>;
+	if (error)
+		return (
+			<p role="alert" class="text-[var(--danger-text)]">
+				{error}
+			</p>
+		);
+	if (!metrics) return null;
+
+	return (
+		<div>
+			<h1 class="m-0 mb-5 text-2xl font-bold text-text-base">Metrics</h1>
+
+			<div class="mb-8">
+				<h2 class="m-0 mb-3 text-base font-semibold text-text-base">Throughput</h2>
+				<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto">
+					<ThroughputChart data={metrics.throughputOverTime} />
+				</div>
+			</div>
+
+			<DistributionTiles title="Lead time" dist={metrics.leadTime} />
+			<DistributionTiles title="Cycle time" dist={metrics.cycleTime} />
+
+			<div class="mb-8">
+				<h2 class="m-0 mb-3 text-base font-semibold text-text-base">WIP over time</h2>
+				<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto">
+					<WipChart data={metrics.wipOverTime} />
+				</div>
+			</div>
+
+			<AgentVsHumanTiles agentVsHuman={metrics.agentVsHuman} />
+		</div>
+	);
+}

--- a/apps/web/src/islands/MetricsDashboard.tsx
+++ b/apps/web/src/islands/MetricsDashboard.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "preact/hooks";
+import { useEffect, useMemo, useState } from "preact/hooks";
 import uPlot from "uplot";
 import { apiFetch } from "../utils/api-client";
-import UplotChart from "./charts/UplotChart";
+import UplotChart, { createTooltipPlugin } from "./charts/UplotChart";
 
 interface Distribution {
 	count: number;
@@ -29,6 +29,37 @@ function formatDuration(seconds: number | null): string {
 	if (abs < 3600) return `${(seconds / 60).toFixed(1)}m`;
 	if (abs < 86400) return `${(seconds / 3600).toFixed(1)}h`;
 	return `${(seconds / 86400).toFixed(1)}d`;
+}
+
+// uPlot bakes colors into the canvas at creation time, so callers re-read these live
+// (rather than caching) whenever a chart is (re)built, including on theme toggle.
+function readThemeColor(token: string, fallback: string): string {
+	const value = getComputedStyle(document.documentElement).getPropertyValue(token).trim();
+	return value || fallback;
+}
+
+function hexToRgba(hex: string, alpha: number): string {
+	const match = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+	if (!match) return hex;
+	const [r, g, b] = match.slice(1).map((h) => parseInt(h, 16));
+	return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function formatShortDate(iso: string): string {
+	const d = new Date(`${iso}T00:00:00Z`);
+	if (Number.isNaN(d.getTime())) return iso;
+	return d.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
+}
+
+function formatFullDate(iso: string): string {
+	const d = new Date(`${iso}T00:00:00Z`);
+	if (Number.isNaN(d.getTime())) return iso;
+	return d.toLocaleDateString("en-US", {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+		timeZone: "UTC",
+	});
 }
 
 function useFlowMetrics(workspaceSlug: string | undefined) {
@@ -85,61 +116,119 @@ function DistributionTiles({ title, dist }: { title: string; dist: Distribution 
 	);
 }
 
-function ThroughputChart({ data }: { data: FlowMetrics["throughputOverTime"] }) {
-	if (data.length === 0) {
-		return <p class="text-sm text-text-muted m-0">No completed issues in this window yet.</p>;
-	}
-
-	const labels = data.map((d) => d.weekStart);
-	const xs = data.map((_, i) => i);
-	const ys = data.map((d) => d.count);
-
+function EmptyChartState({ message }: { message: string }) {
 	return (
-		<UplotChart
-			data={[xs, ys]}
-			options={{
-				width: 600,
-				height: 220,
+		<div class="flex items-center justify-center h-[220px] text-sm text-text-muted">{message}</div>
+	);
+}
+
+function ThroughputChart({ data }: { data: FlowMetrics["throughputOverTime"] }) {
+	const labels = useMemo(() => data.map((d) => d.weekStart), [data]);
+	const chartData = useMemo<uPlot.AlignedData>(
+		() => [data.map((_, i) => i), data.map((d) => d.count)],
+		[data]
+	);
+
+	const buildOptions = useMemo(() => {
+		return (width: number, height: number): uPlot.Options => {
+			const accent = readThemeColor("--accent", "#4f46e5");
+			const border = readThemeColor("--border", "#e2e8f0");
+			const textMuted = readThemeColor("--text-muted", "#6b7280");
+
+			return {
+				width,
+				height,
 				scales: { x: { time: false } },
+				legend: { show: false },
 				series: [
 					{},
 					{
 						label: "Issues completed",
-						stroke: "rgba(37,99,235,0.8)",
-						fill: "rgba(37,99,235,0.25)",
+						stroke: accent,
+						fill: hexToRgba(accent, 0.25),
 						paths: uPlot.paths.bars?.(),
 					},
 				],
 				axes: [
 					{
-						values: (_u, splits) => splits.map((s) => labels[s] ?? ""),
+						stroke: textMuted,
+						grid: { stroke: border },
+						splits: (u) => {
+							const n = labels.length;
+							const maxTicks = Math.max(2, Math.floor(u.width / 70));
+							const stride = Math.max(1, Math.ceil(n / maxTicks));
+							const idxs: number[] = [];
+							for (let i = 0; i < n; i += stride) idxs.push(i);
+							if (idxs[idxs.length - 1] !== n - 1) idxs.push(n - 1);
+							return idxs;
+						},
+						values: (_u, splits) => splits.map((s) => formatShortDate(labels[s] ?? "")),
 					},
-					{},
+					{ stroke: textMuted, grid: { stroke: border } },
 				],
-			}}
-		/>
-	);
+				plugins: [
+					createTooltipPlugin({
+						formatX: (xVal) => formatFullDate(labels[xVal] ?? ""),
+						formatY: (yVal) => `${yVal} completed`,
+					}),
+				],
+			};
+		};
+	}, [labels]);
+
+	if (data.length === 0) {
+		return <EmptyChartState message="No completed issues yet" />;
+	}
+
+	return <UplotChart data={chartData} buildOptions={buildOptions} />;
 }
 
 function WipChart({ data }: { data: FlowMetrics["wipOverTime"] }) {
+	const chartData = useMemo<uPlot.AlignedData>(
+		() => [
+			data.map((d) => Math.floor(new Date(d.date).getTime() / 1000)),
+			data.map((d) => d.count),
+		],
+		[data]
+	);
+
+	const buildOptions = useMemo(() => {
+		return (width: number, height: number): uPlot.Options => {
+			const border = readThemeColor("--border", "#e2e8f0");
+			const textMuted = readThemeColor("--text-muted", "#6b7280");
+			const wipLine = "#0d9488";
+
+			return {
+				width,
+				height,
+				scales: { x: { time: true } },
+				legend: { show: false },
+				series: [{}, { label: "WIP", stroke: wipLine, width: 2 }],
+				axes: [
+					{ stroke: textMuted, grid: { stroke: border }, space: 60 },
+					{ stroke: textMuted, grid: { stroke: border } },
+				],
+				plugins: [
+					createTooltipPlugin({
+						formatX: (xVal) =>
+							new Date(xVal * 1000).toLocaleDateString("en-US", {
+								month: "short",
+								day: "numeric",
+								year: "numeric",
+								timeZone: "UTC",
+							}),
+						formatY: (yVal) => `${yVal} in progress`,
+					}),
+				],
+			};
+		};
+	}, []);
+
 	if (data.length === 0) {
-		return <p class="text-sm text-text-muted m-0">No WIP data in this window yet.</p>;
+		return <EmptyChartState message="No WIP data yet" />;
 	}
 
-	const xs = data.map((d) => Math.floor(new Date(d.date).getTime() / 1000));
-	const ys = data.map((d) => d.count);
-
-	return (
-		<UplotChart
-			data={[xs, ys]}
-			options={{
-				width: 600,
-				height: 220,
-				scales: { x: { time: true } },
-				series: [{}, { label: "WIP", stroke: "rgba(22,163,74,0.8)", width: 2 }],
-			}}
-		/>
-	);
+	return <UplotChart data={chartData} buildOptions={buildOptions} />;
 }
 
 function AgentVsHumanTiles({ agentVsHuman }: { agentVsHuman: FlowMetrics["agentVsHuman"] }) {

--- a/apps/web/src/islands/ProjectNav.tsx
+++ b/apps/web/src/islands/ProjectNav.tsx
@@ -18,6 +18,7 @@ const TABS = [
 	{ label: "Wiki", path: "/wiki" },
 	{ label: "Sprints", path: "/sprints" },
 	{ label: "Epics", path: "/epics" },
+	{ label: "Metrics", path: "/metrics" },
 ];
 
 const KEY_BADGE_CLASS =

--- a/apps/web/src/islands/charts/UplotChart.tsx
+++ b/apps/web/src/islands/charts/UplotChart.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from "preact/hooks";
+import uPlot from "uplot";
+import "uplot/dist/uPlot.min.css";
+
+interface Props {
+	data: uPlot.AlignedData;
+	options: uPlot.Options;
+	height?: number;
+}
+
+// uPlot is vanilla JS/canvas, not Preact-aware — it must be manually created/destroyed
+// against a ref'd container rather than rendered as JSX.
+export default function UplotChart({ data, options, height = 220 }: Props) {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const chartRef = useRef<uPlot | null>(null);
+
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container) return;
+
+		const width = container.clientWidth || 600;
+		const chart = new uPlot({ ...options, width, height }, data, container);
+		chartRef.current = chart;
+
+		return () => {
+			chart.destroy();
+			chartRef.current = null;
+		};
+	}, [data, options, height]);
+
+	return <div ref={containerRef} class="w-full" />;
+}

--- a/apps/web/src/islands/charts/UplotChart.tsx
+++ b/apps/web/src/islands/charts/UplotChart.tsx
@@ -4,13 +4,15 @@ import "uplot/dist/uPlot.min.css";
 
 interface Props {
 	data: uPlot.AlignedData;
-	options: uPlot.Options;
+	buildOptions: (width: number, height: number) => uPlot.Options;
 	height?: number;
 }
 
 // uPlot is vanilla JS/canvas, not Preact-aware — it must be manually created/destroyed
-// against a ref'd container rather than rendered as JSX.
-export default function UplotChart({ data, options, height = 220 }: Props) {
+// against a ref'd container rather than rendered as JSX. `buildOptions` is re-invoked
+// (and the chart rebuilt) whenever the theme flips, since uPlot bakes colors into the
+// canvas at creation time rather than reading CSS live.
+export default function UplotChart({ data, buildOptions, height = 220 }: Props) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const chartRef = useRef<uPlot | null>(null);
 
@@ -18,15 +20,86 @@ export default function UplotChart({ data, options, height = 220 }: Props) {
 		const container = containerRef.current;
 		if (!container) return;
 
-		const width = container.clientWidth || 600;
-		const chart = new uPlot({ ...options, width, height }, data, container);
-		chartRef.current = chart;
+		function create(el: HTMLDivElement) {
+			chartRef.current?.destroy();
+			const width = el.clientWidth || 600;
+			chartRef.current = new uPlot(buildOptions(width, height), data, el);
+		}
+
+		create(container);
+
+		const themeObserver = new MutationObserver((mutations) => {
+			if (mutations.some((m) => m.attributeName === "data-theme")) create(container);
+		});
+		themeObserver.observe(document.documentElement, {
+			attributes: true,
+			attributeFilter: ["data-theme"],
+		});
+
+		const systemTheme = window.matchMedia("(prefers-color-scheme: dark)");
+		const onSystemThemeChange = () => {
+			// Only the system query matters when the user hasn't picked an explicit theme.
+			if (!document.documentElement.getAttribute("data-theme")) create(container);
+		};
+		systemTheme.addEventListener("change", onSystemThemeChange);
 
 		return () => {
-			chart.destroy();
+			themeObserver.disconnect();
+			systemTheme.removeEventListener("change", onSystemThemeChange);
+			chartRef.current?.destroy();
 			chartRef.current = null;
 		};
-	}, [data, options, height]);
+	}, [data, buildOptions, height]);
 
 	return <div ref={containerRef} class="w-full" />;
+}
+
+interface TooltipPluginOpts {
+	formatX: (xVal: number) => string;
+	formatY: (yVal: number) => string;
+}
+
+// Single-series charts don't need uPlot's default cursor-sync legend (swatches/toggles
+// are pointless with one series); this replaces it with a small hover tooltip instead.
+export function createTooltipPlugin({ formatX, formatY }: TooltipPluginOpts): uPlot.Plugin {
+	let tooltip: HTMLDivElement;
+
+	return {
+		hooks: {
+			init: (u) => {
+				tooltip = document.createElement("div");
+				Object.assign(tooltip.style, {
+					position: "absolute",
+					pointerEvents: "none",
+					padding: "4px 8px",
+					borderRadius: "4px",
+					fontSize: "0.75rem",
+					fontWeight: "500",
+					whiteSpace: "nowrap",
+					background: "var(--surface)",
+					border: "1px solid var(--border)",
+					color: "var(--text)",
+					boxShadow: "var(--shadow-sm)",
+					zIndex: "10",
+					display: "none",
+				});
+				u.over.appendChild(tooltip);
+			},
+			setCursor: (u) => {
+				const idx = u.cursor.idx;
+				const yVal = idx == null ? null : (u.data[1][idx] as number | null | undefined);
+				if (idx == null || yVal == null) {
+					tooltip.style.display = "none";
+					return;
+				}
+				const xVal = u.data[0][idx] as number;
+				tooltip.textContent = `${formatX(xVal)}: ${formatY(yVal)}`;
+				const left = u.cursor.left ?? 0;
+				const top = u.cursor.top ?? 0;
+				tooltip.style.left = `${left + 12}px`;
+				tooltip.style.top = `${Math.max(0, top - 8)}px`;
+				tooltip.style.display = "block";
+			},
+		},
+	};
 }

--- a/apps/web/src/islands/charts/UplotChart.tsx
+++ b/apps/web/src/islands/charts/UplotChart.tsx
@@ -43,9 +43,23 @@ export default function UplotChart({ data, buildOptions, height = 220 }: Props) 
 		};
 		systemTheme.addEventListener("change", onSystemThemeChange);
 
+		// Width is baked into series/axis options (e.g. tick-thinning reads u.width at
+		// creation time), so a resize needs a full rebuild, not just uPlot's setSize —
+		// otherwise a window resize or mobile orientation change leaves stale tick density.
+		let lastWidth = container.clientWidth;
+		const resizeObserver = new ResizeObserver((entries) => {
+			const newWidth = entries[0]?.contentRect.width;
+			if (newWidth && Math.abs(newWidth - lastWidth) > 1) {
+				lastWidth = newWidth;
+				create(container);
+			}
+		});
+		resizeObserver.observe(container);
+
 		return () => {
 			themeObserver.disconnect();
 			systemTheme.removeEventListener("change", onSystemThemeChange);
+			resizeObserver.disconnect();
 			chartRef.current?.destroy();
 			chartRef.current = null;
 		};

--- a/apps/web/src/pages/metrics.astro
+++ b/apps/web/src/pages/metrics.astro
@@ -1,0 +1,13 @@
+---
+import Base from '../layouts/Base.astro';
+import ProjectNav from '../islands/ProjectNav';
+import MetricsDashboard from '../islands/MetricsDashboard';
+
+const workspaceSlug = import.meta.env.PUBLIC_WORKSPACE_SLUG as string | undefined;
+---
+<Base title="Metrics — Projektor">
+  <ProjectNav client:load workspaceSlug={workspaceSlug} pageLabel="Metrics" />
+  <div class="page-container">
+    <MetricsDashboard client:load workspaceSlug={workspaceSlug} />
+  </div>
+</Base>

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -22,6 +22,15 @@ if (!window.matchMedia) {
 	})) as unknown as typeof window.matchMedia;
 }
 
+// jsdom has no ResizeObserver; UplotChart uses one to rebuild on container resize.
+if (typeof window.ResizeObserver === "undefined") {
+	window.ResizeObserver = class {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	} as unknown as typeof ResizeObserver;
+}
+
 beforeEach(() => {
 	vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) }));
 });

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -13,6 +13,15 @@
 import { cleanup } from "@testing-library/preact";
 import { afterEach, beforeEach, vi } from "vitest";
 
+// jsdom has no matchMedia; uPlot's pixel-ratio watcher calls it at import time.
+if (!window.matchMedia) {
+	window.matchMedia = vi.fn().mockImplementation(() => ({
+		matches: false,
+		addEventListener: vi.fn(),
+		removeEventListener: vi.fn(),
+	})) as unknown as typeof window.matchMedia;
+}
+
 beforeEach(() => {
 	vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) }));
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
       preact:
         specifier: ^10.25.0
         version: 10.29.2
+      uplot:
+        specifier: ^1.6.32
+        version: 1.6.32
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.0
@@ -6045,6 +6048,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  uplot@1.6.32:
+    resolution: {integrity: sha512-KIMVnG68zvu5XXUbC4LQEPnhwOxBuLyW1AHtpm6IKTXImkbLgkMy+jabjLgSLMasNuGGzQm/ep3tOkyTxpiQIw==}
 
   url-extras@0.1.0:
     resolution: {integrity: sha512-8tzwTeXFPuX/5PHuCDQE5Dd9Ts4rwoq2t9aIT+HS4iAVpmj5l4Ao7Q+BuuFjvWRqrLswBhQDk8O96ZicgCqQqw==}
@@ -13228,6 +13234,8 @@ snapshots:
       browserslist: 4.28.4
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  uplot@1.6.32: {}
 
   url-extras@0.1.0: {}
 


### PR DESCRIPTION
## Summary
- Add a per-project **Metrics** tab surfacing throughput, lead/cycle time, WIP-over-time, and agent-vs-human cycle time — this data previously had no UI at all, only API/MCP access via `get_flow_metrics`.
- Backend: new weekly throughput aggregation (`buildThroughputOverTime`) added to the existing `getFlowMetrics` service, surfaced identically through REST (`GET /api/projects/:id/flow-metrics`) and the `get_flow_metrics` MCP tool.
- Frontend: `MetricsDashboard.tsx` island with uPlot bar/line charts (branded colors, CVD-validated, live dark-mode re-theming, custom hover tooltips), plus stat tiles for lead/cycle time and agent-vs-human comparison.

## Notable fixes made during self-review
- Throughput buckets were Thursday-aligned (an artifact of aligning to the raw Unix epoch) and could pull in completions from just outside a caller's `since`/`until` window on edge buckets. Fixed to align on Monday and clamp each bucket to the requested window, matching how `leadTime`/`cycleTime` are windowed.
- The chart empty-state check (`data.length === 0`) never actually triggered, because the API always returns a fixed-size bucket window (all zeros) rather than `[]` for a project with no completions — charts degraded into a broken-looking flat 0–100 axis instead of showing "No completed issues yet". Fixed the detection and added a regression test using the real API response shape.

## Test plan
- [x] `pnpm --filter @projektor/api test` — 618 passed (incl. new bucket-boundary/window-clamp/Monday-alignment tests)
- [x] `pnpm --filter @projektor/web test` — 271 passed (incl. new empty-state regression test)
- [x] `pnpm lint` / `pnpm turbo type-check` — clean
- [x] Manually validated in-browser (light + dark mode, hover tooltips, empty-project state) against seeded local data
- [x] Reviewed by an independent Opus pass; findings addressed (see fixes above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TY1D3bVN6adzcSQ7c6stSk