### PR TITLE
PROJ-286 hardening remainder: flow-metrics/MCP-parity tests, lockfile dedupe, dogfood version docs (PROJ-298, PROJ-299, PROJ-301)

### DIFF
--- a/apps/api/src/routes/mcp.ts
+++ b/apps/api/src/routes/mcp.ts
@@ -25,6 +25,9 @@ import { pluginRegistry } from "../plugins/registry";
 
 // __PROJEKTOR_VERSION__ is injected by esbuild --define at release-build time
 // (scripts/build-release.sh); it's absent in local `wrangler dev` and tests.
+// The dogfood deploy (local wrangler-OAuth post-commit hook, outside this repo) also
+// skips build-release.sh, so dogfood intentionally reports "dev" here - only versioned
+// release tarballs carry a real version string.
 const SERVER_VERSION = typeof __PROJEKTOR_VERSION__ === "string" ? __PROJEKTOR_VERSION__ : "dev";
 
 // Surfaced to every MCP client at `initialize` (the MCP spec's optional

--- a/apps/api/src/test/flow-metrics.test.ts
+++ b/apps/api/src/test/flow-metrics.test.ts
@@ -389,6 +389,50 @@ describe("Flow metrics (PROJ-252)", () => {
 		expect(metrics.throughputOverTime.every((b) => b.count === 0)).toBe(true);
 	});
 
+	it("returns null (not NaN/throw) percentiles for a project with zero issues (PROJ-301)", async () => {
+		const res = await SELF.fetch(`http://localhost/api/projects/${projectId}/flow-metrics`, {
+			headers: authHeaders(token, slug),
+		});
+		expect(res.status).toBe(200);
+		const metrics = (await res.json()) as FlowMetrics;
+
+		for (const dist of [metrics.leadTime, metrics.cycleTime, metrics.reviewLatency]) {
+			expect(dist.count).toBe(0);
+			expect(dist.avg).toBeNull();
+			expect(dist.p50).toBeNull();
+			expect(dist.p90).toBeNull();
+		}
+	});
+
+	it("excludes a NULL-timestamp legacy issue from lead/cycle time without crashing (PROJ-301)", async () => {
+		const now = Math.floor(Date.now() / 1000);
+
+		// Pre-dates the PROJ-328 backfill: ready_at/claimed_at/done_at all NULL, even
+		// though the issue is otherwise done.
+		const legacyIssue = await seedIssue(workspaceId, projectId, userId, {
+			title: "Legacy done issue",
+			status: "done",
+		});
+
+		const modernIssue = await seedIssue(workspaceId, projectId, userId, { title: "Modern issue" });
+		await stampFlowTimestamps(modernIssue.id, {
+			readyAt: now - 300,
+			claimedAt: now - 200,
+			doneAt: now,
+		});
+
+		const res = await SELF.fetch(`http://localhost/api/projects/${projectId}/flow-metrics`, {
+			headers: authHeaders(token, slug),
+		});
+		expect(res.status).toBe(200);
+		const metrics = (await res.json()) as FlowMetrics;
+
+		// The legacy issue contributes nothing — only the modern issue is counted.
+		expect(metrics.leadTime.count).toBe(1);
+		expect(metrics.cycleTime.count).toBe(1);
+		expect(metrics.agingWip.every((a) => a.id !== legacyIssue.id)).toBe(true);
+	});
+
 	// PROJ-328: collaboration-shape metrics (review latency, human interventions, autonomy ratio).
 	async function stampLease(
 		id: string,

--- a/apps/api/src/test/issue-leases.test.ts
+++ b/apps/api/src/test/issue-leases.test.ts
@@ -300,4 +300,61 @@ describe("claim_issue agent WIP limit (PROJ-253)", () => {
 		const res = await claim(second.id, agent);
 		expect(res.status).toBe(409);
 	});
+
+	// --- REST/MCP parity (PROJ-301) ---
+
+	it("MCP parity: update_project sets agent_wip_limit the same as REST PATCH", async () => {
+		const mcpRes = await SELF.fetch(`http://localhost/mcp/${workspaceId}`, {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({
+				jsonrpc: "2.0",
+				id: 1,
+				method: "tools/call",
+				params: { name: "update_project", arguments: { id: projectId, agentWipLimit: 1 } },
+			}),
+		});
+		expect(mcpRes.status).toBe(200);
+
+		const agent = await registerAgent("worker");
+		const [first, second] = await Promise.all([
+			seedIssue(workspaceId, projectId, userId, { title: "First" }),
+			seedIssue(workspaceId, projectId, userId, { title: "Second" }),
+		]);
+
+		expect((await claim(first.id, agent)).status).toBe(201);
+		const res = await claim(second.id, agent);
+		expect(res.status).toBe(409);
+	});
+
+	it("MCP parity: create_project sets agent_wip_limit the same as REST create", async () => {
+		const mcpRes = await SELF.fetch(`http://localhost/mcp/${workspaceId}`, {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({
+				jsonrpc: "2.0",
+				id: 1,
+				method: "tools/call",
+				params: {
+					name: "create_project",
+					arguments: { name: "MCP WIP Project", key: "MCPWIP", agentWipLimit: 1 },
+				},
+			}),
+		});
+		expect(mcpRes.status).toBe(200);
+		const body = (await mcpRes.json()) as {
+			result: { content: Array<{ text: string }> };
+		};
+		const created = JSON.parse(body.result.content[0].text) as { id: string };
+
+		const agent = await registerAgent("worker2");
+		const [first, second] = await Promise.all([
+			seedIssue(workspaceId, created.id, userId, { title: "First" }),
+			seedIssue(workspaceId, created.id, userId, { title: "Second" }),
+		]);
+
+		expect((await claim(first.id, agent)).status).toBe(201);
+		const res = await claim(second.id, agent);
+		expect(res.status).toBe(409);
+	});
 });

--- a/apps/api/src/version.d.ts
+++ b/apps/api/src/version.d.ts
@@ -1,5 +1,8 @@
 /**
  * Injected by esbuild's `--define` at release-build time (scripts/build-release.sh).
  * Undefined in local `wrangler dev` and in tests - callers must guard with `typeof`.
+ * The dogfood deploy path (local wrangler-OAuth post-commit hook, outside this repo)
+ * does not run build-release.sh, so it intentionally reports "dev" - only versioned
+ * release tarballs get a real version string.
  */
 declare const __PROJEKTOR_VERSION__: string | undefined;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3234,11 +3234,6 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
   browserslist@4.28.4:
     resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -5252,10 +5247,6 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.16:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -6892,9 +6883,9 @@ snapshots:
   '@astrojs/tailwind@6.0.2(astro@5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       astro: 5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
-      autoprefixer: 10.5.1(postcss@8.5.15)
-      postcss: 8.5.15
-      postcss-load-config: 4.0.2(postcss@8.5.15)
+      autoprefixer: 10.5.1(postcss@8.5.16)
+      postcss: 8.5.16
+      postcss-load-config: 4.0.2(postcss@8.5.16)
       tailwindcss: 3.4.19(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - ts-node
@@ -6967,7 +6958,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -8271,8 +8262,8 @@ snapshots:
       hast-util-to-html: 9.0.5
       hast-util-to-text: 4.0.2
       hastscript: 9.0.1
-      postcss: 8.5.15
-      postcss-nested: 6.2.0(postcss@8.5.15)
+      postcss: 8.5.16
+      postcss-nested: 6.2.0(postcss@8.5.16)
       unist-util-visit: 5.1.0
       unist-util-visit-parents: 6.0.2
 
@@ -9612,13 +9603,13 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
-  autoprefixer@10.5.1(postcss@8.5.15):
+  autoprefixer@10.5.1(postcss@8.5.16):
     dependencies:
       browserslist: 4.28.4
       caniuse-lite: 1.0.30001799
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.15
+      postcss: 8.5.16
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -9701,14 +9692,6 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
-
-  browserslist@4.28.2:
-    dependencies:
-      baseline-browser-mapping: 2.10.38
-      caniuse-lite: 1.0.30001799
-      electron-to-chromium: 1.5.376
-      node-releases: 2.0.48
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   browserslist@4.28.4:
     dependencies:
@@ -12157,37 +12140,37 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-import@15.1.0(postcss@8.5.15):
+  postcss-import@15.1.0(postcss@8.5.16):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.16
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.12
 
-  postcss-js@4.1.0(postcss@8.5.15):
+  postcss-js@4.1.0(postcss@8.5.16):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.15
+      postcss: 8.5.16
 
-  postcss-load-config@4.0.2(postcss@8.5.15):
+  postcss-load-config@4.0.2(postcss@8.5.16):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.9.0
     optionalDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.16
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.22.4)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.16)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
-      postcss: 8.5.15
+      postcss: 8.5.16
       tsx: 4.22.4
       yaml: 2.9.0
 
-  postcss-nested@6.2.0(postcss@8.5.15):
+  postcss-nested@6.2.0(postcss@8.5.16):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.16
       postcss-selector-parser: 6.1.4
 
   postcss-selector-parser@6.0.10:
@@ -12201,12 +12184,6 @@ snapshots:
       util-deprecate: 1.0.2
 
   postcss-value-parser@4.2.0: {}
-
-  postcss@8.5.15:
-    dependencies:
-      nanoid: 3.3.14
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.16:
     dependencies:
@@ -12963,11 +12940,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.15
-      postcss-import: 15.1.0(postcss@8.5.15)
-      postcss-js: 4.1.0(postcss@8.5.15)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.22.4)(yaml@2.9.0)
-      postcss-nested: 6.2.0(postcss@8.5.15)
+      postcss: 8.5.16
+      postcss-import: 15.1.0(postcss@8.5.16)
+      postcss-js: 4.1.0(postcss@8.5.16)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.16)(tsx@4.22.4)(yaml@2.9.0)
+      postcss-nested: 6.2.0(postcss@8.5.16)
       postcss-selector-parser: 6.1.4
       resolve: 1.22.12
       sucrase: 3.35.1
@@ -13239,12 +13216,6 @@ snapshots:
 
   upath@1.2.0: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
-    dependencies:
-      browserslist: 4.28.2
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
   update-browserslist-db@1.2.3(browserslist@4.28.4):
     dependencies:
       browserslist: 4.28.4
@@ -13321,7 +13292,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.16
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
## Summary
Final three tickets of the PROJ-286 post-review hardening epic. Small, low-risk: regression tests + a lockfile dedupe + two explanatory comments. No product-behavior changes.

- **PROJ-301** — Regression coverage for flow-metrics edge cases and REST/MCP parity:
  - `flow-metrics.test.ts`: empty-result percentiles return `null` (not `NaN`/throw) on a zero-issue project; a NULL-timestamp legacy issue (`ready_at`/`claimed_at`/`done_at` genuinely NULL via the seed helper, which omits those columns) is excluded from lead/cycle time and aging-WIP without crashing.
  - `issue-leases.test.ts`: `agentWipLimit` on `create_project`/`update_project` now exercised through the real MCP `tools/call` surface (`POST /mcp/:ws`), proving REST/MCP parity — previously only REST PATCH was tested.
- **PROJ-298** — `pnpm dedupe` to collapse stale postcss/browserslist duplicate versions. **Scope correction (see PROJ-298 comment):** the ticket's "orphan `astro@5.18.2`" premise is a misdiagnosis — astro@5.18.2 is the resolved version of `apps/web`'s intentional direct dep `astro@^5.0.0` (apps/docs is on `^7.0.6`), so `grep -c "astro@5"` → 0 is unachievable and out of scope; Astro major unification is tracked as PROJ-302. The AC's `engines.node >= 22.12` and CI Node pin (`22.12.0` in ci.yml/docs.yml) were already satisfied by prior merges.
- **PROJ-299** — Documented that the dogfood deploy path (local wrangler-OAuth post-commit hook, outside this repo) never runs `build-release.sh`, so `serverInfo.version` intentionally reports `"dev"`; comments added to `version.d.ts` and `routes/mcp.ts`. The `__PROJEKTOR_VERSION__: string | undefined` type (AC part 1) was already in place from a prior merge; the guarded `SERVER_VERSION` use compiles.

## Test plan
- [x] `pnpm --filter api test` — 660 passed, 5 todo, 1 skipped file (green)
- [x] `pnpm --filter web test` — 286 passed (green; verifies shared-lockfile dedupe didn't break web)
- [x] `pnpm --filter api type-check` clean (0 errors)
- [x] `pnpm --filter web type-check` clean (0 errors; only a pre-existing unrelated Select.tsx deprecation hint)
- [x] `pnpm exec biome check` clean on all changed files
- [x] `pnpm install` produces zero lockfile drift; lockfile diff is purely postcss/browserslist collapse — zero astro-version changes
- [x] `pnpm gen:docs` produces no drift (generated catalog/conventions unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PCF5RkfY5t6Zwoeecvgfm
