### PR TITLE
docs: fix onboarding gaps from fable review of self-hosting stories (PROJ-366..372)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 **Documentation:** <https://tajd.github.io/projektor/> - self-hosting, connecting an
 agent, architecture, and the full MCP tool catalog.
 
+**Live demo:** <https://projektor-demo.tajdickson.workers.dev> - see it running before you deploy your own (no login configured; see the [live demo guide](https://tajd.github.io/projektor/guides/live-demo/) for why).
+
 ## What it is
 
 ![Projektor issue backlog - list view with projects sidebar, issue refs, status, priority, and assignees](docs/images/backlog.png)

--- a/apps/docs/src/content/docs/agents/mcp-connection.md
+++ b/apps/docs/src/content/docs/agents/mcp-connection.md
@@ -168,7 +168,7 @@ Once connected, give Claude Code natural-language instructions:
 
 ## 7. Cloudflare Access note
 
-If your projektor instance is behind Cloudflare Access (which it should be in production), headless agents need a **service token** rather than a user JWT. See the CF Access docs for minting service tokens.
+If your projektor instance is behind Cloudflare Access (which it should be in production), headless agents need a **service token** rather than a user JWT. See the [Cloudflare Access docs on service tokens](https://developers.cloudflare.com/cloudflare-one/identity/service-tokens/) for minting one.
 
 Pass the service token credentials alongside the API token:
 

--- a/apps/docs/src/content/docs/guides/deploying.md
+++ b/apps/docs/src/content/docs/guides/deploying.md
@@ -89,7 +89,8 @@ Pin a version and run the deploy script once - it downloads the release and
 scaffolds your `wrangler.toml` from the template:
 
 ```bash
-echo "v1.0.0" > projektor.version          # a published release tag
+gh release list -R TAJD/projektor          # find a real tag - releases are all v0.x so far
+echo "v0.3.7" > projektor.version          # pin whichever tag you picked
 ./deploy.sh                                 # creates wrangler.toml, then asks you to fill it
 ```
 

--- a/apps/docs/src/content/docs/guides/live-demo.md
+++ b/apps/docs/src/content/docs/guides/live-demo.md
@@ -8,6 +8,13 @@ Want to see Projektor running before you deploy your own? Check out the
 [live demo](https://projektor-demo.tajdickson.workers.dev) - a fresh, unseeded instance
 standing up the wiki + issue tracker on a single Cloudflare Worker.
 
+No login is configured on the demo, so you'll see the app shell load and then the
+project/issue views get stuck on "Loading projects..." - that's expected, not broken.
+The API requires Cloudflare Access, which the demo deliberately leaves unconfigured, so
+`/api/projects` returns 401 and the UI never gets past the loading state. It's the same
+Worker code you'd deploy yourself, just kept empty and login-less on purpose. To actually
+use Projektor, deploy your own instance.
+
 When you're ready to stand up your own instance, the
 [`projektor-deploy-example`](https://github.com/TAJD/projektor-deploy-example) repo is
 the config-only starting point - see [Self-hosting](/projektor/guides/self-hosting/) for

--- a/apps/docs/src/content/docs/guides/self-hosting.md
+++ b/apps/docs/src/content/docs/guides/self-hosting.md
@@ -25,7 +25,7 @@ Clone the deploy repo and run the zero-config script; wrangler auto-provisions t
 resources, applies migrations, and deploys:
 
 ```bash
-PROJEKTOR_REPO=you/projektor ADMIN_EMAILS=you@example.com ./deploy-auto.sh
+PROJEKTOR_REPO=TAJD/projektor ADMIN_EMAILS=you@example.com ./deploy-auto.sh
 ```
 
 Or hand the repo to an AI agent - *"deploy projektor to my Cloudflare account"* - and

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -12,6 +12,9 @@ hero:
     - text: Self-host in 5 minutes
       link: /projektor/guides/self-hosting/
       icon: rocket
+    - text: See the live demo
+      link: /projektor/guides/live-demo/
+      icon: open-book
     - text: GitHub
       link: https://github.com/TAJD/projektor
       icon: github
@@ -45,7 +48,7 @@ Clone the [deploy repo](https://github.com/TAJD/projektor-deploy-example) and ru
 zero-config script - wrangler auto-provisions D1, KV, and R2, applies migrations, and deploys:
 
 ```bash
-PROJEKTOR_REPO=you/projektor ADMIN_EMAILS=you@example.com ./deploy-auto.sh
+PROJEKTOR_REPO=TAJD/projektor ADMIN_EMAILS=you@example.com ./deploy-auto.sh
 ```
 
 Or hand the repo to an AI agent - *"deploy projektor to my Cloudflare account"* - and let it


### PR DESCRIPTION
## Summary
Implements the 6 projektor-side sub-issues of PROJ-365 (epic), a fable-model review of the onboarding/self-hosting docs against 7 concrete user stories:

- **PROJ-366** — live-demo.md now explains the demo's "Loading projects..." hang is expected (no CF Access configured, 401 on `/api/projects`), not broken.
- **PROJ-367** — replaced the misleading `PROJEKTOR_REPO=you/projektor` placeholder with `TAJD/projektor` in self-hosting.md and index.mdx (deploy-example repo counterparts in a separate PR).
- **PROJ-368** — fixed the nonexistent `v1.0.0` example release tag in deploying.md; now points at `gh release list` + a real tag.
- **PROJ-371** — (deploy-example side, see companion PR) — n/a here.
- **PROJ-372** — added a live-demo hero link + root README line, and the missing CF Access service-token docs URL in mcp-connection.md.

The `projektor-deploy-example` sub-issues (PROJ-369, PROJ-370, PROJ-371, and the deploy-example half of PROJ-367/368/372) are committed separately in that repo, per the epic's cross-repo instructions.

## Test plan
- [x] Reviewed each diff manually for correctness (doc-only changes, no build tooling available in this worktree)
- [ ] Human review + merge via the projektor issue tracker workflow (agent sessions can't self-transition to done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG4F7B3e8xN4Fy5zzPUj2d