### PR TITLE
fix(api): sample CFD bucket state at bucket-end, not bucket-start (PROJ-377)

### DIFF
--- a/apps/api/src/services/flow-metrics.ts
+++ b/apps/api/src/services/flow-metrics.ts
@@ -203,16 +203,25 @@ function buildArrivalVsCompletion(
 	return buckets;
 }
 
-// PROJ-329: cumulative flow diagram bands, sampled at each bucket start from the
-// write-once transition timestamps. An issue's band at time t is the furthest stage
-// it has reached by t (done > in_review > in_progress > backlog/todo); the done band
-// is therefore monotonic non-decreasing (an issue never leaves it), which is what
-// makes CFD bands readable as a choke-point signal.
+// PROJ-329: cumulative flow diagram bands, sampled at each bucket's end (clamped to
+// `until`/`now`) from the write-once transition timestamps. An issue's band at the
+// sample instant is the furthest stage it has reached by then (done > in_review >
+// in_progress > backlog/todo); the done band is therefore monotonic non-decreasing
+// (an issue never leaves it), which is what makes CFD bands readable as a choke-point
+// signal.
+//
+// PROJ-377: sampling at the bucket's *end* (not its start) matters for the always-
+// partial current bucket — a bucket-start sample lands before any activity in that
+// bucket has happened, so a bucket-worth of newly created/completed issues reads as
+// all zeros even though `arrivalVsCompletionOverTime` (which counts events across the
+// whole bucket range) shows them. `now` additionally clamps so we never sample into
+// the future when `until` extends past the present.
 function buildCfdOverTime(
 	issues: FlowIssueRow[],
 	since: number,
 	until: number,
-	granularity: "day" | "week"
+	granularity: "day" | "week",
+	now: number
 ): Array<{
 	bucketStart: string;
 	backlogTodo: number;
@@ -231,15 +240,16 @@ function buildCfdOverTime(
 		done: number;
 	}> = [];
 	for (let t = firstBucket; t <= until; t += bucketSize) {
+		const sampleAt = Math.min(t + bucketSize - 1, until, now);
 		let backlogTodo = 0;
 		let inProgress = 0;
 		let inReview = 0;
 		let done = 0;
 		for (const i of issues) {
-			if (i.createdAt > t) continue;
-			if (i.doneAt !== null && i.doneAt <= t) done++;
-			else if (i.inReviewAt !== null && i.inReviewAt <= t) inReview++;
-			else if (i.claimedAt !== null && i.claimedAt <= t) inProgress++;
+			if (i.createdAt > sampleAt) continue;
+			if (i.doneAt !== null && i.doneAt <= sampleAt) done++;
+			else if (i.inReviewAt !== null && i.inReviewAt <= sampleAt) inReview++;
+			else if (i.claimedAt !== null && i.claimedAt <= sampleAt) inProgress++;
 			else backlogTodo++;
 		}
 		buckets.push({
@@ -555,7 +565,7 @@ export async function getFlowMetrics(ctx: ServiceCtx, raw: unknown) {
 		throughputUntil,
 		granularity
 	);
-	const cfdOverTime = buildCfdOverTime(issues, throughputSince, throughputUntil, granularity);
+	const cfdOverTime = buildCfdOverTime(issues, throughputSince, throughputUntil, granularity, now);
 	const bugShareOverTime = buildBugShareOverTime(
 		issues,
 		throughputSince,

--- a/apps/api/src/test/flow-metrics.test.ts
+++ b/apps/api/src/test/flow-metrics.test.ts
@@ -592,9 +592,12 @@ describe("Flow metrics (PROJ-252)", () => {
 			expect(metrics.cfdOverTime[i].done).toBeGreaterThanOrEqual(metrics.cfdOverTime[i - 1].done);
 		}
 
+		// PROJ-377: buckets are now sampled at their *end* (clamped to until/now), not
+		// their start — the "Done" issue's claimedAt (since + 10s) already falls before
+		// the first bucket's end, so it reads as in_progress rather than backlog/todo.
 		const firstBucket = metrics.cfdOverTime[0];
-		expect(firstBucket.backlogTodo).toBe(3);
-		expect(firstBucket.inProgress).toBe(0);
+		expect(firstBucket.backlogTodo).toBe(2);
+		expect(firstBucket.inProgress).toBe(1);
 		expect(firstBucket.inReview).toBe(0);
 		expect(firstBucket.done).toBe(0);
 
@@ -602,6 +605,34 @@ describe("Flow metrics (PROJ-252)", () => {
 		expect(lastBucket.backlogTodo).toBe(1);
 		expect(lastBucket.inProgress).toBe(1);
 		expect(lastBucket.done).toBe(1);
+	});
+
+	// PROJ-377: the current (still-partial) bucket must reflect state as of "now", not
+	// as of the bucket's start — previously an issue created and completed entirely
+	// within the current week's bucket read as all-zero because the sample instant (the
+	// bucket's start) predated the activity.
+	it("reflects a same-bucket create+complete burst in the current (partial) bucket", async () => {
+		const now = Math.floor(Date.now() / 1000);
+
+		const burstIssue = await seedIssue(workspaceId, projectId, userId, {
+			title: "Created and finished this week",
+			createdAt: now - 100,
+		});
+		await stampFlowTimestamps(burstIssue.id, {
+			readyAt: now - 90,
+			claimedAt: now - 60,
+			doneAt: now - 10,
+		});
+
+		const res = await SELF.fetch(
+			`http://localhost/api/projects/${projectId}/flow-metrics?granularity=week`,
+			{ headers: authHeaders(token, slug) }
+		);
+		expect(res.status).toBe(200);
+		const metrics = (await res.json()) as FlowMetrics;
+
+		const currentBucket = metrics.cfdOverTime[metrics.cfdOverTime.length - 1];
+		expect(currentBucket.done).toBe(1);
 	});
 
 	it("computes time in progress (claimed -> next stage) for issues completing in the window", async () => {


### PR DESCRIPTION
## Summary
- `buildCfdOverTime` sampled each bucket's stage counts as of the bucket's *start* timestamp, so the always-partial current bucket was sampled before any of its own activity happened — reading as all zeros even when the project has plenty of recent movement (e.g. a brand-new project like Start Line, where 110 issues were created and 59 completed entirely within the current week).
- Fix: sample at `min(bucketEnd, until, now)` instead of `t`, matching how the other over-time builders (throughput, arrivalVsCompletion, bugShare) scope activity to the bucket rather than a single instant.
- Updated the existing CFD test's first-bucket expectations to match the new sampling point, and added a regression test for a same-bucket create+complete burst landing in the current bucket.

Fixes PROJ-377.

## Test plan
- [x] `pnpm test flow-metrics` (27/27 passing, including new regression test)
- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [x] Full `pnpm test` (api + web) passing via pre-push hook

https://claude.ai/code/session_01RdqfeifXFj77N7CtmoyRFD