### PR TITLE
fix(api): simplify dead conditional in coordination-access visibility filter (PROJ-316)

### DIFF
--- a/apps/api/src/services/agents.ts
+++ b/apps/api/src/services/agents.ts
@@ -155,8 +155,7 @@ export async function listActiveAgents(ctx: ServiceCtx, raw: unknown) {
 		sql`(SELECT i.project_id FROM issues i WHERE i.id = ${schema.agentSessions.issueId})`
 	);
 	if (vis) {
-		const visibleOrUnpinned = or(isNull(schema.agentSessions.issueId), vis);
-		if (visibleOrUnpinned) conditions.push(visibleOrUnpinned);
+		conditions.push(or(isNull(schema.agentSessions.issueId), vis) ?? vis);
 	}
 
 	const items = await orm


### PR DESCRIPTION
## Summary
- Follow-up cleanup from the PROJ-314 epic (PR #60) Opus review: `listActiveAgents`' `if (visibleOrUnpinned) conditions.push(visibleOrUnpinned)` was dead — `or(isNull(...), vis)` always returns a truthy SQL node in this call shape, so the guard never short-circuited.
- Collapsed to a single push with a type-satisfying `?? vis` fallback (safe: it can only ever produce an equal-or-more-restrictive predicate, never a leak).
- No behavior change.

## Test plan
- [x] `coordination-access.test.ts` 4/4 pass in isolation
- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [x] Independent Opus review of this diff: approved, no blocking issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mz8oT3y5KCnaLCRhfuNwib