### PR TITLE
Frontend test coverage: MyIssues/ShareView unit tests + epics/my-issues/tokens/share/auth E2E (PROJ-217, PROJ-218, PROJ-222)

### DIFF
--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * PROJ-222: E2E coverage for the auth/login flow.
+ *
+ * Tests:
+ *  1. GET /auth/me returns the authenticated user + their workspaces
+ *     (dev-bypass auth on the target deployment).
+ *  2. GET /auth/login redirects (302) to the Cloudflare Access login URL,
+ *     preserving the requested redirect_url.
+ *
+ * Prerequisites: globalSetup must have written e2e/.e2e-ctx.json.
+ * Target: E2E_BASE_URL pointing at a dev deployment (ENVIRONMENT=development,
+ * DEV_USER_EMAIL set for the server-side auth bypass).
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { expect, test } from "@playwright/test";
+import type { E2EContext } from "./global-setup";
+
+function readCtx(): E2EContext {
+	const file = path.resolve(process.cwd(), "e2e", ".e2e-ctx.json");
+	if (!fs.existsSync(file)) {
+		throw new Error(
+			"e2e/.e2e-ctx.json not found — did globalSetup succeed?\n" +
+				"Run with E2E_BASE_URL set to a dev deployment."
+		);
+	}
+	return JSON.parse(fs.readFileSync(file, "utf-8")) as E2EContext;
+}
+
+test.describe("Auth flow", () => {
+	test("GET /auth/me returns the authenticated user and their workspaces", async ({ request }) => {
+		test.skip(!process.env.E2E_BASE_URL, "E2E_BASE_URL not set — skipping live deployment test");
+
+		const ctx = readCtx();
+		const res = await request.get("/auth/me", {
+			headers: { "X-Workspace-Slug": ctx.workspaceSlug },
+		});
+		expect(res.ok()).toBe(true);
+
+		const body = (await res.json()) as {
+			user: { id: string; email: string };
+			workspaces: Array<{ slug: string }>;
+		};
+		expect(body.user.id).toBeTruthy();
+		expect(body.user.email).toBeTruthy();
+		expect(body.workspaces.some((w) => w.slug === ctx.workspaceSlug)).toBe(true);
+	});
+
+	test("GET /auth/login redirects to the Cloudflare Access login URL", async ({ request }) => {
+		test.skip(!process.env.E2E_BASE_URL, "E2E_BASE_URL not set — skipping live deployment test");
+
+		const res = await request.get("/auth/login?redirect_url=%2Fmy-issues", {
+			maxRedirects: 0,
+		});
+		expect(res.status()).toBe(302);
+
+		const location = res.headers().location ?? "";
+		expect(location).toContain("/cdn-cgi/access/login");
+		expect(location).toContain(encodeURIComponent("/my-issues"));
+	});
+});

--- a/apps/web/e2e/epics.spec.ts
+++ b/apps/web/e2e/epics.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * PROJ-222: E2E coverage for the Epics page.
+ *
+ * Tests:
+ *  1. Navigate to /epics for the seeded project and confirm the page renders.
+ *  2. Create a new epic via the "+ New Epic" modal.
+ *  3. Assert it appears in the epics table.
+ *  4. Filter by priority via the Filters popover and assert the epic disappears
+ *     when the filter doesn't match, then reappears when cleared.
+ *
+ * Prerequisites: globalSetup must have written e2e/.e2e-ctx.json.
+ * Target: E2E_BASE_URL pointing at a dev deployment (ENVIRONMENT=development,
+ * DEV_USER_EMAIL set for the server-side auth bypass).
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { expect, test, type Page } from "@playwright/test";
+import type { E2EContext } from "./global-setup";
+
+const EPIC_TITLE = "E2E Test Epic";
+
+function readCtx(): E2EContext {
+	const file = path.resolve(process.cwd(), "e2e", ".e2e-ctx.json");
+	if (!fs.existsSync(file)) {
+		throw new Error(
+			"e2e/.e2e-ctx.json not found — did globalSetup succeed?\n" +
+				"Run with E2E_BASE_URL set to a dev deployment."
+		);
+	}
+	return JSON.parse(fs.readFileSync(file, "utf-8")) as E2EContext;
+}
+
+/** Navigate to /epics scoped to the seeded project, inject the workspace slug, and reload. */
+async function openEpics(page: Page, ctx: E2EContext) {
+	await page.goto(`/epics?projectId=${encodeURIComponent(ctx.grantedProjectId)}`);
+	await page.evaluate(
+		({ slug }: { slug: string }) => {
+			localStorage.setItem("workspace-slug", slug);
+		},
+		{ slug: ctx.workspaceSlug }
+	);
+	await page.reload();
+}
+
+test.describe("Epics page", () => {
+	test("creates an epic, sees it in the table, and filters it by priority", async ({ page }) => {
+		test.skip(!process.env.E2E_BASE_URL, "E2E_BASE_URL not set — skipping live deployment test");
+
+		const ctx = readCtx();
+		await openEpics(page, ctx);
+
+		// Page heading always renders (before async data).
+		await expect(page.locator("h1", { hasText: "Epics" })).toBeVisible({ timeout: 15_000 });
+
+		// -----------------------------------------------------------------------
+		// Step 1: Create a new epic
+		// -----------------------------------------------------------------------
+		const newEpicBtn = page.locator("button", { hasText: "+ New Epic" });
+		await expect(newEpicBtn).toBeVisible({ timeout: 15_000 });
+		await newEpicBtn.click();
+
+		await expect(page.locator('[role="dialog"]', { hasText: "New Epic" })).toBeVisible({
+			timeout: 5_000,
+		});
+
+		await page.locator("#create-epic-title").fill(EPIC_TITLE);
+		await page.locator("button", { hasText: "Create Epic" }).click();
+
+		// -----------------------------------------------------------------------
+		// Step 2: Verify it appears in the epics table
+		// -----------------------------------------------------------------------
+		const epicRow = page.locator('table[aria-label="Epics"] a', { hasText: EPIC_TITLE });
+		await expect(epicRow).toBeVisible({ timeout: 15_000 });
+
+		// -----------------------------------------------------------------------
+		// Step 3: Filter by a priority the new epic doesn't have — it should disappear
+		// -----------------------------------------------------------------------
+		await page.locator("button", { hasText: /^Filters/ }).click();
+		await page.locator("button", { hasText: "urgent" }).click();
+
+		await expect(
+			page.locator("p", { hasText: "No epics match the active filters." })
+		).toBeVisible({ timeout: 10_000 });
+		await expect(epicRow).not.toBeVisible();
+
+		// -----------------------------------------------------------------------
+		// Step 4: Clear filters — the epic should reappear
+		// -----------------------------------------------------------------------
+		await page.locator("button", { hasText: "✕ Clear all" }).click();
+		await expect(epicRow).toBeVisible({ timeout: 10_000 });
+	});
+});

--- a/apps/web/e2e/my-issues.spec.ts
+++ b/apps/web/e2e/my-issues.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * PROJ-222: E2E coverage for the My Issues page.
+ *
+ * Tests:
+ *  1. Create an issue assigned to the dev-bypass user via the API.
+ *  2. Navigate to /my-issues and confirm the issue appears grouped under its project.
+ *  3. Mark the issue done, confirm it disappears from the default (open-only) view.
+ *  4. Toggle "Include done" and confirm it reappears.
+ *
+ * Prerequisites: globalSetup must have written e2e/.e2e-ctx.json.
+ * Target: E2E_BASE_URL pointing at a dev deployment (ENVIRONMENT=development,
+ * DEV_USER_EMAIL set for the server-side auth bypass).
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { expect, test, type Page } from "@playwright/test";
+import type { E2EContext } from "./global-setup";
+
+const ISSUE_TITLE = "E2E my-issues test issue";
+
+function readCtx(): E2EContext {
+	const file = path.resolve(process.cwd(), "e2e", ".e2e-ctx.json");
+	if (!fs.existsSync(file)) {
+		throw new Error(
+			"e2e/.e2e-ctx.json not found — did globalSetup succeed?\n" +
+				"Run with E2E_BASE_URL set to a dev deployment."
+		);
+	}
+	return JSON.parse(fs.readFileSync(file, "utf-8")) as E2EContext;
+}
+
+async function openMyIssues(page: Page, ctx: E2EContext) {
+	await page.goto("/my-issues");
+	await page.evaluate(
+		({ slug }: { slug: string }) => {
+			localStorage.setItem("workspace-slug", slug);
+		},
+		{ slug: ctx.workspaceSlug }
+	);
+	await page.reload();
+}
+
+test.describe("My Issues page", () => {
+	test("shows an issue assigned to the current user, respects the done filter", async ({
+		page,
+		request,
+	}) => {
+		test.skip(!process.env.E2E_BASE_URL, "E2E_BASE_URL not set — skipping live deployment test");
+
+		const ctx = readCtx();
+
+		// Resolve the dev-bypass user id via /auth/me.
+		const meRes = await request.get("/auth/me", {
+			headers: { "X-Workspace-Slug": ctx.workspaceSlug },
+		});
+		expect(meRes.ok()).toBe(true);
+		const me = (await meRes.json()) as { user: { id: string } };
+
+		// Find a "done" status to move the issue to later.
+		const statusesRes = await request.get("/api/task-statuses", {
+			headers: { "X-Workspace-Slug": ctx.workspaceSlug },
+		});
+		const statuses = (await statusesRes.json()) as Array<{ id: string; category: string }>;
+		const doneStatus = statuses.find((s) => s.category === "done");
+		expect(doneStatus).toBeTruthy();
+
+		// Create an issue assigned to the current (dev-bypass) user.
+		const createRes = await request.post("/api/issues", {
+			headers: { "X-Workspace-Slug": ctx.workspaceSlug },
+			data: {
+				projectId: ctx.grantedProjectId,
+				title: ISSUE_TITLE,
+				priority: "medium",
+				assigneeId: me.user.id,
+			},
+		});
+		expect(createRes.status()).toBe(201);
+		const issue = (await createRes.json()) as { id: string };
+
+		// -----------------------------------------------------------------------
+		// Step 1: Issue appears on /my-issues by default (open)
+		// -----------------------------------------------------------------------
+		await openMyIssues(page, ctx);
+		await expect(page.locator("h1", { hasText: "My Issues" })).toBeVisible({ timeout: 15_000 });
+
+		const issueEntry = page.getByText(ISSUE_TITLE).first();
+		await expect(issueEntry).toBeVisible({ timeout: 15_000 });
+
+		// -----------------------------------------------------------------------
+		// Step 2: Mark the issue done via the API, reload — it should disappear
+		// -----------------------------------------------------------------------
+		const patchRes = await request.patch(`/api/issues/${issue.id}`, {
+			headers: { "X-Workspace-Slug": ctx.workspaceSlug },
+			data: { statusId: doneStatus?.id },
+		});
+		expect(patchRes.ok()).toBe(true);
+
+		await page.reload();
+		await expect(page.locator("h1", { hasText: "My Issues" })).toBeVisible({ timeout: 15_000 });
+		await expect(page.getByText(ISSUE_TITLE)).toHaveCount(0, { timeout: 10_000 });
+
+		// -----------------------------------------------------------------------
+		// Step 3: Toggle "Include done" — the issue reappears
+		// -----------------------------------------------------------------------
+		await page.getByLabel(/Include done/i).check();
+		await expect(page.getByText(ISSUE_TITLE).first()).toBeVisible({ timeout: 10_000 });
+	});
+});

--- a/apps/web/e2e/settings-tokens.spec.ts
+++ b/apps/web/e2e/settings-tokens.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * PROJ-222: E2E coverage for the Settings → API Tokens page.
+ *
+ * Tests:
+ *  1. Navigate to /settings/tokens and confirm the page renders.
+ *  2. Create a new API token via the form.
+ *  3. Assert the one-time token panel appears and the token is listed in the table.
+ *  4. Revoke the token and confirm it's removed from the list.
+ *
+ * Prerequisites: globalSetup must have written e2e/.e2e-ctx.json.
+ * Target: E2E_BASE_URL pointing at a dev deployment (ENVIRONMENT=development,
+ * DEV_USER_EMAIL set for the server-side auth bypass).
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { expect, test, type Page } from "@playwright/test";
+import type { E2EContext } from "./global-setup";
+
+function readCtx(): E2EContext {
+	const file = path.resolve(process.cwd(), "e2e", ".e2e-ctx.json");
+	if (!fs.existsSync(file)) {
+		throw new Error(
+			"e2e/.e2e-ctx.json not found — did globalSetup succeed?\n" +
+				"Run with E2E_BASE_URL set to a dev deployment."
+		);
+	}
+	return JSON.parse(fs.readFileSync(file, "utf-8")) as E2EContext;
+}
+
+async function openTokens(page: Page, ctx: E2EContext) {
+	await page.goto("/settings/tokens");
+	await page.evaluate(
+		({ slug }: { slug: string }) => {
+			localStorage.setItem("workspace-slug", slug);
+		},
+		{ slug: ctx.workspaceSlug }
+	);
+	await page.reload();
+}
+
+test.describe("Settings → API Tokens page", () => {
+	test("creates a token, sees the one-time reveal and table row, then revokes it", async ({
+		page,
+	}) => {
+		test.skip(!process.env.E2E_BASE_URL, "E2E_BASE_URL not set — skipping live deployment test");
+
+		const ctx = readCtx();
+		const tokenName = `E2E Test Token ${Date.now()}`;
+
+		await openTokens(page, ctx);
+
+		// Heading always renders (before async data).
+		await expect(page.locator("h1", { hasText: "API Tokens" })).toBeVisible({ timeout: 15_000 });
+
+		// -----------------------------------------------------------------------
+		// Step 1: Open the create form and submit
+		// -----------------------------------------------------------------------
+		const newTokenBtn = page.locator("button", { hasText: "+ New token" });
+		await expect(newTokenBtn).toBeVisible({ timeout: 15_000 });
+		await newTokenBtn.click();
+
+		await expect(page.locator("h3", { hasText: "New API token" })).toBeVisible({ timeout: 5_000 });
+		await page.locator("#tok-name").fill(tokenName);
+		await page.locator("button", { hasText: "Create token" }).click();
+
+		// -----------------------------------------------------------------------
+		// Step 2: One-time token reveal panel appears
+		// -----------------------------------------------------------------------
+		await expect(page.locator("p", { hasText: `Token created: ${tokenName}` })).toBeVisible({
+			timeout: 10_000,
+		});
+		await expect(page.locator("code")).toBeVisible();
+
+		await page.locator("button", { hasText: "Done" }).click();
+
+		// -----------------------------------------------------------------------
+		// Step 3: Token appears in the table
+		// -----------------------------------------------------------------------
+		const tokenRow = page.locator("tr", { hasText: tokenName });
+		await expect(tokenRow).toBeVisible({ timeout: 10_000 });
+
+		// -----------------------------------------------------------------------
+		// Step 4: Revoke the token
+		// -----------------------------------------------------------------------
+		await tokenRow.locator("button", { hasText: "Revoke" }).click();
+		await tokenRow.locator("button", { hasText: "Yes" }).click();
+
+		await expect(page.locator("tr", { hasText: tokenName })).toHaveCount(0, { timeout: 10_000 });
+	});
+});

--- a/apps/web/e2e/share.spec.ts
+++ b/apps/web/e2e/share.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * PROJ-222: E2E coverage for the public (unauthenticated) share view.
+ *
+ * Tests:
+ *  1. Create an issue and a share link for it via the API.
+ *  2. Navigate to /share/:token with no auth headers and confirm the issue
+ *     title, priority, and project render.
+ *  3. Navigate to /share/:token for a nonexistent token and confirm the
+ *     "not found or expired" state renders.
+ *
+ * Prerequisites: globalSetup must have written e2e/.e2e-ctx.json.
+ * Target: E2E_BASE_URL pointing at a dev deployment (ENVIRONMENT=development,
+ * DEV_USER_EMAIL set for the server-side auth bypass).
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { expect, test } from "@playwright/test";
+import type { E2EContext } from "./global-setup";
+
+const ISSUE_TITLE = "E2E share view test issue";
+
+function readCtx(): E2EContext {
+	const file = path.resolve(process.cwd(), "e2e", ".e2e-ctx.json");
+	if (!fs.existsSync(file)) {
+		throw new Error(
+			"e2e/.e2e-ctx.json not found — did globalSetup succeed?\n" +
+				"Run with E2E_BASE_URL set to a dev deployment."
+		);
+	}
+	return JSON.parse(fs.readFileSync(file, "utf-8")) as E2EContext;
+}
+
+test.describe("Public share view", () => {
+	test("renders a shared issue's title, priority, and project with no auth", async ({
+		page,
+		request,
+	}) => {
+		test.skip(!process.env.E2E_BASE_URL, "E2E_BASE_URL not set — skipping live deployment test");
+
+		const ctx = readCtx();
+
+		const createRes = await request.post("/api/issues", {
+			headers: { "X-Workspace-Slug": ctx.workspaceSlug },
+			data: {
+				projectId: ctx.grantedProjectId,
+				title: ISSUE_TITLE,
+				priority: "urgent",
+			},
+		});
+		expect(createRes.status()).toBe(201);
+		const issue = (await createRes.json()) as { id: string };
+
+		const shareRes = await request.post(`/api/issues/${issue.id}/share`, {
+			headers: { "X-Workspace-Slug": ctx.workspaceSlug },
+		});
+		expect(shareRes.status()).toBe(201);
+		const share = (await shareRes.json()) as { token: string };
+
+		// Fresh, unauthenticated context — no CF Access / bearer headers from
+		// playwright.config.ts should be required for this public route.
+		const publicContext = await page.context().browser()?.newContext();
+		const publicPage = await publicContext?.newPage();
+		if (!publicPage) throw new Error("failed to create an unauthenticated browser context");
+
+		try {
+			await publicPage.goto(`/share/${share.token}`);
+			await expect(publicPage.locator("h1", { hasText: ISSUE_TITLE })).toBeVisible({
+				timeout: 15_000,
+			});
+			await expect(publicPage.getByText("Urgent")).toBeVisible();
+			await expect(publicPage.getByText(new RegExp(ctx.grantedProjectKey))).toBeVisible();
+		} finally {
+			await publicContext?.close();
+		}
+	});
+
+	test("shows the expired/not-found state for a nonexistent share token", async ({ page }) => {
+		test.skip(!process.env.E2E_BASE_URL, "E2E_BASE_URL not set — skipping live deployment test");
+
+		await page.goto("/share/this-token-does-not-exist");
+		await expect(page.locator("h2", { hasText: "Link not found or expired" })).toBeVisible({
+			timeout: 15_000,
+		});
+	});
+});

--- a/apps/web/src/islands/MyIssues.test.tsx
+++ b/apps/web/src/islands/MyIssues.test.tsx
@@ -123,7 +123,10 @@ describe("MyIssues — loading and error states", () => {
 			vi.fn().mockImplementation((url: string) => {
 				const u = String(url);
 				if (u.includes("/auth/me"))
-					return Promise.resolve({ ok: true, json: () => Promise.resolve({ user: { id: USER_ID } }) });
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve({ user: { id: USER_ID } }),
+					});
 				return Promise.reject(new Error("boom"));
 			})
 		);
@@ -162,7 +165,9 @@ describe("MyIssues — cross-project fetch and grouping", () => {
 		render(<MyIssues />);
 		await waitForLoaded();
 
-		await waitFor(() => expect(screen.getAllByText("Open issue in Alpha").length).toBeGreaterThan(0));
+		await waitFor(() =>
+			expect(screen.getAllByText("Open issue in Alpha").length).toBeGreaterThan(0)
+		);
 		expect(screen.queryAllByText("Done issue in Alpha")).toHaveLength(0);
 	});
 

--- a/apps/web/src/islands/MyIssues.test.tsx
+++ b/apps/web/src/islands/MyIssues.test.tsx
@@ -1,0 +1,242 @@
+// MyIssues island — mock-fetch tests.
+//
+// MyIssues first resolves the current user via /auth/me, then fetches
+// /api/issues?assignee=<userId> and groups the results by project. The
+// pattern: stub global fetch to branch on URL, render, and await the
+// post-load UI (view-mode buttons in IssueList's pattern don't apply here —
+// instead wait for the "Include done" checkbox which only renders post-load).
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/preact";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Issue } from "./board-utils";
+import MyIssues from "./MyIssues";
+
+const USER_ID = "user-1";
+
+const OPEN_ISSUE_PROJ_A: Issue = {
+	id: "i1",
+	number: 1,
+	title: "Open issue in Alpha",
+	priority: "high",
+	assignee_id: USER_ID,
+	assignee_name: "Test User",
+	parent_id: null,
+	project_key: "ALPHA",
+	project_name: "Alpha Project",
+	type_key: null,
+	type_name: null,
+	status_id: "st-todo",
+	status_key: "todo",
+	status_name: "Todo",
+	status_category: "todo",
+	sprint_id: null,
+	updated_at: 1000,
+	created_at: 1000,
+};
+
+const DONE_ISSUE_PROJ_A: Issue = {
+	id: "i2",
+	number: 2,
+	title: "Done issue in Alpha",
+	priority: "low",
+	assignee_id: USER_ID,
+	assignee_name: "Test User",
+	parent_id: null,
+	project_key: "ALPHA",
+	project_name: "Alpha Project",
+	type_key: null,
+	type_name: null,
+	status_id: "st-done",
+	status_key: "done",
+	status_name: "Done",
+	status_category: "done",
+	sprint_id: null,
+	updated_at: 2000,
+	created_at: 1000,
+};
+
+const OPEN_ISSUE_PROJ_B: Issue = {
+	id: "i3",
+	number: 5,
+	title: "Open issue in Beta",
+	priority: "medium",
+	assignee_id: USER_ID,
+	assignee_name: "Test User",
+	parent_id: null,
+	project_key: "BETA",
+	project_name: "Beta Project",
+	type_key: null,
+	type_name: null,
+	status_id: "st-todo",
+	status_key: "todo",
+	status_name: "Todo",
+	status_category: "todo",
+	sprint_id: null,
+	updated_at: 1500,
+	created_at: 1000,
+};
+
+function setupFetch(issues: Issue[] = [OPEN_ISSUE_PROJ_A, DONE_ISSUE_PROJ_A, OPEN_ISSUE_PROJ_B]) {
+	return vi.fn().mockImplementation((url: string) => {
+		const u = String(url);
+		if (u.includes("/auth/me")) {
+			return Promise.resolve({ ok: true, json: () => Promise.resolve({ user: { id: USER_ID } }) });
+		}
+		if (u.includes("/api/issues")) {
+			return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: issues }) });
+		}
+		return Promise.reject(new Error(`unexpected fetch: ${u}`));
+	});
+}
+
+async function waitForLoaded() {
+	await waitFor(() => screen.getByLabelText(/Include done/i));
+}
+
+afterEach(() => {
+	cleanup();
+	vi.unstubAllGlobals();
+});
+
+describe("MyIssues — loading and error states", () => {
+	it("shows a loading indicator before data resolves", () => {
+		vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => {})));
+		render(<MyIssues />);
+		expect(screen.getByText(/Loading/i)).toBeTruthy();
+	});
+
+	it("shows an error message when /auth/me fails", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation((url: string) => {
+				if (String(url).includes("/auth/me")) return Promise.reject(new Error("network down"));
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [] }) });
+			})
+		);
+		render(<MyIssues />);
+		expect(await screen.findByRole("alert")).toBeTruthy();
+		expect(screen.getByText(/Failed to load issues/i)).toBeTruthy();
+	});
+
+	it("shows an error message when the issues fetch fails", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation((url: string) => {
+				const u = String(url);
+				if (u.includes("/auth/me"))
+					return Promise.resolve({ ok: true, json: () => Promise.resolve({ user: { id: USER_ID } }) });
+				return Promise.reject(new Error("boom"));
+			})
+		);
+		render(<MyIssues />);
+		expect(await screen.findByRole("alert")).toBeTruthy();
+	});
+});
+
+describe("MyIssues — cross-project fetch and grouping", () => {
+	it("resolves the user via /auth/me then fetches issues scoped to that assignee", async () => {
+		const mockFetch = setupFetch();
+		vi.stubGlobal("fetch", mockFetch);
+		render(<MyIssues />);
+		await waitForLoaded();
+
+		const calls = (mockFetch.mock.calls as [string, unknown][]).map(([u]) => String(u));
+		expect(calls.some((u) => u.includes("/auth/me"))).toBe(true);
+		expect(calls.some((u) => u.includes(`assignee=${USER_ID}`))).toBe(true);
+	});
+
+	it("groups issues by project under a heading per project", async () => {
+		vi.stubGlobal("fetch", setupFetch());
+		render(<MyIssues />);
+		await waitForLoaded();
+
+		// Titles render twice (desktop table + mobile card, toggled via CSS), so
+		// assert on the unique project heading and count of title occurrences.
+		expect(await screen.findByText("Alpha Project")).toBeTruthy();
+		expect(screen.getByText("Beta Project")).toBeTruthy();
+		expect(screen.getAllByText("Open issue in Alpha").length).toBeGreaterThan(0);
+		expect(screen.getAllByText("Open issue in Beta").length).toBeGreaterThan(0);
+	});
+
+	it("hides done issues by default", async () => {
+		vi.stubGlobal("fetch", setupFetch());
+		render(<MyIssues />);
+		await waitForLoaded();
+
+		await waitFor(() => expect(screen.getAllByText("Open issue in Alpha").length).toBeGreaterThan(0));
+		expect(screen.queryAllByText("Done issue in Alpha")).toHaveLength(0);
+	});
+
+	it("shows done issues once 'Include done' is checked", async () => {
+		vi.stubGlobal("fetch", setupFetch());
+		render(<MyIssues />);
+		await waitForLoaded();
+
+		fireEvent.click(screen.getByLabelText(/Include done/i));
+
+		await waitFor(() =>
+			expect(screen.getAllByText("Done issue in Alpha").length).toBeGreaterThan(0)
+		);
+	});
+
+	it("shows the issue count reflecting the current filter", async () => {
+		vi.stubGlobal("fetch", setupFetch());
+		render(<MyIssues />);
+		await waitForLoaded();
+
+		await waitFor(() => expect(screen.getByText("2 issues")).toBeTruthy());
+
+		fireEvent.click(screen.getByLabelText(/Include done/i));
+		await waitFor(() => expect(screen.getByText("3 issues")).toBeTruthy());
+	});
+});
+
+describe("MyIssues — empty states", () => {
+	it("shows the open-issues empty state when there are no assigned issues", async () => {
+		vi.stubGlobal("fetch", setupFetch([]));
+		render(<MyIssues />);
+		await waitForLoaded();
+
+		expect(await screen.findByText("No issues assigned to you")).toBeTruthy();
+		expect(screen.getByText(/Toggle "Include done"/i)).toBeTruthy();
+	});
+
+	it("shows the all-projects empty state once 'Include done' is toggled with no issues at all", async () => {
+		vi.stubGlobal("fetch", setupFetch([]));
+		render(<MyIssues />);
+		await waitForLoaded();
+
+		fireEvent.click(screen.getByLabelText(/Include done/i));
+
+		await waitFor(() =>
+			expect(screen.getByText("You have no issues across any project.")).toBeTruthy()
+		);
+	});
+});
+
+describe("MyIssues — workspace-slug header contract", () => {
+	it("includes X-Workspace-Slug header on both requests when workspaceSlug prop is passed", async () => {
+		const mockFetch = setupFetch();
+		vi.stubGlobal("fetch", mockFetch);
+		render(<MyIssues workspaceSlug="my-workspace" />);
+		await waitForLoaded();
+
+		const calls = mockFetch.mock.calls as [string, RequestInit][];
+		for (const [, init] of calls) {
+			const headers = (init?.headers as Record<string, string>) ?? {};
+			expect(headers["X-Workspace-Slug"]).toBe("my-workspace");
+		}
+	});
+
+	it("omits X-Workspace-Slug header when workspaceSlug prop is not passed", async () => {
+		const mockFetch = setupFetch();
+		vi.stubGlobal("fetch", mockFetch);
+		render(<MyIssues />);
+		await waitForLoaded();
+
+		const calls = mockFetch.mock.calls as [string, RequestInit][];
+		for (const [, init] of calls) {
+			const headers = (init?.headers as Record<string, string>) ?? {};
+			expect(headers["X-Workspace-Slug"]).toBeUndefined();
+		}
+	});
+});

--- a/apps/web/src/islands/ShareView.test.tsx
+++ b/apps/web/src/islands/ShareView.test.tsx
@@ -1,0 +1,157 @@
+// ShareView island — mock-fetch tests.
+//
+// ShareView is the public (unauthenticated) share-link view. It parses the
+// token out of window.location.pathname (/share/:token), fetches
+// /api/share/:token, and renders the issue or an error/expiry state. The
+// pattern: set the pathname via history.pushState, stub fetch, render, and
+// await the async result.
+import { cleanup, render, screen, waitFor } from "@testing-library/preact";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ShareView from "./ShareView";
+
+const SHARED_ISSUE = {
+	title: "Shared Bug Report",
+	body: "## Steps to reproduce\n\n1. Do the thing",
+	priority: "high",
+	status_name: "In Review",
+	status_category: "in_review",
+	project_key: "PROJ",
+	project_name: "Project",
+	assignee_name: "Jane Doe",
+	created_at: 1700000000,
+	expires_at: 1700600000,
+	customFields: [{ key: "story_points", label: "Story Points", type: "text", value: "5" }],
+};
+
+function setupFetch(body: unknown = SHARED_ISSUE, ok = true, status = 200) {
+	return vi.fn().mockImplementation(() =>
+		Promise.resolve({
+			ok,
+			status,
+			json: () => Promise.resolve(body),
+		})
+	);
+}
+
+beforeEach(() => {
+	history.pushState(null, "", "/share/tok-abc123");
+});
+
+afterEach(() => {
+	cleanup();
+	vi.unstubAllGlobals();
+	history.pushState(null, "", "/");
+});
+
+describe("ShareView — loading state", () => {
+	it("shows a loading indicator before the fetch resolves", () => {
+		vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => {})));
+		render(<ShareView />);
+		expect(screen.getByText(/Loading/i)).toBeTruthy();
+	});
+});
+
+describe("ShareView — data fetch/render path", () => {
+	it("fetches /api/share/:token parsed from the URL path", async () => {
+		const mockFetch = setupFetch();
+		vi.stubGlobal("fetch", mockFetch);
+		render(<ShareView />);
+
+		await waitFor(() => {
+			const calls = (mockFetch.mock.calls as [string, unknown][]).map(([u]) => String(u));
+			expect(calls.some((u) => u.includes("/api/share/tok-abc123"))).toBe(true);
+		});
+	});
+
+	it("renders the issue title, priority, status, and project", async () => {
+		vi.stubGlobal("fetch", setupFetch());
+		render(<ShareView />);
+
+		expect(await screen.findByText("Shared Bug Report")).toBeTruthy();
+		expect(screen.getByText("High")).toBeTruthy();
+		expect(screen.getByText("In Review")).toBeTruthy();
+		expect(screen.getByText(/Project \(PROJ\)/)).toBeTruthy();
+	});
+
+	it("renders the assignee name and formatted created date", async () => {
+		vi.stubGlobal("fetch", setupFetch());
+		render(<ShareView />);
+
+		expect(await screen.findByText(/Assignee: Jane Doe/)).toBeTruthy();
+		expect(screen.getByText(/Created Nov 14, 2023/)).toBeTruthy();
+	});
+
+	it("renders the markdown body as rendered HTML", async () => {
+		vi.stubGlobal("fetch", setupFetch());
+		render(<ShareView />);
+
+		await waitFor(() => expect(screen.getByText("Steps to reproduce")).toBeTruthy());
+		expect(screen.getByText("Do the thing")).toBeTruthy();
+	});
+
+	it("shows 'No description.' when body is null", async () => {
+		vi.stubGlobal("fetch", setupFetch({ ...SHARED_ISSUE, body: null }));
+		render(<ShareView />);
+
+		expect(await screen.findByText("No description.")).toBeTruthy();
+	});
+
+	it("renders custom fields when present", async () => {
+		vi.stubGlobal("fetch", setupFetch());
+		render(<ShareView />);
+
+		expect(await screen.findByText("Story Points")).toBeTruthy();
+		expect(screen.getByText("5")).toBeTruthy();
+	});
+
+	it("omits the custom fields section when there are none", async () => {
+		vi.stubGlobal("fetch", setupFetch({ ...SHARED_ISSUE, customFields: [] }));
+		render(<ShareView />);
+
+		await screen.findByText("Shared Bug Report");
+		expect(screen.queryByText("Story Points")).toBeNull();
+	});
+
+	it("shows the expiry banner with the formatted expiry date", async () => {
+		vi.stubGlobal("fetch", setupFetch());
+		render(<ShareView />);
+
+		expect(await screen.findByText(/Shared view · Expires Nov 21, 2023/)).toBeTruthy();
+	});
+});
+
+describe("ShareView — invalid link", () => {
+	it("shows the generic error state when the URL path doesn't match /share/:token", async () => {
+		history.pushState(null, "", "/not-a-share-link");
+		vi.stubGlobal("fetch", vi.fn());
+		render(<ShareView />);
+
+		expect(await screen.findByText("Something went wrong")).toBeTruthy();
+	});
+});
+
+describe("ShareView — expiry/error states", () => {
+	it("shows the 'not found or expired' state on a 404 response", async () => {
+		vi.stubGlobal("fetch", setupFetch({}, false, 404));
+		render(<ShareView />);
+
+		expect(await screen.findByText("Link not found or expired")).toBeTruthy();
+		expect(screen.getByText(/valid for 3 days/i)).toBeTruthy();
+	});
+
+	it("shows the generic error state on a non-404 failure", async () => {
+		vi.stubGlobal("fetch", setupFetch({}, false, 500));
+		render(<ShareView />);
+
+		expect(await screen.findByText("Something went wrong")).toBeTruthy();
+	});
+
+	it("provides a link back to the app in the error state", async () => {
+		vi.stubGlobal("fetch", setupFetch({}, false, 404));
+		render(<ShareView />);
+
+		await screen.findByText("Link not found or expired");
+		const link = screen.getByRole("link", { name: /Go to Projektor/i });
+		expect(link.getAttribute("href")).toBe("/");
+	});
+});


### PR DESCRIPTION
## Summary

- **PROJ-217**: Add `MyIssues.test.tsx` — covers the loading/error states, the cross-project `/auth/me` → `/api/issues?assignee=` fetch chain, project grouping, the "Include done" filter (default-hidden done issues, count text, empty states), and the workspace-slug header contract.
- **PROJ-218**: Add `ShareView.test.tsx` — covers the public share-link loading state, the data-fetch/render path (title, priority, status, project, assignee, date, markdown body, custom fields), the invalid-link case (no token in the path), and the expired/not-found (404) vs generic-error states.
- **PROJ-222**: Add five new Playwright specs following the existing pattern (skip via `test.skip(!process.env.E2E_BASE_URL, ...)`, so they require a live dev deployment and don't run in CI — same as the existing board/sprint/wiki-flow specs):
  - `e2e/epics.spec.ts` — create an epic, verify it renders in the table, filter by priority.
  - `e2e/my-issues.spec.ts` — assign an issue to the dev-bypass user, verify it appears on `/my-issues`, verify the done filter hides/shows it.
  - `e2e/settings-tokens.spec.ts` — create an API token, verify the one-time reveal panel and table row, then revoke it.
  - `e2e/share.spec.ts` — create a share link via the API and verify the public view renders with no auth headers, plus the not-found state for a bogus token.
  - `e2e/auth.spec.ts` — verify `/auth/me` returns the authenticated user + workspaces, and `/auth/login` redirects to the CF Access login URL preserving `redirect_url`.

No source files were modified — test-only changes. No bugs were found in `MyIssues.tsx` or `ShareView.tsx` while writing these tests.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm turbo type-check` — clean
- [x] `pnpm --filter @projektor/web test` — 311 tests passing (28 files)
- [x] `pnpm --filter @projektor/web build` — succeeds
- [x] `npx playwright test --list` — all 5 new specs discovered correctly across desktop/mobile projects (42 total tests); full runs require `E2E_BASE_URL` pointing at a live dev deployment (documented as a manual/non-CI step in this repo — see `ci.yml`), so they weren't executed end-to-end here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WvGJoDyqGTdAeo7q9HL9YN