### PR TITLE
PROJ-240/241/242: harden share tokens (authz, field visibility, revocation)

### DIFF
--- a/apps/api/src/routes/share.ts
+++ b/apps/api/src/routes/share.ts
@@ -1,10 +1,10 @@
 import type { HonoEnv } from "@projektor/types";
 import { Hono } from "hono";
 import { serviceErrToResponse } from "../http/error-adapter";
-import { createShareToken, getSharedIssue } from "../services/share";
+import { createShareToken, getSharedIssue, revokeShareToken } from "../services/share";
 import { ctxFromHono } from "../services/types";
 
-// Authenticated router — POST /api/issues/:id/share
+// Authenticated router — POST/DELETE /api/issues/:id/share
 const authedRouter = new Hono<HonoEnv>();
 
 authedRouter.post("/:id/share", async (c) => {
@@ -13,6 +13,17 @@ authedRouter.post("/:id/share", async (c) => {
 	try {
 		const result = await createShareToken(ctx, issueId);
 		return c.json(result, 201);
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
+});
+
+authedRouter.delete("/:id/share", async (c) => {
+	const ctx = ctxFromHono(c);
+	const issueId = c.req.param("id");
+	try {
+		await revokeShareToken(ctx, issueId);
+		return c.json({ ok: true });
 	} catch (e) {
 		return serviceErrToResponse(c, e);
 	}

--- a/apps/api/src/services/share.ts
+++ b/apps/api/src/services/share.ts
@@ -1,4 +1,4 @@
-import { NotFoundError } from "./errors";
+import { ForbiddenError, NotFoundError } from "./errors";
 import type { ServiceCtx } from "./types";
 
 async function hashToken(token: string): Promise<string> {
@@ -12,6 +12,8 @@ export async function createShareToken(
 	ctx: ServiceCtx,
 	issueId: string
 ): Promise<{ token: string; url: string }> {
+	if (ctx.role === "viewer") throw new ForbiddenError("Insufficient permissions");
+
 	const now = Math.floor(Date.now() / 1000);
 
 	// Verify the issue belongs to this workspace
@@ -93,10 +95,25 @@ export async function getSharedIssue(
 			`SELECT cfd.key, cfd.label, cfd.type, cfv.value
        FROM custom_field_values cfv
        JOIN custom_field_definitions cfd ON cfd.id = cfv.field_id
-       WHERE cfv.issue_id = ?`
+       WHERE cfv.issue_id = ? AND cfd.is_internal = 0`
 		)
 		.bind(tokenMeta.issue_id)
 		.all<{ key: string; label: string; type: string; value: string }>();
 
 	return { ...row, customFields: cfRows.results ?? [] };
+}
+
+export async function revokeShareToken(ctx: ServiceCtx, issueId: string): Promise<void> {
+	if (ctx.role === "viewer") throw new ForbiddenError("Insufficient permissions");
+
+	const issue = await ctx.db
+		.prepare("SELECT id FROM issues WHERE id = ? AND workspace_id = ?")
+		.bind(issueId, ctx.workspaceId)
+		.first<{ id: string }>();
+	if (!issue) throw new NotFoundError("Issue not found");
+
+	await ctx.db
+		.prepare("DELETE FROM share_tokens WHERE issue_id = ? AND workspace_id = ?")
+		.bind(issueId, ctx.workspaceId)
+		.run();
 }

--- a/apps/api/src/test/migrations.ts
+++ b/apps/api/src/test/migrations.ts
@@ -33,6 +33,7 @@ import m0029 from "../../../../packages/db/migrations/0029_issue_review_timestam
 import m0030 from "../../../../packages/db/migrations/0030_backfill_review_timestamp.sql?raw";
 import m0031 from "../../../../packages/db/migrations/0031_factory_health.sql?raw";
 import m0032 from "../../../../packages/db/migrations/0032_claim_conflicts.sql?raw";
+import m0033 from "../../../../packages/db/migrations/0033_custom_field_is_internal.sql?raw";
 
 export const MIGRATIONS = [
 	m0000,
@@ -68,4 +69,5 @@ export const MIGRATIONS = [
 	m0030,
 	m0031,
 	m0032,
+	m0033,
 ];

--- a/apps/api/src/test/share.test.ts
+++ b/apps/api/src/test/share.test.ts
@@ -132,4 +132,97 @@ describe("Share tokens", () => {
 			expect(res.status).toBe(200);
 		}
 	});
+
+	it("PROJ-240: viewer role cannot create a share link", async () => {
+		const viewerFixture = await seedIssueFixture({ role: "viewer" });
+		const res = await SELF.fetch(`http://localhost/api/issues/${viewerFixture.issueId}/share`, {
+			method: "POST",
+			headers: authHeaders(viewerFixture.token, viewerFixture.slug),
+		});
+		expect(res.status).toBe(403);
+	});
+
+	it("PROJ-241: excludes internal custom fields and includes non-internal ones from the public share payload", async () => {
+		const { env } = await import("cloudflare:test");
+		const now = Math.floor(Date.now() / 1000);
+
+		const internalFieldId = crypto.randomUUID();
+		await env.DB.prepare(
+			"INSERT INTO custom_field_definitions (id, workspace_id, project_id, key, label, type, options, created_at, is_internal) VALUES (?, ?, NULL, ?, ?, 'text', NULL, ?, 1)"
+		)
+			.bind(internalFieldId, workspaceId, "secret_notes", "Secret Notes", now)
+			.run();
+		await env.DB.prepare(
+			"INSERT INTO custom_field_values (issue_id, field_id, value) VALUES (?, ?, ?)"
+		)
+			.bind(issueId, internalFieldId, "confidential")
+			.run();
+
+		const publicFieldId = crypto.randomUUID();
+		await env.DB.prepare(
+			"INSERT INTO custom_field_definitions (id, workspace_id, project_id, key, label, type, options, created_at, is_internal) VALUES (?, ?, NULL, ?, ?, 'text', NULL, ?, 0)"
+		)
+			.bind(publicFieldId, workspaceId, "public_note", "Public Note", now)
+			.run();
+		await env.DB.prepare(
+			"INSERT INTO custom_field_values (issue_id, field_id, value) VALUES (?, ?, ?)"
+		)
+			.bind(issueId, publicFieldId, "hello world")
+			.run();
+
+		const createRes = await SELF.fetch(`http://localhost/api/issues/${issueId}/share`, {
+			method: "POST",
+			headers: authHeaders(token, slug),
+		});
+		const { token: shareToken } = (await createRes.json()) as { token: string; url: string };
+
+		const res = await SELF.fetch(`http://localhost/api/share/${shareToken}`);
+		expect(res.status).toBe(200);
+		const data = (await res.json()) as {
+			customFields: Array<{ key: string; value: string }>;
+		};
+		expect(data.customFields.some((f) => f.key === "secret_notes")).toBe(false);
+		expect(data.customFields.some((f) => f.key === "public_note")).toBe(true);
+	});
+
+	it("PROJ-242: revokes a share token so it no longer resolves", async () => {
+		const createRes = await SELF.fetch(`http://localhost/api/issues/${issueId}/share`, {
+			method: "POST",
+			headers: authHeaders(token, slug),
+		});
+		const { token: shareToken } = (await createRes.json()) as { token: string; url: string };
+
+		const revokeRes = await SELF.fetch(`http://localhost/api/issues/${issueId}/share`, {
+			method: "DELETE",
+			headers: authHeaders(token, slug),
+		});
+		expect(revokeRes.status).toBe(200);
+
+		const res = await SELF.fetch(`http://localhost/api/share/${shareToken}`);
+		expect(res.status).toBe(404);
+	});
+
+	it("PROJ-242: viewer role cannot revoke a share link", async () => {
+		const viewerFixture = await seedIssueFixture({ role: "viewer" });
+		const { env } = await import("cloudflare:test");
+		const now = Math.floor(Date.now() / 1000);
+		await env.DB.prepare(
+			"INSERT INTO share_tokens (id, issue_id, workspace_id, created_by, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?)"
+		)
+			.bind(
+				await hashToken("11111111111111111111111111111111"),
+				viewerFixture.issueId,
+				viewerFixture.workspaceId,
+				viewerFixture.userId,
+				now + 86400,
+				now
+			)
+			.run();
+
+		const res = await SELF.fetch(`http://localhost/api/issues/${viewerFixture.issueId}/share`, {
+			method: "DELETE",
+			headers: authHeaders(viewerFixture.token, viewerFixture.slug),
+		});
+		expect(res.status).toBe(403);
+	});
 });

--- a/packages/db/migrations/0033_custom_field_is_internal.sql
+++ b/packages/db/migrations/0033_custom_field_is_internal.sql
@@ -1,0 +1,5 @@
+-- PROJ-241: custom field definitions have no privacy flag, so getSharedIssue (public,
+-- unauthenticated) leaks every custom field on a shared issue. Add an opt-in visibility
+-- flag defaulting to internal (1) so existing and newly created fields stay hidden from
+-- public share payloads unless explicitly marked otherwise.
+ALTER TABLE `custom_field_definitions` ADD COLUMN `is_internal` integer NOT NULL DEFAULT 1;

--- a/packages/db/src/schema/custom-fields.ts
+++ b/packages/db/src/schema/custom-fields.ts
@@ -15,6 +15,7 @@ export const customFieldDefinitions = sqliteTable(
 		type: text("type", { enum: ["text", "number", "select", "date", "user"] }).notNull(),
 		options: text("options"),
 		createdAt: integer("created_at").notNull(),
+		isInternal: integer("is_internal", { mode: "boolean" }).notNull().default(true),
 	},
 	(t) => ({
 		wsIdx: index("cfd_workspace_idx").on(t.workspaceId),


### PR DESCRIPTION
## Summary

Three related hardening fixes for the public issue-sharing feature, implemented together since they share `services/share.ts`:

- **PROJ-240** — `createShareToken` never checked `ctx.role`, so a `viewer` could create public share links. Added a role check (blocking `viewer`, matching the pattern used elsewhere e.g. `issue-links.ts`/`wiki.ts`) that throws `ForbiddenError` → 403.
- **PROJ-241** — `getSharedIssue` selected every `custom_field_values` row for the shared issue with no privacy filter. Added an `is_internal` boolean column to `custom_field_definitions` (migration `0033_custom_field_is_internal.sql`, defaults to `1`/internal — opt-in to public sharing, so nothing leaks by default), updated the Drizzle schema, and filtered the public share query on `cfd.is_internal = 0`. I did **not** expose a way to toggle this flag via the existing custom-fields create/update routes/service/schema (out of scope for `services/share.ts` file ownership in this batch, and those files are owned by another domain) — worth a fast-follow ticket for an admin UI/API to mark specific fields shareable.
- **PROJ-242** — there was no revocation path for share tokens. Added `revokeShareToken` to `services/share.ts` and `DELETE /api/issues/:id/share`, gated by the same viewer-blocked + workspace-scoped check as creation (same route mount as POST, so it reuses the existing authenticated router).

Per AGENTS.md's REST↔MCP parity exceptions, public issue sharing stays REST-only — no MCP surface added.

## Test plan
- [x] Added to `test/share.test.ts`: viewer blocked from creating a share link (403)
- [x] Added: internal custom field excluded from public payload, non-internal field included
- [x] Added: revoke removes the token so the public GET 404s afterward
- [x] Added: viewer blocked from revoking a share link (403)
- [x] `pnpm lint`
- [x] `pnpm turbo type-check`
- [x] `pnpm --filter @projektor/api test` (664 passed)
- [x] Registered migration 0033 in `apps/api/src/test/migrations.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfH2XeGNAkSbpuZeY5Xdx9