### PR TITLE
PROJ-348: MCP workspace resolution without X-Workspace-Slug (unblock Claude app Connectors)

### DIFF
--- a/apps/api/src/middleware/workspace.ts
+++ b/apps/api/src/middleware/workspace.ts
@@ -40,6 +40,14 @@ async function warnIfIgnoredSubdomain(
 	}
 }
 
+// PROJ-348: the MCP endpoint (POST /mcp/<workspaceId>) carries the workspace UUID
+// in its path, so it can resolve the workspace without an X-Workspace-Slug header.
+// The Claude app's Connectors UI restricts custom request headers to a fixed
+// allowlist that excludes X-Workspace-Slug, so header-only resolution blocks it.
+function mcpWorkspaceIdFromPath(path: string): string | undefined {
+	return /^\/mcp\/([^/]+)$/.exec(path)?.[1];
+}
+
 export async function workspaceMiddleware(c: Context<HonoEnv>, next: Next) {
 	// Workspace resolved from the X-Workspace-Slug header, or (opt-in) the Host header's
 	// subdomain. See WORKSPACE_SUBDOMAIN_ROUTING in packages/types/src/env.ts. (PROJ-267)
@@ -47,7 +55,12 @@ export async function workspaceMiddleware(c: Context<HonoEnv>, next: Next) {
 	const routingEnabled = subdomainRoutingEnabled(c.env.WORKSPACE_SUBDOMAIN_ROUTING);
 	const slug = headerSlug ?? (routingEnabled ? c.req.header("host")?.split(".")[0] : undefined);
 
-	if (!slug) {
+	// PROJ-348: fall back to the MCP path's workspace UUID when no slug was resolved.
+	// The token-workspace-scope check below is unchanged and remains the security
+	// boundary — a token minted for another workspace is still rejected here.
+	const mcpWorkspaceId = slug ? undefined : mcpWorkspaceIdFromPath(c.req.path);
+
+	if (!slug && !mcpWorkspaceId) {
 		await warnIfIgnoredSubdomain(c, headerSlug, routingEnabled);
 		return c.json(
 			{
@@ -59,9 +72,13 @@ export async function workspaceMiddleware(c: Context<HonoEnv>, next: Next) {
 		);
 	}
 
-	const workspace = await c.env.DB.prepare("SELECT id, name, slug FROM workspaces WHERE slug = ?")
-		.bind(slug)
-		.first<{ id: string; name: string; slug: string }>();
+	const workspace = mcpWorkspaceId
+		? await c.env.DB.prepare("SELECT id, name, slug FROM workspaces WHERE id = ?")
+				.bind(mcpWorkspaceId)
+				.first<{ id: string; name: string; slug: string }>()
+		: await c.env.DB.prepare("SELECT id, name, slug FROM workspaces WHERE slug = ?")
+				.bind(slug)
+				.first<{ id: string; name: string; slug: string }>();
 
 	if (!workspace) return c.json({ error: "Workspace not found" }, 404);
 

--- a/apps/api/src/test/mcp-workspace-resolution.test.ts
+++ b/apps/api/src/test/mcp-workspace-resolution.test.ts
@@ -1,0 +1,89 @@
+import { SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { seedFixture, seedMember, seedToken } from "./helpers";
+
+// PROJ-348: the MCP endpoint (POST /mcp/<workspaceId>) must resolve its workspace
+// from the URL path UUID when no X-Workspace-Slug header is sent — the Claude app's
+// Connectors UI can't send custom headers. The token-workspace-scope check stays the
+// security boundary: a token minted for another workspace is still rejected.
+describe("MCP workspace resolution without X-Workspace-Slug (PROJ-348)", () => {
+	function mcpRequest(workspaceId: string, token: string, extraHeaders?: Record<string, string>) {
+		return SELF.fetch(`http://localhost/mcp/${workspaceId}`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
+				...extraHeaders,
+			},
+			body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
+		});
+	}
+
+	it("succeeds with only Authorization when the token matches the path workspace", async () => {
+		const fixture = await seedFixture();
+		const res = await mcpRequest(fixture.workspace.id, fixture.token);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { result?: { tools: unknown[] } };
+		expect(Array.isArray(body.result?.tools)).toBe(true);
+	});
+
+	it("rejects a token scoped to a different workspace than the path UUID (no slug header)", async () => {
+		const owner = await seedFixture();
+		const other = await seedFixture();
+		// owner's token is a member of `other` too, so the membership check would pass —
+		// only the token-workspace-scope check should reject the cross-workspace use.
+		await seedMember(other.workspace.id, owner.user.id, "member");
+
+		const res = await mcpRequest(other.workspace.id, owner.token);
+		expect(res.status).toBe(403);
+	});
+
+	it("returns 404 for an unknown workspace UUID in the path", async () => {
+		const fixture = await seedFixture();
+		const res = await mcpRequest(crypto.randomUUID(), fixture.token);
+		expect(res.status).toBe(404);
+	});
+
+	it("still honors an explicit X-Workspace-Slug header on the MCP route", async () => {
+		const fixture = await seedFixture();
+		const res = await mcpRequest(fixture.workspace.id, fixture.token, {
+			"X-Workspace-Slug": fixture.workspace.slug,
+		});
+		expect(res.status).toBe(200);
+	});
+
+	it("accepts a user-scoped (null-workspace) token against the path workspace", async () => {
+		const fixture = await seedFixture();
+		// A token whose workspace_id is the same workspace still works; a genuinely
+		// user-scoped token is exercised by auth tests. Here we confirm the happy path
+		// resolves purely from the path UUID.
+		const secondToken = await seedToken(fixture.workspace.id, fixture.user.id);
+		const res = await mcpRequest(fixture.workspace.id, secondToken);
+		expect(res.status).toBe(200);
+	});
+});
+
+// PROJ-348: the path-UUID fallback is scoped to the MCP route only. Non-MCP routes
+// must keep requiring X-Workspace-Slug (subdomain routing off by default).
+describe("non-MCP routes still require X-Workspace-Slug (PROJ-348 scope guard)", () => {
+	it("REST route without the header 400s naming the missing header", async () => {
+		const fixture = await seedFixture();
+		const res = await SELF.fetch("http://localhost/api/task-types", {
+			headers: { Authorization: `Bearer ${fixture.token}` },
+		});
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toContain("X-Workspace-Slug");
+	});
+
+	it("REST route with the header still resolves the workspace", async () => {
+		const fixture = await seedFixture();
+		const res = await SELF.fetch("http://localhost/api/task-types", {
+			headers: {
+				Authorization: `Bearer ${fixture.token}`,
+				"X-Workspace-Slug": fixture.workspace.slug,
+			},
+		});
+		expect(res.status).toBe(200);
+	});
+});

--- a/apps/api/src/test/workspace-subdomain-routing.test.ts
+++ b/apps/api/src/test/workspace-subdomain-routing.test.ts
@@ -34,16 +34,15 @@ describe("workspace subdomain routing (WORKSPACE_SUBDOMAIN_ROUTING)", () => {
 		expect(res.status).toBe(200);
 	});
 
+	// Uses a REST route: PROJ-348 gives the /mcp/<id> route a path-UUID fallback, so
+	// the "no header → 400" contract now only holds for non-MCP routes.
 	it("flag off + no header: clean 400 naming the missing header, Host subdomain is ignored", async () => {
 		const fixture = await seedFixture();
-		const res = await SELF.fetch(`http://localhost/mcp/${fixture.workspace.id}`, {
-			method: "POST",
+		const res = await SELF.fetch("http://localhost/api/task-types", {
 			headers: {
 				Authorization: `Bearer ${fixture.token}`,
 				Host: `${fixture.workspace.slug}.example.com`,
-				"Content-Type": "application/json",
 			},
-			body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
 		});
 		expect(res.status).toBe(400);
 		const body = (await res.json()) as { error: string };
@@ -83,14 +82,11 @@ describe("workspace subdomain routing (WORKSPACE_SUBDOMAIN_ROUTING)", () => {
 	it("flag off + no header + a resolvable subdomain warns before the 400", async () => {
 		const fixture = await seedFixture();
 		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-		const res = await SELF.fetch(`http://localhost/mcp/${fixture.workspace.id}`, {
-			method: "POST",
+		const res = await SELF.fetch("http://localhost/api/task-types", {
 			headers: {
 				Authorization: `Bearer ${fixture.token}`,
 				Host: `${fixture.workspace.slug}.example.com`,
-				"Content-Type": "application/json",
 			},
-			body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
 		});
 		expect(res.status).toBe(400);
 		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(fixture.workspace.slug));

--- a/apps/docs/src/content/docs/agents/mcp-connection.md
+++ b/apps/docs/src/content/docs/agents/mcp-connection.md
@@ -89,7 +89,7 @@ The Claude app (desktop and web, at claude.ai) doesn't use the `claude mcp add` 
 2. **Server URL:** paste `https://<your-worker>.workers.dev/mcp/<workspace-uuid>` - the same URL shape used in §3, with the workspace UUID (not the slug) in the path.
 3. **Headers:** open the **Request headers** section of the dialog and add:
    - `Authorization` → `Bearer pk_<64 hex chars>` (enter the scheme yourself - Claude sends the value verbatim, it does not prepend `Bearer`).
-   - `X-Workspace-Slug` → `<slug>`
+   - **No `X-Workspace-Slug` needed.** The MCP endpoint resolves the workspace from the UUID already in the server URL's path, so the app connects with the `Authorization` header alone (PROJ-348). The token stays workspace-scoped - a token minted for another workspace is still rejected regardless of the path.
    - If the instance is behind Cloudflare Access, also add `CF-Access-Client-Id` / `CF-Access-Client-Secret` as described in [§7](#7-cloudflare-access-note).
 4. Click **Add**. Claude calls `initialize` against the URL to confirm the connection before tools become available in a conversation.
 
@@ -98,7 +98,7 @@ For minting the `pk_...` token itself, use the same Settings → Tokens → "New
 :::caution
 **Request headers are a beta feature**, rolled out gradually - if you don't see a **Request headers** section in the dialog, contact Anthropic to request access.
 
-Header *names* are also restricted to an allowlist (`authorization`, `x-api-key`, `x-auth-token`, and similar standard names) - Claude rejects arbitrary custom header names for security reasons. `Authorization` is allowlisted, but **`X-Workspace-Slug` and the `CF-Access-Client-*` headers are non-standard names and may be rejected** unless Anthropic has added them to the allowlist for your organization. If the connector fails with an authorization error after adding these headers, ask your Anthropic representative to allowlist them, or use the Claude Code CLI path (§2/§3) instead, which sends arbitrary headers with no such restriction.
+Header *names* are restricted to an allowlist (`authorization`, `x-api-key`, `x-auth-token`, and similar standard names) - Claude rejects arbitrary custom header names for security reasons. `Authorization` is allowlisted, so the standard connection works out of the box. The one exception is a Cloudflare Access-protected instance: the `CF-Access-Client-*` header names are non-standard and may be rejected unless Anthropic has added them to the allowlist for your organization. If the connector fails with a `403` on such an instance, ask your Anthropic representative to allowlist those two headers, or use the Claude Code CLI path (§2/§3) instead, which sends arbitrary headers with no such restriction.
 :::
 
 ---
@@ -203,9 +203,15 @@ Content-Type: application/json
 | Header | Value |
 |--------|-------|
 | `Authorization` | `Bearer pk_<64 hex chars>` |
-| `X-Workspace-Slug` | `<slug>` |
+| `X-Workspace-Slug` | `<slug>` (optional on the MCP route - see below) |
 
 The token is workspace-scoped - a token from workspace A is rejected for workspace B.
+
+`X-Workspace-Slug` is **optional for `POST /mcp/<workspaceId>`**: when it's absent, the
+workspace is resolved from the UUID in the path (PROJ-348, so the Claude app can connect
+with only the `Authorization` header). Every other endpoint still requires it. The
+token-workspace scope check is unchanged either way - it, not the header, is the security
+boundary.
 
 ### initialize
 
@@ -249,6 +255,6 @@ Error codes: `-32600` invalid request, `-32601` method/tool not found, `-32602` 
 These are the load-bearing shapes the Worker enforces - verified against the source:
 
 - **MCP URL shape:** `POST /mcp/<workspaceId>` - UUID in the path, slug only in the header.
-- **Required headers:** both `Authorization` and `X-Workspace-Slug` must be present on every call.
+- **Required headers:** `Authorization` is always required. `X-Workspace-Slug` is required on every non-MCP endpoint; on `POST /mcp/<workspaceId>` it is optional because the path UUID resolves the workspace (PROJ-348).
 - **Token prefix:** `pk_` (64 hex chars); verified via SHA-256 hash lookup against D1.
 - **CORS:** both headers are in the Worker's explicit `allowHeaders` list.


### PR DESCRIPTION
## PROJ-348

`workspaceMiddleware` hard-required an `X-Workspace-Slug` header to resolve the workspace for MCP requests (`POST /mcp/<workspaceId>`). This blocked connecting projektor MCP to the **Claude app** (desktop/web) via Settings → Connectors, because the Connectors UI restricts custom request headers to a fixed allowlist (`authorization`, `x-api-key`, …) that excludes `X-Workspace-Slug`.

## Fix

The workspace UUID is already in the URL path (`/mcp/<workspaceId>`). When no slug is resolved (no `X-Workspace-Slug` header, no subdomain-routing match), the middleware now resolves the workspace from that path UUID — **but only on the MCP route**. Every other endpoint and the CLI path (`claude mcp add`) still require `X-Workspace-Slug` unchanged.

### Security invariant (unchanged)
The token-workspace scope check remains the security boundary. `tokenWorkspaceId` is set from the hashed-token → D1 lookup in `auth.ts` and checked independently of any header in `workspace.ts`: a token minted for workspace A used against workspace B's path UUID is rejected with `403` regardless of headers. This fix leans on that, it does not weaken it. The membership check is also unchanged.

## Tests
- **New `mcp-workspace-resolution.test.ts`:**
  - MCP succeeds with only `Authorization` when the token matches the path workspace
  - MCP rejected (`403`) when the token belongs to a different workspace than the path UUID, even with no slug header (and even when the user is a member of the target workspace — proving it's the token-scope check, not membership, doing the work)
  - unknown path UUID → `404`; explicit `X-Workspace-Slug` still honored on the MCP route
  - non-MCP routes still `400` without the header, and resolve with it (scope guard)
- Retargeted two `workspace-subdomain-routing` tests that had used `/mcp` as a vehicle for the "no header → 400" contract onto a REST route, since MCP now has the path fallback.

## Docs
Updated `apps/docs/.../agents/mcp-connection.md` §3b (Claude app) — removed the blocked-flag language, the app now connects with `Authorization` alone; updated the protocol-reference required-headers note accordingly.

## CI (all green locally)
- `pnpm lint`
- `pnpm turbo type-check`
- `pnpm --filter @projektor/api test` (703 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)