### PR TITLE
feat(web): epic filters, SPA nav, project overview flow charts, wiki scope switching (PROJ-349..352)

### DIFF
--- a/apps/web/src/islands/EpicList.test.tsx
+++ b/apps/web/src/islands/EpicList.test.tsx
@@ -186,6 +186,52 @@ describe("EpicList", () => {
 		expect(screen.getByRole("button", { name: /New Epic/i })).toBeTruthy();
 	});
 
+	it("sends completedAfter/completedBefore query params when a date-range filter is set via the URL", async () => {
+		history.replaceState(
+			null,
+			"",
+			"?projectId=p1&dateField=completed&dateFrom=2024-01-01&dateTo=2024-01-31"
+		);
+		const calledUrls: string[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation((url: string) => {
+				const u = String(url);
+				calledUrls.push(u);
+				if (u.includes("/api/task-types")) {
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve([{ id: "tt1", key: "epic", name: "Epic" }]),
+					});
+				}
+				if (u.includes("/api/issues")) {
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve({ items: [EPIC_ISSUE] }),
+					});
+				}
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			})
+		);
+		render(<EpicList />);
+		await screen.findByText("Big Epic");
+		const issuesCall = calledUrls.find((u) => u.includes("/api/issues?"));
+		expect(issuesCall).toContain("completedAfter=");
+		expect(issuesCall).toContain("completedBefore=");
+	});
+
+	it("shows the Filters button with an active count when a date-range filter is applied", async () => {
+		history.replaceState(
+			null,
+			"",
+			"?projectId=p1&dateField=completed&dateFrom=2024-01-01&dateTo=2024-01-31"
+		);
+		mockFetchEpics([EPIC_ISSUE]);
+		render(<EpicList />);
+		await screen.findByText("Big Epic");
+		expect(screen.getByRole("button", { name: /Filters \(1\)/i })).toBeTruthy();
+	});
+
 	it("shows an error message when the issues fetch fails", async () => {
 		history.replaceState(null, "", "?projectId=p1");
 		vi.stubGlobal(

--- a/apps/web/src/islands/EpicList.tsx
+++ b/apps/web/src/islands/EpicList.tsx
@@ -1,4 +1,3 @@
-import type { Dispatch, MutableRef, StateUpdater } from "preact/hooks";
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { statusDisplayName } from "../lib/status";
 import { apiFetch } from "../utils/api-client";
@@ -6,11 +5,14 @@ import { issueUrl } from "../utils/issue-url";
 import { PRIORITY_OPTIONS } from "../utils/issue-utils";
 import {
 	CATEGORY_COLORS,
-	categoryColor,
 	type Issue,
 	type SortKey,
 	sortIssues,
+	type TaskStatus,
 } from "./board-utils";
+import { applyDateRangeParams } from "./IssueList-helpers";
+import type { DateField } from "./issue-list/FiltersPopover";
+import FiltersPopover from "./issue-list/FiltersPopover";
 import Select from "./Select";
 
 interface Props {
@@ -24,7 +26,6 @@ interface ProjectMeta {
 }
 
 type EpicRollup = { done: number; remaining: number; total: number };
-type DerivedStatus = { id: string; name: string; category: string };
 
 const PRIORITY_LABEL: Record<string, string> = {
 	urgent: "Urgent",
@@ -32,13 +33,6 @@ const PRIORITY_LABEL: Record<string, string> = {
 	medium: "Medium",
 	low: "Low",
 	none: "None",
-};
-
-const PILL_COLORS: Record<string, { bg: string; text: string }> = {
-	urgent: { bg: "#dc2626", text: "#fff" },
-	high: { bg: "#d97706", text: "#fff" },
-	medium: { bg: "#2563eb", text: "#fff" },
-	low: { bg: "#6b7280", text: "#fff" },
 };
 
 const TH_CLASS =
@@ -49,12 +43,25 @@ const MODAL_CLASS =
 	"bg-bg border border-border rounded-lg p-6 w-full max-w-[480px] mx-4 " +
 	"max-sm:rounded-t-lg max-sm:rounded-b-none max-sm:mx-0";
 
-function parseUrlFilters(params: URLSearchParams): { statuses: string[]; priorities: string[] } {
+function parseDateField(v: string | null): DateField {
+	return v === "completed" || v === "updated" ? v : "";
+}
+
+function parseUrlFilters(params: URLSearchParams): {
+	statuses: string[];
+	priorities: string[];
+	dateField: DateField;
+	dateFrom: string;
+	dateTo: string;
+} {
 	const s = params.get("status");
 	const p = params.get("priority");
 	return {
 		statuses: s ? s.split(",").filter(Boolean) : [],
 		priorities: p ? p.split(",").filter(Boolean) : [],
+		dateField: parseDateField(params.get("dateField")),
+		dateFrom: params.get("dateFrom") ?? "",
+		dateTo: params.get("dateTo") ?? "",
 	};
 }
 
@@ -114,16 +121,18 @@ function computeFilteredEpics(
 	});
 }
 
-function computeDerivedStatuses(epics: Issue[]): DerivedStatus[] {
-	const derived: DerivedStatus[] = [];
+function computeDerivedStatuses(epics: Issue[]): TaskStatus[] {
+	const derived: TaskStatus[] = [];
 	const seen = new Set<string>();
 	for (const ep of epics) {
 		if (ep.status_id && !seen.has(ep.status_id)) {
 			seen.add(ep.status_id);
 			derived.push({
 				id: ep.status_id,
+				key: ep.status_key ?? ep.status_id,
 				name: ep.status_name ?? ep.status_key ?? ep.status_id,
 				category: ep.status_category ?? "",
+				color: null,
 			});
 		}
 	}
@@ -135,12 +144,39 @@ function sortIndicator(key: SortKey, sortBy: SortKey, sortDir: "asc" | "desc") {
 	return <span class="ml-1 opacity-60">{sortDir === "asc" ? "↑" : "↓"}</span>;
 }
 
-function EpicListHeader(
-	props: FiltersPopoverProps & { epicTypeId: string | null; onOpenCreate: () => void }
-) {
+interface EpicListHeaderProps {
+	derivedStatuses: TaskStatus[];
+	filterStatuses: string[];
+	setFilterStatuses: (v: string[] | ((prev: string[]) => string[])) => void;
+	filterPriorities: string[];
+	setFilterPriorities: (v: string[] | ((prev: string[]) => string[])) => void;
+	filterDateField: DateField;
+	setFilterDateField: (v: DateField | ((prev: DateField) => DateField)) => void;
+	filterDateFrom: string;
+	setFilterDateFrom: (v: string | ((prev: string) => string)) => void;
+	filterDateTo: string;
+	setFilterDateTo: (v: string | ((prev: string) => string)) => void;
+	epicTypeId: string | null;
+	onOpenCreate: () => void;
+}
+
+function EpicListHeader(props: EpicListHeaderProps) {
 	return (
 		<div class="flex items-center justify-between mb-4 gap-2 flex-wrap">
-			<FiltersPopover {...props} />
+			<FiltersPopover
+				derivedStatuses={props.derivedStatuses}
+				filterStatuses={props.filterStatuses}
+				setFilterStatuses={props.setFilterStatuses}
+				filterPriorities={props.filterPriorities}
+				setFilterPriorities={props.setFilterPriorities}
+				filterDateField={props.filterDateField}
+				setFilterDateField={props.setFilterDateField}
+				filterDateFrom={props.filterDateFrom}
+				setFilterDateFrom={props.setFilterDateFrom}
+				filterDateTo={props.filterDateTo}
+				setFilterDateTo={props.setFilterDateTo}
+				isSearchActive={false}
+			/>
 			{props.epicTypeId && (
 				<button type="button" onClick={props.onOpenCreate} class="btn btn-primary btn-sm">
 					+ New Epic
@@ -153,18 +189,18 @@ function EpicListHeader(
 function useEpicFilters() {
 	const [filterStatuses, setFilterStatuses] = useState<string[]>([]);
 	const [filterPriorities, setFilterPriorities] = useState<string[]>([]);
-	const [showFiltersPopover, setShowFiltersPopover] = useState(false);
-
-	const filtersContainerRef = useRef<HTMLDivElement>(null);
-	const filtersPopoverRef = useRef<HTMLDivElement>(null);
-	const filtersButtonRef = useRef<HTMLButtonElement>(null);
-	const filtersPopoverPos = useRef({ top: 0, left: 0 });
+	const [filterDateField, setFilterDateField] = useState<DateField>("");
+	const [filterDateFrom, setFilterDateFrom] = useState("");
+	const [filterDateTo, setFilterDateTo] = useState("");
 
 	useEffect(() => {
 		const params = new URLSearchParams(window.location.search);
-		const { statuses, priorities } = parseUrlFilters(params);
+		const { statuses, priorities, dateField, dateFrom, dateTo } = parseUrlFilters(params);
 		if (statuses.length > 0) setFilterStatuses(statuses);
 		if (priorities.length > 0) setFilterPriorities(priorities);
+		if (dateField) setFilterDateField(dateField);
+		if (dateFrom) setFilterDateFrom(dateFrom);
+		if (dateTo) setFilterDateTo(dateTo);
 	}, []);
 
 	// Sync filter state to URL without page reload
@@ -180,37 +216,35 @@ function useEpicFilters() {
 		} else {
 			params.delete("priority");
 		}
-		history.replaceState(null, "", `?${params.toString()}`);
-	}, [filterStatuses, filterPriorities]);
-
-	// Close filters popover on outside click
-	useEffect(() => {
-		if (!showFiltersPopover) return;
-		function onPointer(e: MouseEvent) {
-			const target = e.target as Node;
-			if (
-				!filtersContainerRef.current?.contains(target) &&
-				!filtersPopoverRef.current?.contains(target)
-			) {
-				setShowFiltersPopover(false);
-			}
+		if (filterDateField) {
+			params.set("dateField", filterDateField);
+		} else {
+			params.delete("dateField");
 		}
-		document.addEventListener("mousedown", onPointer);
-		return () => document.removeEventListener("mousedown", onPointer);
-	}, [showFiltersPopover]);
+		if (filterDateFrom) {
+			params.set("dateFrom", filterDateFrom);
+		} else {
+			params.delete("dateFrom");
+		}
+		if (filterDateTo) {
+			params.set("dateTo", filterDateTo);
+		} else {
+			params.delete("dateTo");
+		}
+		history.replaceState(null, "", `?${params.toString()}`);
+	}, [filterStatuses, filterPriorities, filterDateField, filterDateFrom, filterDateTo]);
 
 	return {
 		filterStatuses,
 		setFilterStatuses,
 		filterPriorities,
 		setFilterPriorities,
-		showFiltersPopover,
-		setShowFiltersPopover,
-		filtersContainerRef,
-		filtersPopoverRef,
-		filtersButtonRef,
-		filtersPopoverPos,
-		activeFilterCount: filterStatuses.length + filterPriorities.length,
+		filterDateField,
+		setFilterDateField,
+		filterDateFrom,
+		setFilterDateFrom,
+		filterDateTo,
+		setFilterDateTo,
 	};
 }
 
@@ -286,7 +320,10 @@ function useEpicsData(
 	projectId: string | null,
 	projectIdReady: boolean,
 	epicTypeId: string | null,
-	workspaceSlug: string | undefined
+	workspaceSlug: string | undefined,
+	filterDateField: DateField,
+	filterDateFrom: string,
+	filterDateTo: string
 ) {
 	const [epics, setEpics] = useState<Issue[]>([]);
 	const [epicRollups, setEpicRollups] = useState<Record<string, EpicRollup>>({});
@@ -302,10 +339,13 @@ function useEpicsData(
 		setLoading(true);
 		setError(null);
 		try {
-			const data = await apiFetch<{ items: Issue[] }>(
-				`/api/issues?project=${encodeURIComponent(projectId)}&typeId=${encodeURIComponent(epicTypeId)}&limit=100`,
-				{ workspaceSlug }
-			);
+			const qs = new URLSearchParams({
+				project: projectId,
+				typeId: epicTypeId,
+				limit: "100",
+			});
+			applyDateRangeParams(qs, filterDateField, filterDateFrom, filterDateTo);
+			const data = await apiFetch<{ items: Issue[] }>(`/api/issues?${qs}`, { workspaceSlug });
 			const epicItems = data.items ?? [];
 			setEpics(epicItems);
 			setEpicRollups({});
@@ -318,7 +358,7 @@ function useEpicsData(
 		} finally {
 			setLoading(false);
 		}
-	}, [projectId, epicTypeId, workspaceSlug]);
+	}, [projectId, epicTypeId, workspaceSlug, filterDateField, filterDateFrom, filterDateTo]);
 
 	useEffect(() => {
 		if (projectIdReady) fetchEpics();
@@ -396,13 +436,12 @@ export default function EpicList({ workspaceSlug }: Props) {
 		setFilterStatuses,
 		filterPriorities,
 		setFilterPriorities,
-		showFiltersPopover,
-		setShowFiltersPopover,
-		filtersContainerRef,
-		filtersPopoverRef,
-		filtersButtonRef,
-		filtersPopoverPos,
-		activeFilterCount,
+		filterDateField,
+		setFilterDateField,
+		filterDateFrom,
+		setFilterDateFrom,
+		filterDateTo,
+		setFilterDateTo,
 	} = useEpicFilters();
 
 	const { projectId, projectIdReady, epicTypeId, projects } = useProjectSelection(workspaceSlug);
@@ -414,7 +453,10 @@ export default function EpicList({ workspaceSlug }: Props) {
 		projectId,
 		projectIdReady,
 		epicTypeId,
-		workspaceSlug
+		workspaceSlug,
+		filterDateField,
+		filterDateFrom,
+		filterDateTo
 	);
 
 	const {
@@ -455,18 +497,17 @@ export default function EpicList({ workspaceSlug }: Props) {
 	return (
 		<div>
 			<EpicListHeader
-				filtersContainerRef={filtersContainerRef}
-				filtersPopoverRef={filtersPopoverRef}
-				filtersButtonRef={filtersButtonRef}
-				filtersPopoverPos={filtersPopoverPos}
-				showFiltersPopover={showFiltersPopover}
-				setShowFiltersPopover={setShowFiltersPopover}
-				activeFilterCount={activeFilterCount}
 				derivedStatuses={derivedStatuses}
 				filterStatuses={filterStatuses}
 				setFilterStatuses={setFilterStatuses}
 				filterPriorities={filterPriorities}
 				setFilterPriorities={setFilterPriorities}
+				filterDateField={filterDateField}
+				setFilterDateField={setFilterDateField}
+				filterDateFrom={filterDateFrom}
+				setFilterDateFrom={setFilterDateFrom}
+				filterDateTo={filterDateTo}
+				setFilterDateTo={setFilterDateTo}
 				epicTypeId={epicTypeId}
 				onOpenCreate={openCreate}
 			/>
@@ -494,202 +535,6 @@ export default function EpicList({ workspaceSlug }: Props) {
 				projects={projects}
 				submitCreate={submitCreate}
 			/>
-		</div>
-	);
-}
-
-interface FiltersPopoverProps {
-	filtersContainerRef: MutableRef<HTMLDivElement | null>;
-	filtersPopoverRef: MutableRef<HTMLDivElement | null>;
-	filtersButtonRef: MutableRef<HTMLButtonElement | null>;
-	filtersPopoverPos: MutableRef<{ top: number; left: number }>;
-	showFiltersPopover: boolean;
-	setShowFiltersPopover: (v: boolean) => void;
-	activeFilterCount: number;
-	derivedStatuses: DerivedStatus[];
-	filterStatuses: string[];
-	setFilterStatuses: Dispatch<StateUpdater<string[]>>;
-	filterPriorities: string[];
-	setFilterPriorities: Dispatch<StateUpdater<string[]>>;
-}
-
-function StatusFilterPills({
-	derivedStatuses,
-	filterStatuses,
-	setFilterStatuses,
-}: {
-	derivedStatuses: DerivedStatus[];
-	filterStatuses: string[];
-	setFilterStatuses: Dispatch<StateUpdater<string[]>>;
-}) {
-	if (derivedStatuses.length === 0) {
-		return <span class="text-[0.78rem] text-text-muted">No epics loaded</span>;
-	}
-	return (
-		<>
-			{derivedStatuses.map((s) => {
-				const active = filterStatuses.includes(s.id);
-				return (
-					<button
-						type="button"
-						key={s.id}
-						aria-pressed={active}
-						onClick={() =>
-							setFilterStatuses((prev) =>
-								active ? prev.filter((id) => id !== s.id) : [...prev, s.id]
-							)
-						}
-						style={{
-							padding: "0.25rem 0.625rem",
-							borderRadius: "9999px",
-							border: active ? "none" : "1px solid var(--border)",
-							background: active ? categoryColor(s.category) : "var(--bg)",
-							color: active ? "#fff" : "var(--text)",
-							cursor: "pointer",
-							fontSize: "0.8rem",
-							fontWeight: active ? 600 : 400,
-						}}
-					>
-						{s.name}
-					</button>
-				);
-			})}
-		</>
-	);
-}
-
-function PriorityFilterPills({
-	filterPriorities,
-	setFilterPriorities,
-}: {
-	filterPriorities: string[];
-	setFilterPriorities: Dispatch<StateUpdater<string[]>>;
-}) {
-	return (
-		<>
-			{(["urgent", "high", "medium", "low"] as const).map((pr) => {
-				const active = filterPriorities.includes(pr);
-				const col = PILL_COLORS[pr];
-				return (
-					<button
-						type="button"
-						key={pr}
-						aria-pressed={active}
-						onClick={() =>
-							setFilterPriorities((prev) => (active ? prev.filter((k) => k !== pr) : [...prev, pr]))
-						}
-						style={{
-							padding: "0.25rem 0.625rem",
-							borderRadius: "9999px",
-							border: active ? "none" : "1px solid var(--border)",
-							background: active ? col.bg : "var(--bg)",
-							color: active ? col.text : "var(--text)",
-							cursor: "pointer",
-							fontSize: "0.8rem",
-							fontWeight: active ? 600 : 400,
-							textTransform: "capitalize" as const,
-						}}
-					>
-						{pr}
-					</button>
-				);
-			})}
-		</>
-	);
-}
-
-function FiltersPopover({
-	filtersContainerRef,
-	filtersPopoverRef,
-	filtersButtonRef,
-	filtersPopoverPos,
-	showFiltersPopover,
-	setShowFiltersPopover,
-	activeFilterCount,
-	derivedStatuses,
-	filterStatuses,
-	setFilterStatuses,
-	filterPriorities,
-	setFilterPriorities,
-}: FiltersPopoverProps) {
-	return (
-		<div class="relative" ref={filtersContainerRef}>
-			<button
-				ref={filtersButtonRef}
-				type="button"
-				onClick={() => {
-					if (showFiltersPopover) {
-						setShowFiltersPopover(false);
-					} else {
-						const rect = filtersButtonRef.current?.getBoundingClientRect();
-						if (rect) filtersPopoverPos.current = { top: rect.bottom + 4, left: rect.left };
-						setShowFiltersPopover(true);
-					}
-				}}
-				style={{
-					padding: "0.25rem 0.625rem",
-					borderRadius: "9999px",
-					border: activeFilterCount > 0 ? "none" : "1px solid var(--border)",
-					background: activeFilterCount > 0 ? "var(--accent)" : "var(--bg)",
-					color: activeFilterCount > 0 ? "#fff" : "var(--text)",
-					cursor: "pointer",
-					fontSize: "0.8rem",
-					fontWeight: activeFilterCount > 0 ? 600 : 400,
-				}}
-			>
-				{activeFilterCount > 0 ? `Filters (${activeFilterCount})` : "Filters"}
-			</button>
-			{showFiltersPopover && (
-				<div
-					ref={filtersPopoverRef}
-					style={{
-						position: "fixed",
-						top: `${filtersPopoverPos.current.top}px`,
-						left: `${filtersPopoverPos.current.left}px`,
-						zIndex: 100,
-						background: "var(--surface)",
-						border: "1px solid var(--border)",
-						borderRadius: "0.5rem",
-						padding: "0.75rem",
-						boxShadow: "var(--shadow-sm)",
-						minWidth: "16rem",
-					}}
-				>
-					<div class="text-[0.7rem] font-semibold text-text-muted uppercase tracking-[0.04em] mb-2">
-						Status
-					</div>
-					<div class="flex flex-wrap gap-1 mb-3">
-						<StatusFilterPills
-							derivedStatuses={derivedStatuses}
-							filterStatuses={filterStatuses}
-							setFilterStatuses={setFilterStatuses}
-						/>
-					</div>
-					<div class="text-[0.7rem] font-semibold text-text-muted uppercase tracking-[0.04em] mb-2">
-						Priority
-					</div>
-					<div class="flex flex-wrap gap-1">
-						<PriorityFilterPills
-							filterPriorities={filterPriorities}
-							setFilterPriorities={setFilterPriorities}
-						/>
-					</div>
-					{activeFilterCount > 0 && (
-						<div class="border-t border-border pt-2 mt-3">
-							<button
-								type="button"
-								onClick={() => {
-									setFilterStatuses([]);
-									setFilterPriorities([]);
-								}}
-								class="bg-transparent border-none text-text-muted cursor-pointer text-[0.8rem] p-0"
-							>
-								✕ Clear all
-							</button>
-						</div>
-					)}
-				</div>
-			)}
 		</div>
 	);
 }

--- a/apps/web/src/islands/IssueList-helpers.ts
+++ b/apps/web/src/islands/IssueList-helpers.ts
@@ -43,7 +43,7 @@ function applyEpicParams(
 
 // Date-range filter (PROJ-212) runs server-side against the chosen timestamp
 // column; bounds are inclusive (from = start of day, to = end).
-function applyDateRangeParams(
+export function applyDateRangeParams(
 	qs: URLSearchParams,
 	filterDateField: FilterQueryFilters["filterDateField"],
 	filterDateFrom: string,

--- a/apps/web/src/islands/MetricsDashboard.tsx
+++ b/apps/web/src/islands/MetricsDashboard.tsx
@@ -1,11 +1,20 @@
 import type { ComponentChildren } from "preact";
 import { useEffect, useMemo, useState } from "preact/hooks";
-import uPlot from "uplot";
+import type uPlot from "uplot";
 import { apiFetch } from "../utils/api-client";
 import CodeHeatmap from "./charts/CodeHeatmap";
 import UplotChart, { createTooltipPlugin } from "./charts/UplotChart";
 import { MetricHelp, SectionHeading } from "./MetricHelp";
 import { METRIC_DEFINITIONS, type MetricId } from "./metric-definitions";
+import {
+	CfdChart,
+	EmptyChartState,
+	formatFullDate,
+	formatShortDate,
+	readChartSeqColors,
+	readThemeColor,
+	ThroughputChart,
+} from "./metrics/flow-charts";
 import Select, { type SelectOption } from "./Select";
 
 interface Distribution {
@@ -143,37 +152,6 @@ function formatDuration(seconds: number | null): string {
 	if (abs < 3600) return `${(seconds / 60).toFixed(1)}m`;
 	if (abs < 86400) return `${(seconds / 3600).toFixed(1)}h`;
 	return `${(seconds / 86400).toFixed(1)}d`;
-}
-
-// uPlot bakes colors into the canvas at creation time, so callers re-read these live
-// (rather than caching) whenever a chart is (re)built, including on theme toggle.
-function readThemeColor(token: string, fallback: string): string {
-	const value = getComputedStyle(document.documentElement).getPropertyValue(token).trim();
-	return value || fallback;
-}
-
-function hexToRgba(hex: string, alpha: number): string {
-	const match = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
-	if (!match) return hex;
-	const [r, g, b] = match.slice(1).map((h) => parseInt(h, 16));
-	return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-}
-
-function formatShortDate(iso: string): string {
-	const d = new Date(`${iso}T00:00:00Z`);
-	if (Number.isNaN(d.getTime())) return iso;
-	return d.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
-}
-
-function formatFullDate(iso: string): string {
-	const d = new Date(`${iso}T00:00:00Z`);
-	if (Number.isNaN(d.getTime())) return iso;
-	return d.toLocaleDateString("en-US", {
-		month: "short",
-		day: "numeric",
-		year: "numeric",
-		timeZone: "UTC",
-	});
 }
 
 function useFlowMetrics(workspaceSlug: string | undefined, range: RangeState) {
@@ -355,73 +333,6 @@ function HealthTile({ metricId, value }: { metricId: MetricId; value: number }) 
 	);
 }
 
-function EmptyChartState({ message }: { message: string }) {
-	return (
-		<div class="flex items-center justify-center h-[220px] text-sm text-text-muted">{message}</div>
-	);
-}
-
-function ThroughputChart({ data }: { data: FlowMetrics["throughputOverTime"] }) {
-	const labels = useMemo(() => data.map((d) => d.bucketStart), [data]);
-	const chartData = useMemo<uPlot.AlignedData>(
-		() => [data.map((_, i) => i), data.map((d) => d.count)],
-		[data]
-	);
-
-	const buildOptions = useMemo(() => {
-		return (width: number, height: number): uPlot.Options => {
-			const accent = readThemeColor("--accent", "#4f46e5");
-			const border = readThemeColor("--border", "#e2e8f0");
-			const textMuted = readThemeColor("--text-muted", "#6b7280");
-
-			return {
-				width,
-				height,
-				scales: { x: { time: false } },
-				legend: { show: false },
-				series: [
-					{},
-					{
-						label: "Issues completed",
-						stroke: accent,
-						fill: hexToRgba(accent, 0.25),
-						paths: uPlot.paths.bars?.(),
-					},
-				],
-				axes: [
-					{
-						stroke: textMuted,
-						grid: { stroke: border },
-						splits: (u) => {
-							const n = labels.length;
-							const maxTicks = Math.max(2, Math.floor(u.width / 70));
-							const stride = Math.max(1, Math.ceil(n / maxTicks));
-							const idxs: number[] = [];
-							for (let i = 0; i < n; i += stride) idxs.push(i);
-							if (idxs[idxs.length - 1] !== n - 1) idxs.push(n - 1);
-							return idxs;
-						},
-						values: (_u, splits) => splits.map((s) => formatShortDate(labels[s] ?? "")),
-					},
-					{ stroke: textMuted, grid: { stroke: border } },
-				],
-				plugins: [
-					createTooltipPlugin({
-						formatX: (xVal) => formatFullDate(labels[xVal] ?? ""),
-						formatY: (yVal) => `${yVal} completed`,
-					}),
-				],
-			};
-		};
-	}, [labels]);
-
-	if (data.length === 0 || data.every((d) => d.count === 0)) {
-		return <EmptyChartState message="No completed issues yet" />;
-	}
-
-	return <UplotChart data={chartData} buildOptions={buildOptions} />;
-}
-
 // PROJ-331: bug share % trend line, chosen over stacked-bars-by-type per the ticket's
 // "or" — this dashboard already has a lot of charts landing in this epic, and a single
 // trend line answers the ticket's actual question ("is the factory shipping more
@@ -541,108 +452,6 @@ function ReviewLatencyChart({ data }: { data: FlowMetrics["reviewLatencyOverTime
 
 	if (data.length === 0 || data.every((d) => d.p50 === null)) {
 		return <EmptyChartState message="No review-latency data yet" />;
-	}
-
-	return <UplotChart data={chartData} buildOptions={buildOptions} />;
-}
-
-// PROJ-329: cumulative flow diagram. Bands are stacked bottom-up (done at the base,
-// backlog/todo on top) by plotting cumulative sums and drawing widest-first so each
-// later, narrower fill paints over the tail of the one before it — the classic uPlot
-// stacked-area trick, since uPlot has no native "stacked" series mode. Colors are a
-// single-hue ordinal ramp (lightest = earliest stage, darkest = done) rather than
-// unrelated categorical hues, since the bands read as an ordered progression, not
-// independent categories. Read from the --chart-seq-* tokens (Base.astro) rather than
-// baked-in hex so the ramp repaints on theme toggle, same as every other chart color here.
-function readChartSeqColors() {
-	return {
-		backlogTodo: readThemeColor("--chart-seq-1", "#86b6ef"),
-		inProgress: readThemeColor("--chart-seq-2", "#5598e7"),
-		inReview: readThemeColor("--chart-seq-3", "#2a78d6"),
-		done: readThemeColor("--chart-seq-4", "#1c5cab"),
-	};
-}
-
-function CfdChart({ data }: { data: FlowMetrics["cfdOverTime"] }) {
-	const labels = useMemo(() => data.map((d) => d.bucketStart), [data]);
-	const chartData = useMemo<uPlot.AlignedData>(() => {
-		const total = data.map((d) => d.backlogTodo + d.inProgress + d.inReview + d.done);
-		const upToInProgress = data.map((d) => d.inProgress + d.inReview + d.done);
-		const upToInReview = data.map((d) => d.inReview + d.done);
-		const done = data.map((d) => d.done);
-		return [data.map((_, i) => i), total, upToInProgress, upToInReview, done];
-	}, [data]);
-
-	const buildOptions = useMemo(() => {
-		return (width: number, height: number): uPlot.Options => {
-			const border = readThemeColor("--border", "#e2e8f0");
-			const textMuted = readThemeColor("--text-muted", "#6b7280");
-			const seq = readChartSeqColors();
-
-			return {
-				width,
-				height,
-				scales: { x: { time: false } },
-				legend: { show: true },
-				series: [
-					{},
-					// Series carry cumulative sums (for the stacked-area geometry), so the legend
-					// `value` de-cumulates each back to its own band count — otherwise the legend
-					// would report the running total, not the band's actual size.
-					{
-						label: "Backlog/todo",
-						stroke: seq.backlogTodo,
-						fill: seq.backlogTodo,
-						value: (u, _v, _si, i) =>
-							i == null ? "" : (u.data[1][i] as number) - (u.data[2][i] as number),
-					},
-					{
-						label: "In progress",
-						stroke: seq.inProgress,
-						fill: seq.inProgress,
-						value: (u, _v, _si, i) =>
-							i == null ? "" : (u.data[2][i] as number) - (u.data[3][i] as number),
-					},
-					{
-						label: "In review",
-						stroke: seq.inReview,
-						fill: seq.inReview,
-						value: (u, _v, _si, i) =>
-							i == null ? "" : (u.data[3][i] as number) - (u.data[4][i] as number),
-					},
-					{
-						label: "Done",
-						stroke: seq.done,
-						fill: seq.done,
-						value: (_u, v) => v ?? "",
-					},
-				],
-				axes: [
-					{
-						stroke: textMuted,
-						grid: { stroke: border },
-						splits: (u) => {
-							const n = labels.length;
-							const maxTicks = Math.max(2, Math.floor(u.width / 70));
-							const stride = Math.max(1, Math.ceil(n / maxTicks));
-							const idxs: number[] = [];
-							for (let i = 0; i < n; i += stride) idxs.push(i);
-							if (idxs[idxs.length - 1] !== n - 1) idxs.push(n - 1);
-							return idxs;
-						},
-						values: (_u, splits) => splits.map((s) => formatShortDate(labels[s] ?? "")),
-					},
-					{ stroke: textMuted, grid: { stroke: border } },
-				],
-			};
-		};
-	}, [labels]);
-
-	if (
-		data.length === 0 ||
-		data.every((d) => d.backlogTodo + d.inProgress + d.inReview + d.done === 0)
-	) {
-		return <EmptyChartState message="No issues in this window yet" />;
 	}
 
 	return <UplotChart data={chartData} buildOptions={buildOptions} />;

--- a/apps/web/src/islands/ProjectFlowCharts.tsx
+++ b/apps/web/src/islands/ProjectFlowCharts.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from "preact/hooks";
+import { apiFetch } from "../utils/api-client";
+import {
+	CfdChart,
+	type CfdPoint,
+	ThroughputChart,
+	type ThroughputPoint,
+} from "./metrics/flow-charts";
+
+interface FlowMetrics {
+	throughputOverTime: ThroughputPoint[];
+	cfdOverTime: CfdPoint[];
+}
+
+const SECTION_HEADING_CLASS =
+	"text-xs font-semibold text-text-muted m-0 mb-3 uppercase tracking-[0.05em]";
+
+function mondayOfWeek(d: Date): Date {
+	const monday = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+	const daysSinceMonday = (monday.getUTCDay() + 6) % 7;
+	monday.setUTCDate(monday.getUTCDate() - daysSinceMonday);
+	return monday;
+}
+
+// Same 6-week weekly default window as MetricsDashboard's defaultRange, so a project's
+// overview and its full /metrics page agree on "recent" without a picker on this page.
+function defaultSinceUntil(): { since: number; until: number } {
+	const today = new Date();
+	const monday = mondayOfWeek(today);
+	monday.setUTCDate(monday.getUTCDate() - 5 * 7);
+	const since = Math.floor(monday.getTime() / 1000);
+	const until = Math.floor(today.getTime() / 1000) + 86399;
+	return { since, until };
+}
+
+function useProjectFlowCharts(workspaceSlug: string | undefined, projectId: string | null) {
+	const [metrics, setMetrics] = useState<FlowMetrics | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (!projectId) {
+			setLoading(false);
+			return;
+		}
+		setLoading(true);
+		setError(null);
+		const { since, until } = defaultSinceUntil();
+		const query = new URLSearchParams({
+			since: String(since),
+			until: String(until),
+			granularity: "week",
+		});
+		apiFetch<FlowMetrics>(`/api/projects/${encodeURIComponent(projectId)}/flow-metrics?${query}`, {
+			workspaceSlug,
+		})
+			.then((data) => setMetrics(data))
+			.catch((e) => setError(String(e)))
+			.finally(() => setLoading(false));
+	}, [projectId, workspaceSlug]);
+
+	return { metrics, loading, error };
+}
+
+export default function ProjectFlowCharts({
+	workspaceSlug,
+	projectId,
+}: {
+	workspaceSlug: string | undefined;
+	projectId: string;
+}) {
+	const { metrics, loading, error } = useProjectFlowCharts(workspaceSlug, projectId);
+
+	if (loading) return null;
+	if (error || !metrics) return null;
+
+	return (
+		<section class="mb-8" aria-labelledby="flow-charts-heading">
+			<h2 id="flow-charts-heading" class={SECTION_HEADING_CLASS}>
+				Flow (last 6 weeks)
+			</h2>
+			<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+				<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto">
+					<p class="m-0 mb-2 text-[0.72rem] font-medium text-text-muted">Throughput</p>
+					<ThroughputChart data={metrics.throughputOverTime} />
+				</div>
+				<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto">
+					<p class="m-0 mb-2 text-[0.72rem] font-medium text-text-muted">Cumulative flow</p>
+					<CfdChart data={metrics.cfdOverTime} />
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/apps/web/src/islands/ProjectFlowCharts.tsx
+++ b/apps/web/src/islands/ProjectFlowCharts.tsx
@@ -24,12 +24,19 @@ function mondayOfWeek(d: Date): Date {
 
 // Same 6-week weekly default window as MetricsDashboard's defaultRange, so a project's
 // overview and its full /metrics page agree on "recent" without a picker on this page.
+// `until` matches MetricsDashboard's dateStrToEpochEnd (end of today, UTC) rather than
+// `Date.now() + 86399`, which would reach ~24h into tomorrow.
 function defaultSinceUntil(): { since: number; until: number } {
 	const today = new Date();
 	const monday = mondayOfWeek(today);
 	monday.setUTCDate(monday.getUTCDate() - 5 * 7);
 	const since = Math.floor(monday.getTime() / 1000);
-	const until = Math.floor(today.getTime() / 1000) + 86399;
+	const todayUtcMidnight = Date.UTC(
+		today.getUTCFullYear(),
+		today.getUTCMonth(),
+		today.getUTCDate()
+	);
+	const until = Math.floor(todayUtcMidnight / 1000) + 86399;
 	return { since, until };
 }
 
@@ -82,11 +89,11 @@ export default function ProjectFlowCharts({
 			<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 				<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto">
 					<p class="m-0 mb-2 text-[0.72rem] font-medium text-text-muted">Throughput</p>
-					<ThroughputChart data={metrics.throughputOverTime} />
+					<ThroughputChart data={metrics.throughputOverTime ?? []} />
 				</div>
 				<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto">
 					<p class="m-0 mb-2 text-[0.72rem] font-medium text-text-muted">Cumulative flow</p>
-					<CfdChart data={metrics.cfdOverTime} />
+					<CfdChart data={metrics.cfdOverTime ?? []} />
 				</div>
 			</div>
 		</section>

--- a/apps/web/src/islands/ProjectLanding.test.tsx
+++ b/apps/web/src/islands/ProjectLanding.test.tsx
@@ -29,6 +29,13 @@ const ISSUE = {
 	updated_at: 1000,
 };
 
+const WIKI_PAGE = {
+	id: "w1",
+	slug: "getting-started",
+	title: "Getting Started",
+	updated_at: 1000,
+};
+
 function mockFetchProject(issues: (typeof ISSUE)[] = [ISSUE], wiki: unknown[] = []) {
 	vi.stubGlobal(
 		"fetch",
@@ -89,5 +96,13 @@ describe("ProjectLanding", () => {
 		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
 		render(<ProjectLanding />);
 		expect(await screen.findByRole("alert")).toBeTruthy();
+	});
+
+	it("recent-wiki links preserve projectId so the destination stays scoped (PROJ-352)", async () => {
+		history.replaceState(null, "", "?id=p1");
+		mockFetchProject([ISSUE], [WIKI_PAGE]);
+		render(<ProjectLanding />);
+		const link = (await screen.findByText("Getting Started")).closest("a");
+		expect(link?.getAttribute("href")).toBe("/wiki?slug=getting-started&projectId=p1");
 	});
 });

--- a/apps/web/src/islands/ProjectLanding.test.tsx
+++ b/apps/web/src/islands/ProjectLanding.test.tsx
@@ -29,7 +29,11 @@ const ISSUE = {
 	updated_at: 1000,
 };
 
-function mockFetchProject(issues: (typeof ISSUE)[] = [ISSUE], wiki: unknown[] = []) {
+function mockFetchProject(
+	issues: (typeof ISSUE)[] = [ISSUE],
+	wiki: unknown[] = [],
+	flowMetrics: unknown = { throughputOverTime: [], cfdOverTime: [] }
+) {
 	vi.stubGlobal(
 		"fetch",
 		vi.fn().mockImplementation((url: string) => {
@@ -39,6 +43,9 @@ function mockFetchProject(issues: (typeof ISSUE)[] = [ISSUE], wiki: unknown[] = 
 			}
 			if (u.includes("/api/wiki")) {
 				return Promise.resolve({ ok: true, json: () => Promise.resolve(wiki) });
+			}
+			if (u.includes("/flow-metrics")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve(flowMetrics) });
 			}
 			// project fetch
 			return Promise.resolve({ ok: true, json: () => Promise.resolve(PROJECT) });
@@ -89,5 +96,29 @@ describe("ProjectLanding", () => {
 		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
 		render(<ProjectLanding />);
 		expect(await screen.findByRole("alert")).toBeTruthy();
+	});
+
+	it("shows an empty state for the flow charts on a project with no history", async () => {
+		history.replaceState(null, "", "?id=p1");
+		mockFetchProject([ISSUE], [], { throughputOverTime: [], cfdOverTime: [] });
+		render(<ProjectLanding />);
+		await screen.findByRole("heading", { name: "Projektor" });
+		expect(await screen.findByText(/Flow \(last 6 weeks\)/i)).toBeTruthy();
+		expect(screen.getAllByText(/No (completed issues|issues in this window)/i).length).toBe(2);
+	});
+
+	it("renders throughput and cumulative flow charts when the project has flow history", async () => {
+		history.replaceState(null, "", "?id=p1");
+		mockFetchProject([ISSUE], [], {
+			throughputOverTime: [{ bucketStart: "2024-01-01", count: 3 }],
+			cfdOverTime: [
+				{ bucketStart: "2024-01-01", backlogTodo: 2, inProgress: 1, inReview: 0, done: 3 },
+			],
+		});
+		render(<ProjectLanding />);
+		await screen.findByRole("heading", { name: "Projektor" });
+		expect(await screen.findByText(/Flow \(last 6 weeks\)/i)).toBeTruthy();
+		expect(screen.getByText("Throughput")).toBeTruthy();
+		expect(screen.getByText("Cumulative flow")).toBeTruthy();
 	});
 });

--- a/apps/web/src/islands/ProjectLanding.tsx
+++ b/apps/web/src/islands/ProjectLanding.tsx
@@ -297,7 +297,7 @@ function RecentIssuesSection({ issues }: { issues: RecentIssue[] }) {
 	);
 }
 
-function RecentWikiSection({ pages }: { pages: RecentWikiPage[] }) {
+function RecentWikiSection({ pages, projectId }: { pages: RecentWikiPage[]; projectId: string }) {
 	return (
 		<section class="mb-8" aria-labelledby="recent-wiki-heading">
 			<h2 id="recent-wiki-heading" class={SECTION_HEADING_CLASS}>
@@ -311,7 +311,7 @@ function RecentWikiSection({ pages }: { pages: RecentWikiPage[] }) {
 						<div key={page.id} class="py-2 border-b border-border last:border-b-0">
 							<div class="flex justify-between items-baseline gap-2">
 								<a
-									href={`/wiki?slug=${encodeURIComponent(page.slug)}`}
+									href={`/wiki?slug=${encodeURIComponent(page.slug)}&projectId=${encodeURIComponent(projectId)}`}
 									class="text-text-base no-underline text-sm hover:underline focus:underline"
 								>
 									{page.title}
@@ -426,7 +426,7 @@ export default function ProjectLanding({ workspaceSlug }: Props) {
 			</header>
 
 			<RecentIssuesSection issues={recentIssues} />
-			<RecentWikiSection pages={recentWiki} />
+			<RecentWikiSection pages={recentWiki} projectId={project.id} />
 		</div>
 	);
 }

--- a/apps/web/src/islands/ProjectLanding.tsx
+++ b/apps/web/src/islands/ProjectLanding.tsx
@@ -2,6 +2,7 @@ import type { RefObject } from "preact";
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { statusDisplayName } from "../lib/status";
 import { apiFetch } from "../utils/api-client";
+import ProjectFlowCharts from "./ProjectFlowCharts";
 
 interface Project {
 	id: string;
@@ -425,6 +426,7 @@ export default function ProjectLanding({ workspaceSlug }: Props) {
 				</div>
 			</header>
 
+			<ProjectFlowCharts workspaceSlug={workspaceSlug} projectId={project.id} />
 			<RecentIssuesSection issues={recentIssues} />
 			<RecentWikiSection pages={recentWiki} />
 		</div>

--- a/apps/web/src/islands/WikiPage.test.tsx
+++ b/apps/web/src/islands/WikiPage.test.tsx
@@ -98,6 +98,52 @@ describe("WikiPage", () => {
 	});
 });
 
+describe("WikiPage — project scope control (PROJ-352)", () => {
+	function mockFetchWikiWithProjects(page: WikiPageData | null) {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation((url: string) => {
+				const u = String(url);
+				if (u.includes("/revisions")) {
+					return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+				}
+				if (u.includes("/tree")) {
+					return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+				}
+				if (u.includes("/api/projects")) {
+					return Promise.resolve({
+						ok: true,
+						json: () => Promise.resolve([{ id: "p1", key: "PROJ", name: "Projektor" }]),
+					});
+				}
+				return Promise.resolve({ ok: true, json: () => Promise.resolve(page) });
+			})
+		);
+	}
+
+	it("defaults to 'Workspace (all projects)' scope when no projectId is set", async () => {
+		history.replaceState(null, "", "?slug=my-page");
+		mockFetchWikiWithProjects(PAGE);
+		render(<WikiPage />);
+		await screen.findByText("My Page");
+		expect(screen.getByRole("combobox", { name: "Wiki project scope" }).textContent).toMatch(
+			/Workspace \(all projects\)/i
+		);
+	});
+
+	it("shows the project's scope when projectId is set via the URL", async () => {
+		history.replaceState(null, "", "?slug=my-page&projectId=p1");
+		mockFetchWikiWithProjects(PAGE);
+		render(<WikiPage />);
+		await screen.findByText("My Page");
+		await waitFor(() => {
+			expect(screen.getByRole("combobox", { name: "Wiki project scope" }).textContent).toMatch(
+				/PROJ — Projektor/i
+			);
+		});
+	});
+});
+
 async function startEditingWithTitleInput(): Promise<HTMLInputElement> {
 	history.replaceState(null, "", "?slug=my-page");
 	mockFetchWiki(PAGE);

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -6,6 +6,13 @@ import { apiFetch } from "../utils/api-client";
 import { renderMdWithWikilinks, renderMermaidDiagrams } from "../utils/markdown";
 import AccessPending from "./AccessPending";
 import MarkdownEditor from "./MarkdownEditor";
+import Select, { type SelectOption } from "./Select";
+
+interface ProjectOption {
+	id: string;
+	key: string;
+	name: string;
+}
 
 interface SearchResult {
 	id: string;
@@ -203,7 +210,52 @@ function PageTreeList({
 	);
 }
 
+// Lets a user viewing the workspace-wide wiki (or one project's wiki) switch to another
+// scope explicitly, since the only other entry point is a project's nav tab. Switching
+// scope is a full navigation (fresh tree/search for the new scope), not an in-place swap.
+function useProjects(workspaceSlug: string | undefined) {
+	const [projects, setProjects] = useState<ProjectOption[]>([]);
+
+	useEffect(() => {
+		apiFetch<ProjectOption[]>("/api/projects", { workspaceSlug })
+			.then((list) => setProjects(Array.isArray(list) ? list : []))
+			.catch(() => {});
+	}, [workspaceSlug]);
+
+	return projects;
+}
+
+function ScopeControl({
+	workspaceSlug,
+	projectId,
+}: {
+	workspaceSlug: string | undefined;
+	projectId: string;
+}) {
+	const projects = useProjects(workspaceSlug);
+	const options: SelectOption[] = [
+		{ value: "", label: "Workspace (all projects)" },
+		...projects.map((p) => ({ value: p.id, label: `${p.key} — ${p.name}` })),
+	];
+
+	return (
+		<div class="mb-3">
+			<p class="m-0 mb-1 text-[0.7rem] text-text-muted">Scope</p>
+			<Select
+				value={projectId}
+				options={options}
+				ariaLabel="Wiki project scope"
+				onChange={(value) => {
+					window.location.href = value ? `/wiki?projectId=${encodeURIComponent(value)}` : "/wiki";
+				}}
+			/>
+		</div>
+	);
+}
+
 function WikiSidebar({
+	workspaceSlug,
+	projectId,
 	searchQuery,
 	onSearchQueryChange,
 	searchResults,
@@ -214,6 +266,8 @@ function WikiSidebar({
 	onNavigate,
 	onCreate,
 }: {
+	workspaceSlug: string | undefined;
+	projectId: string;
 	searchQuery: string;
 	onSearchQueryChange: (value: string) => void;
 	searchResults: SearchResult[];
@@ -230,6 +284,7 @@ function WikiSidebar({
 	].join(" ");
 	return (
 		<aside class={asideClass}>
+			<ScopeControl workspaceSlug={workspaceSlug} projectId={projectId} />
 			<button
 				type="button"
 				onClick={onCreate}
@@ -1576,6 +1631,8 @@ const WIKI_PAGE_STYLES = `
 `;
 
 function WikiPageShell(props: {
+	workspaceSlug: string | undefined;
+	projectId: string;
 	searchQuery: string;
 	onSearchQueryChange: (v: string) => void;
 	searchResults: SearchResult[];
@@ -1599,6 +1656,8 @@ function WikiPageShell(props: {
 		<div class="flex min-h-screen max-sm:flex-col">
 			<style>{WIKI_PAGE_STYLES}</style>
 			<WikiSidebar
+				workspaceSlug={props.workspaceSlug}
+				projectId={props.projectId}
 				searchQuery={props.searchQuery}
 				onSearchQueryChange={props.onSearchQueryChange}
 				searchResults={props.searchResults}
@@ -1821,6 +1880,8 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 
 	return (
 		<WikiPageShell
+			workspaceSlug={workspaceSlug}
+			projectId={projectId}
 			searchQuery={searchQuery}
 			onSearchQueryChange={setSearchQuery}
 			searchResults={searchResults}

--- a/apps/web/src/islands/metrics/flow-charts.tsx
+++ b/apps/web/src/islands/metrics/flow-charts.tsx
@@ -1,0 +1,208 @@
+import { useMemo } from "preact/hooks";
+import uPlot from "uplot";
+import UplotChart, { createTooltipPlugin } from "../charts/UplotChart";
+
+export interface ThroughputPoint {
+	bucketStart: string;
+	count: number;
+}
+
+export interface CfdPoint {
+	bucketStart: string;
+	backlogTodo: number;
+	inProgress: number;
+	inReview: number;
+	done: number;
+}
+
+// uPlot bakes colors into the canvas at creation time, so callers re-read these live
+// (rather than caching) whenever a chart is (re)built, including on theme toggle.
+export function readThemeColor(token: string, fallback: string): string {
+	const value = getComputedStyle(document.documentElement).getPropertyValue(token).trim();
+	return value || fallback;
+}
+
+export function hexToRgba(hex: string, alpha: number): string {
+	const match = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+	if (!match) return hex;
+	const [r, g, b] = match.slice(1).map((h) => parseInt(h, 16));
+	return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+export function formatShortDate(iso: string): string {
+	const d = new Date(`${iso}T00:00:00Z`);
+	if (Number.isNaN(d.getTime())) return iso;
+	return d.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
+}
+
+export function formatFullDate(iso: string): string {
+	const d = new Date(`${iso}T00:00:00Z`);
+	if (Number.isNaN(d.getTime())) return iso;
+	return d.toLocaleDateString("en-US", {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+		timeZone: "UTC",
+	});
+}
+
+// Single-hue ordinal ramp (lightest = earliest stage, darkest = done) for the CFD bands —
+// read from the --chart-seq-* tokens (Base.astro) so the ramp repaints on theme toggle.
+export function readChartSeqColors() {
+	return {
+		backlogTodo: readThemeColor("--chart-seq-1", "#86b6ef"),
+		inProgress: readThemeColor("--chart-seq-2", "#5598e7"),
+		inReview: readThemeColor("--chart-seq-3", "#2a78d6"),
+		done: readThemeColor("--chart-seq-4", "#1c5cab"),
+	};
+}
+
+export function EmptyChartState({ message }: { message: string }) {
+	return (
+		<div class="flex items-center justify-center h-[220px] text-sm text-text-muted">{message}</div>
+	);
+}
+
+function tickIndices(width: number, labels: string[]): number[] {
+	const n = labels.length;
+	const maxTicks = Math.max(2, Math.floor(width / 70));
+	const stride = Math.max(1, Math.ceil(n / maxTicks));
+	const idxs: number[] = [];
+	for (let i = 0; i < n; i += stride) idxs.push(i);
+	if (idxs[idxs.length - 1] !== n - 1) idxs.push(n - 1);
+	return idxs;
+}
+
+export function ThroughputChart({ data }: { data: ThroughputPoint[] }) {
+	const labels = useMemo(() => data.map((d) => d.bucketStart), [data]);
+	const chartData = useMemo<uPlot.AlignedData>(
+		() => [data.map((_, i) => i), data.map((d) => d.count)],
+		[data]
+	);
+
+	const buildOptions = useMemo(() => {
+		return (width: number, height: number): uPlot.Options => {
+			const accent = readThemeColor("--accent", "#4f46e5");
+			const border = readThemeColor("--border", "#e2e8f0");
+			const textMuted = readThemeColor("--text-muted", "#6b7280");
+
+			return {
+				width,
+				height,
+				scales: { x: { time: false } },
+				legend: { show: false },
+				series: [
+					{},
+					{
+						label: "Issues completed",
+						stroke: accent,
+						fill: hexToRgba(accent, 0.25),
+						paths: uPlot.paths.bars?.(),
+					},
+				],
+				axes: [
+					{
+						stroke: textMuted,
+						grid: { stroke: border },
+						splits: (u) => tickIndices(u.width, labels),
+						values: (_u, splits) => splits.map((s) => formatShortDate(labels[s] ?? "")),
+					},
+					{ stroke: textMuted, grid: { stroke: border } },
+				],
+				plugins: [
+					createTooltipPlugin({
+						formatX: (xVal) => formatFullDate(labels[xVal] ?? ""),
+						formatY: (yVal) => `${yVal} completed`,
+					}),
+				],
+			};
+		};
+	}, [labels]);
+
+	if (data.length === 0 || data.every((d) => d.count === 0)) {
+		return <EmptyChartState message="No completed issues yet" />;
+	}
+
+	return <UplotChart data={chartData} buildOptions={buildOptions} />;
+}
+
+// Bands are stacked bottom-up (done at the base, backlog/todo on top) by plotting
+// cumulative sums and drawing widest-first so each later, narrower fill paints over the
+// tail of the one before it — the classic uPlot stacked-area trick, since uPlot has no
+// native "stacked" series mode.
+export function CfdChart({ data }: { data: CfdPoint[] }) {
+	const labels = useMemo(() => data.map((d) => d.bucketStart), [data]);
+	const chartData = useMemo<uPlot.AlignedData>(() => {
+		const total = data.map((d) => d.backlogTodo + d.inProgress + d.inReview + d.done);
+		const upToInProgress = data.map((d) => d.inProgress + d.inReview + d.done);
+		const upToInReview = data.map((d) => d.inReview + d.done);
+		const done = data.map((d) => d.done);
+		return [data.map((_, i) => i), total, upToInProgress, upToInReview, done];
+	}, [data]);
+
+	const buildOptions = useMemo(() => {
+		return (width: number, height: number): uPlot.Options => {
+			const border = readThemeColor("--border", "#e2e8f0");
+			const textMuted = readThemeColor("--text-muted", "#6b7280");
+			const seq = readChartSeqColors();
+
+			return {
+				width,
+				height,
+				scales: { x: { time: false } },
+				legend: { show: true },
+				series: [
+					{},
+					// Series carry cumulative sums (for the stacked-area geometry), so the legend
+					// `value` de-cumulates each back to its own band count — otherwise the legend
+					// would report the running total, not the band's actual size.
+					{
+						label: "Backlog/todo",
+						stroke: seq.backlogTodo,
+						fill: seq.backlogTodo,
+						value: (u, _v, _si, i) =>
+							i == null ? "" : (u.data[1][i] as number) - (u.data[2][i] as number),
+					},
+					{
+						label: "In progress",
+						stroke: seq.inProgress,
+						fill: seq.inProgress,
+						value: (u, _v, _si, i) =>
+							i == null ? "" : (u.data[2][i] as number) - (u.data[3][i] as number),
+					},
+					{
+						label: "In review",
+						stroke: seq.inReview,
+						fill: seq.inReview,
+						value: (u, _v, _si, i) =>
+							i == null ? "" : (u.data[3][i] as number) - (u.data[4][i] as number),
+					},
+					{
+						label: "Done",
+						stroke: seq.done,
+						fill: seq.done,
+						value: (_u, v) => v ?? "",
+					},
+				],
+				axes: [
+					{
+						stroke: textMuted,
+						grid: { stroke: border },
+						splits: (u) => tickIndices(u.width, labels),
+						values: (_u, splits) => splits.map((s) => formatShortDate(labels[s] ?? "")),
+					},
+					{ stroke: textMuted, grid: { stroke: border } },
+				],
+			};
+		};
+	}, [labels]);
+
+	if (
+		data.length === 0 ||
+		data.every((d) => d.backlogTodo + d.inProgress + d.inReview + d.done === 0)
+	) {
+		return <EmptyChartState message="No issues in this window yet" />;
+	}
+
+	return <UplotChart data={chartData} buildOptions={buildOptions} />;
+}

--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -30,13 +30,20 @@ const navItems = [
     <title>{title}</title>
     <ClientRouter />
     <!-- safe-ls: 'theme' is a cosmetic preference (dark/light). No API dependency - a
-         stale or missing value falls back to the system color-scheme media query. -->
+         stale or missing value falls back to the system color-scheme media query.
+         Astro's ClientRouter swaps <html>'s attributes to match the incoming (server-
+         rendered, theme-unaware) document on every client-side nav, wiping data-theme -
+         so this re-applies on astro:after-swap, not just on first load. -->
     <script is:inline>
       (function () {
-        try {
-          var t = localStorage.getItem('theme');
-          if (t === 'dark' || t === 'light') document.documentElement.setAttribute('data-theme', t);
-        } catch (e) {}
+        function applyTheme() {
+          try {
+            var t = localStorage.getItem('theme');
+            if (t === 'dark' || t === 'light') document.documentElement.setAttribute('data-theme', t);
+          } catch (e) {}
+        }
+        applyTheme();
+        document.addEventListener('astro:after-swap', applyTheme);
       })();
     </script>
     <style is:global>
@@ -616,42 +623,56 @@ const navItems = [
         <slot />
       </div>
     </div>
+    <!-- Astro's ClientRouter replaces <body> wholesale on every client-side nav (the
+         sidebar is deliberately not transition:persist'ed - see PROJ-350), so the
+         hamburger/overlay/sidebar/theme-toggle nodes below are recreated each time and
+         need their listeners rebound via astro:page-load (fires on first load too).
+         The document-level keydown/matchMedia listeners are bound once and re-query
+         '.app-shell' at call time instead of closing over a node that gets replaced. -->
     <script is:inline>
       (function () {
-        var shell = document.querySelector('.app-shell');
-        var hamburger = document.querySelector('.hamburger');
-        var overlay = document.querySelector('.drawer-overlay');
-        var sidebar = document.getElementById('app-sidebar');
-        if (!shell || !hamburger) return;
-
-        function setOpen(open) {
+        function setShellOpen(open) {
+          var shell = document.querySelector('.app-shell');
+          var hamburger = document.querySelector('.hamburger');
+          if (!shell || !hamburger) return;
           shell.classList.toggle('drawer-open', open);
           hamburger.setAttribute('aria-expanded', open ? 'true' : 'false');
           hamburger.setAttribute('aria-label', open ? 'Close navigation menu' : 'Open navigation menu');
         }
-        hamburger.addEventListener('click', function () {
-          setOpen(!shell.classList.contains('drawer-open'));
-        });
-        if (overlay) overlay.addEventListener('click', function () { setOpen(false); });
-        // Tapping any nav link closes the drawer
-        if (sidebar) {
-          sidebar.addEventListener('click', function (e) {
-            if (e.target.closest('a')) setOpen(false);
+
+        function bindDrawerControls() {
+          var hamburger = document.querySelector('.hamburger');
+          var overlay = document.querySelector('.drawer-overlay');
+          var sidebar = document.getElementById('app-sidebar');
+          if (!hamburger) return;
+          hamburger.addEventListener('click', function () {
+            var shell = document.querySelector('.app-shell');
+            setShellOpen(!(shell && shell.classList.contains('drawer-open')));
           });
+          if (overlay) overlay.addEventListener('click', function () { setShellOpen(false); });
+          // Tapping any nav link closes the drawer
+          if (sidebar) {
+            sidebar.addEventListener('click', function (e) {
+              if (e.target.closest('a')) setShellOpen(false);
+            });
+          }
         }
+
+        document.addEventListener('astro:page-load', bindDrawerControls);
+
         document.addEventListener('keydown', function (e) {
-          if (e.key === 'Escape' && shell.classList.contains('drawer-open')) setOpen(false);
+          var shell = document.querySelector('.app-shell');
+          if (e.key === 'Escape' && shell && shell.classList.contains('drawer-open')) setShellOpen(false);
         });
         // Reset drawer state if the viewport grows past the mobile breakpoint
         window.matchMedia('(min-width: 641px)').addEventListener('change', function (e) {
-          if (e.matches) setOpen(false);
+          if (e.matches) setShellOpen(false);
         });
       })();
     </script>
     <script is:inline>
       (function () {
-        var themeBtn = document.querySelector('.theme-toggle');
-        function updateThemeIcon() {
+        function updateThemeIcon(themeBtn) {
           if (!themeBtn) return;
           var t = document.documentElement.getAttribute('data-theme');
           var isDark = t === 'dark' ||
@@ -659,8 +680,11 @@ const navItems = [
           themeBtn.textContent = isDark ? '☀️' : '🌙';
           themeBtn.setAttribute('aria-label', isDark ? 'Switch to light mode' : 'Switch to dark mode');
         }
-        updateThemeIcon();
-        if (themeBtn) {
+
+        function bindThemeToggle() {
+          var themeBtn = document.querySelector('.theme-toggle');
+          if (!themeBtn) return;
+          updateThemeIcon(themeBtn);
           themeBtn.addEventListener('click', function () {
             var cur = document.documentElement.getAttribute('data-theme');
             var isDark = cur === 'dark' ||
@@ -668,9 +692,11 @@ const navItems = [
             var next = isDark ? 'light' : 'dark';
             document.documentElement.setAttribute('data-theme', next);
             try { localStorage.setItem('theme', next); } catch (e) {} // safe-ls: cosmetic only
-            updateThemeIcon();
+            updateThemeIcon(themeBtn);
           });
         }
+
+        document.addEventListener('astro:page-load', bindThemeToggle);
       })();
     </script>
   </body>

--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -1,4 +1,5 @@
 ---
+import { ClientRouter } from 'astro:transitions';
 import pkg from '../../package.json';
 
 interface Props {
@@ -27,6 +28,7 @@ const navItems = [
     <meta name="theme-color" content="#6366f1" />
     <link rel="apple-touch-icon" href="/icon-192.png" />
     <title>{title}</title>
+    <ClientRouter />
     <!-- safe-ls: 'theme' is a cosmetic preference (dark/light). No API dependency - a
          stale or missing value falls back to the system color-scheme media query. -->
     <script is:inline>


### PR DESCRIPTION
## Summary
Combines four independently-implemented tickets into one PR for review, superseding the separate PRs #84, #85, #86, #87 (same branches, merged together here with no additional changes beyond conflict resolution in `ProjectLanding.test.tsx`).

- **PROJ-349**: Epics view gets the same status/priority/date-range filters as the Issues view, via the shared `FiltersPopover` component (`EpicList.tsx`). Assignee/custom-field filters were intentionally excluded — they don't exist in the Issues UI either, only the backend API.
- **PROJ-350**: Switching between a project's Overview/Issues/etc. tabs no longer does a full page reload — adds Astro's `<ClientRouter />` to `Base.astro`. The sidebar is deliberately not `transition:persist`ed since its active-link state is server-computed per request.
- **PROJ-351**: Throughput and cumulative-flow charts now appear on the project Overview page, reusing the exact chart implementations from `MetricsDashboard.tsx` (extracted into `islands/metrics/flow-charts.tsx`) rather than duplicating them. New `ProjectFlowCharts` island, project-scoped, no backend changes needed.
- **PROJ-352**: The wiki UI gets an explicit Scope control (workspace-wide vs. a specific project) in the sidebar, and `ProjectLanding`'s "Recent Wiki" links now preserve `projectId` so navigating from a project's Overview keeps the destination scoped. No DB/API changes — wiki scoping was already correct end-to-end in those layers.

## Test plan
- [x] `pnpm --filter web run type-check` — 0 errors
- [x] `pnpm --filter web exec biome check` — clean
- [x] `pnpm --filter web exec vitest run` — 318/318 pass
- [x] Full pre-push suite (lint + 703 api tests + 318 web tests) passed on push
- [ ] Manual click-through on the dogfood instance — not done in this session (no local dev stack); recommend a human check before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APQYanmALGfKTKZv7jrb7z