### PR TITLE
fix(api): bump chunk-boundary custom-fields test timeout to 15s

### DIFF
--- a/apps/api/src/test/custom-fields.test.ts
+++ b/apps/api/src/test/custom-fields.test.ts
@@ -615,5 +615,5 @@ describe("PROJ-197: batchLoadCustomFields is workspace-scoped", () => {
 			expect(loaded[issueIds[i]]).toHaveLength(1);
 			expect(loaded[issueIds[i]][0].value).toBe(String(i));
 		}
-	});
+	}, 15000); // seeds 95 issues sequentially; coverage instrumentation pushes this past the 5s default
 });


### PR DESCRIPTION
CI's PROJ-223 switch to `test:coverage` adds instrumentation overhead. The chunk-boundary test in custom-fields.test.ts seeds 95 issues sequentially and now sometimes exceeds vitest's 5s default timeout, flaking PRs unrelated to the change (seen on #82). Bumps that one test's timeout to 15s.