### PR TITLE
Compact ProjectNav on mobile so content isn't pushed below the fold (PROJ-346)

### DIFF
--- a/apps/web/src/islands/ProjectNav.test.tsx
+++ b/apps/web/src/islands/ProjectNav.test.tsx
@@ -63,4 +63,23 @@ describe("ProjectNav", () => {
 		await screen.findByText("Projektor");
 		expect(document.title).toBe("unchanged");
 	});
+
+	// jsdom doesn't compute layout, so this only proves the compacting classes are
+	// present at render time — not that they actually shrink the nav in a real
+	// viewport. See PROJ-346; real-viewport confirmation happens separately.
+	it("applies compact-mobile and horizontal-scroll classes to the header and tab row", async () => {
+		window.history.pushState({}, "", "/issues?id=p1");
+		mockFetchProject(PROJECT);
+		render(<ProjectNav />);
+		await screen.findByText("Projektor");
+
+		const nav = screen.getByRole("navigation", { name: "Project sections" });
+		expect(nav.className).toContain("max-sm:overflow-x-auto");
+
+		const issuesTab = screen.getByRole("link", { name: "Issues" });
+		expect(issuesTab.className).toContain("max-sm:px-2.5");
+
+		const heading = screen.getByText("Projektor");
+		expect(heading.className).toContain("max-sm:text-[0.8125rem]");
+	});
 });

--- a/apps/web/src/islands/ProjectNav.tsx
+++ b/apps/web/src/islands/ProjectNav.tsx
@@ -26,8 +26,9 @@ const KEY_BADGE_CLASS =
 	" text-text-muted";
 
 const TAB_BASE_CLASS =
-	"inline-flex items-center px-3 py-2 rounded-t-md text-sm font-medium no-underline border border-b-0 -mb-px" +
-	" transition-[color,background] duration-100";
+	"inline-flex items-center shrink-0 whitespace-nowrap px-3 py-2 rounded-t-md text-sm font-medium no-underline" +
+	" border border-b-0 -mb-px transition-[color,background] duration-100 max-sm:px-2.5 max-sm:py-1.5" +
+	" max-sm:text-[0.8125rem]";
 
 function tabClass(active: boolean): string {
 	return `${TAB_BASE_CLASS} ${
@@ -110,13 +111,18 @@ export default function ProjectNav({ workspaceSlug, pageLabel }: Props) {
 
 	return (
 		<div class="border-b border-border bg-[var(--nav-bg)]">
-			<div class="flex items-center gap-2 px-6 pt-3 pb-[0.375rem]">
+			<div class="flex items-center gap-2 px-6 pt-3 pb-[0.375rem] max-sm:px-3 max-sm:pt-1.5 max-sm:pb-1">
 				<a href={`/projects/view?id=${encodeURIComponent(project.id)}`} class="no-underline">
-					<h2 class="m-0 text-[0.9375rem] font-semibold text-text-base">{project.name}</h2>
+					<h2 class="m-0 text-[0.9375rem] max-sm:text-[0.8125rem] font-semibold text-text-base">
+						{project.name}
+					</h2>
 				</a>
 				<span class={KEY_BADGE_CLASS}>{project.key}</span>
 			</div>
-			<nav class="flex gap-0.5 px-5" aria-label="Project sections">
+			<nav
+				class="flex gap-0.5 px-5 max-sm:px-3 max-sm:overflow-x-auto"
+				aria-label="Project sections"
+			>
 				{tabs.map((tab) => {
 					const active = activePath === tab.path;
 					return (


### PR DESCRIPTION
## Summary
- **PROJ-346**: `ProjectNav` (`apps/web/src/islands/ProjectNav.tsx`) rendered a full-size two-row header (project name/key + a 6-tab row) stacked below the fixed `.mobile-topbar`, eating enough vertical space on a phone that page content started below the initial viewport. Added `max-sm:` (640px, the breakpoint convention already used throughout `Base.astro`) variants that shrink the project-name row's padding/font-size and turn the tab row into a horizontal-scroll container (`max-sm:overflow-x-auto`, tabs get `shrink-0 whitespace-nowrap` + reduced mobile padding/font) instead of overflowing. No tabs or navigation capability removed — density/layout only.

Sonnet-implemented and opus-reviewed adversarially against the filed AC, with real-browser verification at a 375px viewport (Playwright) against a locally-seeded page (API stubbed at the network layer — production/dogfood never touched).

### Verified in a real browser at 375px (not an error page — real seeded issue content rendered)
Measured header + tab-row content heights directly (scrollbar-independent, since Playwright's Desktop-Chrome emulation reserves a classic scrollbar track that real mobile renders as a zero-height overlay):

| | header | tab row | nav content | + fixed topbar | combined |
|---|---|---|---|---|---|
| Before (origin/main) | 41px | 37px | **78px** | 56px | **134px** |
| After (this branch) | 32px | 33px | **65px** | 56px | **121px** |

The ProjectNav shrinks **78 → 65px (−13px, ~17%)**, so ~13px more content sits above the fold on a phone. The change also fixes a real pre-existing defect: before, the 6 tabs overflowed to 507px and Epics/Metrics sat beyond the 375px viewport — clipped/unreachable under PROJ-344's body-overflow containment. After, they live in a horizontal-scroll container and Metrics is reachable (scrolled to the end, last tab fully in view). Desktop (≥640px) is provably unaffected: at 1024px the nav keeps `overflow-x: visible`, 15px heading, 24px padding — the `max-sm:` variants have zero effect above the breakpoint.

## Test plan
- [x] `pnpm --filter web test` — full suite green (286 passed; includes a new class-presence guard in `ProjectNav.test.tsx`)
- [x] `pnpm --filter web type-check` clean (0 errors; only a pre-existing unrelated Select.tsx deprecation warning)
- [x] `pnpm exec biome check` clean on all changed files
- [x] Playwright @ 375px on a real seeded `/issues` page — compact nav renders real issue content, tab row is a single horizontally-scrollable row (all 6 tabs reachable, Metrics fully visible after scroll), ~13px more content above the fold (screenshots captured)
- [x] Playwright @ 1024px — desktop nav identical to origin/main (max-sm: scoping confirmed inert above 640px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PCF5RkfY5t6Zwoeecvgfm