### PR TITLE
Claim contention tracking + heat-map surfacing (PROJ-337, PROJ-338)

### DIFF
--- a/apps/api/src/mcp/code-heatmap.ts
+++ b/apps/api/src/mcp/code-heatmap.ts
@@ -12,7 +12,8 @@ export const codeHeatmapTools: MCPTool[] = [
 			"released ones). Each entry's `path` is the drill-down cursor: re-call with `prefix` set " +
 			"to it to see what's under a directory; `isLeaf` marks an entry that is itself a claimed " +
 			"file path, not a directory. Defaults to the current ISO week plus the preceding 5 weeks, " +
-			"matching get_flow_metrics.",
+			"matching get_flow_metrics. `mode` switches sizing between claim volume and claim " +
+			"contention (claim_conflicts).",
 		inputSchema: {
 			type: "object",
 			required: ["projectId"],
@@ -29,6 +30,14 @@ export const codeHeatmapTools: MCPTool[] = [
 				prefix: {
 					type: "string",
 					description: "Directory path to drill into; omit for the top-level segments",
+				},
+				mode: {
+					type: "string",
+					enum: ["claims", "contention"],
+					description:
+						'"claims" (default) sizes by file-claim volume; "contention" sizes by ' +
+						"claim_conflicts — rejected/overridden claimFiles attempts, i.e. where the fleet " +
+						"queued up.",
 				},
 			},
 		},

--- a/apps/api/src/routes/code-heatmap.ts
+++ b/apps/api/src/routes/code-heatmap.ts
@@ -12,12 +12,14 @@ router.get("/:id/code-heatmap", async (c) => {
 		const since = c.req.query("since");
 		const until = c.req.query("until");
 		const prefix = c.req.query("prefix");
+		const mode = c.req.query("mode");
 		return c.json(
 			await getCodeHeatmap(ctx, {
 				projectId: c.req.param("id"),
 				since: since ? Number(since) : undefined,
 				until: until ? Number(until) : undefined,
 				prefix,
+				mode,
 			})
 		);
 	} catch (e) {

--- a/apps/api/src/schemas/code-heatmap.ts
+++ b/apps/api/src/schemas/code-heatmap.ts
@@ -7,4 +7,5 @@ export const GetCodeHeatmapSchema = z.object({
 	// Drill-down cursor: aggregate the next path segment under this directory. Root call
 	// omits it (or passes "") to see top-level segments.
 	prefix: z.string().optional(),
+	mode: z.enum(["claims", "contention"]).optional(),
 });

--- a/apps/api/src/services/code-heatmap.ts
+++ b/apps/api/src/services/code-heatmap.ts
@@ -32,6 +32,16 @@ export interface CodeHeatmapEntry {
 	claimCount: number;
 }
 
+// PROJ-338: contention-mode counterpart to CodeHeatmapEntry — sized by claim_conflicts
+// (rejected/overridden claimFiles attempts) instead of successful claims.
+export interface ContentionHeatmapEntry {
+	path: string;
+	segment: string;
+	isLeaf: boolean;
+	distinctRejectedIssueCount: number;
+	conflictCount: number;
+}
+
 // PROJ-332: group claims one path segment below `prefix` — the natural "list this
 // directory's children" step a file explorer takes, so the caller drills down by
 // re-requesting with `prefix` set to the entry clicked.
@@ -74,10 +84,55 @@ function groupClaimsByNextSegment(
 		.sort((a, b) => b.distinctIssueCount - a.distinctIssueCount || a.path.localeCompare(b.path));
 }
 
+// PROJ-338: contention counterpart to groupClaimsByNextSegment — same segment-splitting
+// and isLeaf-freeze behavior, but tracks rejected-issue ids and raw conflict rows.
+function groupConflictsByNextSegment(
+	conflicts: Array<{ path: string; rejectedIssueId: string }>,
+	prefix: string
+): ContentionHeatmapEntry[] {
+	const prefixWithSlash = prefix ? `${prefix}/` : "";
+	const groups = new Map<
+		string,
+		{ rejectedIssueIds: Set<string>; conflictCount: number; isLeaf: boolean }
+	>();
+
+	for (const conflict of conflicts) {
+		if (prefix && !conflict.path.startsWith(prefixWithSlash)) continue;
+		const rest = conflict.path.slice(prefixWithSlash.length);
+		if (!rest) continue;
+		const slashIdx = rest.indexOf("/");
+		const isLeaf = slashIdx === -1;
+		const segment = isLeaf ? rest : rest.slice(0, slashIdx);
+		const path = prefix ? `${prefix}/${segment}` : segment;
+
+		let group = groups.get(path);
+		if (!group) {
+			group = { rejectedIssueIds: new Set(), conflictCount: 0, isLeaf };
+			groups.set(path, group);
+		}
+		if (!isLeaf) group.isLeaf = false;
+		group.rejectedIssueIds.add(conflict.rejectedIssueId);
+		group.conflictCount++;
+	}
+
+	return [...groups.entries()]
+		.map(([path, group]) => ({
+			path,
+			segment: path.slice(prefixWithSlash.length),
+			isLeaf: group.isLeaf,
+			distinctRejectedIssueCount: group.rejectedIssueIds.size,
+			conflictCount: group.conflictCount,
+		}))
+		.sort(
+			(a, b) =>
+				b.distinctRejectedIssueCount - a.distinctRejectedIssueCount || a.path.localeCompare(b.path)
+		);
+}
+
 export async function getCodeHeatmap(ctx: ServiceCtx, raw: unknown) {
 	const result = GetCodeHeatmapSchema.safeParse(raw);
 	if (!result.success) throw new ValidationError(result.error.flatten());
-	const { projectId, since, until, prefix } = result.data;
+	const { projectId, since, until, prefix, mode } = result.data;
 
 	await assertProjectExists(ctx, projectId);
 
@@ -89,6 +144,41 @@ export async function getCodeHeatmap(ctx: ServiceCtx, raw: unknown) {
 	const now = Math.floor(Date.now() / 1000);
 	const windowSince = since ?? now - 42 * 86400;
 	const windowUntil = until ?? now;
+
+	const resolvedMode = mode ?? "claims";
+
+	if (resolvedMode === "contention") {
+		// PROJ-338: same window predicate as claims mode, but over claim_conflicts —
+		// occurredAt within [since, until], joined to issues (via rejectedIssueId) to scope
+		// by project.
+		const conflicts = await orm
+			.select({
+				path: schema.claimConflicts.path,
+				rejectedIssueId: schema.claimConflicts.rejectedIssueId,
+			})
+			.from(schema.claimConflicts)
+			.innerJoin(schema.issues, eq(schema.claimConflicts.rejectedIssueId, schema.issues.id))
+			.where(
+				and(
+					eq(schema.claimConflicts.workspaceId, ctx.workspaceId),
+					eq(schema.issues.projectId, projectId),
+					gte(schema.claimConflicts.occurredAt, windowSince),
+					lte(schema.claimConflicts.occurredAt, windowUntil)
+				)
+			);
+
+		const entries = groupConflictsByNextSegment(conflicts, prefix ?? "");
+
+		return {
+			prefix: prefix ?? "",
+			mode: resolvedMode,
+			// Reuses the claims-mode field name so the response shape doesn't fork in two —
+			// here it's the distinct count of *rejected* issues, i.e. issues whose claim
+			// attempt lost.
+			totalDistinctIssues: new Set(conflicts.map((c) => c.rejectedIssueId)).size,
+			entries,
+		};
+	}
 
 	// PROJ-332: window predicate matches the rest of flow-metrics — claimedAt within
 	// [since, until], not claim overlap. issue_file_claims has no project column, so join
@@ -110,6 +200,7 @@ export async function getCodeHeatmap(ctx: ServiceCtx, raw: unknown) {
 
 	return {
 		prefix: prefix ?? "",
+		mode: resolvedMode,
 		totalDistinctIssues: new Set(claims.map((c) => c.issueId)).size,
 		entries,
 	};

--- a/apps/api/src/services/file-claims.ts
+++ b/apps/api/src/services/file-claims.ts
@@ -56,13 +56,32 @@ async function loadActiveClaimsByPath(
 	return new Map(activeClaims.map((c) => [c.path, c]));
 }
 
-function assertNoConflicts(
-	paths: string[],
-	claimsByPath: Map<string, { issueId: string; agentId: string | null }>
+async function assertNoConflicts(
+	orm: ReturnType<typeof drizzle>,
+	params: {
+		workspaceId: string;
+		issueId: string;
+		agentId: string | undefined;
+		paths: string[];
+		claimsByPath: Map<string, { issueId: string; agentId: string | null }>;
+		now: number;
+	}
 ) {
+	const { workspaceId, issueId, agentId, paths, claimsByPath, now } = params;
 	for (const path of paths) {
 		const existing = claimsByPath.get(path);
 		if (existing) {
+			await orm.insert(schema.claimConflicts).values({
+				id: crypto.randomUUID(),
+				workspaceId,
+				path,
+				rejectedIssueId: issueId,
+				rejectedAgentId: agentId ?? null,
+				holdingIssueId: existing.issueId,
+				holdingAgentId: existing.agentId,
+				forced: 0,
+				occurredAt: now,
+			});
 			throw new ConflictError(
 				`Path "${path}" is held by issue ${existing.issueId}${existing.agentId ? ` (agent ${existing.agentId})` : ""}`
 			);
@@ -74,6 +93,7 @@ async function overrideConflictingClaims(
 	ctx: ServiceCtx,
 	orm: ReturnType<typeof drizzle>,
 	params: {
+		workspaceId: string;
 		issueId: string;
 		agentId: string | undefined;
 		paths: string[];
@@ -81,7 +101,7 @@ async function overrideConflictingClaims(
 		now: number;
 	}
 ) {
-	const { issueId, agentId, paths, claimsByPath, now } = params;
+	const { workspaceId, issueId, agentId, paths, claimsByPath, now } = params;
 	const overridden: (typeof schema.issueFileClaims.$inferSelect)[] = [];
 	for (const path of paths) {
 		const existing = claimsByPath.get(path);
@@ -95,6 +115,17 @@ async function overrideConflictingClaims(
 				.update(schema.issueFileClaims)
 				.set({ releasedAt: now, releaseReason: "overridden" })
 				.where(eq(schema.issueFileClaims.id, existing.id));
+			await orm.insert(schema.claimConflicts).values({
+				id: crypto.randomUUID(),
+				workspaceId,
+				path,
+				rejectedIssueId: issueId,
+				rejectedAgentId: agentId ?? null,
+				holdingIssueId: existing.issueId,
+				holdingAgentId: existing.agentId,
+				forced: 1,
+				occurredAt: now,
+			});
 			overridden.push({ ...existing, releasedAt: now, releaseReason: "overridden" });
 		}
 	}
@@ -150,14 +181,22 @@ export async function claimFiles(ctx: ServiceCtx, raw: unknown) {
 	// Pre-check all paths for active claims — all-or-nothing on conflict.
 	const claimsByPath = await loadActiveClaimsByPath(orm, ctx.workspaceId, paths);
 
-	if (!force) {
-		assertNoConflicts(paths, claimsByPath);
-	}
-
 	const now = Math.floor(Date.now() / 1000);
+
+	if (!force) {
+		await assertNoConflicts(orm, {
+			workspaceId: ctx.workspaceId,
+			issueId,
+			agentId: agentId ?? undefined,
+			paths,
+			claimsByPath,
+			now,
+		});
+	}
 
 	// Release conflicting claims when force is true, then insert new ones
 	const overridden = await overrideConflictingClaims(ctx, orm, {
+		workspaceId: ctx.workspaceId,
 		issueId,
 		agentId: agentId ?? undefined,
 		paths,

--- a/apps/api/src/services/file-claims.ts
+++ b/apps/api/src/services/file-claims.ts
@@ -68,6 +68,9 @@ async function assertNoConflicts(
 	}
 ) {
 	const { workspaceId, issueId, agentId, paths, claimsByPath, now } = params;
+	// Record every contended path (rejection is all-or-nothing, but each simultaneously
+	// held path is its own contention signal for the heat map), then throw naming the first.
+	let firstConflict: { path: string; issueId: string; agentId: string | null } | undefined;
 	for (const path of paths) {
 		const existing = claimsByPath.get(path);
 		if (existing) {
@@ -82,10 +85,13 @@ async function assertNoConflicts(
 				forced: 0,
 				occurredAt: now,
 			});
-			throw new ConflictError(
-				`Path "${path}" is held by issue ${existing.issueId}${existing.agentId ? ` (agent ${existing.agentId})` : ""}`
-			);
+			if (!firstConflict) firstConflict = { path, ...existing };
 		}
+	}
+	if (firstConflict) {
+		throw new ConflictError(
+			`Path "${firstConflict.path}" is held by issue ${firstConflict.issueId}${firstConflict.agentId ? ` (agent ${firstConflict.agentId})` : ""}`
+		);
 	}
 }
 

--- a/apps/api/src/test/code-heatmap.test.ts
+++ b/apps/api/src/test/code-heatmap.test.ts
@@ -16,6 +16,20 @@ interface CodeHeatmapResponse {
 	entries: CodeHeatmapEntry[];
 }
 
+interface ContentionHeatmapEntry {
+	path: string;
+	segment: string;
+	isLeaf: boolean;
+	distinctRejectedIssueCount: number;
+	conflictCount: number;
+}
+
+interface ContentionHeatmapResponse {
+	prefix: string;
+	totalDistinctIssues: number;
+	entries: ContentionHeatmapEntry[];
+}
+
 // cofferdam-ignore: Readability.MaxFunctionLength: one describe block, normal test style
 describe("Code heatmap (PROJ-332)", () => {
 	let token: string;
@@ -37,6 +51,28 @@ describe("Code heatmap (PROJ-332)", () => {
 			"INSERT INTO issue_file_claims (id, workspace_id, issue_id, agent_id, path, claimed_at, released_at) VALUES (?, ?, ?, NULL, ?, ?, ?)"
 		)
 			.bind(crypto.randomUUID(), workspaceId, issueId, path, claimedAt, releasedAt ?? null)
+			.run();
+	}
+
+	async function seedConflict(
+		rejectedIssueId: string,
+		holdingIssueId: string,
+		path: string,
+		occurredAt: number,
+		forced = 0
+	) {
+		await env.DB.prepare(
+			"INSERT INTO claim_conflicts (id, workspace_id, path, rejected_issue_id, rejected_agent_id, holding_issue_id, holding_agent_id, forced, occurred_at) VALUES (?, ?, ?, ?, NULL, ?, NULL, ?, ?)"
+		)
+			.bind(
+				crypto.randomUUID(),
+				workspaceId,
+				path,
+				rejectedIssueId,
+				holdingIssueId,
+				forced,
+				occurredAt
+			)
 			.run();
 	}
 
@@ -170,5 +206,123 @@ describe("Code heatmap (PROJ-332)", () => {
 		const mcpBody = JSON.parse(mcpJson.result.content[0].text);
 
 		expect(mcpBody).toEqual(restBody);
+	});
+
+	describe("contention mode (PROJ-338)", () => {
+		it("aggregates distinct rejected issues per top-level directory within the window", async () => {
+			const now = Math.floor(Date.now() / 1000);
+			const holdingIssue = await seedIssue(workspaceId, projectId, userId, { title: "Holder" });
+			const apiIssue = await seedIssue(workspaceId, projectId, userId, { title: "API rejected" });
+			const apiIssue2 = await seedIssue(workspaceId, projectId, userId, {
+				title: "More API rejected",
+			});
+			const webIssue = await seedIssue(workspaceId, projectId, userId, { title: "Web rejected" });
+			const oldIssue = await seedIssue(workspaceId, projectId, userId, { title: "Old rejected" });
+
+			await seedConflict(
+				apiIssue.id,
+				holdingIssue.id,
+				"apps/api/src/services/flow-metrics.ts",
+				now - 1000
+			);
+			await seedConflict(
+				apiIssue.id,
+				holdingIssue.id,
+				"apps/api/src/services/code-heatmap.ts",
+				now - 900
+			);
+			await seedConflict(
+				apiIssue2.id,
+				holdingIssue.id,
+				"apps/api/src/routes/code-heatmap.ts",
+				now - 800
+			);
+			await seedConflict(
+				webIssue.id,
+				holdingIssue.id,
+				"apps/web/src/islands/MetricsDashboard.tsx",
+				now - 700
+			);
+			// Outside the requested window — must not count.
+			await seedConflict(
+				oldIssue.id,
+				holdingIssue.id,
+				"apps/api/src/routes/old.ts",
+				now - 10 * 86400
+			);
+
+			const res = await getHeatmap({
+				since: String(now - 3600),
+				until: String(now),
+				mode: "contention",
+			});
+			expect(res.status).toBe(200);
+			const body = (await res.json()) as ContentionHeatmapResponse;
+
+			expect(body.prefix).toBe("");
+			expect(body.totalDistinctIssues).toBe(3);
+
+			const apps = body.entries.find((e) => e.path === "apps");
+			expect(apps).toBeDefined();
+			expect(apps?.isLeaf).toBe(false);
+			expect(apps?.distinctRejectedIssueCount).toBe(3);
+			expect(apps?.conflictCount).toBe(4);
+		});
+
+		it("drills down via prefix, one segment at a time", async () => {
+			const now = Math.floor(Date.now() / 1000);
+			const holdingIssue = await seedIssue(workspaceId, projectId, userId, { title: "Holder" });
+			const issueA = await seedIssue(workspaceId, projectId, userId, { title: "A" });
+			const issueB = await seedIssue(workspaceId, projectId, userId, { title: "B" });
+
+			await seedConflict(
+				issueA.id,
+				holdingIssue.id,
+				"apps/api/src/services/flow-metrics.ts",
+				now - 100
+			);
+			await seedConflict(
+				issueB.id,
+				holdingIssue.id,
+				"apps/api/src/services/code-heatmap.ts",
+				now - 90
+			);
+			await seedConflict(
+				issueA.id,
+				holdingIssue.id,
+				"apps/web/src/islands/MetricsDashboard.tsx",
+				now - 80
+			);
+
+			const apiRes = await getHeatmap({
+				since: String(now - 3600),
+				until: String(now),
+				prefix: "apps/api/src/services",
+				mode: "contention",
+			});
+			expect(apiRes.status).toBe(200);
+			const apiBody = (await apiRes.json()) as ContentionHeatmapResponse;
+			expect(apiBody.prefix).toBe("apps/api/src/services");
+			const paths = apiBody.entries.map((e) => e.path).sort();
+			expect(paths).toEqual([
+				"apps/api/src/services/code-heatmap.ts",
+				"apps/api/src/services/flow-metrics.ts",
+			]);
+			expect(apiBody.entries.every((e) => e.isLeaf)).toBe(true);
+			expect(apiBody.entries.every((e) => e.distinctRejectedIssueCount === 1)).toBe(true);
+		});
+
+		it("returns an empty entries array when no conflicts exist in the workspace", async () => {
+			const now = Math.floor(Date.now() / 1000);
+			const res = await getHeatmap({
+				since: String(now - 3600),
+				until: String(now),
+				mode: "contention",
+			});
+			expect(res.status).toBe(200);
+			const body = (await res.json()) as ContentionHeatmapResponse;
+			expect(body.entries).toEqual([]);
+			expect(body.totalDistinctIssues).toBe(0);
+		});
 	});
 });

--- a/apps/api/src/test/file-claims.test.ts
+++ b/apps/api/src/test/file-claims.test.ts
@@ -1,4 +1,4 @@
-import { SELF } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
 import { authHeaders, seedFixture, seedIssue, seedIssueFixture } from "./helpers";
 
@@ -226,5 +226,63 @@ describe("File Claims API", () => {
 		expect(otherListRes.status).toBe(200);
 		const otherBody = (await otherListRes.json()) as { items: Array<{ issueId: string }> };
 		expect(otherBody.items.some((i) => i.issueId === issueId)).toBe(false);
+	});
+
+	// PROJ-337: rejecting a conflicting claim inserts a claim_conflicts row (forced=0)
+	// 1 request (claim) + setup claim already counted below — within limit
+	it("PROJ-337: rejecting a conflicting claim inserts a claim_conflicts row with forced=0", async () => {
+		await claimFiles({ issueId, paths: ["src/conflict-log.ts"] });
+
+		const issue2 = await seedIssue(workspaceId, projectId, userId, { title: "Rejected issue" });
+		const res = await claimFiles({ issueId: issue2.id, paths: ["src/conflict-log.ts"] });
+		expect(res.status).toBe(409);
+
+		const rows = await env.DB.prepare(
+			"SELECT * FROM claim_conflicts WHERE workspace_id = ? AND path = ?"
+		)
+			.bind(workspaceId, "src/conflict-log.ts")
+			.all();
+		expect(rows.results).toHaveLength(1);
+		const row = rows.results[0] as Record<string, unknown>;
+		expect(row.forced).toBe(0);
+		expect(row.rejected_issue_id).toBe(issue2.id);
+		expect(row.holding_issue_id).toBe(issueId);
+	});
+
+	// PROJ-337: force:true override inserts a claim_conflicts row (forced=1)
+	it("PROJ-337: force:true override inserts a claim_conflicts row with forced=1", async () => {
+		await claimFiles({ issueId, paths: ["src/force-log.ts"] });
+
+		const issue2 = await seedIssue(workspaceId, projectId, userId, { title: "Forcing issue" });
+		const res = await claimFiles({
+			issueId: issue2.id,
+			paths: ["src/force-log.ts"],
+			force: true,
+		});
+		expect(res.status).toBe(201);
+
+		const rows = await env.DB.prepare(
+			"SELECT * FROM claim_conflicts WHERE workspace_id = ? AND path = ?"
+		)
+			.bind(workspaceId, "src/force-log.ts")
+			.all();
+		expect(rows.results).toHaveLength(1);
+		const row = rows.results[0] as Record<string, unknown>;
+		expect(row.forced).toBe(1);
+		expect(row.rejected_issue_id).toBe(issue2.id);
+		expect(row.holding_issue_id).toBe(issueId);
+	});
+
+	// PROJ-337: a non-conflicting claim inserts no claim_conflicts rows
+	it("PROJ-337: a non-conflicting claim inserts no claim_conflicts rows", async () => {
+		const res = await claimFiles({ issueId, paths: ["src/no-conflict.ts"] });
+		expect(res.status).toBe(201);
+
+		const rows = await env.DB.prepare(
+			"SELECT * FROM claim_conflicts WHERE workspace_id = ? AND path = ?"
+		)
+			.bind(workspaceId, "src/no-conflict.ts")
+			.all();
+		expect(rows.results).toHaveLength(0);
 	});
 });

--- a/apps/api/src/test/file-claims.test.ts
+++ b/apps/api/src/test/file-claims.test.ts
@@ -249,6 +249,27 @@ describe("File Claims API", () => {
 		expect(row.holding_issue_id).toBe(issueId);
 	});
 
+	// PROJ-337: rejecting a call where multiple paths are held records one row per contended path
+	it("PROJ-337: rejecting a multi-path claim records one row per contended path", async () => {
+		await claimFiles({ issueId, paths: ["src/multi-a.ts", "src/multi-b.ts"] });
+
+		const issue2 = await seedIssue(workspaceId, projectId, userId, { title: "Multi rejected" });
+		const res = await claimFiles({
+			issueId: issue2.id,
+			paths: ["src/multi-a.ts", "src/multi-b.ts"],
+		});
+		expect(res.status).toBe(409);
+
+		const rows = await env.DB.prepare(
+			"SELECT path FROM claim_conflicts WHERE workspace_id = ? AND rejected_issue_id = ? AND forced = 0"
+		)
+			.bind(workspaceId, issue2.id)
+			.all();
+		expect(rows.results).toHaveLength(2);
+		const paths = rows.results.map((r) => (r as Record<string, unknown>).path).sort();
+		expect(paths).toEqual(["src/multi-a.ts", "src/multi-b.ts"]);
+	});
+
 	// PROJ-337: force:true override inserts a claim_conflicts row (forced=1)
 	it("PROJ-337: force:true override inserts a claim_conflicts row with forced=1", async () => {
 		await claimFiles({ issueId, paths: ["src/force-log.ts"] });

--- a/apps/api/src/test/migrations.ts
+++ b/apps/api/src/test/migrations.ts
@@ -32,6 +32,7 @@ import m0028 from "../../../../packages/db/migrations/0028_downgrade_viewer_gran
 import m0029 from "../../../../packages/db/migrations/0029_issue_review_timestamp.sql?raw";
 import m0030 from "../../../../packages/db/migrations/0030_backfill_review_timestamp.sql?raw";
 import m0031 from "../../../../packages/db/migrations/0031_factory_health.sql?raw";
+import m0032 from "../../../../packages/db/migrations/0032_claim_conflicts.sql?raw";
 
 export const MIGRATIONS = [
 	m0000,
@@ -66,4 +67,5 @@ export const MIGRATIONS = [
 	m0029,
 	m0030,
 	m0031,
+	m0032,
 ];

--- a/apps/docs/src/content/docs/agents/tool-catalog.md
+++ b/apps/docs/src/content/docs/agents/tool-catalog.md
@@ -190,6 +190,6 @@ running server.
 
 | Tool | Description |
 |------|-------------|
-| `get_code_heatmap` | Where work lands in the codebase, from file-claim history (issue_file_claims) — no git integration needed. Aggregates claims one path segment below `prefix` (omit for the top level), sized by distinctIssueCount (distinct issues that claimed a path under that segment, claimedAt within [since, until]) plus claimCount (raw claim count, including released ones). Each entry's `path` is the drill-down cursor: re-call with `prefix` set to it to see what's under a directory; `isLeaf` marks an entry that is itself a claimed file path, not a directory. Defaults to the current ISO week plus the preceding 5 weeks, matching get_flow_metrics. |
+| `get_code_heatmap` | Where work lands in the codebase, from file-claim history (issue_file_claims) — no git integration needed. Aggregates claims one path segment below `prefix` (omit for the top level), sized by distinctIssueCount (distinct issues that claimed a path under that segment, claimedAt within [since, until]) plus claimCount (raw claim count, including released ones). Each entry's `path` is the drill-down cursor: re-call with `prefix` set to it to see what's under a directory; `isLeaf` marks an entry that is itself a claimed file path, not a directory. Defaults to the current ISO week plus the preceding 5 weeks, matching get_flow_metrics. `mode` switches sizing between claim volume and claim contention (claim_conflicts). |
 
 <!-- gen-mcp-catalog:end -->

--- a/apps/web/src/islands/charts/CodeHeatmap.tsx
+++ b/apps/web/src/islands/charts/CodeHeatmap.tsx
@@ -2,12 +2,16 @@ import { useEffect, useState } from "preact/hooks";
 import { apiFetch } from "../../utils/api-client";
 import { SectionHeading } from "../MetricHelp";
 
+type HeatmapMode = "claims" | "contention";
+
 interface CodeHeatmapEntry {
 	path: string;
 	segment: string;
 	isLeaf: boolean;
-	distinctIssueCount: number;
-	claimCount: number;
+	distinctIssueCount?: number;
+	claimCount?: number;
+	distinctRejectedIssueCount?: number;
+	conflictCount?: number;
 }
 
 interface CodeHeatmapResponse {
@@ -29,6 +33,7 @@ function useCodeHeatmap(
 	since: number,
 	until: number
 ) {
+	const [mode, setMode] = useState<HeatmapMode>("claims");
 	const [prefix, setPrefix] = useState("");
 	const [data, setData] = useState<CodeHeatmapResponse | null>(null);
 	const [loading, setLoading] = useState(true);
@@ -40,10 +45,17 @@ function useCodeHeatmap(
 		setPrefix("");
 	}, [since, until]);
 
+	// A contention drill-down path may not exist in claims mode and vice versa, so reset
+	// to the root when the mode itself changes (but not on range changes above, since
+	// mode is a user-chosen view, not part of the query window).
+	useEffect(() => {
+		setPrefix("");
+	}, [mode]);
+
 	useEffect(() => {
 		setLoading(true);
 		setError(null);
-		const query = new URLSearchParams({ since: String(since), until: String(until) });
+		const query = new URLSearchParams({ since: String(since), until: String(until), mode });
 		if (prefix) query.set("prefix", prefix);
 		apiFetch<CodeHeatmapResponse>(
 			`/api/projects/${encodeURIComponent(projectId)}/code-heatmap?${query}`,
@@ -52,13 +64,17 @@ function useCodeHeatmap(
 			.then((res) => setData(res))
 			.catch((e) => setError(String(e)))
 			.finally(() => setLoading(false));
-	}, [workspaceSlug, projectId, since, until, prefix]);
+	}, [workspaceSlug, projectId, since, until, prefix, mode]);
 
-	return { prefix, setPrefix, data, loading, error };
+	return { mode, setMode, prefix, setPrefix, data, loading, error };
 }
 
 function formatIssueCount(n: number): string {
 	return `${n} ${n === 1 ? "issue" : "issues"}`;
+}
+
+function formatConflictCount(n: number): string {
+	return `${n} ${n === 1 ? "conflict" : "conflicts"}`;
 }
 
 // PROJ-332: sequential heat — one hue (the app accent), lighter-to-darker by each
@@ -112,15 +128,52 @@ function Breadcrumb({
 	);
 }
 
+function ModeToggle({
+	mode,
+	onChange,
+}: {
+	mode: HeatmapMode;
+	onChange: (mode: HeatmapMode) => void;
+}) {
+	return (
+		<div class="flex flex-wrap items-center gap-1 mb-3 text-[0.78rem]">
+			<button
+				type="button"
+				onClick={() => onChange("claims")}
+				class={`px-1.5 py-0.5 rounded hover:bg-border ${
+					mode === "claims" ? "font-semibold text-text-base" : "text-accent"
+				}`}
+			>
+				Claim volume
+			</button>
+			<button
+				type="button"
+				onClick={() => onChange("contention")}
+				class={`px-1.5 py-0.5 rounded hover:bg-border ${
+					mode === "contention" ? "font-semibold text-text-base" : "text-accent"
+				}`}
+			>
+				Contention
+			</button>
+		</div>
+	);
+}
+
 function HeatmapRow({
 	entry,
+	mode,
 	ratio,
 	onDrillDown,
 }: {
 	entry: CodeHeatmapEntry;
+	mode: HeatmapMode;
 	ratio: number;
 	onDrillDown: (path: string) => void;
 }) {
+	const formattedCount =
+		mode === "contention"
+			? formatConflictCount(entry.distinctRejectedIssueCount ?? 0)
+			: formatIssueCount(entry.distinctIssueCount ?? 0);
 	const content = (
 		<>
 			<span class="min-w-0 truncate text-[0.82rem] text-text-base" title={entry.path}>
@@ -137,7 +190,7 @@ function HeatmapRow({
 				/>
 			</span>
 			<span class="w-[5.5rem] shrink-0 text-right text-[0.78rem] tabular-nums text-text-muted">
-				{formatIssueCount(entry.distinctIssueCount)}
+				{formattedCount}
 			</span>
 		</>
 	);
@@ -173,27 +226,44 @@ function CodeHeatmapEmptyState() {
 	);
 }
 
+function ContentionEmptyState() {
+	return (
+		<div class="py-8 text-center">
+			<p class="m-0 text-sm text-text-base">No claim conflicts in this window</p>
+			<p class="m-0 mt-1 text-[0.78rem] text-text-muted">
+				Agents aren't queuing up over the same files — that's a healthy sign for fleet parallelism.
+			</p>
+		</div>
+	);
+}
+
 // PROJ-332: "Where work lands" — a hand-rolled proportional bar list rather than a
 // treemap (per the ticket's fallback: keep the dependency footprint small). Bars carry
 // the sequential heat encoding; sizing (bar length) and shading (fill intensity) are
 // redundant on purpose, which is what makes a "heat map" read at a glance.
 export default function CodeHeatmap({ workspaceSlug, projectId, since, until }: Props) {
-	const { prefix, setPrefix, data, loading, error } = useCodeHeatmap(
+	const { mode, setMode, prefix, setPrefix, data, loading, error } = useCodeHeatmap(
 		workspaceSlug,
 		projectId,
 		since,
 		until
 	);
 
-	const maxCount = data ? Math.max(1, ...data.entries.map((e) => e.distinctIssueCount)) : 1;
+	const countField = mode === "contention" ? "distinctRejectedIssueCount" : "distinctIssueCount";
+	const maxCount = data ? Math.max(1, ...data.entries.map((e) => e[countField] ?? 0)) : 1;
 
 	return (
 		<div class="mb-8">
 			<SectionHeading
-				metricId="code-heatmap"
-				caption="Directories sized by distinct issues claiming files there — click a row to drill in"
+				metricId={mode === "contention" ? "code-heatmap-contention" : "code-heatmap"}
+				caption={
+					mode === "contention"
+						? "Directories sized by distinct issues whose claim was rejected or overridden there — click a row to drill in"
+						: "Directories sized by distinct issues claiming files there — click a row to drill in"
+				}
 			/>
 			<div class="p-4 bg-surface border border-border rounded-lg">
+				<ModeToggle mode={mode} onChange={setMode} />
 				{loading && <p aria-live="polite">Loading…</p>}
 				{!loading && error && (
 					<p role="alert" class="text-[var(--danger-text)]">
@@ -204,14 +274,19 @@ export default function CodeHeatmap({ workspaceSlug, projectId, since, until }: 
 					<>
 						<Breadcrumb prefix={prefix} onNavigate={setPrefix} />
 						{data.entries.length === 0 ? (
-							<CodeHeatmapEmptyState />
+							mode === "contention" ? (
+								<ContentionEmptyState />
+							) : (
+								<CodeHeatmapEmptyState />
+							)
 						) : (
 							<div class="flex flex-col gap-0.5">
 								{data.entries.map((entry) => (
 									<HeatmapRow
 										key={entry.path}
 										entry={entry}
-										ratio={entry.distinctIssueCount / maxCount}
+										mode={mode}
+										ratio={(entry[countField] ?? 0) / maxCount}
 										onDrillDown={setPrefix}
 									/>
 								))}

--- a/apps/web/src/islands/charts/CodeHeatmap.tsx
+++ b/apps/web/src/islands/charts/CodeHeatmap.tsx
@@ -73,10 +73,6 @@ function formatIssueCount(n: number): string {
 	return `${n} ${n === 1 ? "issue" : "issues"}`;
 }
 
-function formatConflictCount(n: number): string {
-	return `${n} ${n === 1 ? "conflict" : "conflicts"}`;
-}
-
 // PROJ-332: sequential heat — one hue (the app accent), lighter-to-darker by each
 // entry's distinct-issue count relative to the strongest sibling at this drill-down
 // level (not a global max), so the ramp stays legible whether you're looking at a
@@ -172,7 +168,7 @@ function HeatmapRow({
 }) {
 	const formattedCount =
 		mode === "contention"
-			? formatConflictCount(entry.distinctRejectedIssueCount ?? 0)
+			? formatIssueCount(entry.distinctRejectedIssueCount ?? 0)
 			: formatIssueCount(entry.distinctIssueCount ?? 0);
 	const content = (
 		<>

--- a/apps/web/src/islands/metric-definitions.ts
+++ b/apps/web/src/islands/metric-definitions.ts
@@ -20,7 +20,8 @@ export type MetricId =
 	| "lease-expiries"
 	| "abandoned-claims"
 	| "gate-rejections"
-	| "code-heatmap";
+	| "code-heatmap"
+	| "code-heatmap-contention";
 
 export interface MetricDefinition {
 	label: string;
@@ -129,5 +130,12 @@ export const METRIC_DEFINITIONS: Record<MetricId, MetricDefinition> = {
 		definition: "Which parts of the codebase are seeing the most work, by file claims.",
 		computation:
 			"Directories/paths sized by distinct issues that claimed files there, from file-claim history in the window.",
+	},
+	"code-heatmap-contention": {
+		label: "Where the fleet queues up",
+		definition:
+			"Which parts of the codebase cause agents to collide over file claims, blocking parallelism.",
+		computation:
+			"Directories/paths sized by distinct issues whose claim_files attempt was rejected or overridden there, in the window.",
 	},
 };

--- a/packages/db/migrations/0032_claim_conflicts.sql
+++ b/packages/db/migrations/0032_claim_conflicts.sql
@@ -1,0 +1,19 @@
+-- Claim conflicts (PROJ-337, design: docs/design/proj-333-claim-contention.md): an event
+-- log of rejected/overridden claimFiles attempts. assertNoConflicts pre-checks and
+-- rejects all-or-nothing before any insert into issue_file_claims, so a rejected attempt
+-- leaves no row for any overlap-derivation approach to find — this table records the
+-- attempt directly, at the point it's already resolved in-process.
+CREATE TABLE claim_conflicts (
+	id TEXT PRIMARY KEY,
+	workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+	path TEXT NOT NULL,
+	rejected_issue_id TEXT NOT NULL REFERENCES issues(id) ON DELETE CASCADE,
+	rejected_agent_id TEXT REFERENCES agent_sessions(id) ON DELETE SET NULL,
+	holding_issue_id TEXT NOT NULL REFERENCES issues(id) ON DELETE CASCADE,
+	holding_agent_id TEXT REFERENCES agent_sessions(id) ON DELETE SET NULL,
+	forced INTEGER NOT NULL DEFAULT 0, -- 1 when this was an override (force: true), not a hard rejection
+	occurred_at INTEGER NOT NULL
+);
+
+CREATE INDEX idx_claim_conflicts_workspace_occurred ON claim_conflicts(workspace_id, occurred_at);
+CREATE INDEX idx_claim_conflicts_path ON claim_conflicts(workspace_id, path);

--- a/packages/db/src/schema/file-claims.ts
+++ b/packages/db/src/schema/file-claims.ts
@@ -26,3 +26,37 @@ export const issueFileClaims = sqliteTable(
 		issueIdx: index("idx_file_claims_issue").on(t.workspaceId, t.issueId),
 	})
 );
+
+// PROJ-337: claim conflicts — an event log of rejected/overridden claimFiles attempts.
+// assertNoConflicts pre-checks and rejects all-or-nothing before any insert into
+// issue_file_claims, so a rejected attempt leaves no row to derive overlap from; this
+// records the attempt directly. `forced` distinguishes a hard rejection (force: false)
+// from an override (force: true, an existing claim was evicted).
+export const claimConflicts = sqliteTable(
+	"claim_conflicts",
+	{
+		id: text("id").primaryKey(),
+		workspaceId: text("workspace_id")
+			.notNull()
+			.references(() => workspaces.id, { onDelete: "cascade" }),
+		path: text("path").notNull(),
+		rejectedIssueId: text("rejected_issue_id")
+			.notNull()
+			.references(() => issues.id, { onDelete: "cascade" }),
+		rejectedAgentId: text("rejected_agent_id").references(() => agentSessions.id, {
+			onDelete: "set null",
+		}),
+		holdingIssueId: text("holding_issue_id")
+			.notNull()
+			.references(() => issues.id, { onDelete: "cascade" }),
+		holdingAgentId: text("holding_agent_id").references(() => agentSessions.id, {
+			onDelete: "set null",
+		}),
+		forced: integer("forced").notNull().default(0),
+		occurredAt: integer("occurred_at").notNull(),
+	},
+	(t) => ({
+		wsOccurredIdx: index("idx_claim_conflicts_workspace_occurred").on(t.workspaceId, t.occurredAt),
+		pathIdx: index("idx_claim_conflicts_path").on(t.workspaceId, t.path),
+	})
+);


### PR DESCRIPTION
## Summary
- PROJ-337: record every rejected/overridden file-claim contention as a row in a new `claim_conflicts` table (migration 0032), scoped per workspace/project, one row per contended path (fixed an initial under-reporting bug in review where multi-path claims only logged the first contended path).
- PROJ-338: surface that data on the existing codebase heat map via a new `mode: "claims" | "contention"` toggle — same directory drill-down, `distinctRejectedIssueCount`/`conflictCount` per node, distinct "healthy sign" empty state when there's no contention.

Both tickets were sonnet-implemented and opus-reviewed adversarially (re-derived claims against the filed AC, re-ran full suites, checked doc/catalog staleness). PROJ-337's review caught and fixed a real multi-path conflict under-reporting bug; PROJ-338's review caught and fixed a UI mislabel (contention count was labelled "conflicts" but is actually a distinct-issue count).

## Test plan
- [x] `apps/api` full suite green (656 passed / 5 todo)
- [x] `apps/web` full suite green (280 passed)
- [x] type-check (api + web) clean
- [x] biome clean
- [x] `gen:docs` re-run confirms committed catalog/spec docs are current
- [x] Manual design-doc cross-check against `docs/design/proj-333-claim-contention.md` (schema → write path → read path → UI, end to end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PCF5RkfY5t6Zwoeecvgfm