### PR TITLE
chore(web): bump version to 0.3.6 for release

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@projektor/web",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": true,
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
Version bump to cut v0.3.6, which includes PROJ-362 (KV caching hardening, PROJ-356..361, #89) plus PROJ-349..352 (#88) and PROJ-348 (#82) — none of which have been released/deployed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GosKDitS7JY4A7jDyHfnbb