### PR TITLE
fix(web): expose explicit project scope switching in the wiki UI (PROJ-352)

### DIFF
--- a/apps/web/src/islands/ProjectLanding.test.tsx
+++ b/apps/web/src/islands/ProjectLanding.test.tsx
@@ -29,6 +29,13 @@ const ISSUE = {
 	updated_at: 1000,
 };
 
+const WIKI_PAGE = {
+	id: "w1",
+	slug: "getting-started",
+	title: "Getting Started",
+	updated_at: 1000,
+};
+
 function mockFetchProject(issues: (typeof ISSUE)[] = [ISSUE], wiki: unknown[] = []) {
 	vi.stubGlobal(
 		"fetch",
@@ -89,5 +96,13 @@ describe("ProjectLanding", () => {
 		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
 		render(<ProjectLanding />);
 		expect(await screen.findByRole("alert")).toBeTruthy();
+	});
+
+	it("recent-wiki links preserve projectId so the destination stays scoped (PROJ-352)", async () => {
+		history.replaceState(null, "", "?id=p1");
+		mockFetchProject([ISSUE], [WIKI_PAGE]);
+		render(<ProjectLanding />);
+		const link = (await screen.findByText("Getting Started")).closest("a");
+		expect(link?.getAttribute("href")).toBe("/wiki?slug=getting-started&projectId=p1");
 	});
 });

--- a/apps/web/src/islands/ProjectLanding.tsx
+++ b/apps/web/src/islands/ProjectLanding.tsx
@@ -297,7 +297,7 @@ function RecentIssuesSection({ issues }: { issues: RecentIssue[] }) {
 	);
 }
 
-function RecentWikiSection({ pages }: { pages: RecentWikiPage[] }) {
+function RecentWikiSection({ pages, projectId }: { pages: RecentWikiPage[]; projectId: string }) {
 	return (
 		<section class="mb-8" aria-labelledby="recent-wiki-heading">
 			<h2 id="recent-wiki-heading" class={SECTION_HEADING_CLASS}>
@@ -311,7 +311,7 @@ function RecentWikiSection({ pages }: { pages: RecentWikiPage[] }) {
 						<div key={page.id} class="py-2 border-b border-border last:border-b-0">
 							<div class="flex justify-between items-baseline gap-2">
 								<a
-									href={`/wiki?slug=${encodeURIComponent(page.slug)}`}
+									href={`/wiki?slug=${encodeURIComponent(page.slug)}&projectId=${encodeURIComponent(projectId)}`}
 									class="text-text-base no-underline text-sm hover:underline focus:underline"
 								>
 									{page.title}
@@ -426,7 +426,7 @@ export default function ProjectLanding({ workspaceSlug }: Props) {
 			</header>
 
 			<RecentIssuesSection issues={recentIssues} />
-			<RecentWikiSection pages={recentWiki} />
+			<RecentWikiSection pages={recentWiki} projectId={project.id} />
 		</div>
 	);
 }

--- a/apps/web/src/islands/WikiPage.test.tsx
+++ b/apps/web/src/islands/WikiPage.test.tsx
@@ -98,6 +98,52 @@ describe("WikiPage", () => {
 	});
 });
 
+describe("WikiPage — project scope control (PROJ-352)", () => {
+	function mockFetchWikiWithProjects(page: WikiPageData | null) {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation((url: string) => {
+				const u = String(url);
+				if (u.includes("/revisions")) {
+					return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+				}
+				if (u.includes("/tree")) {
+					return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+				}
+				if (u.includes("/api/projects")) {
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve([{ id: "p1", key: "PROJ", name: "Projektor" }]),
+					});
+				}
+				return Promise.resolve({ ok: true, json: () => Promise.resolve(page) });
+			})
+		);
+	}
+
+	it("defaults to 'Workspace (all projects)' scope when no projectId is set", async () => {
+		history.replaceState(null, "", "?slug=my-page");
+		mockFetchWikiWithProjects(PAGE);
+		render(<WikiPage />);
+		await screen.findByText("My Page");
+		expect(screen.getByRole("combobox", { name: "Wiki project scope" }).textContent).toMatch(
+			/Workspace \(all projects\)/i
+		);
+	});
+
+	it("shows the project's scope when projectId is set via the URL", async () => {
+		history.replaceState(null, "", "?slug=my-page&projectId=p1");
+		mockFetchWikiWithProjects(PAGE);
+		render(<WikiPage />);
+		await screen.findByText("My Page");
+		await waitFor(() => {
+			expect(screen.getByRole("combobox", { name: "Wiki project scope" }).textContent).toMatch(
+				/PROJ — Projektor/i
+			);
+		});
+	});
+});
+
 async function startEditingWithTitleInput(): Promise<HTMLInputElement> {
 	history.replaceState(null, "", "?slug=my-page");
 	mockFetchWiki(PAGE);

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -6,6 +6,13 @@ import { apiFetch } from "../utils/api-client";
 import { renderMdWithWikilinks, renderMermaidDiagrams } from "../utils/markdown";
 import AccessPending from "./AccessPending";
 import MarkdownEditor from "./MarkdownEditor";
+import Select, { type SelectOption } from "./Select";
+
+interface ProjectOption {
+	id: string;
+	key: string;
+	name: string;
+}
 
 interface SearchResult {
 	id: string;
@@ -203,7 +210,52 @@ function PageTreeList({
 	);
 }
 
+// Lets a user viewing the workspace-wide wiki (or one project's wiki) switch to another
+// scope explicitly, since the only other entry point is a project's nav tab. Switching
+// scope is a full navigation (fresh tree/search for the new scope), not an in-place swap.
+function useProjects(workspaceSlug: string | undefined) {
+	const [projects, setProjects] = useState<ProjectOption[]>([]);
+
+	useEffect(() => {
+		apiFetch<ProjectOption[]>("/api/projects", { workspaceSlug })
+			.then((list) => setProjects(Array.isArray(list) ? list : []))
+			.catch(() => {});
+	}, [workspaceSlug]);
+
+	return projects;
+}
+
+function ScopeControl({
+	workspaceSlug,
+	projectId,
+}: {
+	workspaceSlug: string | undefined;
+	projectId: string;
+}) {
+	const projects = useProjects(workspaceSlug);
+	const options: SelectOption[] = [
+		{ value: "", label: "Workspace (all projects)" },
+		...projects.map((p) => ({ value: p.id, label: `${p.key} — ${p.name}` })),
+	];
+
+	return (
+		<div class="mb-3">
+			<p class="m-0 mb-1 text-[0.7rem] text-text-muted">Scope</p>
+			<Select
+				value={projectId}
+				options={options}
+				ariaLabel="Wiki project scope"
+				onChange={(value) => {
+					window.location.href = value ? `/wiki?projectId=${encodeURIComponent(value)}` : "/wiki";
+				}}
+			/>
+		</div>
+	);
+}
+
 function WikiSidebar({
+	workspaceSlug,
+	projectId,
 	searchQuery,
 	onSearchQueryChange,
 	searchResults,
@@ -214,6 +266,8 @@ function WikiSidebar({
 	onNavigate,
 	onCreate,
 }: {
+	workspaceSlug: string | undefined;
+	projectId: string;
 	searchQuery: string;
 	onSearchQueryChange: (value: string) => void;
 	searchResults: SearchResult[];
@@ -230,6 +284,7 @@ function WikiSidebar({
 	].join(" ");
 	return (
 		<aside class={asideClass}>
+			<ScopeControl workspaceSlug={workspaceSlug} projectId={projectId} />
 			<button
 				type="button"
 				onClick={onCreate}
@@ -1576,6 +1631,8 @@ const WIKI_PAGE_STYLES = `
 `;
 
 function WikiPageShell(props: {
+	workspaceSlug: string | undefined;
+	projectId: string;
 	searchQuery: string;
 	onSearchQueryChange: (v: string) => void;
 	searchResults: SearchResult[];
@@ -1599,6 +1656,8 @@ function WikiPageShell(props: {
 		<div class="flex min-h-screen max-sm:flex-col">
 			<style>{WIKI_PAGE_STYLES}</style>
 			<WikiSidebar
+				workspaceSlug={props.workspaceSlug}
+				projectId={props.projectId}
 				searchQuery={props.searchQuery}
 				onSearchQueryChange={props.onSearchQueryChange}
 				searchResults={props.searchResults}
@@ -1821,6 +1880,8 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 
 	return (
 		<WikiPageShell
+			workspaceSlug={workspaceSlug}
+			projectId={projectId}
 			searchQuery={searchQuery}
 			onSearchQueryChange={setSearchQuery}
 			searchResults={searchResults}


### PR DESCRIPTION
## Summary
- An Opus-confirmed architecture investigation established that wiki-page scoping is an intentional **hybrid** model (nullable `project_id`: null = workspace-wide, non-null = project-scoped), already implemented correctly end-to-end in the DB schema, API service layer, and authz. The gap was entirely in the frontend: there was no way for a user to see or switch scope from within the wiki page itself.
- Adds a **Scope** control to the top of the wiki sidebar (`WikiPage.tsx`), reusing the existing `Select` component. It shows "Workspace (all projects)" when unscoped, or the current project's key/name when scoped, and lets a user explicitly switch — a full navigation to `/wiki` or `/wiki?projectId=<id>` so the tree/search/create-form all refresh for the new scope.
- "+ New page" already correctly passed the current `projectId` to the create API — verified, no change needed there.
- Fixes `ProjectLanding.tsx`'s "Recent Wiki Pages" links, which previously linked to `/wiki?slug=...` and silently dropped project context. They now include `&projectId=<id>` so clicking through from a project's Overview tab keeps the destination page's tree/search scoped to that project instead of reverting to workspace-wide.
- No DB or API changes — confirmed those layers already support project scoping correctly.

## Test plan
- [x] `pnpm --filter web run type-check` — 0 errors
- [x] `pnpm --filter web exec biome check` — clean
- [x] `pnpm --filter web exec vitest run` — 314/314 pass, including new `WikiPage` tests for the scope control's default/scoped states and a new `ProjectLanding` test asserting recent-wiki links preserve `projectId`
- [x] Full pre-push suite (lint + 703 api tests + 314 web tests) passed on push
- [ ] Manual click-through on the dogfood instance: from a project's Overview tab, click a "Recent Wiki" entry and confirm the destination stays scoped; use the new Scope control to switch to/from workspace-wide; create a page in each scope and confirm the correct `project_id` — not done in this session (no local dev stack); recommend a human check before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APQYanmALGfKTKZv7jrb7z