### PR TITLE
feat(web): add throughput and cumulative flow charts to project overview (PROJ-351)

### DIFF
--- a/apps/web/src/islands/MetricsDashboard.tsx
+++ b/apps/web/src/islands/MetricsDashboard.tsx
@@ -1,11 +1,20 @@
 import type { ComponentChildren } from "preact";
 import { useEffect, useMemo, useState } from "preact/hooks";
-import uPlot from "uplot";
+import type uPlot from "uplot";
 import { apiFetch } from "../utils/api-client";
 import CodeHeatmap from "./charts/CodeHeatmap";
 import UplotChart, { createTooltipPlugin } from "./charts/UplotChart";
 import { MetricHelp, SectionHeading } from "./MetricHelp";
 import { METRIC_DEFINITIONS, type MetricId } from "./metric-definitions";
+import {
+	CfdChart,
+	EmptyChartState,
+	formatFullDate,
+	formatShortDate,
+	readChartSeqColors,
+	readThemeColor,
+	ThroughputChart,
+} from "./metrics/flow-charts";
 import Select, { type SelectOption } from "./Select";
 
 interface Distribution {
@@ -143,37 +152,6 @@ function formatDuration(seconds: number | null): string {
 	if (abs < 3600) return `${(seconds / 60).toFixed(1)}m`;
 	if (abs < 86400) return `${(seconds / 3600).toFixed(1)}h`;
 	return `${(seconds / 86400).toFixed(1)}d`;
-}
-
-// uPlot bakes colors into the canvas at creation time, so callers re-read these live
-// (rather than caching) whenever a chart is (re)built, including on theme toggle.
-function readThemeColor(token: string, fallback: string): string {
-	const value = getComputedStyle(document.documentElement).getPropertyValue(token).trim();
-	return value || fallback;
-}
-
-function hexToRgba(hex: string, alpha: number): string {
-	const match = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
-	if (!match) return hex;
-	const [r, g, b] = match.slice(1).map((h) => parseInt(h, 16));
-	return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-}
-
-function formatShortDate(iso: string): string {
-	const d = new Date(`${iso}T00:00:00Z`);
-	if (Number.isNaN(d.getTime())) return iso;
-	return d.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
-}
-
-function formatFullDate(iso: string): string {
-	const d = new Date(`${iso}T00:00:00Z`);
-	if (Number.isNaN(d.getTime())) return iso;
-	return d.toLocaleDateString("en-US", {
-		month: "short",
-		day: "numeric",
-		year: "numeric",
-		timeZone: "UTC",
-	});
 }
 
 function useFlowMetrics(workspaceSlug: string | undefined, range: RangeState) {
@@ -355,73 +333,6 @@ function HealthTile({ metricId, value }: { metricId: MetricId; value: number }) 
 	);
 }
 
-function EmptyChartState({ message }: { message: string }) {
-	return (
-		<div class="flex items-center justify-center h-[220px] text-sm text-text-muted">{message}</div>
-	);
-}
-
-function ThroughputChart({ data }: { data: FlowMetrics["throughputOverTime"] }) {
-	const labels = useMemo(() => data.map((d) => d.bucketStart), [data]);
-	const chartData = useMemo<uPlot.AlignedData>(
-		() => [data.map((_, i) => i), data.map((d) => d.count)],
-		[data]
-	);
-
-	const buildOptions = useMemo(() => {
-		return (width: number, height: number): uPlot.Options => {
-			const accent = readThemeColor("--accent", "#4f46e5");
-			const border = readThemeColor("--border", "#e2e8f0");
-			const textMuted = readThemeColor("--text-muted", "#6b7280");
-
-			return {
-				width,
-				height,
-				scales: { x: { time: false } },
-				legend: { show: false },
-				series: [
-					{},
-					{
-						label: "Issues completed",
-						stroke: accent,
-						fill: hexToRgba(accent, 0.25),
-						paths: uPlot.paths.bars?.(),
-					},
-				],
-				axes: [
-					{
-						stroke: textMuted,
-						grid: { stroke: border },
-						splits: (u) => {
-							const n = labels.length;
-							const maxTicks = Math.max(2, Math.floor(u.width / 70));
-							const stride = Math.max(1, Math.ceil(n / maxTicks));
-							const idxs: number[] = [];
-							for (let i = 0; i < n; i += stride) idxs.push(i);
-							if (idxs[idxs.length - 1] !== n - 1) idxs.push(n - 1);
-							return idxs;
-						},
-						values: (_u, splits) => splits.map((s) => formatShortDate(labels[s] ?? "")),
-					},
-					{ stroke: textMuted, grid: { stroke: border } },
-				],
-				plugins: [
-					createTooltipPlugin({
-						formatX: (xVal) => formatFullDate(labels[xVal] ?? ""),
-						formatY: (yVal) => `${yVal} completed`,
-					}),
-				],
-			};
-		};
-	}, [labels]);
-
-	if (data.length === 0 || data.every((d) => d.count === 0)) {
-		return <EmptyChartState message="No completed issues yet" />;
-	}
-
-	return <UplotChart data={chartData} buildOptions={buildOptions} />;
-}
-
 // PROJ-331: bug share % trend line, chosen over stacked-bars-by-type per the ticket's
 // "or" — this dashboard already has a lot of charts landing in this epic, and a single
 // trend line answers the ticket's actual question ("is the factory shipping more
@@ -541,108 +452,6 @@ function ReviewLatencyChart({ data }: { data: FlowMetrics["reviewLatencyOverTime
 
 	if (data.length === 0 || data.every((d) => d.p50 === null)) {
 		return <EmptyChartState message="No review-latency data yet" />;
-	}
-
-	return <UplotChart data={chartData} buildOptions={buildOptions} />;
-}
-
-// PROJ-329: cumulative flow diagram. Bands are stacked bottom-up (done at the base,
-// backlog/todo on top) by plotting cumulative sums and drawing widest-first so each
-// later, narrower fill paints over the tail of the one before it — the classic uPlot
-// stacked-area trick, since uPlot has no native "stacked" series mode. Colors are a
-// single-hue ordinal ramp (lightest = earliest stage, darkest = done) rather than
-// unrelated categorical hues, since the bands read as an ordered progression, not
-// independent categories. Read from the --chart-seq-* tokens (Base.astro) rather than
-// baked-in hex so the ramp repaints on theme toggle, same as every other chart color here.
-function readChartSeqColors() {
-	return {
-		backlogTodo: readThemeColor("--chart-seq-1", "#86b6ef"),
-		inProgress: readThemeColor("--chart-seq-2", "#5598e7"),
-		inReview: readThemeColor("--chart-seq-3", "#2a78d6"),
-		done: readThemeColor("--chart-seq-4", "#1c5cab"),
-	};
-}
-
-function CfdChart({ data }: { data: FlowMetrics["cfdOverTime"] }) {
-	const labels = useMemo(() => data.map((d) => d.bucketStart), [data]);
-	const chartData = useMemo<uPlot.AlignedData>(() => {
-		const total = data.map((d) => d.backlogTodo + d.inProgress + d.inReview + d.done);
-		const upToInProgress = data.map((d) => d.inProgress + d.inReview + d.done);
-		const upToInReview = data.map((d) => d.inReview + d.done);
-		const done = data.map((d) => d.done);
-		return [data.map((_, i) => i), total, upToInProgress, upToInReview, done];
-	}, [data]);
-
-	const buildOptions = useMemo(() => {
-		return (width: number, height: number): uPlot.Options => {
-			const border = readThemeColor("--border", "#e2e8f0");
-			const textMuted = readThemeColor("--text-muted", "#6b7280");
-			const seq = readChartSeqColors();
-
-			return {
-				width,
-				height,
-				scales: { x: { time: false } },
-				legend: { show: true },
-				series: [
-					{},
-					// Series carry cumulative sums (for the stacked-area geometry), so the legend
-					// `value` de-cumulates each back to its own band count — otherwise the legend
-					// would report the running total, not the band's actual size.
-					{
-						label: "Backlog/todo",
-						stroke: seq.backlogTodo,
-						fill: seq.backlogTodo,
-						value: (u, _v, _si, i) =>
-							i == null ? "" : (u.data[1][i] as number) - (u.data[2][i] as number),
-					},
-					{
-						label: "In progress",
-						stroke: seq.inProgress,
-						fill: seq.inProgress,
-						value: (u, _v, _si, i) =>
-							i == null ? "" : (u.data[2][i] as number) - (u.data[3][i] as number),
-					},
-					{
-						label: "In review",
-						stroke: seq.inReview,
-						fill: seq.inReview,
-						value: (u, _v, _si, i) =>
-							i == null ? "" : (u.data[3][i] as number) - (u.data[4][i] as number),
-					},
-					{
-						label: "Done",
-						stroke: seq.done,
-						fill: seq.done,
-						value: (_u, v) => v ?? "",
-					},
-				],
-				axes: [
-					{
-						stroke: textMuted,
-						grid: { stroke: border },
-						splits: (u) => {
-							const n = labels.length;
-							const maxTicks = Math.max(2, Math.floor(u.width / 70));
-							const stride = Math.max(1, Math.ceil(n / maxTicks));
-							const idxs: number[] = [];
-							for (let i = 0; i < n; i += stride) idxs.push(i);
-							if (idxs[idxs.length - 1] !== n - 1) idxs.push(n - 1);
-							return idxs;
-						},
-						values: (_u, splits) => splits.map((s) => formatShortDate(labels[s] ?? "")),
-					},
-					{ stroke: textMuted, grid: { stroke: border } },
-				],
-			};
-		};
-	}, [labels]);
-
-	if (
-		data.length === 0 ||
-		data.every((d) => d.backlogTodo + d.inProgress + d.inReview + d.done === 0)
-	) {
-		return <EmptyChartState message="No issues in this window yet" />;
 	}
 
 	return <UplotChart data={chartData} buildOptions={buildOptions} />;

--- a/apps/web/src/islands/ProjectFlowCharts.tsx
+++ b/apps/web/src/islands/ProjectFlowCharts.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from "preact/hooks";
+import { apiFetch } from "../utils/api-client";
+import {
+	CfdChart,
+	type CfdPoint,
+	ThroughputChart,
+	type ThroughputPoint,
+} from "./metrics/flow-charts";
+
+interface FlowMetrics {
+	throughputOverTime: ThroughputPoint[];
+	cfdOverTime: CfdPoint[];
+}
+
+const SECTION_HEADING_CLASS =
+	"text-xs font-semibold text-text-muted m-0 mb-3 uppercase tracking-[0.05em]";
+
+function mondayOfWeek(d: Date): Date {
+	const monday = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+	const daysSinceMonday = (monday.getUTCDay() + 6) % 7;
+	monday.setUTCDate(monday.getUTCDate() - daysSinceMonday);
+	return monday;
+}
+
+// Same 6-week weekly default window as MetricsDashboard's defaultRange, so a project's
+// overview and its full /metrics page agree on "recent" without a picker on this page.
+function defaultSinceUntil(): { since: number; until: number } {
+	const today = new Date();
+	const monday = mondayOfWeek(today);
+	monday.setUTCDate(monday.getUTCDate() - 5 * 7);
+	const since = Math.floor(monday.getTime() / 1000);
+	const until = Math.floor(today.getTime() / 1000) + 86399;
+	return { since, until };
+}
+
+function useProjectFlowCharts(workspaceSlug: string | undefined, projectId: string | null) {
+	const [metrics, setMetrics] = useState<FlowMetrics | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (!projectId) {
+			setLoading(false);
+			return;
+		}
+		setLoading(true);
+		setError(null);
+		const { since, until } = defaultSinceUntil();
+		const query = new URLSearchParams({
+			since: String(since),
+			until: String(until),
+			granularity: "week",
+		});
+		apiFetch<FlowMetrics>(`/api/projects/${encodeURIComponent(projectId)}/flow-metrics?${query}`, {
+			workspaceSlug,
+		})
+			.then((data) => setMetrics(data))
+			.catch((e) => setError(String(e)))
+			.finally(() => setLoading(false));
+	}, [projectId, workspaceSlug]);
+
+	return { metrics, loading, error };
+}
+
+export default function ProjectFlowCharts({
+	workspaceSlug,
+	projectId,
+}: {
+	workspaceSlug: string | undefined;
+	projectId: string;
+}) {
+	const { metrics, loading, error } = useProjectFlowCharts(workspaceSlug, projectId);
+
+	if (loading) return null;
+	if (error || !metrics) return null;
+
+	return (
+		<section class="mb-8" aria-labelledby="flow-charts-heading">
+			<h2 id="flow-charts-heading" class={SECTION_HEADING_CLASS}>
+				Flow (last 6 weeks)
+			</h2>
+			<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+				<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto">
+					<p class="m-0 mb-2 text-[0.72rem] font-medium text-text-muted">Throughput</p>
+					<ThroughputChart data={metrics.throughputOverTime} />
+				</div>
+				<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto">
+					<p class="m-0 mb-2 text-[0.72rem] font-medium text-text-muted">Cumulative flow</p>
+					<CfdChart data={metrics.cfdOverTime} />
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/apps/web/src/islands/ProjectLanding.test.tsx
+++ b/apps/web/src/islands/ProjectLanding.test.tsx
@@ -29,7 +29,11 @@ const ISSUE = {
 	updated_at: 1000,
 };
 
-function mockFetchProject(issues: (typeof ISSUE)[] = [ISSUE], wiki: unknown[] = []) {
+function mockFetchProject(
+	issues: (typeof ISSUE)[] = [ISSUE],
+	wiki: unknown[] = [],
+	flowMetrics: unknown = { throughputOverTime: [], cfdOverTime: [] }
+) {
 	vi.stubGlobal(
 		"fetch",
 		vi.fn().mockImplementation((url: string) => {
@@ -39,6 +43,9 @@ function mockFetchProject(issues: (typeof ISSUE)[] = [ISSUE], wiki: unknown[] = 
 			}
 			if (u.includes("/api/wiki")) {
 				return Promise.resolve({ ok: true, json: () => Promise.resolve(wiki) });
+			}
+			if (u.includes("/flow-metrics")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve(flowMetrics) });
 			}
 			// project fetch
 			return Promise.resolve({ ok: true, json: () => Promise.resolve(PROJECT) });
@@ -89,5 +96,29 @@ describe("ProjectLanding", () => {
 		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
 		render(<ProjectLanding />);
 		expect(await screen.findByRole("alert")).toBeTruthy();
+	});
+
+	it("shows an empty state for the flow charts on a project with no history", async () => {
+		history.replaceState(null, "", "?id=p1");
+		mockFetchProject([ISSUE], [], { throughputOverTime: [], cfdOverTime: [] });
+		render(<ProjectLanding />);
+		await screen.findByRole("heading", { name: "Projektor" });
+		expect(await screen.findByText(/Flow \(last 6 weeks\)/i)).toBeTruthy();
+		expect(screen.getAllByText(/No (completed issues|issues in this window)/i).length).toBe(2);
+	});
+
+	it("renders throughput and cumulative flow charts when the project has flow history", async () => {
+		history.replaceState(null, "", "?id=p1");
+		mockFetchProject([ISSUE], [], {
+			throughputOverTime: [{ bucketStart: "2024-01-01", count: 3 }],
+			cfdOverTime: [
+				{ bucketStart: "2024-01-01", backlogTodo: 2, inProgress: 1, inReview: 0, done: 3 },
+			],
+		});
+		render(<ProjectLanding />);
+		await screen.findByRole("heading", { name: "Projektor" });
+		expect(await screen.findByText(/Flow \(last 6 weeks\)/i)).toBeTruthy();
+		expect(screen.getByText("Throughput")).toBeTruthy();
+		expect(screen.getByText("Cumulative flow")).toBeTruthy();
 	});
 });

--- a/apps/web/src/islands/ProjectLanding.tsx
+++ b/apps/web/src/islands/ProjectLanding.tsx
@@ -2,6 +2,7 @@ import type { RefObject } from "preact";
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { statusDisplayName } from "../lib/status";
 import { apiFetch } from "../utils/api-client";
+import ProjectFlowCharts from "./ProjectFlowCharts";
 
 interface Project {
 	id: string;
@@ -425,6 +426,7 @@ export default function ProjectLanding({ workspaceSlug }: Props) {
 				</div>
 			</header>
 
+			<ProjectFlowCharts workspaceSlug={workspaceSlug} projectId={project.id} />
 			<RecentIssuesSection issues={recentIssues} />
 			<RecentWikiSection pages={recentWiki} />
 		</div>

--- a/apps/web/src/islands/metrics/flow-charts.tsx
+++ b/apps/web/src/islands/metrics/flow-charts.tsx
@@ -1,0 +1,208 @@
+import { useMemo } from "preact/hooks";
+import uPlot from "uplot";
+import UplotChart, { createTooltipPlugin } from "../charts/UplotChart";
+
+export interface ThroughputPoint {
+	bucketStart: string;
+	count: number;
+}
+
+export interface CfdPoint {
+	bucketStart: string;
+	backlogTodo: number;
+	inProgress: number;
+	inReview: number;
+	done: number;
+}
+
+// uPlot bakes colors into the canvas at creation time, so callers re-read these live
+// (rather than caching) whenever a chart is (re)built, including on theme toggle.
+export function readThemeColor(token: string, fallback: string): string {
+	const value = getComputedStyle(document.documentElement).getPropertyValue(token).trim();
+	return value || fallback;
+}
+
+export function hexToRgba(hex: string, alpha: number): string {
+	const match = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+	if (!match) return hex;
+	const [r, g, b] = match.slice(1).map((h) => parseInt(h, 16));
+	return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+export function formatShortDate(iso: string): string {
+	const d = new Date(`${iso}T00:00:00Z`);
+	if (Number.isNaN(d.getTime())) return iso;
+	return d.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
+}
+
+export function formatFullDate(iso: string): string {
+	const d = new Date(`${iso}T00:00:00Z`);
+	if (Number.isNaN(d.getTime())) return iso;
+	return d.toLocaleDateString("en-US", {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+		timeZone: "UTC",
+	});
+}
+
+// Single-hue ordinal ramp (lightest = earliest stage, darkest = done) for the CFD bands —
+// read from the --chart-seq-* tokens (Base.astro) so the ramp repaints on theme toggle.
+export function readChartSeqColors() {
+	return {
+		backlogTodo: readThemeColor("--chart-seq-1", "#86b6ef"),
+		inProgress: readThemeColor("--chart-seq-2", "#5598e7"),
+		inReview: readThemeColor("--chart-seq-3", "#2a78d6"),
+		done: readThemeColor("--chart-seq-4", "#1c5cab"),
+	};
+}
+
+export function EmptyChartState({ message }: { message: string }) {
+	return (
+		<div class="flex items-center justify-center h-[220px] text-sm text-text-muted">{message}</div>
+	);
+}
+
+function tickIndices(width: number, labels: string[]): number[] {
+	const n = labels.length;
+	const maxTicks = Math.max(2, Math.floor(width / 70));
+	const stride = Math.max(1, Math.ceil(n / maxTicks));
+	const idxs: number[] = [];
+	for (let i = 0; i < n; i += stride) idxs.push(i);
+	if (idxs[idxs.length - 1] !== n - 1) idxs.push(n - 1);
+	return idxs;
+}
+
+export function ThroughputChart({ data }: { data: ThroughputPoint[] }) {
+	const labels = useMemo(() => data.map((d) => d.bucketStart), [data]);
+	const chartData = useMemo<uPlot.AlignedData>(
+		() => [data.map((_, i) => i), data.map((d) => d.count)],
+		[data]
+	);
+
+	const buildOptions = useMemo(() => {
+		return (width: number, height: number): uPlot.Options => {
+			const accent = readThemeColor("--accent", "#4f46e5");
+			const border = readThemeColor("--border", "#e2e8f0");
+			const textMuted = readThemeColor("--text-muted", "#6b7280");
+
+			return {
+				width,
+				height,
+				scales: { x: { time: false } },
+				legend: { show: false },
+				series: [
+					{},
+					{
+						label: "Issues completed",
+						stroke: accent,
+						fill: hexToRgba(accent, 0.25),
+						paths: uPlot.paths.bars?.(),
+					},
+				],
+				axes: [
+					{
+						stroke: textMuted,
+						grid: { stroke: border },
+						splits: (u) => tickIndices(u.width, labels),
+						values: (_u, splits) => splits.map((s) => formatShortDate(labels[s] ?? "")),
+					},
+					{ stroke: textMuted, grid: { stroke: border } },
+				],
+				plugins: [
+					createTooltipPlugin({
+						formatX: (xVal) => formatFullDate(labels[xVal] ?? ""),
+						formatY: (yVal) => `${yVal} completed`,
+					}),
+				],
+			};
+		};
+	}, [labels]);
+
+	if (data.length === 0 || data.every((d) => d.count === 0)) {
+		return <EmptyChartState message="No completed issues yet" />;
+	}
+
+	return <UplotChart data={chartData} buildOptions={buildOptions} />;
+}
+
+// Bands are stacked bottom-up (done at the base, backlog/todo on top) by plotting
+// cumulative sums and drawing widest-first so each later, narrower fill paints over the
+// tail of the one before it — the classic uPlot stacked-area trick, since uPlot has no
+// native "stacked" series mode.
+export function CfdChart({ data }: { data: CfdPoint[] }) {
+	const labels = useMemo(() => data.map((d) => d.bucketStart), [data]);
+	const chartData = useMemo<uPlot.AlignedData>(() => {
+		const total = data.map((d) => d.backlogTodo + d.inProgress + d.inReview + d.done);
+		const upToInProgress = data.map((d) => d.inProgress + d.inReview + d.done);
+		const upToInReview = data.map((d) => d.inReview + d.done);
+		const done = data.map((d) => d.done);
+		return [data.map((_, i) => i), total, upToInProgress, upToInReview, done];
+	}, [data]);
+
+	const buildOptions = useMemo(() => {
+		return (width: number, height: number): uPlot.Options => {
+			const border = readThemeColor("--border", "#e2e8f0");
+			const textMuted = readThemeColor("--text-muted", "#6b7280");
+			const seq = readChartSeqColors();
+
+			return {
+				width,
+				height,
+				scales: { x: { time: false } },
+				legend: { show: true },
+				series: [
+					{},
+					// Series carry cumulative sums (for the stacked-area geometry), so the legend
+					// `value` de-cumulates each back to its own band count — otherwise the legend
+					// would report the running total, not the band's actual size.
+					{
+						label: "Backlog/todo",
+						stroke: seq.backlogTodo,
+						fill: seq.backlogTodo,
+						value: (u, _v, _si, i) =>
+							i == null ? "" : (u.data[1][i] as number) - (u.data[2][i] as number),
+					},
+					{
+						label: "In progress",
+						stroke: seq.inProgress,
+						fill: seq.inProgress,
+						value: (u, _v, _si, i) =>
+							i == null ? "" : (u.data[2][i] as number) - (u.data[3][i] as number),
+					},
+					{
+						label: "In review",
+						stroke: seq.inReview,
+						fill: seq.inReview,
+						value: (u, _v, _si, i) =>
+							i == null ? "" : (u.data[3][i] as number) - (u.data[4][i] as number),
+					},
+					{
+						label: "Done",
+						stroke: seq.done,
+						fill: seq.done,
+						value: (_u, v) => v ?? "",
+					},
+				],
+				axes: [
+					{
+						stroke: textMuted,
+						grid: { stroke: border },
+						splits: (u) => tickIndices(u.width, labels),
+						values: (_u, splits) => splits.map((s) => formatShortDate(labels[s] ?? "")),
+					},
+					{ stroke: textMuted, grid: { stroke: border } },
+				],
+			};
+		};
+	}, [labels]);
+
+	if (
+		data.length === 0 ||
+		data.every((d) => d.backlogTodo + d.inProgress + d.inReview + d.done === 0)
+	) {
+		return <EmptyChartState message="No issues in this window yet" />;
+	}
+
+	return <UplotChart data={chartData} buildOptions={buildOptions} />;
+}


### PR DESCRIPTION
## Summary
- Extracts `ThroughputChart`/`CfdChart` and their shared uPlot/theming utilities out of `MetricsDashboard.tsx` into a new `islands/metrics/flow-charts.tsx` module, so both `/metrics` and the project overview page render from the exact same chart implementation instead of duplicating ~150 lines of uPlot config.
- Adds a new `ProjectFlowCharts` island, wired into `ProjectLanding.tsx` between the project header and the "Recent Issues" section. It fetches `/api/projects/:id/flow-metrics` scoped to the project already selected on the overview page (no separate picker), defaulting to the same 6-week weekly window as `MetricsDashboard`'s default range.
- Each chart shows its existing empty-chart state (reused from `flow-charts.tsx`) when a project has no flow history yet, and the whole section renders nothing while loading or on fetch error, so it fails quietly rather than showing a broken panel.
- No backend changes — `/api/projects/:id/flow-metrics` was already project-scoped.
- `/metrics` page itself is behaviorally unchanged (same charts, same data, now imported from the shared module).

## Test plan
- [x] `pnpm --filter web run type-check` — 0 errors
- [x] `pnpm --filter web exec biome check` — clean
- [x] `pnpm --filter web exec vitest run` — 313/313 pass, including new `ProjectLanding` tests covering the flow-charts empty state and the populated-data state
- [x] Full pre-push suite (lint + 703 api tests + 313 web tests) passed on push
- [ ] Manual click-through on the dogfood instance comparing a project's Overview tab charts against `/metrics?projectId=` for the same project — not done in this session (no local dev stack); recommend a human check before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APQYanmALGfKTKZv7jrb7z