### PR TITLE
Groups UI tabs + mobile body-overflow containment (PROJ-343, PROJ-344)

### DIFF
--- a/apps/web/src/islands/GroupManager.test.tsx
+++ b/apps/web/src/islands/GroupManager.test.tsx
@@ -91,3 +91,60 @@ describe("GroupManager rename", () => {
 		});
 	});
 });
+
+// PROJ-343: Members and Groups now render as separate tabs, defaulting to
+// Groups so the flows above stay reachable without switching tabs first.
+const REGULAR_MEMBER = { id: "u2", email: "mo@example.com", name: "Mo Member", role: "member" };
+
+function mockFetchForTabs(opts: { role: string }) {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn().mockImplementation((url: string) => {
+			const u = String(url);
+			const json = (body: unknown) =>
+				Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+			if (u.includes("/member-groups")) {
+				return json([{ userId: "u2", groups: [{ id: "g1", name: "Engineering" }] }]);
+			}
+			if (u.includes("/groups")) return json([GROUP]);
+			if (u.includes("/api/projects")) return json([]);
+			return json({ members: [REGULAR_MEMBER], currentUserRole: opts.role });
+		})
+	);
+}
+
+describe("GroupManager tabs", () => {
+	it("renders both Members and Groups tabs for an admin, defaulting to Groups", async () => {
+		mockFetchForTabs({ role: "admin" });
+		render(<GroupManager workspaceSlug="my-ws" />);
+
+		const groupsTab = await screen.findByRole("tab", { name: "Groups" });
+		const membersTab = screen.getByRole("tab", { name: "Members" });
+		expect(groupsTab.getAttribute("aria-selected")).toBe("true");
+		expect(membersTab.getAttribute("aria-selected")).toBe("false");
+
+		expect(screen.getByText("Engineering")).toBeTruthy();
+		expect(screen.queryByText("Mo Member")).toBeNull();
+	});
+
+	it("shows the Members panel and hides Groups when the Members tab is clicked", async () => {
+		mockFetchForTabs({ role: "admin" });
+		render(<GroupManager workspaceSlug="my-ws" />);
+
+		await screen.findByText("Engineering");
+		fireEvent.click(screen.getByRole("tab", { name: "Members" }));
+
+		expect(await screen.findByText("Mo Member")).toBeTruthy();
+		expect(screen.queryByPlaceholderText("New group name")).toBeNull();
+		expect(screen.getByRole("tab", { name: "Members" }).getAttribute("aria-selected")).toBe("true");
+	});
+
+	it("shows no Members tab (or tablist) for a non-admin caller", async () => {
+		mockFetchForTabs({ role: "member" });
+		render(<GroupManager workspaceSlug="my-ws" />);
+
+		await screen.findByText("Your groups");
+		expect(screen.queryByRole("tab", { name: "Members" })).toBeNull();
+		expect(screen.queryByRole("tablist")).toBeNull();
+	});
+});

--- a/apps/web/src/islands/GroupManager.tsx
+++ b/apps/web/src/islands/GroupManager.tsx
@@ -1,4 +1,3 @@
-import type { JSX } from "preact";
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { apiFetch } from "../utils/api-client";
 import { resolveWorkspaceSlug } from "../utils/workspace";
@@ -554,7 +553,7 @@ export default function GroupManager({ workspaceSlug }: Props) {
 
 	// WAI-ARIA tabs pattern: arrow keys move focus AND activate (automatic
 	// activation), Home/End jump to the first/last tab.
-	function onTabKeyDown(e: JSX.TargetedKeyboardEvent<HTMLDivElement>) {
+	function onTabKeyDown(e: KeyboardEvent) {
 		const idx = tabs.indexOf(activeTab);
 		let nextId: TabId | null = null;
 		if (e.key === "ArrowRight") nextId = tabs[(idx + 1) % tabs.length];

--- a/apps/web/src/islands/GroupManager.tsx
+++ b/apps/web/src/islands/GroupManager.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from "preact/hooks";
+import type { JSX } from "preact";
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { apiFetch } from "../utils/api-client";
 import { resolveWorkspaceSlug } from "../utils/workspace";
 
@@ -83,6 +84,14 @@ const TH =
 const TD =
 	"px-3 py-2 border-b border-border align-middle text-[0.85rem] [tr:last-child_&]:border-b-0";
 const H2 = "text-[1.05rem] font-bold text-text-base m-0 mb-3";
+const TAB_LIST = "flex gap-1 border-b border-border mb-4";
+const tabBtnClass = (active: boolean) =>
+	"px-4 py-2 text-[0.85rem] font-semibold border-b-2 -mb-px bg-transparent cursor-pointer " +
+	(active
+		? "border-accent text-text-base"
+		: "border-transparent text-text-muted hover:text-text-base");
+
+type TabId = "members" | "groups";
 
 function isForbidden(e: unknown): boolean {
 	return String(e).includes(": 403");
@@ -468,6 +477,11 @@ export default function GroupManager({ workspaceSlug }: Props) {
 	const [newName, setNewName] = useState("");
 	const [createErr, setCreateErr] = useState<string | null>(null);
 	const [busy, setBusy] = useState(false);
+	// Default admins to the Groups tab so the existing create/rename/grant flows
+	// (and their tests) stay reachable without an extra click; non-admins always
+	// land on Groups anyway since they have no Members tab.
+	const [tab, setTab] = useState<TabId>("groups");
+	const tabRefs = useRef<Partial<Record<TabId, HTMLButtonElement | null>>>({});
 
 	const refetch = useCallback(async () => {
 		if (!slug) return;
@@ -531,13 +545,32 @@ export default function GroupManager({ workspaceSlug }: Props) {
 	}
 
 	const { isAdmin } = data;
+	const tabs: TabId[] = isAdmin ? ["members", "groups"] : ["groups"];
+	const activeTab: TabId = isAdmin ? tab : "groups";
 
-	return (
-		<div>
-			<RoleBanner role={data.role} isAdmin={isAdmin} />
+	function focusTab(id: TabId) {
+		tabRefs.current[id]?.focus();
+	}
 
-			{isAdmin && <MembersOverview members={data.members} memberGroups={data.memberGroups} />}
+	// WAI-ARIA tabs pattern: arrow keys move focus AND activate (automatic
+	// activation), Home/End jump to the first/last tab.
+	function onTabKeyDown(e: JSX.TargetedKeyboardEvent<HTMLDivElement>) {
+		const idx = tabs.indexOf(activeTab);
+		let nextId: TabId | null = null;
+		if (e.key === "ArrowRight") nextId = tabs[(idx + 1) % tabs.length];
+		else if (e.key === "ArrowLeft") nextId = tabs[(idx - 1 + tabs.length) % tabs.length];
+		else if (e.key === "Home") nextId = tabs[0];
+		else if (e.key === "End") nextId = tabs[tabs.length - 1];
+		if (!nextId) return;
+		e.preventDefault();
+		setTab(nextId);
+		focusTab(nextId);
+	}
 
+	const TAB_LABELS: Record<TabId, string> = { members: "Members", groups: "Groups" };
+
+	const groupsSection = (
+		<>
 			<section class={CARD}>
 				<h2 class={H2}>{isAdmin ? "Groups" : "Your groups"}</h2>
 				{isAdmin && (
@@ -628,6 +661,50 @@ export default function GroupManager({ workspaceSlug }: Props) {
 					onClose={() => setSelected(null)}
 				/>
 			)}
+		</>
+	);
+
+	return (
+		<div>
+			<RoleBanner role={data.role} isAdmin={isAdmin} />
+
+			{tabs.length > 1 && (
+				<div role="tablist" aria-label="Groups" class={TAB_LIST} onKeyDown={onTabKeyDown}>
+					{tabs.map((id) => (
+						<button
+							key={id}
+							ref={(el) => {
+								tabRefs.current[id] = el;
+							}}
+							type="button"
+							role="tab"
+							id={`group-tab-${id}`}
+							aria-selected={activeTab === id}
+							aria-controls={`group-tabpanel-${id}`}
+							tabIndex={activeTab === id ? 0 : -1}
+							class={tabBtnClass(activeTab === id)}
+							onClick={() => setTab(id)}
+						>
+							{TAB_LABELS[id]}
+						</button>
+					))}
+				</div>
+			)}
+
+			{isAdmin && activeTab === "members" && (
+				<div role="tabpanel" id="group-tabpanel-members" aria-labelledby="group-tab-members">
+					<MembersOverview members={data.members} memberGroups={data.memberGroups} />
+				</div>
+			)}
+
+			{activeTab === "groups" &&
+				(isAdmin ? (
+					<div role="tabpanel" id="group-tabpanel-groups" aria-labelledby="group-tab-groups">
+						{groupsSection}
+					</div>
+				) : (
+					groupsSection
+				))}
 		</div>
 	);
 }

--- a/apps/web/src/islands/IssueDetail.test.tsx
+++ b/apps/web/src/islands/IssueDetail.test.tsx
@@ -1,6 +1,19 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { cleanup, render, screen, waitFor } from "@testing-library/preact";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import IssueDetail from "./IssueDetail";
+
+// PROJ-344: on mobile the two-column body collapses to a column (items-start),
+// so the main column must be pinned to full width — otherwise it grows to its
+// widest child (a wide table / long code line) and the whole page overflows,
+// leaving BodySection's own overflow-x-auto with nothing to scroll against.
+describe("IssueDetail — mobile main-column width", () => {
+	it("pins the main column to full width on mobile so wide body content can't widen the page", () => {
+		const source = readFileSync(join(__dirname, "IssueDetail.tsx"), "utf-8");
+		expect(source).toMatch(/class="flex-1 min-w-0 max-sm:w-full"/);
+	});
+});
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 

--- a/apps/web/src/islands/IssueDetail.tsx
+++ b/apps/web/src/islands/IssueDetail.tsx
@@ -445,7 +445,7 @@ function IssueDetailView(props: {
 			{/* Two-column body */}
 			<div class="flex gap-8 items-start max-sm:flex-col">
 				{/* ── Main column ── */}
-				<div class="flex-1 min-w-0">
+				<div class="flex-1 min-w-0 max-sm:w-full">
 					<BodySection
 						issue={issue}
 						issueId={issueId}

--- a/apps/web/src/islands/IssueDetailParts.test.tsx
+++ b/apps/web/src/islands/IssueDetailParts.test.tsx
@@ -1,0 +1,67 @@
+// IssueDetailParts island — BodySection overflow-containment regression test (PROJ-344).
+//
+// A wide markdown table or a long unbroken code line must not force the whole
+// page to scroll horizontally on mobile; the rendered-markdown container must
+// carry its own horizontal scroll instead. jsdom doesn't lay out real pixel
+// widths, so this asserts the containing class rather than measured overflow.
+import { render, screen } from "@testing-library/preact";
+import { describe, expect, it } from "vitest";
+import { BodySection } from "./IssueDetailParts";
+import type { IssueData } from "./issue-detail-helpers";
+
+const WIDE_TABLE_BODY = `
+| Column A | Column B | Column C | Column D | Column E | Column F | Column G |
+| --- | --- | --- | --- | --- | --- | --- |
+| aaaaaaaaaa | bbbbbbbbbb | cccccccccc | dddddddddd | eeeeeeeeee | ffffffffff | gggggggggg |
+
+\`\`\`
+${"x".repeat(200)}
+\`\`\`
+`;
+
+const ISSUE: IssueData = {
+	id: "i1",
+	number: 1,
+	title: "Issue with wide content",
+	body: WIDE_TABLE_BODY,
+	priority: "medium",
+	assignee_id: null,
+	assignee_name: null,
+	parent_id: null,
+	project_key: "PROJ",
+	project_name: "Projektor",
+	type_key: null,
+	type_name: null,
+	status_id: null,
+	status_key: null,
+	status_name: null,
+	status_category: null,
+	created_at: 1000,
+	updated_at: 1000,
+	customFields: [],
+};
+
+describe("BodySection", () => {
+	it("wraps the rendered markdown body in a horizontally-scrollable container", async () => {
+		render(
+			<BodySection
+				issue={ISSUE}
+				issueId={ISSUE.id}
+				workspaceSlug="ws"
+				fetchIssue={async () => {}}
+			/>
+		);
+
+		const table = await screen.findByRole("table");
+		const container = table.closest(".prose");
+		expect(container).toBeTruthy();
+		expect(container?.className).toContain("overflow-x-auto");
+		expect(container?.className).toContain("break-words");
+
+		// The long code line rendered inside <pre> — the wrapping container is
+		// still the scroll boundary, not the page.
+		const pre = container?.querySelector("pre");
+		expect(pre).toBeTruthy();
+		expect(pre?.closest(".prose")).toBe(container);
+	});
+});

--- a/apps/web/src/islands/IssueDetailParts.tsx
+++ b/apps/web/src/islands/IssueDetailParts.tsx
@@ -422,7 +422,7 @@ export function BodySection({
 				</div>
 			) : issue.body ? (
 				<div
-					class="prose prose-sm max-w-none"
+					class="prose prose-sm max-w-none overflow-x-auto break-words"
 					dangerouslySetInnerHTML={{ __html: renderMd(issue.body) }}
 				/>
 			) : (
@@ -974,7 +974,7 @@ function CommentItem({
 				</div>
 			) : (
 				<div
-					class="prose prose-sm max-w-none"
+					class="prose prose-sm max-w-none overflow-x-auto break-words"
 					dangerouslySetInnerHTML={{ __html: renderMd(comment.body) }}
 				/>
 			)}


### PR DESCRIPTION
## Summary
- **PROJ-343**: split the workspace Groups page into two WAI-ARIA tabs — **Members** (`MembersOverview`, admin-only) and **Groups** (groups table, create form, `GroupDetailEditor` / read-only "your groups"). `RoleBanner` stays above both tabs. Roving tabindex, arrow-key + Home/End navigation with automatic activation (focus moves to the newly-selected tab), unique `aria-selected`/`aria-controls`/`id` wiring. Non-admins render no tablist and land straight on the read-only Groups view. Admins default to the Groups tab (the ticket left the default open; Groups keeps the existing create/rename/grant flows reachable without a click).
- **PROJ-344**: contain rendered-markdown body overflow so wide tables / long code lines scroll inside the `.prose` container instead of widening the page on mobile.

Both tickets were sonnet-implemented and opus-reviewed adversarially against the filed ACs, with real-browser verification at a 375px viewport (Playwright).

### Review found and fixed a real mobile bug (PROJ-344)
The initial change only added `overflow-x-auto break-words` to the `.prose` body/comment containers. Verified in a real browser at 375px that this was **inert on mobile**: the issue-detail two-column body collapses to a column (`max-sm:flex-col` + `items-start`), so the `flex-1 min-w-0` main column sized to its widest child (a wide table ≈920px) rather than the viewport — the overflow container had nothing to scroll against and the page still overflowed. `min-w-0` only constrains the (vertical) main axis in column mode. Fixed by pinning the main column to `max-sm:w-full` (mirroring the sidebar's existing pattern); the `.prose` `overflow-x-auto` then engages and the table/code scroll internally with no page-level overflow (measured: content 920px scrolls inside a 328px container, page docScrollWidth 360 ≤ 375). Added a regression guard for the width class. Also dropped a deprecated `JSX.TargetedKeyboardEvent` tab-handler type for the plain `KeyboardEvent` the rest of the codebase uses.

## Test plan
- [x] `apps/web` full suite green (285 passed)
- [x] `pnpm --filter web type-check` clean (0 errors; only a pre-existing unrelated Select.tsx deprecation warning)
- [x] `pnpm exec biome check` clean on all changed files
- [x] Playwright @ 375px — issue body with wide table + long code line: no page-level horizontal scroll, table/code scroll internally (before/after screenshots captured)
- [x] Playwright @ 375px — Groups page: tablist fits without wrapping, tap switches tabs, arrow-key nav moves focus + activates, `RoleBanner` stays above the tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PCF5RkfY5t6Zwoeecvgfm