### PR TITLE
Implement PROJ-376, PROJ-374, PROJ-353, PROJ-339, PROJ-324

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -247,15 +247,19 @@ app.route("/api/workflow", workflowRouter);
 // Only active in production where the ASSETS binding is present.
 // Issue pretty-URL paths (/projects/KEY/issues/N/title-slug) get the issue-detail
 // page so its IssueDetail island can resolve the issue from the URL path client-side.
+// Project pretty-URL paths (/projects/view/<slug>, PROJ-376) get the project-view
+// page so its ProjectLanding/ProjectNav islands can resolve it the same way.
 // Everything else gets the homepage.
 app.get("*", async (c) => {
 	if (!c.env.ASSETS) return c.notFound();
 	const { pathname } = new URL(c.req.url);
 	const fallbackPath = /^\/projects\/[^/]+\/issues\/\d+\//.test(pathname)
 		? "/issues/view/index.html"
-		: /^\/share\//.test(pathname)
-			? "/share/view/index.html"
-			: "/index.html";
+		: /^\/projects\/view\/[^/]+/.test(pathname)
+			? "/projects/view/index.html"
+			: /^\/share\//.test(pathname)
+				? "/share/view/index.html"
+				: "/index.html";
 	return c.env.ASSETS.fetch(new Request(new URL(fallbackPath, c.req.url).toString()));
 });
 

--- a/apps/api/src/mcp/issues.ts
+++ b/apps/api/src/mcp/issues.ts
@@ -256,6 +256,11 @@ export const issuesTools: MCPTool[] = [
 						"Include issues that fail the definition-of-ready check, annotated with " +
 						"needsGrooming and missingCriteria (default false)",
 				},
+				projectId: {
+					type: "string",
+					description:
+						"Scope ranking to a single project's issues (default: workspace-wide, all visible projects)",
+				},
 			},
 		},
 		handler(input, ctx) {

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -1,10 +1,18 @@
 import type { HonoEnv } from "@projektor/types";
 import { Hono } from "hono";
 import { serviceErrToResponse } from "../http/error-adapter";
-import { createProject, deleteProject, getProject, updateProject } from "../services/projects";
+import {
+	createProject,
+	deleteProject,
+	getProject,
+	getProjectBySlug,
+	updateProject,
+} from "../services/projects";
 import { ctxFromHono } from "../services/types";
 
 const router = new Hono<HonoEnv>();
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 router.post("/", async (c) => {
 	const ctx = ctxFromHono(c);
@@ -18,8 +26,13 @@ router.post("/", async (c) => {
 
 router.get("/:id", async (c) => {
 	const ctx = ctxFromHono(c);
+	const param = c.req.param("id");
 	try {
-		return c.json(await getProject(ctx, c.req.param("id")));
+		// PROJ-376: pretty project URLs pass a slug (e.g. "start-line") here instead
+		// of a UUID.
+		return c.json(
+			UUID_RE.test(param) ? await getProject(ctx, param) : await getProjectBySlug(ctx, param)
+		);
 	} catch (e) {
 		return serviceErrToResponse(c, e);
 	}

--- a/apps/api/src/services/comments.ts
+++ b/apps/api/src/services/comments.ts
@@ -73,6 +73,7 @@ export async function addComment(ctx: ServiceCtx, input: unknown): Promise<{ id:
 	const { issueId, body } = parsed.data;
 
 	await assertIssueVisible(ctx, issueId);
+	if (ctx.role === "viewer") throw new ForbiddenError("Insufficient permissions");
 
 	const id = crypto.randomUUID();
 	const now = Math.floor(Date.now() / 1000);

--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -1167,6 +1167,7 @@ type PrioritizedFilters = {
 	includeBacklog: boolean;
 	excludeClaimed: boolean;
 	includeNotReady: boolean;
+	projectId: string | undefined;
 };
 
 function parsePrioritizedFilters(raw: unknown): PrioritizedFilters {
@@ -1175,6 +1176,7 @@ function parsePrioritizedFilters(raw: unknown): PrioritizedFilters {
 		includeBacklog?: unknown;
 		excludeClaimed?: unknown;
 		includeNotReady?: unknown;
+		projectId?: unknown;
 	};
 	const limit =
 		typeof input.limit === "number" && input.limit > 0
@@ -1183,13 +1185,16 @@ function parsePrioritizedFilters(raw: unknown): PrioritizedFilters {
 	const includeBacklog = input.includeBacklog !== false;
 	const excludeClaimed = input.excludeClaimed === true;
 	const includeNotReady = input.includeNotReady === true;
-	return { limit, includeBacklog, excludeClaimed, includeNotReady };
+	const projectId =
+		typeof input.projectId === "string" && input.projectId ? input.projectId : undefined;
+	return { limit, includeBacklog, excludeClaimed, includeNotReady, projectId };
 }
 
 async function fetchOpenIssuesForPrioritization(
 	orm: ReturnType<typeof drizzle>,
 	ctx: ServiceCtx,
-	includeBacklog: boolean
+	includeBacklog: boolean,
+	projectId: string | undefined
 ) {
 	const visible = visibleProjectPredicate(ctx, schema.issues.projectId);
 	return orm
@@ -1211,6 +1216,7 @@ async function fetchOpenIssuesForPrioritization(
 				eq(schema.issues.workspaceId, ctx.workspaceId),
 				// PROJ-311: only prioritize issues in projects the user can see.
 				...(visible ? [visible as Condition] : []),
+				...(projectId ? [eq(schema.issues.projectId, projectId)] : []),
 				or(
 					and(
 						isNull(schema.issues.statusId),
@@ -1314,11 +1320,12 @@ function scoreOpenIssues(
 }
 
 export async function getPrioritizedIssues(ctx: ServiceCtx, raw: unknown) {
-	const { limit, includeBacklog, excludeClaimed, includeNotReady } = parsePrioritizedFilters(raw);
+	const { limit, includeBacklog, excludeClaimed, includeNotReady, projectId } =
+		parsePrioritizedFilters(raw);
 
 	const orm = drizzle(ctx.db, { schema });
 
-	const issues = await fetchOpenIssuesForPrioritization(orm, ctx, includeBacklog);
+	const issues = await fetchOpenIssuesForPrioritization(orm, ctx, includeBacklog, projectId);
 	if (issues.length === 0) return { issues: [] };
 
 	// excludeClaimed (PROJ-184): drop issues held by a live lease so "what should

--- a/apps/api/src/services/projects.ts
+++ b/apps/api/src/services/projects.ts
@@ -43,6 +43,7 @@ export interface ProjectSummary {
 	id: string;
 	name: string;
 	key: string;
+	slug: string | null;
 	description: string | null;
 	workspace_id: string;
 	workspace_name: string;
@@ -59,6 +60,7 @@ export async function listAllProjects(userId: string, db: D1Database): Promise<P
         p.id,
         p.name,
         p.key,
+        p.slug,
         p.description,
         p.created_at,
         p.updated_at,
@@ -78,7 +80,7 @@ export async function listAllProjects(userId: string, db: D1Database): Promise<P
               SELECT 1 FROM user_group_members ugm
               JOIN group_project_grants gpg ON gpg.group_id = ugm.group_id
               WHERE ugm.user_id = ? AND gpg.project_id = p.id)
-      GROUP BY p.id, p.name, p.key, p.description, p.created_at, p.updated_at,
+      GROUP BY p.id, p.name, p.key, p.slug, p.description, p.created_at, p.updated_at,
                w.id, w.name, w.slug
       ORDER BY w.slug, p.name`
 		)
@@ -103,6 +105,53 @@ export async function getProject(ctx: ServiceCtx, id: string) {
 	return project;
 }
 
+// PROJ-376: pretty project URLs (/projects/view/<slug>) resolve here instead of
+// the UUID route. Same visibility rules as getProject.
+export async function getProjectBySlug(ctx: ServiceCtx, slug: string) {
+	const orm = drizzle(ctx.db, { schema });
+	const project = await orm
+		.select()
+		.from(schema.projects)
+		.where(and(eq(schema.projects.slug, slug), eq(schema.projects.workspaceId, ctx.workspaceId)))
+		.get();
+	if (!project) throw new NotFoundError("Project not found");
+
+	if (!isWorkspaceAdmin(ctx.role) && (await effectiveProjectRole(ctx, project.id)) === null) {
+		throw new NotFoundError("Project not found");
+	}
+	return project;
+}
+
+function slugify(name: string): string {
+	return (
+		name
+			.trim()
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, "-")
+			.replace(/^-+|-+$/g, "") || "project"
+	);
+}
+
+// Generates a workspace-unique slug from the project name, appending -2, -3, ...
+// on collision. Bounded query count: at most one SELECT per candidate tried.
+async function generateUniqueSlug(
+	orm: ReturnType<typeof drizzle>,
+	workspaceId: string,
+	name: string
+): Promise<string> {
+	const base = slugify(name);
+	let candidate = base;
+	for (let n = 2; ; n++) {
+		const existing = await orm
+			.select({ id: schema.projects.id })
+			.from(schema.projects)
+			.where(and(eq(schema.projects.workspaceId, workspaceId), eq(schema.projects.slug, candidate)))
+			.get();
+		if (!existing) return candidate;
+		candidate = `${base}-${n}`;
+	}
+}
+
 export async function createProject(ctx: ServiceCtx, input: unknown) {
 	if (ctx.role === "member" || ctx.role === "viewer") throw new ForbiddenError();
 
@@ -121,12 +170,14 @@ export async function createProject(ctx: ServiceCtx, input: unknown) {
 
 	const id = crypto.randomUUID();
 	const now = Math.floor(Date.now() / 1000);
+	const slug = await generateUniqueSlug(orm, ctx.workspaceId, name);
 
 	await orm.insert(schema.projects).values({
 		id,
 		workspaceId: ctx.workspaceId,
 		name,
 		key,
+		slug,
 		description: description ?? null,
 		agentWipLimit: agentWipLimit ?? null,
 		createdAt: now,
@@ -135,7 +186,7 @@ export async function createProject(ctx: ServiceCtx, input: unknown) {
 
 	await recordActivity(ctx, { entityType: "project", entityId: id, action: "created" });
 	await cache.invalidate(ctx.kv, PROJECTS_CACHE_KEY(ctx.workspaceId));
-	return { id, name, key };
+	return { id, name, key, slug };
 }
 
 export async function updateProject(ctx: ServiceCtx, id: string, input: unknown) {

--- a/apps/api/src/test/authorization.test.ts
+++ b/apps/api/src/test/authorization.test.ts
@@ -6,10 +6,11 @@
  * domain tests ("rejects requests from non-members").
  *
  * Resources that enforce viewer/member restrictions:
- *   projects, task-types, task-statuses, custom-fields, wiki (DELETE only)
+ *   projects, task-types, task-statuses, custom-fields, wiki (DELETE only),
+ *   comments (create only — PROJ-374)
  *
- * Issues and comments do NOT enforce a viewer role — any member can write —
- * so they are intentionally excluded from the viewer-403 matrix below.
+ * Issues do NOT enforce a viewer role — any member can write — so they are
+ * intentionally excluded from the viewer-403 matrix below.
  */
 
 import { env, SELF } from "cloudflare:test";
@@ -18,7 +19,10 @@ import {
 	authHeaders,
 	seedCustomFieldDef,
 	seedFixture,
+	seedGroupGrant,
+	seedIssue,
 	seedMember,
+	seedProject,
 	seedTaskStatus,
 	seedTaskType,
 	seedToken,
@@ -67,6 +71,8 @@ describe("PROJ-78: same-workspace viewer role → 403 on mutating routes", () =>
 	let workspaceId: string;
 	let ownerHeaders: Record<string, string>;
 	let viewerHeaders: Record<string, string>;
+	let ownerId: string;
+	let viewerId: string;
 
 	beforeEach(async () => {
 		const roles = await seedWorkspaceRoles();
@@ -74,6 +80,8 @@ describe("PROJ-78: same-workspace viewer role → 403 on mutating routes", () =>
 		workspaceId = roles.workspace.id;
 		ownerHeaders = authHeaders(roles.owner.token, slug);
 		viewerHeaders = authHeaders(roles.viewer.token, slug);
+		ownerId = roles.owner.user.id;
+		viewerId = roles.viewer.user.id;
 	});
 
 	// -- Projects --
@@ -285,6 +293,25 @@ describe("PROJ-78: same-workspace viewer role → 403 on mutating routes", () =>
 		expect(res.status).toBe(200);
 		// Suppress unused variable warning from the extra seedWorkspaceRoles call above
 		void roles;
+	});
+
+	// -- Comments --
+	// PROJ-374: addComment now rejects viewers, mirroring the other
+	// mutating-route guards in this file.
+
+	it("viewer cannot POST /api/issues/:issueId/comments", async () => {
+		const project = await seedProject(workspaceId);
+		const issue = await seedIssue(workspaceId, project.id, ownerId);
+		// Grant the viewer visibility into the project (PROJ-311 default-deny)
+		// so the request reaches the viewer-role guard instead of a 404.
+		await seedGroupGrant(workspaceId, viewerId, project.id, "viewer");
+
+		const res = await SELF.fetch(`http://localhost/api/issues/${issue.id}/comments`, {
+			method: "POST",
+			headers: viewerHeaders,
+			body: JSON.stringify({ body: "a comment" }),
+		});
+		expect(res.status).toBe(403);
 	});
 });
 

--- a/apps/api/src/test/issues.test.ts
+++ b/apps/api/src/test/issues.test.ts
@@ -1756,4 +1756,43 @@ describe("get_prioritized_issues MCP tool", () => {
 		const readyRow = data.issues.find((i) => i.title === "Ready");
 		expect(readyRow?.needsGrooming).toBeUndefined();
 	});
+
+	// ─── PROJ-324: projectId scoping ───────────────────────────────────────────
+	it("scopes ranking to projectId, and droppedNotReady reflects only that project", async () => {
+		const otherProject = await seedProject(workspaceId, "OTHER");
+		await seedIssue(workspaceId, projectId, userId, { title: "In target project" });
+		await seedIssue(workspaceId, otherProject.id, userId, { title: "In other project" });
+
+		const body = await callPrioritized({ projectId, includeNotReady: true });
+		expect(body.error).toBeUndefined();
+		const data = JSON.parse(body.result!.content[0].text) as { issues: Array<{ title: string }> };
+		const titles = data.issues.map((i) => i.title);
+		expect(titles).toContain("In target project");
+		expect(titles).not.toContain("In other project");
+	});
+
+	it("computes droppedNotReady scoped to projectId", async () => {
+		const otherProject = await seedProject(workspaceId, "OTHER");
+		// Neither issue has a body, so both fail the definition-of-ready check.
+		await seedIssue(workspaceId, projectId, userId, { title: "Not ready in target" });
+		await seedIssue(workspaceId, otherProject.id, userId, { title: "Not ready in other" });
+
+		const body = await callPrioritized({ projectId });
+		expect(body.error).toBeUndefined();
+		const data = JSON.parse(body.result!.content[0].text) as { droppedNotReady: number };
+		expect(data.droppedNotReady).toBe(1);
+	});
+
+	it("workspace-wide behavior (no projectId) is unchanged", async () => {
+		const otherProject = await seedProject(workspaceId, "OTHER");
+		await seedIssue(workspaceId, projectId, userId, { title: "In target project" });
+		await seedIssue(workspaceId, otherProject.id, userId, { title: "In other project" });
+
+		const body = await callPrioritized({ includeNotReady: true });
+		expect(body.error).toBeUndefined();
+		const data = JSON.parse(body.result!.content[0].text) as { issues: Array<{ title: string }> };
+		const titles = data.issues.map((i) => i.title);
+		expect(titles).toContain("In target project");
+		expect(titles).toContain("In other project");
+	});
 });

--- a/apps/api/src/test/migrations.ts
+++ b/apps/api/src/test/migrations.ts
@@ -35,6 +35,7 @@ import m0031 from "../../../../packages/db/migrations/0031_factory_health.sql?ra
 import m0032 from "../../../../packages/db/migrations/0032_claim_conflicts.sql?raw";
 import m0033 from "../../../../packages/db/migrations/0033_custom_field_is_internal.sql?raw";
 import m0034 from "../../../../packages/db/migrations/0034_issue_needs_audit.sql?raw";
+import m0035 from "../../../../packages/db/migrations/0035_project_slug.sql?raw";
 
 export const MIGRATIONS = [
 	m0000,
@@ -72,4 +73,5 @@ export const MIGRATIONS = [
 	m0032,
 	m0033,
 	m0034,
+	m0035,
 ];

--- a/apps/web/src/islands/ProjectLanding.test.tsx
+++ b/apps/web/src/islands/ProjectLanding.test.tsx
@@ -12,6 +12,7 @@ const PROJECT = {
 	id: "p1",
 	name: "Projektor",
 	key: "PROJ",
+	slug: "projektor",
 	description: "An issue tracker.",
 	workspaceId: "w1",
 	createdAt: 0,
@@ -135,5 +136,23 @@ describe("ProjectLanding", () => {
 		render(<ProjectLanding />);
 		const link = (await screen.findByText("Getting Started")).closest("a");
 		expect(link?.getAttribute("href")).toBe("/wiki?slug=getting-started&projectId=p1");
+	});
+
+	// PROJ-376: pretty project URLs (/projects/view/<slug>) resolve via the path,
+	// not just ?id=.
+	it("resolves the project from a /projects/view/<slug> path with no query param", async () => {
+		history.replaceState(null, "", "/projects/view/projektor");
+		mockFetchProject();
+		render(<ProjectLanding />);
+		expect(await screen.findByRole("heading", { name: "Projektor" })).toBeTruthy();
+	});
+
+	it("breadcrumb has no redundant 'Projektor /' prefix (PROJ-353)", async () => {
+		history.replaceState(null, "", "?id=p1");
+		mockFetchProject();
+		render(<ProjectLanding />);
+		await screen.findByRole("heading", { name: "Projektor" });
+		const nav = screen.getByRole("navigation");
+		expect(nav.textContent?.trim()).toBe("Projects/Projektor");
 	});
 });

--- a/apps/web/src/islands/ProjectLanding.tsx
+++ b/apps/web/src/islands/ProjectLanding.tsx
@@ -8,6 +8,7 @@ interface Project {
 	id: string;
 	name: string;
 	key: string;
+	slug: string | null;
 	description: string | null;
 	workspaceId: string;
 	createdAt: number;
@@ -65,7 +66,7 @@ function sortByRecency<T extends { updated_at: number }>(items: unknown, limit: 
 }
 
 async function loadProjectData(
-	id: string,
+	idOrSlug: string,
 	workspaceSlug: string | undefined,
 	setters: {
 		setProject: (p: Project) => void;
@@ -73,17 +74,22 @@ async function loadProjectData(
 		setRecentWiki: (v: RecentWikiPage[]) => void;
 	}
 ) {
-	const [proj, issuesData, wikiData] = await Promise.all([
-		apiFetch<Project>(`/api/projects/${id}`, { workspaceSlug }),
-		apiFetch<{ items: RecentIssue[] }>(`/api/issues?project=${id}`, { workspaceSlug }).catch(
+	// /api/projects/:id resolves either a UUID or a slug, but the issues/wiki
+	// endpoints below filter on the real project UUID — resolve the project first.
+	const proj = await apiFetch<Project>(`/api/projects/${encodeURIComponent(idOrSlug)}`, {
+		workspaceSlug,
+	});
+	setters.setProject(proj);
+
+	const [issuesData, wikiData] = await Promise.all([
+		apiFetch<{ items: RecentIssue[] }>(`/api/issues?project=${proj.id}`, { workspaceSlug }).catch(
 			() => null
 		),
-		apiFetch<RecentWikiPage[]>(`/api/wiki?projectId=${encodeURIComponent(id)}`, {
+		apiFetch<RecentWikiPage[]>(`/api/wiki?projectId=${encodeURIComponent(proj.id)}`, {
 			workspaceSlug,
 		}).catch(() => null),
 	]);
 
-	setters.setProject(proj);
 	if (issuesData) setters.setRecentIssues(sortByRecency<RecentIssue>(issuesData?.items, 5));
 	if (wikiData) setters.setRecentWiki(sortByRecency<RecentWikiPage>(wikiData, 5));
 }
@@ -332,7 +338,11 @@ function RecentWikiSection({ pages, projectId }: { pages: RecentWikiPage[]; proj
 export default function ProjectLanding({ workspaceSlug }: Props) {
 	const [projectId, setProjectId] = useState<string | null>(null);
 	useEffect(() => {
-		const id = new URLSearchParams(window.location.search).get("id");
+		// Pretty-URL route (/projects/view/<slug>) falls back to this same page
+		// (see the SPA fallback in apps/api/src/index.ts) — read the slug from the
+		// path when there's no ?id= query param.
+		const slugMatch = window.location.pathname.match(/^\/projects\/view\/([^/]+)\/?$/);
+		const id = new URLSearchParams(window.location.search).get("id") ?? slugMatch?.[1] ?? null;
 		setProjectId(id);
 	}, []);
 
@@ -394,10 +404,6 @@ export default function ProjectLanding({ workspaceSlug }: Props) {
 			<header class="mb-6">
 				<nav class="text-sm text-text-muted mb-2">
 					<a href="/" class="text-text-muted no-underline">
-						Projektor
-					</a>
-					<span class="mx-[0.375rem]">/</span>
-					<a href="/projects" class="text-text-muted no-underline">
 						Projects
 					</a>
 					<span class="mx-[0.375rem]">/</span>

--- a/apps/web/src/islands/ProjectList.tsx
+++ b/apps/web/src/islands/ProjectList.tsx
@@ -7,6 +7,7 @@ interface Project {
 	id: string;
 	name: string;
 	key: string;
+	slug: string | null;
 	description: string | null;
 	workspace_id: string;
 	workspace_name: string;
@@ -216,16 +217,20 @@ function useProjectCreateForm(workspaceSlug: string | undefined, onCreated: (p: 
 		setSubmitting(true);
 
 		try {
-			const created = await apiFetch<{ id: string; name: string; key: string }>("/api/projects", {
-				method: "POST",
-				workspaceSlug,
-				body: { name, key, description },
-			});
+			const created = await apiFetch<{ id: string; name: string; key: string; slug: string }>(
+				"/api/projects",
+				{
+					method: "POST",
+					workspaceSlug,
+					body: { name, key, description },
+				}
+			);
 
 			onCreated({
 				id: created.id,
 				name: created.name,
 				key: created.key,
+				slug: created.slug,
 				description: description ?? null,
 				workspace_id: "",
 				workspace_name: "",
@@ -265,7 +270,14 @@ function ProjectCard({ project }: { project: Project }) {
 		count === 0 ? "No open issues" : `${count} open issue${count !== 1 ? "s" : ""}`;
 
 	return (
-		<a href={`/projects/view?id=${project.id}`} class={PROJECT_CARD_CLASS}>
+		<a
+			href={
+				project.slug
+					? `/projects/view/${encodeURIComponent(project.slug)}`
+					: `/projects/view?id=${project.id}`
+			}
+			class={PROJECT_CARD_CLASS}
+		>
 			<div class="flex items-center gap-2">
 				<span class="font-bold text-[var(--text)] text-base">{project.name}</span>
 				<span class={KEY_BADGE_CLASS}>{project.key}</span>

--- a/apps/web/src/islands/ProjectNav.test.tsx
+++ b/apps/web/src/islands/ProjectNav.test.tsx
@@ -10,7 +10,7 @@ import { render, screen } from "@testing-library/preact";
 import { describe, expect, it, vi } from "vitest";
 import ProjectNav from "./ProjectNav";
 
-const PROJECT = { id: "p1", key: "PROJ", name: "Projektor" };
+const PROJECT = { id: "p1", key: "PROJ", name: "Projektor", slug: "projektor" };
 
 function mockFetchProject(project: typeof PROJECT | null) {
 	vi.stubGlobal(
@@ -81,5 +81,33 @@ describe("ProjectNav", () => {
 
 		const heading = screen.getByText("Projektor");
 		expect(heading.className).toContain("max-sm:text-[0.8125rem]");
+	});
+
+	// PROJ-376: pretty project URLs (/projects/view/<slug>).
+	it("resolves the project from a /projects/view/<slug> path with no query param", async () => {
+		window.history.pushState({}, "", "/projects/view/projektor");
+		mockFetchProject(PROJECT);
+		render(<ProjectNav />);
+		expect(await screen.findByText("Projektor")).toBeTruthy();
+	});
+
+	it("builds the Overview tab link and header link from the project's slug", async () => {
+		window.history.pushState({}, "", "/issues?id=p1");
+		mockFetchProject(PROJECT);
+		render(<ProjectNav />);
+		await screen.findByText("Projektor");
+		const overviewTab = screen.getByRole("link", { name: "Overview" });
+		expect(overviewTab.getAttribute("href")).toBe("/projects/view/projektor");
+		const headerLink = screen.getByText("Projektor").closest("a");
+		expect(headerLink?.getAttribute("href")).toBe("/projects/view/projektor");
+	});
+
+	it("marks Overview active when on its slug path, even without a matching plain-path tab", async () => {
+		window.history.pushState({}, "", "/projects/view/projektor");
+		mockFetchProject(PROJECT);
+		render(<ProjectNav />);
+		await screen.findByText("Projektor");
+		const overviewTab = screen.getByRole("link", { name: "Overview" });
+		expect(overviewTab.getAttribute("aria-current")).toBe("page");
 	});
 });

--- a/apps/web/src/islands/ProjectNav.tsx
+++ b/apps/web/src/islands/ProjectNav.tsx
@@ -5,6 +5,7 @@ interface Project {
 	id: string;
 	key: string;
 	name: string;
+	slug: string | null;
 }
 
 interface Props {
@@ -46,7 +47,11 @@ export default function ProjectNav({ workspaceSlug, pageLabel }: Props) {
 		setActivePath(window.location.pathname);
 
 		const params = new URLSearchParams(window.location.search);
-		const rawId = params.get("id") || params.get("projectId");
+		// Pretty-URL route (/projects/view/<slug>) falls back to this same page
+		// (see the SPA fallback in apps/api/src/index.ts) — read the slug from the
+		// path when there's no query param.
+		const slugMatch = window.location.pathname.match(/^\/projects\/view\/([^/]+)\/?$/);
+		const rawId = params.get("id") || params.get("projectId") || slugMatch?.[1];
 		const rawProject = params.get("project");
 
 		const resolve = (p: Project) => {
@@ -94,11 +99,15 @@ export default function ProjectNav({ workspaceSlug, pageLabel }: Props) {
 
 	if (!project) return null;
 
+	const overviewHref = project.slug
+		? `/projects/view/${encodeURIComponent(project.slug)}`
+		: `/projects/view?id=${encodeURIComponent(project.id)}`;
+
 	const tabs = TABS.map((t) => {
 		let href: string;
 		switch (t.path) {
 			case "/projects/view":
-				href = `/projects/view?id=${encodeURIComponent(project.id)}`;
+				href = overviewHref;
 				break;
 			case "/issues":
 				href = `/issues?project=${encodeURIComponent(project.key)}`;
@@ -112,7 +121,7 @@ export default function ProjectNav({ workspaceSlug, pageLabel }: Props) {
 	return (
 		<div class="border-b border-border bg-[var(--nav-bg)]">
 			<div class="flex items-center gap-2 px-6 pt-3 pb-[0.375rem] max-sm:px-3 max-sm:pt-1.5 max-sm:pb-1">
-				<a href={`/projects/view?id=${encodeURIComponent(project.id)}`} class="no-underline">
+				<a href={overviewHref} class="no-underline">
 					<h2 class="m-0 text-[0.9375rem] max-sm:text-[0.8125rem] font-semibold text-text-base">
 						{project.name}
 					</h2>
@@ -124,7 +133,10 @@ export default function ProjectNav({ workspaceSlug, pageLabel }: Props) {
 				aria-label="Project sections"
 			>
 				{tabs.map((tab) => {
-					const active = activePath === tab.path;
+					const active =
+						tab.path === "/projects/view"
+							? activePath === "/projects/view" || activePath.startsWith("/projects/view/")
+							: activePath === tab.path;
 					return (
 						<a
 							key={tab.path}

--- a/docs/design/agentic-workflow.md
+++ b/docs/design/agentic-workflow.md
@@ -133,25 +133,24 @@ lower it.
 
 ### Identifying "an agent did this"
 
-`agent_sessions.kind` (`'agent' | 'human'`) already distinguishes the two — a human
-using the browser never has an `agentSessionId` to pass. Mutations that need the gate
-accept an optional `agentSessionId` (same shape as `claim_issue`/`release_issue`); when
-present, the service looks up the session's `kind`.
+PROJ-287 rebound this off the self-declared `agent_sessions.kind` to a live-lease
+check (`issueHasLiveAgentLease`) — spoof-resistant, since `kind` is just a string the
+caller chose when opening the session. PROJ-336 went further and deprecated `kind`
+entirely; the gate is keyed on lease/principal state, not session kind.
 
 ### The gate
 
-1. **Entering `in_review` with an `agentSessionId` whose session `kind = 'agent'`**
-   requires a completion report in the same call: `{ summary, verification, prLink? }`
-   (`summary`/`verification` required, non-empty). Missing fields throw a
-   `ValidationError` naming exactly which are missing. On success the service writes
-   the report as a formatted `issue_comments` row (visible in the normal comment
-   timeline) and stamps a new indexed `issues.completion_report_at` column.
-2. **Transitioning to `done`**: if the call carries an `agentSessionId` whose session
-   `kind = 'agent'`, reject with `ForbiddenError` — agents can never self-approve,
-   full stop, regardless of whether a report exists. If no `agentSessionId` is present
-   (a human, via browser or a human-kind session), the transition is allowed only if
-   `completion_report_at IS NOT NULL` on the issue; otherwise `ValidationError` naming
-   the missing `completionReport`.
+1. **Entering `in_review` while the issue has a live agent lease**
+   (`issueHasLiveAgentLease`) requires a completion report in the same call:
+   `{ summary, verification, prLink? }` (`summary`/`verification` required,
+   non-empty). Missing fields throw a `ValidationError` naming exactly which are
+   missing. On success the service writes the report as a formatted `issue_comments`
+   row (visible in the normal comment timeline) and stamps a new indexed
+   `issues.completion_report_at` column.
+2. **Transitioning to `done`**: originally, an agent-initiated call (live lease)
+   rejected with `ForbiddenError` — agents could never self-approve. Phase 5 below
+   removed this hard block; see that section for the current behavior
+   (audit-after-the-fact instead of a pre-close gate).
 
 This keeps the check inside `services/issues.ts::updateIssue` (single home for both
 REST and MCP, per the service-layer contract) rather than duplicating it in the two

--- a/packages/db/migrations/0035_project_slug.sql
+++ b/packages/db/migrations/0035_project_slug.sql
@@ -3,12 +3,31 @@
 -- multiple pre-backfill NULLs don't collide; application code generates and
 -- dedupes the slug on project creation (services/projects.ts).
 ALTER TABLE `projects` ADD COLUMN `slug` text;
-CREATE UNIQUE INDEX `idx_projects_workspace_slug` ON `projects` (`workspace_id`, `slug`) WHERE `slug` IS NOT NULL;
 
 -- Backfill existing rows with a basic kebab-case slug derived from the name.
--- Good enough for names made of plain words/spaces (all current projects);
--- doesn't strip punctuation, so a name with special characters could still
--- collide or produce an odd slug — acceptable for a one-time backfill.
+-- Doesn't strip punctuation, so unusual names could still produce an odd
+-- slug — acceptable for a one-time backfill. Collisions ARE handled: two
+-- projects in the same workspace slugifying to the same base value get a
+-- `-2`, `-3`, ... suffix via ROW_NUMBER(), so this can't violate the unique
+-- index created below (a single un-deduped UPDATE previously could, and
+-- would abort the whole migration on any real workspace with two
+-- similarly-named projects).
+WITH base AS (
+	SELECT
+		id,
+		lower(replace(replace(trim(name), ' ', '-'), '_', '-')) AS base_slug,
+		ROW_NUMBER() OVER (
+			PARTITION BY workspace_id, lower(replace(replace(trim(name), ' ', '-'), '_', '-'))
+			ORDER BY created_at, id
+		) AS rn
+	FROM `projects`
+)
 UPDATE `projects`
-SET `slug` = lower(replace(replace(trim(`name`), ' ', '-'), '_', '-'))
+SET `slug` = (
+	SELECT CASE WHEN base.rn = 1 THEN base.base_slug ELSE base.base_slug || '-' || base.rn END
+	FROM base
+	WHERE base.id = `projects`.id
+)
 WHERE `slug` IS NULL;
+
+CREATE UNIQUE INDEX `idx_projects_workspace_slug` ON `projects` (`workspace_id`, `slug`) WHERE `slug` IS NOT NULL;

--- a/packages/db/migrations/0035_project_slug.sql
+++ b/packages/db/migrations/0035_project_slug.sql
@@ -1,0 +1,14 @@
+-- PROJ-376: human-readable project URL slugs (e.g. "start-line") instead of
+-- raw UUIDs. Nullable + a partial unique index (not NOT NULL UNIQUE) so
+-- multiple pre-backfill NULLs don't collide; application code generates and
+-- dedupes the slug on project creation (services/projects.ts).
+ALTER TABLE `projects` ADD COLUMN `slug` text;
+CREATE UNIQUE INDEX `idx_projects_workspace_slug` ON `projects` (`workspace_id`, `slug`) WHERE `slug` IS NOT NULL;
+
+-- Backfill existing rows with a basic kebab-case slug derived from the name.
+-- Good enough for names made of plain words/spaces (all current projects);
+-- doesn't strip punctuation, so a name with special characters could still
+-- collide or produce an odd slug — acceptable for a one-time backfill.
+UPDATE `projects`
+SET `slug` = lower(replace(replace(trim(`name`), ' ', '-'), '_', '-'))
+WHERE `slug` IS NULL;

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -15,9 +15,15 @@ export const projects = sqliteTable(
 		updatedAt: integer("updated_at").notNull(),
 		// Per-project agent WIP cap (PROJ-253). NULL = use the workspace default.
 		agentWipLimit: integer("agent_wip_limit"),
+		// Human-readable URL slug, e.g. "start-line" (PROJ-376). Nullable for
+		// pre-migration rows that failed backfill; unique per workspace, enforced
+		// by a partial index (see migrations/0035_project_slug.sql) so NULLs don't
+		// collide.
+		slug: text("slug"),
 	},
 	(t) => ({
 		wsIdx: index("projects_workspace_idx").on(t.workspaceId),
+		slugIdx: index("projects_workspace_slug_idx").on(t.workspaceId, t.slug),
 	})
 );
 

--- a/packages/db/src/test/migrations.test.ts
+++ b/packages/db/src/test/migrations.test.ts
@@ -1,5 +1,11 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { loadMigrations, migratedDb } from "./helpers";
+
+const MIGRATIONS_DIR = join(dirname(fileURLToPath(import.meta.url)), "../../migrations");
 
 describe("migrations", () => {
 	it("apply cleanly in order against a fresh database", () => {
@@ -133,5 +139,61 @@ describe("schema constraints", () => {
 				)
 				.run("i2", "w1", "p1", 1, "Duplicate number", "u1", 0, 0)
 		).toThrow();
+	});
+
+	// PROJ-376: the 0035 backfill must not violate its own unique index when two
+	// pre-existing projects in the same workspace slugify to the same value —
+	// this previously aborted the whole migration on real data (opus review finding).
+	it("0035_project_slug backfill dedupes colliding slugs instead of aborting", () => {
+		const migrationFiles = readdirSync(MIGRATIONS_DIR)
+			.filter((f) => f.endsWith(".sql"))
+			.sort();
+		const preSlugFiles = migrationFiles.filter((f) => f < "0035");
+		const slugFile = migrationFiles.find((f) => f.startsWith("0035"));
+		expect(slugFile).toBeDefined();
+
+		const db = new DatabaseSync(":memory:");
+		db.exec("PRAGMA foreign_keys = ON;");
+		const splitStatements = (sql: string) =>
+			sql
+				.replace(/--[^\n]*/g, "")
+				.split(";")
+				.map((s) => s.trim())
+				.filter((s) => s.length > 0);
+		for (const file of preSlugFiles) {
+			const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf8");
+			for (const stmt of splitStatements(sql)) {
+				if (/\bfts5\b/i.test(stmt) || /\bissues_fts\b/i.test(stmt)) continue;
+				db.exec(stmt);
+			}
+		}
+
+		db.prepare("INSERT INTO workspaces (id, name, slug, created_at) VALUES (?, ?, ?, ?)").run(
+			"w1",
+			"Acme",
+			"acme",
+			0
+		);
+		// Two projects that slugify to the same base value ("start-line").
+		db.prepare(
+			"INSERT INTO projects (id, workspace_id, name, key, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)"
+		).run("p1", "w1", "Start Line", "SL", 0, 0);
+		db.prepare(
+			"INSERT INTO projects (id, workspace_id, name, key, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)"
+		).run("p2", "w1", "Start_Line", "SL2", 1, 1);
+
+		const slugSql = readFileSync(join(MIGRATIONS_DIR, slugFile!), "utf8");
+		expect(() => {
+			for (const stmt of splitStatements(slugSql)) db.exec(stmt);
+		}).not.toThrow();
+
+		const rows = db.prepare("SELECT id, slug FROM projects ORDER BY id").all() as {
+			id: string;
+			slug: string;
+		}[];
+		const slugs = rows.map((r) => r.slug);
+		expect(new Set(slugs).size).toBe(2);
+		expect(slugs).toContain("start-line");
+		expect(slugs).toContain("start-line-2");
 	});
 });


### PR DESCRIPTION
## Summary
- **PROJ-376**: Human-readable project URL slugs (`/projects/view/<slug>`), backward-compatible with the existing `?id=` UUID route. New `projects.slug` column (nullable, unique per workspace via partial index), auto-generated + deduped on create, backfilled for existing rows.
- **PROJ-374**: Fix viewer role being able to add issue comments — `addComment` was missing the `ForbiddenError` guard every other write path in `services/*.ts` has.
- **PROJ-353**: Drop the redundant "Projektor /" breadcrumb prefix on the project overview page; also fixed the breadcrumb's dead "Projects" link (`/projects` had no matching page — now points at `/`).
- **PROJ-339**: Fix the stale pre-lease-gate description in `docs/design/agentic-workflow.md` — it described the old `agent_sessions.kind`-based gate; now matches the actual lease/principal-bound gate (and points to the Phase 5 audit-based replacement for the removed done-transition block).
- **PROJ-324**: Add an optional `projectId` filter to `get_prioritized_issues` (MCP tool), scoping both the ranked set and the `droppedNotReady` count to a single project. Workspace-wide (no `projectId`) behavior is unchanged.

## Test plan
- [x] `pnpm --filter @projektor/api test` — 731 passed (new tests for PROJ-374 addComment guard and PROJ-324 projectId scoping)
- [x] `pnpm --filter @projektor/web test` — 323 passed (new tests for PROJ-376 slug resolution/links and PROJ-353 breadcrumb)
- [x] `pnpm --filter @projektor/db test` — 9 passed (migration applies cleanly)
- [x] `pnpm turbo type-check` — clean
- [x] `npx biome check .` — clean
- [x] `pnpm --filter @projektor/api test:coverage` / `pnpm --filter @projektor/web test:coverage` — pass
- [x] `pnpm --filter @projektor/web build` — clean, confirms `/projects/view/index.html` static asset + worker SPA fallback routing for `/projects/view/<slug>`
- [x] `pnpm gen:docs` — no diff (tool catalog doesn't need updating for the new MCP param)
- [x] `node scripts/check-island-api.mjs` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X99hjMGogfMs5iMhwKMguH