### PR TITLE
fix(web): resolve feedback page projectId client-side, not from Astro.url

### DIFF
--- a/apps/web/src/islands/FeedbackList.tsx
+++ b/apps/web/src/islands/FeedbackList.tsx
@@ -37,7 +37,7 @@ function formatDate(ts: number): string {
 
 export default function FeedbackList({ workspaceSlug, projectId: projectIdProp }: Props) {
 	const [projectId] = useState(
-		() => projectIdProp || new URLSearchParams(window.location.search).get("projectId") || "",
+		() => projectIdProp || new URLSearchParams(window.location.search).get("projectId") || ""
 	);
 	const [rows, setRows] = useState<Feedback[]>([]);
 	const [status, setStatus] = useState("");

--- a/apps/web/src/islands/FeedbackList.tsx
+++ b/apps/web/src/islands/FeedbackList.tsx
@@ -36,9 +36,12 @@ function formatDate(ts: number): string {
 }
 
 export default function FeedbackList({ workspaceSlug, projectId: projectIdProp }: Props) {
-	const [projectId] = useState(
-		() => projectIdProp || new URLSearchParams(window.location.search).get("projectId") || ""
-	);
+	const [projectId, setProjectId] = useState(projectIdProp ?? "");
+	useEffect(() => {
+		if (projectIdProp) return;
+		const fromUrl = new URLSearchParams(window.location.search).get("projectId");
+		if (fromUrl) setProjectId(fromUrl);
+	}, [projectIdProp]);
 	const [rows, setRows] = useState<Feedback[]>([]);
 	const [status, setStatus] = useState("");
 	const [sourceFilter, setSourceFilter] = useState("");
@@ -46,6 +49,7 @@ export default function FeedbackList({ workspaceSlug, projectId: projectIdProp }
 	const [error, setError] = useState<string | null>(null);
 
 	const fetchRows = useCallback(async () => {
+		if (!projectId) return;
 		setLoading(true);
 		setError(null);
 		try {

--- a/apps/web/src/islands/FeedbackList.tsx
+++ b/apps/web/src/islands/FeedbackList.tsx
@@ -18,7 +18,7 @@ interface Feedback {
 
 interface Props {
 	workspaceSlug?: string;
-	projectId: string;
+	projectId?: string;
 }
 
 const TD = "px-3 py-2 border-b border-border align-top text-[0.875rem]";
@@ -35,7 +35,10 @@ function formatDate(ts: number): string {
 	return new Date(ts * 1000).toLocaleDateString();
 }
 
-export default function FeedbackList({ workspaceSlug, projectId }: Props) {
+export default function FeedbackList({ workspaceSlug, projectId: projectIdProp }: Props) {
+	const [projectId] = useState(
+		() => projectIdProp || new URLSearchParams(window.location.search).get("projectId") || "",
+	);
 	const [rows, setRows] = useState<Feedback[]>([]);
 	const [status, setStatus] = useState("");
 	const [sourceFilter, setSourceFilter] = useState("");

--- a/apps/web/src/islands/FeedbackSourceManager.test.tsx
+++ b/apps/web/src/islands/FeedbackSourceManager.test.tsx
@@ -63,4 +63,24 @@ describe("FeedbackSourceManager", () => {
 		render(<FeedbackSourceManager workspaceSlug="my-ws" projectId="p1" />);
 		expect(await screen.findByText(/Only workspace owners and admins/i)).toBeTruthy();
 	});
+
+	it("falls back to projectId from the URL when no prop is passed", async () => {
+		// Regression: feedback.astro is prerendered under `output: 'static'`, so
+		// Astro.url.searchParams is always empty and can't supply projectId as a
+		// prop. The island must resolve it from window.location.search itself.
+		const originalLocation = window.location;
+		Object.defineProperty(window, "location", {
+			value: { ...originalLocation, search: "?projectId=p1" },
+			writable: true,
+		});
+		stubFetch();
+		try {
+			render(<FeedbackSourceManager workspaceSlug="my-ws" />);
+			expect(await screen.findByText("Onboarding survey")).toBeTruthy();
+			const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+			expect(fetchMock.mock.calls[0][0]).toContain("/api/projects/p1/feedback-sources");
+		} finally {
+			Object.defineProperty(window, "location", { value: originalLocation, writable: true });
+		}
+	});
 });

--- a/apps/web/src/islands/FeedbackSourceManager.tsx
+++ b/apps/web/src/islands/FeedbackSourceManager.tsx
@@ -19,7 +19,7 @@ interface NewSourceResult {
 
 interface Props {
 	workspaceSlug?: string;
-	projectId: string;
+	projectId?: string;
 }
 
 const INPUT_CLASS =
@@ -41,7 +41,10 @@ function parseOrigins(raw: string): string[] | undefined {
 	return list.length > 0 ? list : undefined;
 }
 
-export default function FeedbackSourceManager({ workspaceSlug, projectId }: Props) {
+export default function FeedbackSourceManager({ workspaceSlug, projectId: projectIdProp }: Props) {
+	const [projectId] = useState(
+		() => projectIdProp || new URLSearchParams(window.location.search).get("projectId") || "",
+	);
 	const [sources, setSources] = useState<FeedbackSource[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [forbidden, setForbidden] = useState(false);

--- a/apps/web/src/islands/FeedbackSourceManager.tsx
+++ b/apps/web/src/islands/FeedbackSourceManager.tsx
@@ -43,7 +43,7 @@ function parseOrigins(raw: string): string[] | undefined {
 
 export default function FeedbackSourceManager({ workspaceSlug, projectId: projectIdProp }: Props) {
 	const [projectId] = useState(
-		() => projectIdProp || new URLSearchParams(window.location.search).get("projectId") || "",
+		() => projectIdProp || new URLSearchParams(window.location.search).get("projectId") || ""
 	);
 	const [sources, setSources] = useState<FeedbackSource[]>([]);
 	const [loading, setLoading] = useState(true);

--- a/apps/web/src/islands/FeedbackSourceManager.tsx
+++ b/apps/web/src/islands/FeedbackSourceManager.tsx
@@ -42,9 +42,12 @@ function parseOrigins(raw: string): string[] | undefined {
 }
 
 export default function FeedbackSourceManager({ workspaceSlug, projectId: projectIdProp }: Props) {
-	const [projectId] = useState(
-		() => projectIdProp || new URLSearchParams(window.location.search).get("projectId") || ""
-	);
+	const [projectId, setProjectId] = useState(projectIdProp ?? "");
+	useEffect(() => {
+		if (projectIdProp) return;
+		const fromUrl = new URLSearchParams(window.location.search).get("projectId");
+		if (fromUrl) setProjectId(fromUrl);
+	}, [projectIdProp]);
 	const [sources, setSources] = useState<FeedbackSource[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [forbidden, setForbidden] = useState(false);
@@ -59,6 +62,7 @@ export default function FeedbackSourceManager({ workspaceSlug, projectId: projec
 	const [rotateId, setRotateId] = useState<string | null>(null);
 
 	const fetchSources = useCallback(async () => {
+		if (!projectId) return;
 		setLoading(true);
 		setError(null);
 		setForbidden(false);

--- a/apps/web/src/pages/feedback.astro
+++ b/apps/web/src/pages/feedback.astro
@@ -9,7 +9,7 @@ const workspaceSlug = import.meta.env.PUBLIC_WORKSPACE_SLUG as string | undefine
 <Base title="Feedback — Projektor">
   <ProjectNav client:load workspaceSlug={workspaceSlug} pageLabel="Feedback" />
   <div class="page-container">
-    <FeedbackSourceManager client:load workspaceSlug={workspaceSlug} projectId={Astro.url.searchParams.get('projectId') ?? ''} />
-    <FeedbackList client:load workspaceSlug={workspaceSlug} projectId={Astro.url.searchParams.get('projectId') ?? ''} />
+    <FeedbackSourceManager client:load workspaceSlug={workspaceSlug} />
+    <FeedbackList client:load workspaceSlug={workspaceSlug} />
   </div>
 </Base>

--- a/packages/db/src/test/migrations.test.ts
+++ b/packages/db/src/test/migrations.test.ts
@@ -150,7 +150,7 @@ describe("schema constraints", () => {
 			.sort();
 		const preSlugFiles = migrationFiles.filter((f) => f < "0035");
 		const slugFile = migrationFiles.find((f) => f.startsWith("0035"));
-		expect(slugFile).toBeDefined();
+		if (!slugFile) throw new Error("expected a 0035 migration file");
 
 		const db = new DatabaseSync(":memory:");
 		db.exec("PRAGMA foreign_keys = ON;");
@@ -182,7 +182,7 @@ describe("schema constraints", () => {
 			"INSERT INTO projects (id, workspace_id, name, key, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)"
 		).run("p2", "w1", "Start_Line", "SL2", 1, 1);
 
-		const slugSql = readFileSync(join(MIGRATIONS_DIR, slugFile!), "utf8");
+		const slugSql = readFileSync(join(MIGRATIONS_DIR, slugFile), "utf8");
 		expect(() => {
 			for (const stmt of splitStatements(slugSql)) db.exec(stmt);
 		}).not.toThrow();


### PR DESCRIPTION
## Summary
- `apps/web` builds with `output: 'static'`, so `Astro.url.searchParams` is always empty at prerender time. `feedback.astro` passed that always-empty value as `projectId` to `FeedbackSourceManager`/`FeedbackList`, producing malformed `/api/projects//feedback-sources` calls that hit a fallback route returning HTML instead of JSON — the `/feedback` admin page has never actually worked in production.
- `FeedbackSourceManager` and `FeedbackList` now resolve `projectId` from `window.location.search` themselves, matching the existing pattern already used in `ProjectLanding.tsx`.
- Added a regression test that fails against the old code (`/api/projects/undefined/...`) and passes with the fix.

## Test plan
- [x] `vitest run src/islands/FeedbackSourceManager.test.tsx src/islands/FeedbackList.test.tsx` — 8/8 pass
- [x] Confirmed the new test fails on the pre-fix code (`git stash` the component change and re-run)
- [x] Verified live: logged into the dogfood instance, hit `/feedback/?projectId=...`, confirmed the "Unexpected token '<'" JSON parse error and malformed double-slash API calls before this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fe31KJGn2YMX5JpC1UHSGV