### PR TITLE
fix(web): avoid full page reload on project tab navigation (PROJ-350)

### DIFF
--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -1,4 +1,5 @@
 ---
+import { ClientRouter } from 'astro:transitions';
 import pkg from '../../package.json';
 
 interface Props {
@@ -27,6 +28,7 @@ const navItems = [
     <meta name="theme-color" content="#6366f1" />
     <link rel="apple-touch-icon" href="/icon-192.png" />
     <title>{title}</title>
+    <ClientRouter />
     <!-- safe-ls: 'theme' is a cosmetic preference (dark/light). No API dependency - a
          stale or missing value falls back to the system color-scheme media query. -->
     <script is:inline>


### PR DESCRIPTION
## Summary
- Every navigation in the app (including the Overview <-> Issues project tabs, which are plain `<a href>` links in `ProjectNav.tsx`) was a full browser document reload.
- Adds Astro's built-in `ClientRouter` (`astro:transitions`) to `Base.astro`, which fetches and swaps document content client-side instead of doing a full navigation, while keeping the app's standard MPA structure (each page still has its own URL/bundle/back-forward behavior).

**Tradeoff (documented per the ticket's acceptance criteria):** did not mark the sidebar with `transition:persist`. The sidebar's active-link highlighting (`isActive`) is computed server-side per-request from `Astro.url.pathname`; persisting the DOM node would freeze that highlight instead of updating it when navigating between unrelated sidebar items (Projects/My Issues/Groups/Tokens). `ClientRouter`'s default swap already eliminates the full-reload cost for all navigations, including the project tabs — persist can be added separately if sidebar flicker turns out to matter in practice.

## Test plan
- [x] `pnpm --filter web run type-check` — 0 errors
- [x] `pnpm --filter web exec vitest run src/islands/ProjectNav.test.tsx src/islands/ProjectLanding.test.tsx` — all pass
- [x] `pnpm --filter web run build` — succeeds; confirmed `astro-view-transitions-enabled` meta tag present in built `/projects/view` and `/issues` pages
- [x] Full pre-push suite (lint + api tests + web tests) — all green
- [ ] Manual click-through on a deployed preview to confirm via the Network tab that switching tabs no longer triggers a full "Document" navigation (couldn't spin up the full local Cloudflare Workers + D1 dev stack in this session — recommend a human click-through before merge, per this repo's deploy-verify-before-merge convention)

Closes PROJ-350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)