### PR TITLE
PROJ-362: KV caching hardening (PROJ-356..361)

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -66,10 +66,16 @@ function checkTokenScope(
 	return null;
 }
 
+// PROJ-360: last_used_at is a coarse "when was this token last seen" audit field,
+// not something that needs per-request precision — only rewrite it once per
+// this window to cut D1 write volume on the hottest auth path (bearer/agent
+// traffic hits this on every request).
+const LAST_USED_AT_THROTTLE_SECS = 60;
+
 async function authenticateApiToken(c: Context<HonoEnv>, token: string): Promise<AuthOutcome> {
 	const hash = await hashToken(token);
 	const row = await c.env.DB.prepare(
-		`SELECT at.workspace_id, at.expires_at, at.scopes,
+		`SELECT at.workspace_id, at.expires_at, at.scopes, at.last_used_at,
               u.id as user_id, u.email, u.name
        FROM api_tokens at
        LEFT JOIN users u ON u.id = at.user_id
@@ -83,6 +89,7 @@ async function authenticateApiToken(c: Context<HonoEnv>, token: string): Promise
 			workspace_id: string | null;
 			expires_at: number | null;
 			scopes: string | null;
+			last_used_at: number | null;
 		}>();
 
 	if (!row) {
@@ -101,11 +108,14 @@ async function authenticateApiToken(c: Context<HonoEnv>, token: string): Promise
 	c.set("tokenScopes", scopes);
 	c.set("authKind", "agent");
 
-	c.executionCtx.waitUntil(
-		c.env.DB.prepare("UPDATE api_tokens SET last_used_at = ? WHERE token_hash = ?")
-			.bind(Math.floor(Date.now() / 1000), hash)
-			.run()
-	);
+	const now = Math.floor(Date.now() / 1000);
+	if (!row.last_used_at || now - row.last_used_at >= LAST_USED_AT_THROTTLE_SECS) {
+		c.executionCtx.waitUntil(
+			c.env.DB.prepare("UPDATE api_tokens SET last_used_at = ? WHERE token_hash = ?")
+				.bind(now, hash)
+				.run()
+		);
+	}
 
 	return { kind: "allow" };
 }
@@ -232,12 +242,28 @@ async function validateCfAccessJwt(jwt: string, env: Env): Promise<AuthUser | nu
 	}
 	// All field checks passed — now fetch keys and verify the signature.
 	const keys = await getCfAccessKeys(env);
-	const result = await verifyJwtPayload(
+	let result = await verifyJwtPayload(
 		jwt,
 		keys,
 		env.CF_ACCESS_AUDIENCE,
 		`https://${env.CF_ACCESS_TEAM_DOMAIN}`
 	);
+	if (!result) {
+		// PROJ-358: claims already passed the pre-screen above, so a null result
+		// here means the signature didn't match any cached key — most likely
+		// Cloudflare rotated its Access signing keys since we cached them. Force
+		// one rate-limited refetch and retry before giving up, instead of
+		// leaving every login failing until both cache layers expire.
+		const freshKeys = await getCfAccessKeys(env, { forceRefresh: true });
+		if (freshKeys !== keys) {
+			result = await verifyJwtPayload(
+				jwt,
+				freshKeys,
+				env.CF_ACCESS_AUDIENCE,
+				`https://${env.CF_ACCESS_TEAM_DOMAIN}`
+			);
+		}
+	}
 	if (!result) return null;
 	return upsertUserByEmail(result.email, env.DB, env.KV);
 }
@@ -251,7 +277,32 @@ async function validateCfAccessJwt(jwt: string, env: Env): Promise<AuthUser | nu
 let inMemoryCertsCache: { keys: JsonWebKey[]; expiresAt: number } | null = null;
 const CERTS_LOCAL_TTL_MS = 3600 * 1000;
 
-async function getCfAccessKeys(env: Env): Promise<JsonWebKey[]> {
+// PROJ-358: bounds how often a burst of stale-key-signed tokens can force a real
+// network fetch of the JWKS endpoint.
+let lastForcedRefreshAt = 0;
+const FORCE_REFRESH_COOLDOWN_MS = 60 * 1000;
+
+async function fetchAndCacheCfAccessKeys(env: Env): Promise<JsonWebKey[]> {
+	const res = await fetch(`https://${env.CF_ACCESS_TEAM_DOMAIN}/cdn-cgi/access/certs`);
+	if (!res.ok) throw new Error("Failed to fetch CF Access certs");
+	const { keys } = await res.json<{ keys: JsonWebKey[] }>();
+
+	await env.KV.put("cf-access-certs", JSON.stringify(keys), { expirationTtl: 3600 });
+	inMemoryCertsCache = { keys, expiresAt: Date.now() + CERTS_LOCAL_TTL_MS };
+	return keys;
+}
+
+async function getCfAccessKeys(env: Env, opts?: { forceRefresh?: boolean }): Promise<JsonWebKey[]> {
+	if (opts?.forceRefresh) {
+		const now = Date.now();
+		if (now - lastForcedRefreshAt >= FORCE_REFRESH_COOLDOWN_MS) {
+			lastForcedRefreshAt = now;
+			return fetchAndCacheCfAccessKeys(env);
+		}
+		// Within cooldown — another request already forced a refresh recently;
+		// fall through to whatever's cached rather than hitting the network again.
+	}
+
 	if (inMemoryCertsCache && inMemoryCertsCache.expiresAt > Date.now()) {
 		return inMemoryCertsCache.keys;
 	}
@@ -263,13 +314,7 @@ async function getCfAccessKeys(env: Env): Promise<JsonWebKey[]> {
 		return keys;
 	}
 
-	const res = await fetch(`https://${env.CF_ACCESS_TEAM_DOMAIN}/cdn-cgi/access/certs`);
-	if (!res.ok) throw new Error("Failed to fetch CF Access certs");
-	const { keys } = await res.json<{ keys: JsonWebKey[] }>();
-
-	await env.KV.put("cf-access-certs", JSON.stringify(keys), { expirationTtl: 3600 });
-	inMemoryCertsCache = { keys, expiresAt: Date.now() + CERTS_LOCAL_TTL_MS };
-	return keys;
+	return fetchAndCacheCfAccessKeys(env);
 }
 
 const inMemoryUserCache = new Map<string, { user: AuthUser; expiresAt: number }>();

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -242,26 +242,54 @@ async function validateCfAccessJwt(jwt: string, env: Env): Promise<AuthUser | nu
 	return upsertUserByEmail(result.email, env.DB, env.KV);
 }
 
+// PROJ-354: both caches below are read on every authenticated CF Access request.
+// A Worker isolate serves many requests before Cloudflare recycles it, so an
+// isolate-local (module-scope) cache in front of the KV read cuts the vast
+// majority of that KV read volume — KV remains the cross-isolate/cold-start
+// fallback and the TTL source of truth; these local TTLs only bound staleness
+// within a single isolate's lifetime.
+let inMemoryCertsCache: { keys: JsonWebKey[]; expiresAt: number } | null = null;
+const CERTS_LOCAL_TTL_MS = 3600 * 1000;
+
 async function getCfAccessKeys(env: Env): Promise<JsonWebKey[]> {
+	if (inMemoryCertsCache && inMemoryCertsCache.expiresAt > Date.now()) {
+		return inMemoryCertsCache.keys;
+	}
+
 	const cached = await env.KV.get("cf-access-certs", "json");
-	if (cached) return cached as JsonWebKey[];
+	if (cached) {
+		const keys = cached as JsonWebKey[];
+		inMemoryCertsCache = { keys, expiresAt: Date.now() + CERTS_LOCAL_TTL_MS };
+		return keys;
+	}
 
 	const res = await fetch(`https://${env.CF_ACCESS_TEAM_DOMAIN}/cdn-cgi/access/certs`);
 	if (!res.ok) throw new Error("Failed to fetch CF Access certs");
 	const { keys } = await res.json<{ keys: JsonWebKey[] }>();
 
 	await env.KV.put("cf-access-certs", JSON.stringify(keys), { expirationTtl: 3600 });
+	inMemoryCertsCache = { keys, expiresAt: Date.now() + CERTS_LOCAL_TTL_MS };
 	return keys;
 }
+
+const inMemoryUserCache = new Map<string, { user: AuthUser; expiresAt: number }>();
+const USER_LOCAL_TTL_MS = 300 * 1000;
 
 async function upsertUserByEmail(
 	email: string,
 	db: D1Database,
 	kv?: KVNamespace
 ): Promise<AuthUser> {
+	const local = inMemoryUserCache.get(email);
+	if (local && local.expiresAt > Date.now()) return local.user;
+
 	if (kv) {
 		const cached = await kv.get(`user-by-email:${email}`, "json");
-		if (cached) return cached as AuthUser;
+		if (cached) {
+			const user = cached as AuthUser;
+			inMemoryUserCache.set(email, { user, expiresAt: Date.now() + USER_LOCAL_TTL_MS });
+			return user;
+		}
 	}
 
 	const id = crypto.randomUUID();
@@ -287,6 +315,7 @@ async function upsertUserByEmail(
 	if (kv) {
 		await kv.put(`user-by-email:${email}`, JSON.stringify(user), { expirationTtl: 300 });
 	}
+	inMemoryUserCache.set(email, { user, expiresAt: Date.now() + USER_LOCAL_TTL_MS });
 
 	return user;
 }

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -47,7 +47,7 @@ export async function rateLimitMiddleware(
 		limit = parseInt(c.env.RATE_LIMIT_AUTH_MAX ?? "300", 10);
 	}
 
-	const count = await incrementCounter(c.env.DB, key, slot);
+	const count = await incrementCounter(c.env.DB, key, slot, windowSecs);
 	if (count > limit) {
 		const windowRemaining = slot + windowSecs - now;
 		c.header("Retry-After", String(windowRemaining > 0 ? windowRemaining : windowSecs));
@@ -68,7 +68,7 @@ export async function bumpRateCounter(
 	windowSecs: number
 ): Promise<number> {
 	const slot = Math.floor(Math.floor(Date.now() / 1000) / windowSecs) * windowSecs;
-	return incrementCounter(db, key, slot);
+	return incrementCounter(db, key, slot, windowSecs);
 }
 
 async function sha256Prefix(input: string): Promise<string> {
@@ -78,7 +78,25 @@ async function sha256Prefix(input: string): Promise<string> {
 		.join("");
 }
 
-async function incrementCounter(db: D1Database, key: string, slot: number): Promise<number> {
+// PROJ-361: rate_limit gets one permanent row per distinct IP/token (scanners,
+// crawlers, one-off visitors never come back to roll their window over) with no
+// cleanup path. Rather than a scheduled job for what's small, low-priority
+// housekeeping, prune opportunistically from inside the hot path — rows several
+// windows old are never read again by the fixed-window logic above.
+const PRUNE_PROBABILITY = 0.01;
+const PRUNE_RETENTION_WINDOWS = 10;
+
+async function pruneStaleRateLimitRows(db: D1Database, windowSecs: number): Promise<void> {
+	const cutoff = Math.floor(Date.now() / 1000) - windowSecs * PRUNE_RETENTION_WINDOWS;
+	await db.prepare("DELETE FROM rate_limit WHERE window_start < ?").bind(cutoff).run();
+}
+
+async function incrementCounter(
+	db: D1Database,
+	key: string,
+	slot: number,
+	windowSecs: number
+): Promise<number> {
 	// Upsert: if same window slot, increment; if window has rolled over, reset to 1.
 	// We use a separate SELECT because D1's local runtime may not reliably return
 	// RETURNING values from DML statements.
@@ -91,6 +109,10 @@ async function incrementCounter(db: D1Database, key: string, slot: number): Prom
   `)
 		.bind(key, slot, slot, slot)
 		.run();
+
+	if (Math.random() < PRUNE_PROBABILITY) {
+		await pruneStaleRateLimitRows(db, windowSecs);
+	}
 
 	const row = await db
 		.prepare("SELECT count FROM rate_limit WHERE key = ?")

--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -433,6 +433,19 @@ export async function getIssue(ctx: ServiceCtx, raw: unknown) {
 
 	const issueId = (issue as Record<string, unknown>).id as string;
 
+	// PROJ-359: a ref lookup ("PROJ-42" — the primary MCP agent read path) resolves
+	// via fetchIssueByRef above rather than the id-keyed cache check at the top of
+	// this function, so it never got any cache benefit and paid for a KV write on
+	// every single call. Now that the id is known, check the cache before paying
+	// for the rollup/links/custom-fields queries below.
+	if (ref) {
+		const cached = await cache.get<Record<string, unknown>>(
+			ctx.kv,
+			`issue:${ctx.workspaceId}:${issueId}`
+		);
+		if (cached) return cached;
+	}
+
 	type ChildCount = { status: string; count: number };
 	const childRows = (await orm.all(
 		sql`SELECT status, COUNT(*) as count FROM issues

--- a/apps/api/src/services/projects.ts
+++ b/apps/api/src/services/projects.ts
@@ -9,6 +9,7 @@ import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from ".
 import type { ServiceCtx } from "./types";
 
 const WS_META_TTL = 60;
+const PROJECTS_CACHE_KEY = (workspaceId: string) => `ws-meta:${workspaceId}:projects`;
 
 export async function listProjects(ctx: ServiceCtx) {
 	const orm = drizzle(ctx.db, { schema });
@@ -19,7 +20,7 @@ export async function listProjects(ctx: ServiceCtx) {
 	// "effective on next request" guarantee — no stale project can linger.
 	const visible = visibleProjectPredicate(ctx, schema.projects.id);
 	if (!visible) {
-		const cacheKey = `ws-meta:${ctx.workspaceId}:projects`;
+		const cacheKey = PROJECTS_CACHE_KEY(ctx.workspaceId);
 		const cached = await cache.get<unknown[]>(ctx.kv, cacheKey);
 		if (cached) return cached;
 		const result = await orm
@@ -133,6 +134,7 @@ export async function createProject(ctx: ServiceCtx, input: unknown) {
 	});
 
 	await recordActivity(ctx, { entityType: "project", entityId: id, action: "created" });
+	await cache.invalidate(ctx.kv, PROJECTS_CACHE_KEY(ctx.workspaceId));
 	return { id, name, key };
 }
 
@@ -170,6 +172,7 @@ export async function updateProject(ctx: ServiceCtx, id: string, input: unknown)
 	const diff: Record<string, unknown> = { ...setObj };
 	delete diff.updatedAt;
 	await recordActivity(ctx, { entityType: "project", entityId: id, action: "updated", diff });
+	await cache.invalidate(ctx.kv, PROJECTS_CACHE_KEY(ctx.workspaceId));
 
 	return { ok: true };
 }
@@ -186,5 +189,6 @@ export async function deleteProject(ctx: ServiceCtx, id: string) {
 		.where(and(eq(schema.projects.id, id), eq(schema.projects.workspaceId, ctx.workspaceId)));
 
 	await recordActivity(ctx, { entityType: "project", entityId: id, action: "deleted" });
+	await cache.invalidate(ctx.kv, PROJECTS_CACHE_KEY(ctx.workspaceId));
 	return { ok: true };
 }

--- a/apps/api/src/services/sprints.ts
+++ b/apps/api/src/services/sprints.ts
@@ -1,5 +1,5 @@
 import { drizzle, schema } from "@projektor/db";
-import { and, asc, eq, inArray } from "drizzle-orm";
+import { and, asc, eq, inArray, ne } from "drizzle-orm";
 import type { z } from "zod";
 import { IdSchema } from "../schemas/common";
 import {
@@ -9,6 +9,7 @@ import {
 	UpdateSprintSchema,
 } from "../schemas/sprints";
 import { canWriteProject, effectiveProjectRole, isWorkspaceAdmin } from "./access";
+import * as cache from "./cache";
 import { ForbiddenError, NotFoundError, ValidationError } from "./errors";
 import { inChunks } from "./sql";
 import type { ServiceCtx } from "./types";
@@ -206,6 +207,27 @@ export async function moveIssuesToSprint(ctx: ServiceCtx, raw: unknown) {
 	if (!sprint) throw new NotFoundError("Sprint not found");
 	await requireSprintProjectWrite(ctx, sprint.projectId);
 
+	// PROJ-357: requireSprintProjectWrite only checked the *sprint's* project.
+	// Reject any caller-supplied issue that doesn't belong to that project —
+	// otherwise a write grant on the sprint's project alone would let a caller
+	// move issues from a project they have no access to (and sprints are
+	// project-scoped, so cross-project membership would also be a data bug).
+	const foreignIssues = await inChunks(issueIds, async (chunk) =>
+		orm
+			.select({ id: schema.issues.id })
+			.from(schema.issues)
+			.where(
+				and(
+					inArray(schema.issues.id, chunk),
+					eq(schema.issues.workspaceId, ctx.workspaceId),
+					ne(schema.issues.projectId, sprint.projectId)
+				)
+			)
+	);
+	if (foreignIssues.length > 0) {
+		throw new NotFoundError(`Issue not found: ${foreignIssues[0].id}`);
+	}
+
 	const now = Math.floor(Date.now() / 1000);
 	// inChunks: issueIds is a caller-supplied batch, so keep each UPDATE under D1's
 	// 100-bound-parameter cap. See services/sql.ts.
@@ -216,6 +238,12 @@ export async function moveIssuesToSprint(ctx: ServiceCtx, raw: unknown) {
 			.where(and(inArray(schema.issues.id, chunk), eq(schema.issues.workspaceId, ctx.workspaceId)));
 		return [];
 	});
+
+	// PROJ-356: invalidate the per-issue KV cache so a subsequent getIssue reflects
+	// the new sprint_id instead of serving a stale cached issue for up to ISSUE_TTL.
+	await Promise.all(
+		issueIds.map((id) => cache.invalidate(ctx.kv, `issue:${ctx.workspaceId}:${id}`))
+	);
 
 	return { ok: true, count: issueIds.length };
 }

--- a/apps/api/src/services/task-statuses.ts
+++ b/apps/api/src/services/task-statuses.ts
@@ -8,10 +8,11 @@ import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from ".
 import type { ServiceCtx } from "./types";
 
 const WS_META_TTL = 60;
+const TASK_STATUSES_CACHE_KEY = (workspaceId: string) => `ws-meta:${workspaceId}:task-statuses`;
 
 export async function listTaskStatuses(ctx: ServiceCtx) {
 	// cofferdam-ignore: Refactor.DuplicateBlock: mirrors task-types.ts's cache-read shape
-	const cacheKey = `ws-meta:${ctx.workspaceId}:task-statuses`;
+	const cacheKey = TASK_STATUSES_CACHE_KEY(ctx.workspaceId);
 	const cached = await cache.get<unknown[]>(ctx.kv, cacheKey);
 	if (cached) return cached;
 
@@ -67,6 +68,7 @@ export async function createTaskStatus(ctx: ServiceCtx, raw: unknown) {
 		isDefault: isDefault ? 1 : 0,
 	});
 
+	await cache.invalidate(ctx.kv, TASK_STATUSES_CACHE_KEY(ctx.workspaceId));
 	return { id, key, name };
 }
 
@@ -115,6 +117,7 @@ export async function updateTaskStatus(ctx: ServiceCtx, id: string, raw: unknown
 			and(eq(schema.taskStatuses.id, id), eq(schema.taskStatuses.workspaceId, ctx.workspaceId))
 		);
 
+	await cache.invalidate(ctx.kv, TASK_STATUSES_CACHE_KEY(ctx.workspaceId));
 	return { ok: true };
 }
 
@@ -148,6 +151,7 @@ export async function deleteTaskStatus(ctx: ServiceCtx, id: string) {
 			and(eq(schema.taskStatuses.id, id), eq(schema.taskStatuses.workspaceId, ctx.workspaceId))
 		);
 
+	await cache.invalidate(ctx.kv, TASK_STATUSES_CACHE_KEY(ctx.workspaceId));
 	return { ok: true };
 }
 

--- a/apps/api/src/services/task-types.ts
+++ b/apps/api/src/services/task-types.ts
@@ -8,6 +8,7 @@ import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from ".
 import type { ServiceCtx } from "./types";
 
 const WS_META_TTL = 60;
+const TASK_TYPES_CACHE_KEY = (workspaceId: string) => `ws-meta:${workspaceId}:task-types`;
 
 function buildTaskTypeUpdateSet(
 	data: z.infer<typeof UpdateTaskTypeSchema>
@@ -22,7 +23,7 @@ function buildTaskTypeUpdateSet(
 }
 
 export async function listTaskTypes(ctx: ServiceCtx) {
-	const cacheKey = `ws-meta:${ctx.workspaceId}:task-types`;
+	const cacheKey = TASK_TYPES_CACHE_KEY(ctx.workspaceId);
 	const cached = await cache.get<unknown[]>(ctx.kv, cacheKey);
 	if (cached) return cached;
 
@@ -75,6 +76,7 @@ export async function createTaskType(ctx: ServiceCtx, raw: unknown) {
 		isDefault: isDefault ? 1 : 0,
 	});
 
+	await cache.invalidate(ctx.kv, TASK_TYPES_CACHE_KEY(ctx.workspaceId));
 	return { id, key, name };
 }
 
@@ -106,6 +108,7 @@ export async function updateTaskType(ctx: ServiceCtx, id: string, raw: unknown) 
 		.set(setObj)
 		.where(and(eq(schema.taskTypes.id, id), eq(schema.taskTypes.workspaceId, ctx.workspaceId)));
 
+	await cache.invalidate(ctx.kv, TASK_TYPES_CACHE_KEY(ctx.workspaceId));
 	return { ok: true };
 }
 
@@ -134,6 +137,7 @@ export async function deleteTaskType(ctx: ServiceCtx, id: string) {
 		.delete(schema.taskTypes)
 		.where(and(eq(schema.taskTypes.id, id), eq(schema.taskTypes.workspaceId, ctx.workspaceId)));
 
+	await cache.invalidate(ctx.kv, TASK_TYPES_CACHE_KEY(ctx.workspaceId));
 	return { ok: true };
 }
 

--- a/apps/api/src/test/auth.test.ts
+++ b/apps/api/src/test/auth.test.ts
@@ -9,10 +9,11 @@
  */
 
 import { env, SELF } from "cloudflare:test";
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { verifyJwtPayload } from "../middleware/auth";
 import {
 	authHeaders,
+	hashToken,
 	seedFixture,
 	seedMember,
 	seedToken,
@@ -353,6 +354,142 @@ describe("PROJ-354: CF Access auth caches are isolate-local", () => {
 		const secondBody = (await second.json()) as { user: { id: string; email: string } };
 		expect(secondBody.user.email).toBe(email);
 		expect(secondBody.user.id).toBe(firstBody.user.id);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// PROJ-358: a signature that doesn't match any cached JWKS key forces one
+// rate-limited refetch and retry, instead of failing every login until both
+// cache layers expire on their own.
+// ---------------------------------------------------------------------------
+
+describe("PROJ-358: JWKS force-refresh on signature verification failure", () => {
+	it("token signed by an uncached key authenticates via forced refresh; a further bad signature within the cooldown does not refetch again", async () => {
+		const genKeyPair = () =>
+			crypto.subtle.generateKey(
+				{
+					name: "RSASSA-PKCS1-v1_5",
+					modulusLength: 2048,
+					publicExponent: new Uint8Array([1, 0, 1]),
+					hash: "SHA-256",
+				},
+				true,
+				["sign", "verify"]
+			) as Promise<CryptoKeyPair>;
+
+		// `otherKeyPair` is never returned by the stub below, so a token signed
+		// with it never matches whatever the cache holds — used for the
+		// cooldown assertion without needing a second real refresh.
+		const currentKeyPair = await genKeyPair();
+		const otherKeyPair = await genKeyPair();
+		const currentPublicJwk = (await crypto.subtle.exportKey(
+			"jwk",
+			currentKeyPair.publicKey
+		)) as JsonWebKey;
+
+		const domain = `proj-358-${crypto.randomUUID().slice(0, 8)}.example.com`;
+		const audience = "proj-358-audience";
+		const email = `proj-358-${crypto.randomUUID().slice(0, 8)}@example.com`;
+		const now = Math.floor(Date.now() / 1000);
+
+		env.CF_ACCESS_TEAM_DOMAIN = domain;
+		env.CF_ACCESS_AUDIENCE = audience;
+
+		let fetchCalls = 0;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				fetchCalls++;
+				return new Response(JSON.stringify({ keys: [currentPublicJwk] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			})
+		);
+
+		try {
+			// Whatever's already cached (isolate-local from an earlier test, or
+			// nothing) certainly doesn't verify a brand-new key pair's signature —
+			// this forces getCfAccessKeys to refetch (via the stub) and retry.
+			const currentJwt = await signTestJwt(currentKeyPair.privateKey, {
+				exp: now + 3600,
+				aud: audience,
+				iss: `https://${domain}`,
+				email,
+			});
+			const rotated = await SELF.fetch("http://localhost/auth/me", {
+				headers: { "Cf-Access-Jwt-Assertion": currentJwt },
+			});
+			expect(rotated.status).toBe(200);
+			expect(fetchCalls).toBe(1);
+
+			// The cache now holds only currentPublicJwk, so a token signed by an
+			// unrelated key still doesn't verify — but the forced refresh above
+			// happened moments ago, so the cooldown should block a second fetch.
+			const badJwt = await signTestJwt(otherKeyPair.privateKey, {
+				exp: now + 3600,
+				aud: audience,
+				iss: `https://${domain}`,
+				email,
+			});
+			const stillBad = await SELF.fetch("http://localhost/auth/me", {
+				headers: { "Cf-Access-Jwt-Assertion": badJwt },
+			});
+			expect(stillBad.status).toBe(401);
+			expect(fetchCalls).toBe(1);
+		} finally {
+			vi.unstubAllGlobals();
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// PROJ-360: last_used_at is a coarse audit field, throttled so bearer/agent
+// traffic (the hottest auth path) doesn't rewrite it on every single request.
+// ---------------------------------------------------------------------------
+
+describe("PROJ-360: api_tokens.last_used_at write throttling", () => {
+	it("a request within the throttle window does not rewrite a recent last_used_at", async () => {
+		const fixture = await seedFixture();
+		const hash = await hashToken(fixture.token);
+		const now = Math.floor(Date.now() / 1000);
+		const recentTimestamp = now - 30; // inside the 60s throttle window
+
+		await env.DB.prepare("UPDATE api_tokens SET last_used_at = ? WHERE token_hash = ?")
+			.bind(recentTimestamp, hash)
+			.run();
+
+		const res = await SELF.fetch("http://localhost/auth/me", {
+			headers: { Authorization: `Bearer ${fixture.token}` },
+		});
+		expect(res.status).toBe(200);
+
+		const row = await env.DB.prepare("SELECT last_used_at FROM api_tokens WHERE token_hash = ?")
+			.bind(hash)
+			.first<{ last_used_at: number }>();
+		expect(row?.last_used_at).toBe(recentTimestamp);
+	});
+
+	it("a request outside the throttle window (or with no prior value) updates last_used_at", async () => {
+		const fixture = await seedFixture();
+		const hash = await hashToken(fixture.token);
+		const now = Math.floor(Date.now() / 1000);
+		const staleTimestamp = now - 120; // outside the 60s throttle window
+
+		await env.DB.prepare("UPDATE api_tokens SET last_used_at = ? WHERE token_hash = ?")
+			.bind(staleTimestamp, hash)
+			.run();
+
+		const res = await SELF.fetch("http://localhost/auth/me", {
+			headers: { Authorization: `Bearer ${fixture.token}` },
+		});
+		expect(res.status).toBe(200);
+
+		const row = await env.DB.prepare("SELECT last_used_at FROM api_tokens WHERE token_hash = ?")
+			.bind(hash)
+			.first<{ last_used_at: number }>();
+		expect(row?.last_used_at).not.toBe(staleTimestamp);
+		expect(row?.last_used_at).toBeGreaterThanOrEqual(now);
 	});
 });
 

--- a/apps/api/src/test/auth.test.ts
+++ b/apps/api/src/test/auth.test.ts
@@ -293,6 +293,70 @@ describe("PROJ-79: CF Access JWT HTTP rejection paths", () => {
 });
 
 // ---------------------------------------------------------------------------
+// PROJ-354: isolate-local auth caches survive KV backing-store loss
+// (getCfAccessKeys / upsertUserByEmail are memoized per-isolate so most
+// requests never touch KV at all — this proves the local cache, not just KV,
+// is what's serving the second request).
+// ---------------------------------------------------------------------------
+
+describe("PROJ-354: CF Access auth caches are isolate-local", () => {
+	it("second CF Access login succeeds after both KV cache entries are deleted", async () => {
+		const keyPair = (await crypto.subtle.generateKey(
+			{
+				name: "RSASSA-PKCS1-v1_5",
+				modulusLength: 2048,
+				publicExponent: new Uint8Array([1, 0, 1]),
+				hash: "SHA-256",
+			},
+			true,
+			["sign", "verify"]
+		)) as CryptoKeyPair;
+		const publicJwk = (await crypto.subtle.exportKey("jwk", keyPair.publicKey)) as JsonWebKey;
+
+		const domain = "test-cf-access.example.com";
+		const audience = "proj-354-audience";
+		const email = `proj-354-${crypto.randomUUID().slice(0, 8)}@example.com`;
+
+		env.CF_ACCESS_TEAM_DOMAIN = domain;
+		env.CF_ACCESS_AUDIENCE = audience;
+
+		// Pre-seed the JWKS cache directly in KV, bypassing the real network fetch
+		// that getCfAccessKeys would otherwise make on a cold cache.
+		await env.KV.put("cf-access-certs", JSON.stringify([publicJwk]));
+
+		const jwt = await signTestJwt(keyPair.privateKey, {
+			exp: Math.floor(Date.now() / 1000) + 3600,
+			aud: audience,
+			iss: `https://${domain}`,
+			email,
+		});
+
+		const first = await SELF.fetch("http://localhost/auth/me", {
+			headers: { "Cf-Access-Jwt-Assertion": jwt },
+		});
+		expect(first.status).toBe(200);
+		const firstBody = (await first.json()) as { user: { id: string; email: string } };
+		expect(firstBody.user.email).toBe(email);
+
+		// Delete both KV entries the first request would have populated. If the
+		// second request only relied on KV, it would now have to re-fetch the
+		// JWKS over the network (which fails in this test env) and re-run the
+		// D1 upsert path from scratch — it should instead be served entirely
+		// from the isolate-local caches.
+		await env.KV.delete("cf-access-certs");
+		await env.KV.delete(`user-by-email:${email}`);
+
+		const second = await SELF.fetch("http://localhost/auth/me", {
+			headers: { "Cf-Access-Jwt-Assertion": jwt },
+		});
+		expect(second.status).toBe(200);
+		const secondBody = (await second.json()) as { user: { id: string; email: string } };
+		expect(secondBody.user.email).toBe(email);
+		expect(secondBody.user.id).toBe(firstBody.user.id);
+	});
+});
+
+// ---------------------------------------------------------------------------
 // PROJ-274 (C1): no cached auth path can bypass scope enforcement
 // ---------------------------------------------------------------------------
 

--- a/apps/api/src/test/cache.test.ts
+++ b/apps/api/src/test/cache.test.ts
@@ -85,7 +85,7 @@ describe("KV caching", () => {
 		});
 	});
 
-	describe("workspace metadata cache (TTL 60s, no invalidation)", () => {
+	describe("workspace metadata cache (TTL 60s, write-through invalidation)", () => {
 		it("task statuses list is cached — second GET returns data even after D1 is cleared", async () => {
 			await seedTaskStatus(workspaceId, { key: "todo", name: "Todo", category: "todo" });
 			const url = "http://localhost/api/task-statuses";
@@ -157,6 +157,47 @@ describe("KV caching", () => {
 			// Second call — served from KV cache
 			const second = await mcpListProjects();
 			expect(second.length).toBeGreaterThan(0);
+		});
+
+		it("creating a task status invalidates the cache — subsequent list reflects it immediately", async () => {
+			const url = "http://localhost/api/task-statuses";
+			const hdrs = authHeaders(token, slug);
+
+			// GET to populate cache with the current (empty-ish) list
+			const before = await SELF.fetch(url, { headers: hdrs });
+			const beforeBody = (await before.json()) as unknown[];
+
+			const created = await SELF.fetch(url, {
+				method: "POST",
+				headers: hdrs,
+				body: JSON.stringify({ key: "blocked", name: "Blocked", category: "in_progress" }),
+			});
+			expect(created.status).toBe(201);
+
+			// GET immediately after — must not be served from the pre-create cache entry
+			const after = await SELF.fetch(url, { headers: hdrs });
+			const afterBody = (await after.json()) as Array<{ key: string }>;
+			expect(afterBody.length).toBe(beforeBody.length + 1);
+			expect(afterBody.some((s) => s.key === "blocked")).toBe(true);
+		});
+
+		it("deleting a task type invalidates the cache — subsequent list reflects it immediately", async () => {
+			const taskType = await seedTaskType(workspaceId, { key: "chore", name: "Chore" });
+			const url = "http://localhost/api/task-types";
+			const hdrs = authHeaders(token, slug);
+
+			// GET to populate cache including the seeded type
+			const before = await SELF.fetch(url, { headers: hdrs });
+			const beforeBody = (await before.json()) as Array<{ key: string }>;
+			expect(beforeBody.some((t) => t.key === "chore")).toBe(true);
+
+			const del = await SELF.fetch(`${url}/${taskType.id}`, { method: "DELETE", headers: hdrs });
+			expect(del.status).toBe(200);
+
+			// GET immediately after — must not be served from the pre-delete cache entry
+			const after = await SELF.fetch(url, { headers: hdrs });
+			const afterBody = (await after.json()) as Array<{ key: string }>;
+			expect(afterBody.some((t) => t.key === "chore")).toBe(false);
 		});
 	});
 });

--- a/apps/api/src/test/issues.test.ts
+++ b/apps/api/src/test/issues.test.ts
@@ -1480,6 +1480,48 @@ describe("Issues KV cache", () => {
 		const issue = (await getRes.json()) as { title: string };
 		expect(issue.title).toBe("After update");
 	});
+
+	// PROJ-359: ref lookups ("PROJ-42", the primary MCP agent read path) resolve
+	// via fetchIssueByRef rather than the id-keyed cache check at the top of
+	// getIssue, so they never got any cache benefit before this fix.
+	it("getIssue by ref returns cached value on a second call (KV hit, D1 not re-read)", async () => {
+		const createRes = await SELF.fetch("http://localhost/api/issues", {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"X-Workspace-Slug": slug,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ projectId, title: "Cache me by ref" }),
+		});
+		const { id, number } = (await createRes.json()) as { id: string; number: number };
+		const ref = `PROJ-${number}`;
+
+		// First GET by ref populates KV cache
+		const first = await SELF.fetch(`http://localhost/api/issues/${ref}`, {
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"X-Workspace-Slug": slug,
+				"Content-Type": "application/json",
+			},
+		});
+		const firstIssue = (await first.json()) as { title: string };
+		expect(firstIssue.title).toBe("Cache me by ref");
+
+		// Corrupt the D1 row directly — if the cache is skipped the title would change
+		await env.DB.prepare("UPDATE issues SET title = 'D1 was read' WHERE id = ?").bind(id).run();
+
+		// Second GET by ref should return the cached value, not the corrupted D1 row
+		const second = await SELF.fetch(`http://localhost/api/issues/${ref}`, {
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"X-Workspace-Slug": slug,
+				"Content-Type": "application/json",
+			},
+		});
+		const secondIssue = (await second.json()) as { title: string };
+		expect(secondIssue.title).toBe("Cache me by ref");
+	});
 });
 
 describe("Issues role guards", () => {

--- a/apps/api/src/test/rate-limit.test.ts
+++ b/apps/api/src/test/rate-limit.test.ts
@@ -1,5 +1,5 @@
 import { env, SELF } from "cloudflare:test";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { authHeaders, seedFixture } from "./helpers";
 
 // Must match wrangler.test.toml values.
@@ -137,5 +137,60 @@ describe("PROJ-198: failed bearer-auth throttle (IP-keyed)", () => {
 		});
 		expect(res.status).not.toBe(429);
 		expect(res.status).not.toBe(401);
+	});
+});
+
+describe("PROJ-361: opportunistic rate_limit row pruning", () => {
+	const ENDPOINT = "http://localhost/api/workspaces";
+
+	it("prunes rows several windows stale while leaving the current window's row intact", async () => {
+		const now = Math.floor(Date.now() / 1000);
+		const staleWindowStart = now - WINDOW_SECS * 20; // well past the 10-window retention cutoff
+		await seedCounter("ip:stale-client", 1);
+		await env.DB.prepare("UPDATE rate_limit SET window_start = ? WHERE key = ?")
+			.bind(staleWindowStart, "ip:stale-client")
+			.run();
+
+		// PRUNE_PROBABILITY is 1% — force the opportunistic prune to run this request.
+		const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+		try {
+			const res = await SELF.fetch(ENDPOINT);
+			expect(res.status).not.toBe(429);
+		} finally {
+			randomSpy.mockRestore();
+		}
+
+		const staleRow = await env.DB.prepare("SELECT key FROM rate_limit WHERE key = ?")
+			.bind("ip:stale-client")
+			.first();
+		expect(staleRow).toBeNull();
+
+		// The request above increments the current-window row for its own key (127.0.0.1) —
+		// pruning must not have deleted it too.
+		const currentRow = await env.DB.prepare("SELECT key FROM rate_limit WHERE key = ?")
+			.bind("ip:127.0.0.1")
+			.first();
+		expect(currentRow).not.toBeNull();
+	});
+
+	it("does not prune when the probability roll misses", async () => {
+		const now = Math.floor(Date.now() / 1000);
+		const staleWindowStart = now - WINDOW_SECS * 20;
+		await seedCounter("ip:stale-client-2", 1);
+		await env.DB.prepare("UPDATE rate_limit SET window_start = ? WHERE key = ?")
+			.bind(staleWindowStart, "ip:stale-client-2")
+			.run();
+
+		const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5); // above PRUNE_PROBABILITY
+		try {
+			await SELF.fetch(ENDPOINT);
+		} finally {
+			randomSpy.mockRestore();
+		}
+
+		const staleRow = await env.DB.prepare("SELECT key FROM rate_limit WHERE key = ?")
+			.bind("ip:stale-client-2")
+			.first();
+		expect(staleRow).not.toBeNull();
 	});
 });

--- a/apps/api/src/test/sprints.test.ts
+++ b/apps/api/src/test/sprints.test.ts
@@ -1,4 +1,4 @@
-import { SELF } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
 	authHeaders,
@@ -208,6 +208,34 @@ describe("Sprints API", () => {
 		expect(issueData.sprint_id).toBeNull();
 	});
 
+	it("PROJ-356: move-issues invalidates the issue KV cache — an immediate GET reflects the new sprint_id", async () => {
+		const sprintRes = await createSprint({ projectId, name: "Cache Target Sprint" });
+		const { id: sprintId } = (await sprintRes.json()) as { id: string };
+
+		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Cache issue" });
+
+		// Warm the issue KV cache with the pre-move (sprint_id: null) shape.
+		const before = await SELF.fetch(`http://localhost/api/issues/${issue.id}`, {
+			headers: authHeaders(token, slug),
+		});
+		const beforeBody = (await before.json()) as { sprint_id: string | null };
+		expect(beforeBody.sprint_id).toBeNull();
+
+		const moveRes = await SELF.fetch(`http://localhost/api/sprints/${sprintId}/move-issues`, {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ issueIds: [issue.id] }),
+		});
+		expect(moveRes.status).toBe(200);
+
+		// Immediately after — must not be served from the pre-move cache entry.
+		const after = await SELF.fetch(`http://localhost/api/issues/${issue.id}`, {
+			headers: authHeaders(token, slug),
+		});
+		const afterBody = (await after.json()) as { sprint_id: string | null };
+		expect(afterBody.sprint_id).toBe(sprintId);
+	});
+
 	it("POST /api/sprints/:id/move-issues returns 404 for unknown sprint", async () => {
 		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Orphan issue" });
 
@@ -334,6 +362,39 @@ describe("Sprints role guards", () => {
 			headers: authHeaders(roles.viewer.token, roles.workspace.slug),
 		});
 		expect(completeRes.status).toBe(403);
+	});
+
+	it("PROJ-357: a member with write access only on the sprint's project cannot move an issue from a project they have no grant on", async () => {
+		const roles = await seedWorkspaceRoles();
+		const projectA = await seedProject(roles.workspace.id, "PJA");
+		const projectB = await seedProject(roles.workspace.id, "PJB");
+		// Member has write access to project A only — no grant at all on project B.
+		await seedGroupGrant(roles.workspace.id, roles.member.user.id, projectA.id, "member");
+
+		const createRes = await SELF.fetch("http://localhost/api/sprints", {
+			method: "POST",
+			headers: authHeaders(roles.member.token, roles.workspace.slug),
+			body: JSON.stringify({ projectId: projectA.id, name: "Sprint A" }),
+		});
+		expect(createRes.status).toBe(201);
+		const { id: sprintId } = (await createRes.json()) as { id: string };
+
+		const foreignIssue = await seedIssue(roles.workspace.id, projectB.id, roles.owner.user.id, {
+			title: "Project B issue",
+		});
+
+		const moveRes = await SELF.fetch(`http://localhost/api/sprints/${sprintId}/move-issues`, {
+			method: "POST",
+			headers: authHeaders(roles.member.token, roles.workspace.slug),
+			body: JSON.stringify({ issueIds: [foreignIssue.id] }),
+		});
+		expect(moveRes.status).toBe(404);
+
+		// The issue must be untouched — no partial mutation.
+		const row = await env.DB.prepare("SELECT sprint_id FROM issues WHERE id = ?")
+			.bind(foreignIssue.id)
+			.first<{ sprint_id: string | null }>();
+		expect(row?.sprint_id).toBeNull();
 	});
 
 	it("viewer cannot move issues to a sprint (403)", async () => {


### PR DESCRIPTION
## Summary

Implements all 6 child tickets of the PROJ-362 epic (Cloudflare KV usage efficiency/security review):

- **PROJ-354/355** (foundation commit): isolate-local auth caches + KV invalidation on projects/task-statuses/task-types mutations
- **PROJ-356**: `moveIssuesToSprint` invalidates the per-issue KV cache so a subsequent `getIssue` reflects the new `sprint_id` instead of serving a stale cached issue
- **PROJ-357**: reject moving issues into a sprint from a project the caller has no write grant on (previously only the *sprint's* project was checked)
- **PROJ-358**: force one rate-limited JWKS refetch when a CF Access JWT's signature doesn't match any cached key, so a key rotation doesn't fail every login until both cache layers expire naturally
- **PROJ-359**: `getIssue` by ref ("PROJ-42") now checks the KV cache before recomputing rollup/links/customFields — previously only the id-lookup path got any cache benefit
- **PROJ-360**: throttle `api_tokens.last_used_at` writes to once per 60s instead of on every authenticated request
- **PROJ-361**: opportunistically prune `rate_limit` rows several windows stale from the hot path (1% probability per request)

## Test plan
- [x] `tsc --noEmit` clean
- [x] Full API test suite passes (719 tests, 0 failures — includes new regression tests for PROJ-356/357/358/359/360/361)
- [x] Full web test suite passes (318 tests)
- [x] Biome lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GosKDitS7JY4A7jDyHfnbb