### PR TITLE
PROJ-373: opt-in anonymous read-only viewer + demo link

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,8 +1,18 @@
 import type { Env, HonoEnv } from "@projektor/types";
 import type { Context, Next } from "hono";
 import { capabilityForMethod, parseScopes, tokenAllows } from "../auth/scopes";
-import { provisionUserOnLogin } from "../services/provisioning";
+import { provisionPublicViewer, provisionUserOnLogin } from "../services/provisioning";
 import { bumpRateCounter } from "./rate-limit";
+
+// PROJ-373: the shared identity anonymous requests are provisioned as when
+// PUBLIC_READ_ONLY is on. Fixed and well-known — there's exactly one, since
+// anonymous callers share no session to distinguish them by.
+const PUBLIC_VIEWER_EMAIL = "public-viewer@projektor.local";
+
+// Matches the truthy-string convention used by WORKSPACE_SUBDOMAIN_ROUTING (PROJ-296).
+function isTruthy(v: string | undefined): boolean {
+	return ["true", "1", "yes"].includes(v?.trim().toLowerCase() ?? "");
+}
 
 // PROJ-198: bound bearer-token guessing per source IP. The request rate-limiter keys
 // authenticated traffic by token fingerprint, so a flood of *distinct* invalid tokens
@@ -140,8 +150,27 @@ async function tryDevBypassAuth(c: Context<HonoEnv>): Promise<AuthOutcome> {
 	return { kind: "allow" };
 }
 
+// 4. Public read-only viewer (PROJ-373) — opt-in fallback, only when nothing else matched
+async function tryPublicViewerAuth(c: Context<HonoEnv>): Promise<AuthOutcome> {
+	if (!isTruthy(c.env.PUBLIC_READ_ONLY)) return { kind: "skip" };
+
+	const user = await upsertUserByEmail(PUBLIC_VIEWER_EMAIL, c.env.DB, c.env.KV);
+	await provisionPublicViewer(c.env, user);
+	c.set("user", user);
+	c.set("authKind", "human");
+	return { kind: "allow" };
+}
+
 export async function authMiddleware(c: Context<HonoEnv>, next: Next) {
-	for (const attempt of [tryCfAccessAuth, tryBearerTokenAuth, tryDevBypassAuth]) {
+	// tryPublicViewerAuth is last: a real CF Access session, bearer token, or dev
+	// bypass always wins so a logged-in user is never demoted to the anonymous
+	// viewer just because PUBLIC_READ_ONLY happens to be on too.
+	for (const attempt of [
+		tryCfAccessAuth,
+		tryBearerTokenAuth,
+		tryDevBypassAuth,
+		tryPublicViewerAuth,
+	]) {
 		const outcome = await attempt(c);
 		if (outcome.kind === "deny") return outcome.response;
 		if (outcome.kind === "allow") return next();
@@ -319,6 +348,14 @@ async function getCfAccessKeys(env: Env, opts?: { forceRefresh?: boolean }): Pro
 
 const inMemoryUserCache = new Map<string, { user: AuthUser; expiresAt: number }>();
 const USER_LOCAL_TTL_MS = 300 * 1000;
+
+// Test-only: clear the isolate-local caches above. Without this, a test that exercises a
+// second real CF Access JWT verification with a *different* keypair than an earlier test in
+// the same file would hit the still-warm cache and verify against the wrong keys.
+export function resetAuthCachesForTests(): void {
+	inMemoryCertsCache = null;
+	inMemoryUserCache.clear();
+}
 
 async function upsertUserByEmail(
 	email: string,

--- a/apps/api/src/services/provisioning.ts
+++ b/apps/api/src/services/provisioning.ts
@@ -224,3 +224,32 @@ export async function provisionUserOnLogin(
 		})
 		.onConflictDoNothing();
 }
+
+/**
+ * PROJ-373: idempotently join the shared anonymous "public viewer" user (see
+ * middleware/auth.ts's PUBLIC_READ_ONLY path) to the default workspace as
+ * `viewer`. Deliberately hardcoded to `viewer` — unlike AUTO_JOIN_ROLE, this
+ * has no configurable role; anonymous access is read-only or it doesn't exist.
+ * A no-op until an admin has bootstrapped the default workspace.
+ */
+export async function provisionPublicViewer(env: Env, user: { id: string }): Promise<void> {
+	const slug = env.DEFAULT_WORKSPACE_SLUG?.trim() || "projektor";
+	const orm = drizzle(env.DB, { schema });
+
+	const ws = await orm
+		.select({ id: schema.workspaces.id })
+		.from(schema.workspaces)
+		.where(eq(schema.workspaces.slug, slug))
+		.get();
+	if (!ws) return;
+
+	await orm
+		.insert(schema.workspaceMembers)
+		.values({
+			workspaceId: ws.id,
+			userId: user.id,
+			role: "viewer",
+			joinedAt: Math.floor(Date.now() / 1000),
+		})
+		.onConflictDoNothing();
+}

--- a/apps/api/src/test/auth.test.ts
+++ b/apps/api/src/test/auth.test.ts
@@ -9,8 +9,8 @@
  */
 
 import { env, SELF } from "cloudflare:test";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { verifyJwtPayload } from "../middleware/auth";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetAuthCachesForTests, verifyJwtPayload } from "../middleware/auth";
 import {
 	authHeaders,
 	hashToken,
@@ -546,6 +546,98 @@ describe("PROJ-274: read-scoped token is denied write on every request", () => {
 
 		const res = await SELF.fetch("http://localhost/api/issues", {
 			headers: authHeaders(fixture.token, otherWs.slug),
+		});
+		expect(res.status).toBe(403);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// PROJ-373: opt-in anonymous public-viewer fallback
+// ---------------------------------------------------------------------------
+
+describe("PROJ-373: PUBLIC_READ_ONLY anonymous viewer", () => {
+	// Every test in this block flips PUBLIC_READ_ONLY/DEFAULT_WORKSPACE_SLUG on the shared
+	// worker env — reset them so later describe blocks (which assume the defaults) don't
+	// see an anonymous viewer where they expect a 401.
+	afterEach(() => {
+		env.PUBLIC_READ_ONLY = undefined;
+		env.DEFAULT_WORKSPACE_SLUG = "projektor";
+	});
+
+	it("anonymous request still 401s when PUBLIC_READ_ONLY is unset (default)", async () => {
+		env.PUBLIC_READ_ONLY = undefined;
+		const res = await SELF.fetch("http://localhost/auth/me");
+		expect(res.status).toBe(401);
+	});
+
+	it("anonymous request is provisioned as viewer of the default workspace when PUBLIC_READ_ONLY is on", async () => {
+		const slug = `proj-373-${crypto.randomUUID().slice(0, 8)}`;
+		await seedWorkspace(slug);
+		env.DEFAULT_WORKSPACE_SLUG = slug;
+		env.PUBLIC_READ_ONLY = "true";
+
+		const res = await SELF.fetch("http://localhost/auth/me");
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			user: { email: string };
+			workspaces: Array<{ slug: string; role: string }>;
+		};
+		expect(body.user.email).toBe("public-viewer@projektor.local");
+		const membership = body.workspaces.find((w) => w.slug === slug);
+		expect(membership?.role).toBe("viewer");
+	});
+
+	it("a real CF Access session is not demoted to anonymous viewer when PUBLIC_READ_ONLY is also on", async () => {
+		const keyPair = (await crypto.subtle.generateKey(
+			{
+				name: "RSASSA-PKCS1-v1_5",
+				modulusLength: 2048,
+				publicExponent: new Uint8Array([1, 0, 1]),
+				hash: "SHA-256",
+			},
+			true,
+			["sign", "verify"]
+		)) as CryptoKeyPair;
+		const publicJwk = (await crypto.subtle.exportKey("jwk", keyPair.publicKey)) as JsonWebKey;
+
+		const domain = `proj-373-cf.example.com`;
+		const audience = "proj-373-audience";
+		const email = `proj-373-real-${crypto.randomUUID().slice(0, 8)}@example.com`;
+
+		env.CF_ACCESS_TEAM_DOMAIN = domain;
+		env.CF_ACCESS_AUDIENCE = audience;
+		env.PUBLIC_READ_ONLY = "true";
+		// The PROJ-354 test above already warmed the isolate-local certs cache with its own
+		// keypair; without a reset, getCfAccessKeys would serve those stale keys instead of
+		// fetching the ones seeded below, and this JWT would fail to verify.
+		resetAuthCachesForTests();
+		await env.KV.put("cf-access-certs", JSON.stringify([publicJwk]));
+
+		const jwt = await signTestJwt(keyPair.privateKey, {
+			exp: Math.floor(Date.now() / 1000) + 3600,
+			aud: audience,
+			iss: `https://${domain}`,
+			email,
+		});
+
+		const res = await SELF.fetch("http://localhost/auth/me", {
+			headers: { "Cf-Access-Jwt-Assertion": jwt },
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { user: { email: string } };
+		expect(body.user.email).toBe(email);
+	});
+
+	it("anonymous viewer is blocked from writes (403), same as any viewer-role member", async () => {
+		const slug = `proj-373-write-${crypto.randomUUID().slice(0, 8)}`;
+		await seedWorkspace(slug);
+		env.DEFAULT_WORKSPACE_SLUG = slug;
+		env.PUBLIC_READ_ONLY = "true";
+
+		const res = await SELF.fetch("http://localhost/api/projects", {
+			method: "POST",
+			headers: { "X-Workspace-Slug": slug, "Content-Type": "application/json" },
+			body: JSON.stringify({ name: "Blocked", key: "BLK" }),
 		});
 		expect(res.status).toBe(403);
 	});

--- a/apps/api/src/test/provisioning.test.ts
+++ b/apps/api/src/test/provisioning.test.ts
@@ -1,7 +1,7 @@
 import { env } from "cloudflare:test";
 import type { Env } from "@projektor/types";
 import { describe, expect, it } from "vitest";
-import { provisionUserOnLogin } from "../services/provisioning";
+import { provisionPublicViewer, provisionUserOnLogin } from "../services/provisioning";
 import { seedMember, seedUser, seedWorkspace } from "./helpers";
 
 // provisionUserOnLogin reads its config from the Env it's handed, so each test builds an
@@ -208,5 +208,45 @@ describe("login provisioning", () => {
 			.first<{ id: string }>();
 		expect(ws).not.toBeNull();
 		expect(await memberRole(ws!.id, user.id)).toBe("owner");
+	});
+});
+
+// PROJ-373: the anonymous public-viewer's workspace membership, provisioned by
+// middleware/auth.ts's PUBLIC_READ_ONLY path. HTTP-level behavior (auth fallback
+// order, 401 when off) is covered in auth.test.ts.
+describe("public viewer provisioning (PROJ-373)", () => {
+	it("joins the default workspace as viewer", async () => {
+		const slug = "prov-public-viewer";
+		const ws = await seedWorkspace(slug);
+		const user = await seedUser("public-viewer@projektor.local");
+
+		await provisionPublicViewer(envWith({ DEFAULT_WORKSPACE_SLUG: slug }), user);
+
+		expect(await memberRole(ws.id, user.id)).toBe("viewer");
+	});
+
+	it("is a no-op until the default workspace is bootstrapped", async () => {
+		const user = await seedUser("public-viewer-early@projektor.local");
+
+		await provisionPublicViewer(
+			envWith({ DEFAULT_WORKSPACE_SLUG: "prov-public-viewer-not-yet" }),
+			user
+		);
+
+		const ws = await env.DB.prepare("SELECT id FROM workspaces WHERE slug = ?")
+			.bind("prov-public-viewer-not-yet")
+			.first();
+		expect(ws).toBeNull();
+	});
+
+	it("never promotes an existing membership above viewer (idempotent, not privilege-escalating)", async () => {
+		const slug = "prov-public-viewer-existing-owner";
+		const ws = await seedWorkspace(slug);
+		const user = await seedUser("public-viewer-owner@projektor.local");
+		await seedMember(ws.id, user.id, "owner");
+
+		await provisionPublicViewer(envWith({ DEFAULT_WORKSPACE_SLUG: slug }), user);
+
+		expect(await memberRole(ws.id, user.id)).toBe("owner");
 	});
 });

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -28,6 +28,7 @@ export default defineConfig({
 					label: "Start here",
 					items: [
 						{ label: "Overview", link: "/" },
+						{ label: "Live demo", slug: "guides/live-demo" },
 						{ label: "Self-hosting", slug: "guides/self-hosting" },
 						{ label: "Deploying & operating", slug: "guides/deploying" },
 						{ label: "Releases & changelog", link: "https://github.com/TAJD/projektor/releases" },

--- a/apps/docs/src/content/docs/guides/live-demo.md
+++ b/apps/docs/src/content/docs/guides/live-demo.md
@@ -1,0 +1,14 @@
+---
+title: "Live demo"
+description: "See Projektor running before you deploy your own instance."
+sidebar:
+  order: 1
+---
+Want to see Projektor running before you deploy your own? Check out the
+[live demo](https://projektor-demo.tajdickson.workers.dev) - a fresh, unseeded instance
+standing up the wiki + issue tracker on a single Cloudflare Worker.
+
+When you're ready to stand up your own instance, the
+[`projektor-deploy-example`](https://github.com/TAJD/projektor-deploy-example) repo is
+the config-only starting point - see [Self-hosting](/projektor/guides/self-hosting/) for
+the fastest path.

--- a/apps/docs/src/content/docs/guides/self-hosting.md
+++ b/apps/docs/src/content/docs/guides/self-hosting.md
@@ -9,6 +9,9 @@ Projektor deploys to **your own Cloudflare account** from a small **config-only 
 downloads a pre-built release artifact - no source checkout and no build step. Pick the
 path that suits you; they're ordered easiest first.
 
+Want to see it running before you deploy your own? Check out the
+[live demo](https://projektor-demo.tajdickson.workers.dev).
+
 ## One click
 
 Use the **Deploy to Cloudflare** button in the

--- a/packages/types/src/env.ts
+++ b/packages/types/src/env.ts
@@ -42,6 +42,14 @@ export interface Env {
 	// subdomains are actually provisioned in DNS. Honored truthy values (case-
 	// insensitive, whitespace-trimmed): "true", "1", "yes". (PROJ-267, PROJ-296)
 	WORKSPACE_SUBDOMAIN_ROUTING?: string;
+	// PROJ-373: explicit opt-in. When truthy, anonymous requests (no CF Access
+	// session, no bearer token) are treated as a shared read-only "viewer" of the
+	// default workspace, instead of 401ing. Off by default — an operator who
+	// hasn't configured CF_ACCESS_TEAM_DOMAIN yet must NOT have their instance
+	// silently become world-readable; this only applies when explicitly set.
+	// Independent of whether CF Access is configured. Honored truthy values
+	// (case-insensitive, whitespace-trimmed): "true", "1", "yes".
+	PUBLIC_READ_ONLY?: string;
 }
 
 export interface Variables {


### PR DESCRIPTION
## Summary
- Adds an explicit opt-in `PUBLIC_READ_ONLY` env var (PROJ-373). When truthy, anonymous requests (no CF Access session, no bearer token) are provisioned as a shared read-only "viewer" of the default workspace instead of 401ing. Off by default so a self-hoster mid-setup (CF Access not configured yet) is never silently world-readable.
- Reuses the existing `viewer`-role write-blocking logic across every service rather than inventing a parallel authz mechanism — a real CF Access session/bearer token/dev bypass always wins over the anonymous fallback.
- Adds a "Live demo" link to the self-hosting docs (PROJ-283).

## Test plan
- [x] `pnpm exec vitest run` in `apps/api` — 721 tests passing (added 7 new tests covering: default-off 401, anonymous viewer provisioning + role, real CF Access session not demoted, anonymous viewer blocked from writes 403, plus 3 `provisionPublicViewer` unit tests)
- [x] `pnpm run type-check` — clean
- [x] `pnpm biome check` — clean
- [x] `apps/docs` build — succeeds, all internal links valid