### PR TITLE
PROJ-375: allow agent-initiated done transitions, flag weak evidence for audit

### DIFF
--- a/apps/api/src/mcp/issues.ts
+++ b/apps/api/src/mcp/issues.ts
@@ -79,6 +79,11 @@ export const issuesTools: MCPTool[] = [
 					type: "number",
 					description: "Only issues last edited at or before this epoch-seconds time",
 				},
+				needsAudit: {
+					type: "boolean",
+					description:
+						"Filter to agent-initiated done-closures flagged for human audit (PROJ-375) — true for unverifiable evidence, false for externally-checkable evidence",
+				},
 				cursor: { type: "number", description: "Pagination cursor (created_at of last item)" },
 				limit: { type: "number", default: 50, description: "Max 100" },
 			},
@@ -134,8 +139,10 @@ export const issuesTools: MCPTool[] = [
 		name: "update_issue",
 		description:
 			"Update an issue - status, priority, title, body, assignee, or labels. Review gating " +
-			"(PROJ-254): pass agentSessionId to identify yourself as an agent; entering in_review as an " +
-			"agent requires completionReport, and only a human can transition to done.",
+			"(PROJ-254/375): pass agentSessionId to identify yourself as an agent; entering in_review as " +
+			"an agent requires completionReport. Agents CAN transition directly to done (no human " +
+			"approval gate) — but if the completionReport.verification isn't externally checkable (no " +
+			"CI run/PR/commit link), the issue is flagged needsAudit:true for after-the-fact human review.",
 		inputSchema: {
 			type: "object",
 			required: ["id"],

--- a/apps/api/src/routes/issues.ts
+++ b/apps/api/src/routes/issues.ts
@@ -37,6 +37,7 @@ router.get("/", async (c) => {
 		completedBefore,
 		updatedAfter,
 		updatedBefore,
+		needsAudit,
 		cursor,
 		limit,
 	} = c.req.query();
@@ -63,6 +64,7 @@ router.get("/", async (c) => {
 				completedBefore,
 				updatedAfter,
 				updatedBefore,
+				needsAudit,
 				cursor,
 				limit,
 			})

--- a/apps/api/src/schemas/issues.ts
+++ b/apps/api/src/schemas/issues.ts
@@ -63,6 +63,9 @@ export const ListIssuesSchema = z.object({
 	completedBefore: z.coerce.number().optional(),
 	updatedAfter: z.coerce.number().optional(),
 	updatedBefore: z.coerce.number().optional(),
+	// PROJ-375: surface agent-initiated done-closures whose evidence wasn't
+	// externally checkable, for periodic human audit.
+	needsAudit: z.coerce.boolean().optional(),
 	cursor: z.coerce.number().optional(),
 	limit: z.coerce.number().min(1).max(100).default(30),
 });

--- a/apps/api/src/services/evidence-classification.ts
+++ b/apps/api/src/services/evidence-classification.ts
@@ -1,0 +1,12 @@
+// PROJ-375: classifies a completion report's `verification` text as externally
+// checkable or not — a heuristic, not a real check (no outbound call to GitHub here,
+// that's the deferred "trusted CI/webhook" follow-up). A CI run URL, a PR URL, a
+// commit/comparison URL, or a bare git SHA all point at something a human (or a
+// future automated check) could independently open and verify; plain prose like
+// "ran the tests locally" can't be resolved by anyone but the agent that wrote it.
+const RESOLVABLE_URL_PATTERN = /https?:\/\/\S*\/(pull|pulls|actions\/runs|commit|compare)\/\S+/i;
+const COMMIT_SHA_PATTERN = /\b[0-9a-f]{7,40}\b/i;
+
+export function isExternallyVerifiableEvidence(verification: string): boolean {
+	return RESOLVABLE_URL_PATTERN.test(verification) || COMMIT_SHA_PATTERN.test(verification);
+}

--- a/apps/api/src/services/issue-leases.ts
+++ b/apps/api/src/services/issue-leases.ts
@@ -334,6 +334,38 @@ export async function issueEverHadAgentLease(ctx: ServiceCtx, issueId: string): 
 }
 
 /**
+ * Is `agentSessionId` a currently-live agent session (registered, status
+ * "active", heartbeated within the TTL)? Unlike issueHasLiveAgentLease this
+ * isn't about holding a lease on a specific issue — it's used by the PROJ-375
+ * evidence-audit flag to tell an agent-initiated `done` transition from a
+ * human one, so a caller can't get flagged/unflagged by a lease it released.
+ * Still resistant to the "declare kind:human" spoof (issueHasLiveAgentLease's
+ * docstring) because it doesn't look at kind at all — only that the session
+ * is real and live. A caller can dodge the audit flag by omitting
+ * agentSessionId entirely, same limitation the ticket accepts (PROJ-375: no
+ * trusted CI/webhook verification here, audit-after-the-fact only).
+ */
+export async function isLiveAgentSessionId(
+	ctx: ServiceCtx,
+	agentSessionId: string
+): Promise<boolean> {
+	const orm = drizzle(ctx.db, { schema });
+	const row = await orm
+		.select({ id: schema.agentSessions.id })
+		.from(schema.agentSessions)
+		.where(
+			and(
+				eq(schema.agentSessions.id, agentSessionId),
+				eq(schema.agentSessions.workspaceId, ctx.workspaceId),
+				eq(schema.agentSessions.status, "active"),
+				gt(schema.agentSessions.lastHeartbeatAt, liveCutoff())
+			)
+		)
+		.get();
+	return row != null;
+}
+
+/**
  * List active leases (released_at IS NULL) in the workspace, optionally scoped
  * to an issue or agent. Each row carries a `live` flag (false = the holder
  * stopped heartbeating and the lease is reclaimable).

--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -40,7 +40,13 @@ import {
 } from "./custom-fields";
 import { checkDefinitionOfReady } from "./definition-of-ready";
 import { ForbiddenError, NotFoundError, ValidationError } from "./errors";
-import { issueEverHadAgentLease, issueHasLiveAgentLease, liveLeasedIssueIds } from "./issue-leases";
+import { isExternallyVerifiableEvidence } from "./evidence-classification";
+import {
+	isLiveAgentSessionId,
+	issueEverHadAgentLease,
+	issueHasLiveAgentLease,
+	liveLeasedIssueIds,
+} from "./issue-leases";
 import { listLinksForIssue } from "./issue-links";
 import { inChunks } from "./sql";
 import { resolveStatus } from "./task-statuses";
@@ -127,6 +133,9 @@ function addStatusFilters(conditions: Condition[], filters: ListIssuesFilters): 
 		if (ids.length) conditions.push(inArray(schema.issues.statusId, ids));
 	}
 	if (category) conditions.push(eq(schema.issues.statusCategory, category));
+	if (filters.needsAudit !== undefined) {
+		conditions.push(eq(schema.issues.needsAudit, filters.needsAudit));
+	}
 	if (priority)
 		conditions.push(
 			eq(schema.issues.priority, priority as "urgent" | "high" | "medium" | "low" | "none")
@@ -276,6 +285,7 @@ export async function listIssues(ctx: ServiceCtx, raw: unknown) {
 			created_at: schema.issues.createdAt,
 			updated_at: schema.issues.updatedAt,
 			completed_at: schema.issues.completedAt,
+			needs_audit: schema.issues.needsAudit,
 			assignee_name: schema.users.name,
 			project_key: schema.projects.key,
 			project_name: schema.projects.name,
@@ -333,6 +343,7 @@ const issueColumns = {
 	created_at: schema.issues.createdAt,
 	updated_at: schema.issues.updatedAt,
 	completed_at: schema.issues.completedAt,
+	needs_audit: schema.issues.needsAudit,
 	project_key: schema.projects.key,
 	project_name: schema.projects.name,
 	type_key: schema.taskTypes.key,
@@ -828,12 +839,12 @@ function classifyStatusTransition(
 	return { enteringInReview, enteringDone };
 }
 
-// PROJ-254/287/289/292: the gate is bound to the issue's LIVE AGENT LEASE — the one
-// signal an agent can't spoof by omitting agentSessionId or self-declaring
-// kind:"human". Entering review while an agent holds a live lease requires a
-// completion report; an agent (live lease) can never mark done; and the done-report
-// requirement applies only to issues an agent has actually worked, so ordinary human
-// closes (duplicates, won't-fix, chores) aren't blocked.
+// PROJ-254/287/289/292, relaxed by PROJ-375: entering review while an agent holds a
+// live lease requires a completion report; the done-report requirement applies only
+// to issues an agent has actually worked, so ordinary human closes (duplicates,
+// won't-fix, chores) aren't blocked. PROJ-375 removed the old hard block on an agent
+// (live lease) transitioning to done — agents can close freely now; see
+// computeNeedsAudit below for the audit-after-the-fact replacement.
 async function assertReviewGate(
 	ctx: ServiceCtx,
 	data: UpdateIssueData,
@@ -843,18 +854,14 @@ async function assertReviewGate(
 	const { enteringInReview, enteringDone } = transition;
 	if (!enteringInReview && !enteringDone) return;
 
-	const hasLiveAgentLease = await issueHasLiveAgentLease(ctx, existing.id);
-
-	if (enteringInReview && hasLiveAgentLease) {
-		assertCompletionReportPresent(data);
+	if (enteringInReview) {
+		const hasLiveAgentLease = await issueHasLiveAgentLease(ctx, existing.id);
+		if (hasLiveAgentLease) {
+			assertCompletionReportPresent(data);
+		}
 	}
 
 	if (enteringDone) {
-		if (hasLiveAgentLease) {
-			throw new ForbiddenError(
-				"An agent cannot mark an issue done — a human must approve (PROJ-254)"
-			);
-		}
 		const everAgentWorked = await issueEverHadAgentLease(ctx, existing.id);
 		if (everAgentWorked && existing.completionReportAt == null && !data.completionReport) {
 			throw new ValidationError({
@@ -865,6 +872,20 @@ async function assertReviewGate(
 			});
 		}
 	}
+}
+
+// PROJ-375: audit-after-the-fact replacement for the removed done-gate block. Only
+// flags a call that's actually agent-initiated — `isLiveAgentSessionId` checks the
+// session is real and live, not just a self-declared string, so a caller can't get
+// flagged/unflagged by lease state (the bug that started this ticket: an agent that
+// released its lease before closing slipped the old gate unintentionally). A caller
+// can still dodge the flag by omitting agentSessionId entirely — accepted limitation,
+// see the module doc on evidence-classification.ts.
+async function computeNeedsAudit(ctx: ServiceCtx, data: UpdateIssueData): Promise<boolean> {
+	if (!data.agentSessionId) return false;
+	if (!(await isLiveAgentSessionId(ctx, data.agentSessionId))) return false;
+	if (!data.completionReport) return true;
+	return !isExternallyVerifiableEvidence(data.completionReport.verification);
 }
 
 async function applyStatusFields(
@@ -885,6 +906,10 @@ async function applyStatusFields(
 	const newStatusCategory = await fetchStatusCategory(orm, resolvedStatusId);
 	const transition = classifyStatusTransition(existing, resolvedStatusKey, newStatusCategory);
 	await assertReviewGate(ctx, data, existing, transition);
+
+	if (transition.enteringDone) {
+		setValues.needsAudit = await computeNeedsAudit(ctx, data);
+	}
 
 	setValues.status = resolvedStatusKey;
 	setValues.statusId = resolvedStatusId;

--- a/apps/api/src/services/workflow-content.ts
+++ b/apps/api/src/services/workflow-content.ts
@@ -50,16 +50,16 @@ picking up autonomous work.
 
 - **Ready → Claimed**: may be fully autonomous. Any live agent session can call
   \`claim_issue\` without a human in the loop, subject to the WIP limit below.
-- **In Review → Done**: **always requires a human.** An agent session can never move
-  its own (or any) issue to \`done\` — attempting it is rejected outright, regardless of
-  whether a completion report is attached. A human reviews the report and the diff,
-  then makes the transition themselves (browser, or any session not holding a live
-  lease on the issue).
+- **In Review → Done**: may also be fully autonomous (PROJ-375). An agent session can
+  close its own (or any) issue to \`done\` directly — there's no pre-close block waiting
+  on a human. A completion report is still required before an agent-worked issue can
+  close (see below). Instead of gating the transition, projektor classifies the
+  report's evidence and flags weak closures for **audit after the fact** — see below.
 
 ## Completion reports
 
-Before an agent-held issue can move into \`In Review\`, it must submit a completion
-report with:
+Before an agent-held issue can move into \`In Review\` or \`Done\`, it must submit a
+completion report with:
 
 - **\`summary\`** — what changed, in plain language.
 - **\`verification\`** — the command(s) run and their outcome (the same ones named in
@@ -69,6 +69,22 @@ report with:
 \`summary\` and \`verification\` are required; the transition is rejected with the specific
 missing field(s) named if either is absent. The report is recorded as a normal issue
 comment, so it's visible in the same timeline as everything else.
+
+## Evidence audit (PROJ-375)
+
+Every agent-initiated \`done\` transition — one that passes \`agentSessionId\` for a
+live agent session — has its \`completionReport.verification\` text classified:
+
+- **Externally-verifiable** — contains a resolvable link or reference (a PR URL, a CI
+  run URL, a commit URL, or a bare commit SHA) that a human (or a future automated
+  check) could independently open and check. Not flagged.
+- **Freeform/unverifiable** — plain prose ("manually tested", "confirmed visually")
+  with nothing external to check. Flagged \`needsAudit: true\` on the issue.
+
+This doesn't block the closure — it's audit-after-the-fact, not a gate. Pull flagged
+issues for periodic review with \`list_issues({ needsAudit: true })\`. There's no
+outbound verification call to GitHub or CI here (classification is pattern-based
+only) — treat a resolvable link as "checkable," not "already checked."
 
 ## WIP limits
 

--- a/apps/api/src/test/evidence-classification.test.ts
+++ b/apps/api/src/test/evidence-classification.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { isExternallyVerifiableEvidence } from "../services/evidence-classification";
+
+describe("isExternallyVerifiableEvidence (PROJ-375)", () => {
+	it("is not verifiable for plain prose", () => {
+		expect(isExternallyVerifiableEvidence("Ran the tests locally, all green.")).toBe(false);
+		expect(isExternallyVerifiableEvidence("manually tested in the browser")).toBe(false);
+	});
+
+	it("is verifiable given a PR URL", () => {
+		expect(
+			isExternallyVerifiableEvidence("See https://github.com/TAJD/projektor/pull/93 — CI green.")
+		).toBe(true);
+	});
+
+	it("is verifiable given a CI run URL", () => {
+		expect(
+			isExternallyVerifiableEvidence(
+				"CI: https://github.com/TAJD/projektor/actions/runs/29292287652"
+			)
+		).toBe(true);
+	});
+
+	it("is verifiable given a commit URL", () => {
+		expect(
+			isExternallyVerifiableEvidence(
+				"Fixed in https://github.com/TAJD/projektor/commit/b6ca8a7f9271a6fb6e67d7247e1e9692088e5d48"
+			)
+		).toBe(true);
+	});
+
+	it("is verifiable given a bare commit SHA", () => {
+		expect(isExternallyVerifiableEvidence("Verified at commit b6ca8a7f927")).toBe(true);
+	});
+
+	it("is not verifiable for a short non-hex word that happens to look like a token", () => {
+		expect(isExternallyVerifiableEvidence("looks good, ship it")).toBe(false);
+	});
+});

--- a/apps/api/src/test/migrations.ts
+++ b/apps/api/src/test/migrations.ts
@@ -34,6 +34,7 @@ import m0030 from "../../../../packages/db/migrations/0030_backfill_review_times
 import m0031 from "../../../../packages/db/migrations/0031_factory_health.sql?raw";
 import m0032 from "../../../../packages/db/migrations/0032_claim_conflicts.sql?raw";
 import m0033 from "../../../../packages/db/migrations/0033_custom_field_is_internal.sql?raw";
+import m0034 from "../../../../packages/db/migrations/0034_issue_needs_audit.sql?raw";
 
 export const MIGRATIONS = [
 	m0000,
@@ -70,4 +71,5 @@ export const MIGRATIONS = [
 	m0031,
 	m0032,
 	m0033,
+	m0034,
 ];

--- a/apps/api/src/test/review-gating.test.ts
+++ b/apps/api/src/test/review-gating.test.ts
@@ -8,13 +8,14 @@ import {
 	seedTaskStatus,
 } from "./helpers";
 
-// PROJ-254 gate, hardened by PROJ-287/289/292/293: the review/done gate is bound to
-// the issue's LIVE AGENT LEASE (an agent can't spoof it by omitting agentSessionId or
-// self-declaring kind:"human"), the done-report requirement is scoped to agent-worked
-// issues, review is keyed on any review-like status, and the report is only stamped on
-// a real transition.
+// PROJ-254 gate, hardened by PROJ-287/289/292/293: the in_review report requirement is
+// bound to the issue's LIVE AGENT LEASE (an agent can't spoof it by omitting
+// agentSessionId or self-declaring kind:"human"); the done-report requirement is scoped
+// to agent-worked issues; review is keyed on any review-like status; the report is only
+// stamped on a real transition. PROJ-375 removed the old block on an agent (live lease)
+// transitioning to done — agents can close freely now; see the needsAudit tests below.
 // cofferdam-ignore: Readability.MaxFunctionLength: one describe block, normal test style
-describe("Review gating (PROJ-254/287/289/292/293)", () => {
+describe("Review gating (PROJ-254/287/289/292/293/375)", () => {
 	let token: string;
 	let slug: string;
 	let workspaceId: string;
@@ -38,6 +39,13 @@ describe("Review gating (PROJ-254/287/289/292/293)", () => {
 			.bind(id)
 			.first<{ completion_report_at: number | null }>();
 		return row?.completion_report_at ?? null;
+	}
+
+	async function needsAuditOf(id: string): Promise<boolean> {
+		const row = await env.DB.prepare("SELECT needs_audit FROM issues WHERE id = ?")
+			.bind(id)
+			.first<{ needs_audit: number }>();
+		return Boolean(row?.needs_audit);
 	}
 
 	async function commentBodies(id: string): Promise<string[]> {
@@ -70,71 +78,74 @@ describe("Review gating (PROJ-254/287/289/292/293)", () => {
 		expect((await commentBodies(issue.id)).some((b) => b.includes("Did the thing"))).toBe(true);
 	});
 
-	it("never lets an agent (live lease) transition an issue to done, report or not", async () => {
-		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Agent tries done" });
-		await seedAgentLease(workspaceId, issue.id);
+	// --- PROJ-375: agents close to done directly, no block ---
 
-		const res = await patch(issue.id, { status: "done", completionReport: report });
-		expect(res.status).toBe(403);
+	it("lets an agent (live lease) transition an issue directly to done", async () => {
+		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Agent closes" });
+		const { agentSessionId } = await seedAgentLease(workspaceId, issue.id);
+
+		const res = await patch(issue.id, { status: "done", agentSessionId, completionReport: report });
+		expect(res.status).toBe(200);
 	});
 
-	// --- Regression: the closed bypasses (PROJ-287) ---
+	it("flags an agent-initiated done closure with freeform verification as needsAudit", async () => {
+		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Freeform close" });
+		const { agentSessionId } = await seedAgentLease(workspaceId, issue.id);
 
-	it("REGRESSION: omitting agentSessionId does not let an agent-leased issue skip the done gate", async () => {
-		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Omit bypass" });
-		await seedAgentLease(workspaceId, issue.id);
-
-		// No agentSessionId at all — previously treated as human and allowed straight to done.
-		const res = await patch(issue.id, { status: "done", completionReport: report });
-		expect(res.status).toBe(403);
+		await patch(issue.id, { status: "done", agentSessionId, completionReport: report });
+		expect(await needsAuditOf(issue.id)).toBe(true);
 	});
 
-	it("REGRESSION: a self-declared kind:human session cannot escape a live agent lease", async () => {
-		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Human spoof" });
-		await seedAgentLease(workspaceId, issue.id, { kind: "agent" });
-		// Attach a human-kind session too; it must not downgrade the live agent lease.
-		const human = await seedAgentLease(workspaceId, issue.id, { kind: "human", live: false });
+	it("does not flag an agent-initiated done closure with an externally-checkable link", async () => {
+		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Verifiable close" });
+		const { agentSessionId } = await seedAgentLease(workspaceId, issue.id);
 
-		const res = await patch(issue.id, {
+		await patch(issue.id, {
 			status: "done",
-			agentSessionId: human.agentSessionId,
+			agentSessionId,
+			completionReport: {
+				summary: "Did the thing",
+				verification: "https://github.com/TAJD/projektor/pull/93 — CI green",
+			},
+		});
+		expect(await needsAuditOf(issue.id)).toBe(false);
+	});
+
+	it("does not flag a human-initiated done closure (no agentSessionId) even with freeform evidence", async () => {
+		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Human closes" });
+		await seedAgentLease(workspaceId, issue.id, { live: false });
+
+		await patch(issue.id, { status: "done", completionReport: report });
+		expect(await needsAuditOf(issue.id)).toBe(false);
+	});
+
+	it("does not flag when the agentSessionId given is not a live session (accepted limitation)", async () => {
+		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Stale session close" });
+		await seedAgentLease(workspaceId, issue.id, { live: false });
+
+		await patch(issue.id, {
+			status: "done",
+			agentSessionId: crypto.randomUUID(), // never existed — can't resolve to a live session
 			completionReport: report,
 		});
-		expect(res.status).toBe(403);
+		expect(await needsAuditOf(issue.id)).toBe(false);
 	});
 
-	it("REGRESSION: a lease held ONLY by a self-declared kind:human session still gates the done transition", async () => {
+	it("flags needsAudit even once the agent's lease has been released before closing", async () => {
+		// The exact scenario PROJ-375 was filed for: release_issue then update_issue done.
 		const issue = await seedIssue(workspaceId, projectId, userId, {
-			title: "Human-kind-only lease",
+			title: "Released then closed",
 		});
-		// No agent-kind lease at all — the issue's only lease holder declared kind:"human"
-		// at register_agent time (unprivileged, no role check on that field).
-		await seedAgentLease(workspaceId, issue.id, { kind: "human" });
-
-		const res = await patch(issue.id, { status: "done", completionReport: report });
-		expect(res.status).toBe(403);
-	});
-
-	it("REGRESSION: a released kind:human-only lease still requires a completion report to close", async () => {
-		const issue = await seedIssue(workspaceId, projectId, userId, {
-			title: "Released human lease",
+		const { agentSessionId } = await seedAgentLease(workspaceId, issue.id);
+		await SELF.fetch(`http://localhost/api/issues/${issue.id}/release`, {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ agentId: agentSessionId }),
 		});
-		// The lease is no longer live, so this exercises issueEverHadAgentLease rather
-		// than issueHasLiveAgentLease — it must still count as agent-worked.
-		await seedAgentLease(workspaceId, issue.id, { kind: "human", live: false });
 
-		expect((await patch(issue.id, { status: "done" })).status).toBe(400);
-		expect((await patch(issue.id, { status: "done", completionReport: report })).status).toBe(200);
-	});
-
-	it("REGRESSION: a stale/ended agentSessionId no longer hard-404s a valid update", async () => {
-		const issue = await seedIssue(workspaceId, projectId, userId, { title: "Stale session" });
-
-		const res = await patch(issue.id, {
-			status: "todo",
-			agentSessionId: crypto.randomUUID(), // never existed
-		});
+		const res = await patch(issue.id, { status: "done", agentSessionId, completionReport: report });
 		expect(res.status).toBe(200);
+		expect(await needsAuditOf(issue.id)).toBe(true);
 	});
 
 	// --- Human path scoped to agent-worked issues (PROJ-289) ---
@@ -171,11 +182,11 @@ describe("Review gating (PROJ-254/287/289/292/293)", () => {
 		);
 	});
 
-	// --- REST/MCP parity (PROJ-301) ---
+	// --- REST/MCP parity (PROJ-301/375) ---
 
-	it("MCP parity: update_issue enforces the done gate on an agent-leased issue", async () => {
+	it("MCP parity: update_issue lets an agent close directly to done and flags weak evidence", async () => {
 		const issue = await seedIssue(workspaceId, projectId, userId, { title: "MCP done" });
-		await seedAgentLease(workspaceId, issue.id);
+		const { agentSessionId } = await seedAgentLease(workspaceId, issue.id);
 
 		const res = await SELF.fetch(`http://localhost/mcp/${workspaceId}`, {
 			method: "POST",
@@ -186,12 +197,46 @@ describe("Review gating (PROJ-254/287/289/292/293)", () => {
 				method: "tools/call",
 				params: {
 					name: "update_issue",
-					arguments: { id: issue.id, status: "done", completionReport: report },
+					arguments: { id: issue.id, status: "done", agentSessionId, completionReport: report },
 				},
 			}),
 		});
-		// Agent holds a live lease → an agent cannot mark done; surfaced as a tool error.
-		expect(JSON.stringify(await res.json())).toMatch(/agent cannot mark/i);
+		const body = (await res.json()) as { result?: unknown; error?: unknown };
+		expect(body.error).toBeUndefined();
+		expect(body.result).toBeDefined();
+		expect(await needsAuditOf(issue.id)).toBe(true);
+	});
+
+	// --- Audit query filter (PROJ-375) ---
+
+	it("list_issues({ needsAudit: true }) surfaces flagged closures only", async () => {
+		const flagged = await seedIssue(workspaceId, projectId, userId, { title: "Flagged" });
+		const clean = await seedIssue(workspaceId, projectId, userId, { title: "Clean" });
+		const { agentSessionId: flaggedAgent } = await seedAgentLease(workspaceId, flagged.id);
+		const { agentSessionId: cleanAgent } = await seedAgentLease(workspaceId, clean.id);
+
+		await patch(flagged.id, {
+			status: "done",
+			agentSessionId: flaggedAgent,
+			completionReport: report,
+		});
+		await patch(clean.id, {
+			status: "done",
+			agentSessionId: cleanAgent,
+			completionReport: {
+				summary: "Did the thing",
+				verification: "https://github.com/TAJD/projektor/pull/93",
+			},
+		});
+
+		const res = await SELF.fetch(
+			`http://localhost/api/issues?projectId=${projectId}&needsAudit=true`,
+			{ headers: authHeaders(token, slug) }
+		);
+		const { items } = (await res.json()) as { items: Array<{ id: string }> };
+		const ids = items.map((i) => i.id);
+		expect(ids).toContain(flagged.id);
+		expect(ids).not.toContain(clean.id);
 	});
 
 	// --- Report stamped only on a real transition (PROJ-293) ---

--- a/apps/docs/src/content/docs/agents/tool-catalog.md
+++ b/apps/docs/src/content/docs/agents/tool-catalog.md
@@ -106,7 +106,7 @@ running server.
 | `list_issues` | List issues in the workspace, optionally filtered by status, priority, project, or assignee |
 | `get_issue` | Get a single issue by ID or project key + number (e.g. "PROJ-42") |
 | `create_issue` | Create a new issue in a project |
-| `update_issue` | Update an issue - status, priority, title, body, assignee, or labels. Review gating (PROJ-254): pass agentSessionId to identify yourself as an agent; entering in_review as an agent requires completionReport, and only a human can transition to done. |
+| `update_issue` | Update an issue - status, priority, title, body, assignee, or labels. Review gating (PROJ-254/375): pass agentSessionId to identify yourself as an agent; entering in_review as an agent requires completionReport. Agents CAN transition directly to done (no human approval gate) — but if the completionReport.verification isn't externally checkable (no CI run/PR/commit link), the issue is flagged needsAudit:true for after-the-fact human review. |
 | `search_issues` | Search issues by keyword in title or body |
 | `delete_issue` | Delete an issue by ID |
 | `get_prioritized_issues` | Return open issues ranked by a composite score: link-network centrality (in-degree) + priority + inverse story points. Useful for deciding what to work on next. By default, issues that fail the definition-of-ready check (missing acceptance criteria, scope/files, or verification) are excluded. |

--- a/apps/docs/src/content/docs/agents/workflow-spec.md
+++ b/apps/docs/src/content/docs/agents/workflow-spec.md
@@ -40,16 +40,16 @@ picking up autonomous work.
 
 - **Ready → Claimed**: may be fully autonomous. Any live agent session can call
   `claim_issue` without a human in the loop, subject to the WIP limit below.
-- **In Review → Done**: **always requires a human.** An agent session can never move
-  its own (or any) issue to `done` — attempting it is rejected outright, regardless of
-  whether a completion report is attached. A human reviews the report and the diff,
-  then makes the transition themselves (browser, or any session not holding a live
-  lease on the issue).
+- **In Review → Done**: may also be fully autonomous (PROJ-375). An agent session can
+  close its own (or any) issue to `done` directly — there's no pre-close block waiting
+  on a human. A completion report is still required before an agent-worked issue can
+  close (see below). Instead of gating the transition, projektor classifies the
+  report's evidence and flags weak closures for **audit after the fact** — see below.
 
 ## Completion reports
 
-Before an agent-held issue can move into `In Review`, it must submit a completion
-report with:
+Before an agent-held issue can move into `In Review` or `Done`, it must submit a
+completion report with:
 
 - **`summary`** — what changed, in plain language.
 - **`verification`** — the command(s) run and their outcome (the same ones named in
@@ -59,6 +59,22 @@ report with:
 `summary` and `verification` are required; the transition is rejected with the specific
 missing field(s) named if either is absent. The report is recorded as a normal issue
 comment, so it's visible in the same timeline as everything else.
+
+## Evidence audit (PROJ-375)
+
+Every agent-initiated `done` transition — one that passes `agentSessionId` for a
+live agent session — has its `completionReport.verification` text classified:
+
+- **Externally-verifiable** — contains a resolvable link or reference (a PR URL, a CI
+  run URL, a commit URL, or a bare commit SHA) that a human (or a future automated
+  check) could independently open and check. Not flagged.
+- **Freeform/unverifiable** — plain prose ("manually tested", "confirmed visually")
+  with nothing external to check. Flagged `needsAudit: true` on the issue.
+
+This doesn't block the closure — it's audit-after-the-fact, not a gate. Pull flagged
+issues for periodic review with `list_issues({ needsAudit: true })`. There's no
+outbound verification call to GitHub or CI here (classification is pattern-based
+only) — treat a resolvable link as "checkable," not "already checked."
 
 ## WIP limits
 

--- a/docs/design/agentic-workflow.md
+++ b/docs/design/agentic-workflow.md
@@ -163,6 +163,55 @@ An LLM-judge pre-check (single call, pass/fail score against the spec's DoR/gati
 rubric) is real but out of scope here — call it out as a follow-up ticket if pursued,
 not bundled into Phase 4.
 
+## Phase 5 — Agent-initiated done transitions, audit-after-the-fact (PROJ-375)
+
+### What broke
+
+Phase 4 shipped the done-gate bound to `issueHasLiveAgentLease` (a live-lease check,
+not the self-declared `agentSessionId`/`kind`, for the spoof-resistance reasons in that
+function's docstring). In practice, agents call `release_issue` before their own
+final `update_issue({status:"done"})` — a normal part of finishing review, not an
+attempt to evade the gate — so by the time the done call lands, the lease is no
+longer live and the block never fires. The **spec said** "an agent session can never
+move to done"; the **code** only blocked it while the lease was still held. Observed
+live during an SL-30 session: the agent's own done-transition succeeded, contradicting
+`get_workflow`'s prose.
+
+### Design decision: stop gating, start auditing
+
+Building a trustworthy pre-close gate means verifying the completion report is
+actually true — which means calling out to GitHub Actions/Cloudflare CI status or
+ingesting CI webhooks. That's a real feature, explicitly deferred (see below), not
+something to half-do here. Given that, blocking the transition up front bought
+correctness theater: the "human must approve" promise was already not holding in the
+one case (released lease) that mattered most, and closing that specific loophole
+without real verification would just relocate the false confidence, not remove it.
+
+So Phase 5 embraces what was already happening: **agents can close to `done`
+directly**, full stop — the `ForbiddenError` block is removed. In its place, every
+agent-initiated done-transition (an `agentSessionId` that resolves to a real, live
+agent session — `isLiveAgentSessionId`, deliberately *not* keyed on the released-or-not
+lease that caused the original bug) gets its `completionReport.verification` text
+classified by `evidence-classification.ts`: does it contain a resolvable link (PR,
+CI run, commit URL) or a bare commit SHA, or is it freeform prose? Freeform closures
+still succeed — unchanged from actual (buggy) behavior — but get stamped
+`issues.needs_audit = true`, indexed and filterable via `list_issues({ needsAudit:
+true })`, so a human doing periodic review can pull every weakly-evidenced
+agent-closure without re-reading every closure's timeline.
+
+The completion-report *presence* requirement for agent-worked issues (Phase 4,
+`issueEverHadAgentLease`) is unchanged — this only removes the who's-allowed-to-close
+block and adds the evidence-quality flag on top.
+
+### Deliberately deferred (still)
+
+Real verification — the server spot-checking a PR/CI link against the GitHub API
+before honoring `needsAudit: false`, or ingesting CI webhooks directly — remains a
+follow-up. Evidence classification here is pattern-matching only; a fabricated PR URL
+in freeform text would currently read as "verifiable" with no check that it resolves
+or that its checks are green. Acceptable for an audit signal (a human still opens the
+link), not acceptable as a hard gate.
+
 ## Explicitly out of scope for this epic
 
 Autonomous triage/grooming/status-rollup agents. Revisit once Phase 2 (flow metrics)

--- a/packages/db/migrations/0034_issue_needs_audit.sql
+++ b/packages/db/migrations/0034_issue_needs_audit.sql
@@ -1,0 +1,5 @@
+-- PROJ-375: agents can close issues to done directly (no gate blocks it); this
+-- flags agent-initiated closures whose completion-report verification wasn't
+-- externally checkable (no CI run/PR/commit link) for after-the-fact human review.
+ALTER TABLE `issues` ADD COLUMN `needs_audit` integer DEFAULT false NOT NULL;
+CREATE INDEX `idx_issues_workspace_needs_audit` ON `issues` (`workspace_id`,`needs_audit`);

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -112,6 +112,10 @@ export const issues = sqliteTable(
 		// review back to in-progress (never cleared, never re-derived from history).
 		inReviewAt: integer("in_review_at"),
 		reviewBounceCount: integer("review_bounce_count").notNull().default(0),
+		// PROJ-375: agents can close issues to done directly (no gate blocks it); this
+		// flags agent-initiated closures whose completion-report verification wasn't
+		// externally checkable (no CI run/PR/commit link) for after-the-fact human review.
+		needsAudit: integer("needs_audit", { mode: "boolean" }).notNull().default(false),
 	},
 	(t) => ({
 		projectIdx: index("issues_project_idx").on(t.projectId),
@@ -130,6 +134,7 @@ export const issues = sqliteTable(
 		wsClaimedIdx: index("idx_issues_workspace_claimed_at").on(t.workspaceId, t.claimedAt),
 		wsDoneIdx: index("idx_issues_workspace_done_at").on(t.workspaceId, t.doneAt),
 		wsInReviewIdx: index("idx_issues_workspace_in_review_at").on(t.workspaceId, t.inReviewAt),
+		wsNeedsAuditIdx: index("idx_issues_workspace_needs_audit").on(t.workspaceId, t.needsAudit),
 	})
 );
 


### PR DESCRIPTION
## Summary
- Removes the `ForbiddenError` block on an agent (live lease) transitioning an issue to `done` — agents routinely `release_issue` before their own final `update_issue({status:"done"})`, so the block never actually fired in practice; the spec said "never," the code only blocked while the lease was still live.
- Instead of gating, classifies `completionReport.verification` on every agent-initiated done transition: externally-verifiable (PR/CI/commit URL or bare SHA) vs freeform prose. Freeform closures still succeed but get `issues.needsAudit = true`, filterable via `list_issues({ needsAudit: true })` for periodic human review.
- New `isLiveAgentSessionId` helper (deliberately not lease-bound, unlike the old gate) resolves whether a given `agentSessionId` is a real live agent session.
- Updates the canonical `workflow-content.ts` (source for `get_workflow` + the generated docs page) and `docs/design/agentic-workflow.md` (Phase 5) to describe the new behavior.
- New migration `0034_issue_needs_audit.sql` adds `issues.needs_audit` + an index on `(workspace_id, needs_audit)`.

## Test plan
- [x] `pnpm --filter @projektor/api test` — 728 passed
- [x] `pnpm turbo type-check` — 0 errors across all packages
- [x] `pnpm lint` (biome) — clean
- [x] `node scripts/check-island-api.mjs` — OK
- [x] `pnpm gen:docs` — no staleness diff
- [x] `pnpm --filter @projektor/docs build` — succeeds, links valid
- [x] New tests cover: agent closes directly to done, freeform evidence flags `needsAudit`, PR-link evidence doesn't flag, human closures never flag, released-lease-then-closed still flags (the exact PROJ-375 repro), `list_issues({ needsAudit: true })` filter, MCP parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FG4F7B3e8xN4Fy5zzPUj2d