### PR TITLE
docs(PROJ-399): tested feedback widget integration guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
             apps/docs/src/content/docs/agents/workflow-spec.md \
             apps/docs/src/generated/mcp-stats.json README.md \
             apps/docs/src/content/docs/contributing/conventions.md \
+            apps/docs/src/content/docs/guides/feedback-widget-integration.md \
             || { echo "::error::Generated docs are stale. Run 'pnpm gen:docs' and commit the result."; exit 1; }
       - run: pnpm lint
       - run: pnpm turbo type-check

--- a/apps/api/src/examples/feedback-widget-submit.ts
+++ b/apps/api/src/examples/feedback-widget-submit.ts
@@ -1,0 +1,50 @@
+/**
+ * Minimal, framework-agnostic example: submit end-user feedback from your own
+ * product's client code to a projektor feedback source.
+ *
+ * This file is the single source of truth for the code block in
+ * apps/docs/src/content/docs/guides/feedback-widget-integration.md (mirrored
+ * in by scripts/gen-feedback-example-page.ts) and is executed against a real
+ * projektor instance in apps/api/src/test/feedback-example.test.ts. If either
+ * drifts from this file, CI fails — see the "Generated docs are fresh" step.
+ */
+
+export interface FeedbackPayload {
+	/** -1 or 1 for a "thumbs" ratingScale, or 1-5 for "five_star". */
+	rating?: number;
+	ratingScale?: "thumbs" | "five_star";
+	/** Free-text comment. At least one of rating or body is required. */
+	body?: string;
+	/** Optional label for who submitted this (e.g. an email or username). */
+	submitterLabel?: string;
+	/** Optional context URL — e.g. the page or generated-content URL this feedback is about. */
+	sourceUrl?: string;
+	appVersion?: string;
+}
+
+/**
+ * POSTs to a projektor feedback source's public submit endpoint.
+ *
+ * `token` is the public submit token minted for a feedback source (via the
+ * create_feedback_source MCP tool or the feedback-sources REST API) — it is
+ * meant to be embedded in client-side code, the same trust category as a
+ * Sentry DSN or a Stripe publishable key.
+ */
+export async function submitFeedback(
+	endpoint: string,
+	token: string,
+	feedback: FeedbackPayload
+): Promise<{ id: string }> {
+	const res = await fetch(endpoint, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify(feedback),
+	});
+	if (!res.ok) {
+		throw new Error(`Feedback submit failed: ${res.status} ${await res.text()}`);
+	}
+	return res.json();
+}

--- a/apps/api/src/test/feedback-example.test.ts
+++ b/apps/api/src/test/feedback-example.test.ts
@@ -1,0 +1,52 @@
+import { env, SELF } from "cloudflare:test";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { submitFeedback } from "../examples/feedback-widget-submit";
+import { authHeaders, seedProjectFixture } from "./helpers";
+
+// Proves the exact code shown in the feedback-widget-integration docs guide
+// (mirrored from ../examples/feedback-widget-submit.ts, see that file's header)
+// actually works end-to-end, not just that the API contract it targets does.
+describe("documented feedback widget example", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("submitFeedback() from the docs example submits to a live feedback source", async () => {
+		const f = await seedProjectFixture({ role: "owner" });
+		const created = await SELF.fetch(
+			`http://localhost/api/projects/${f.projectId}/feedback-sources`,
+			{
+				method: "POST",
+				headers: authHeaders(f.token, f.slug),
+				body: JSON.stringify({ name: "Docs example source" }),
+			}
+		);
+		const { token } = (await created.json()) as { token: string };
+
+		// The example calls the ambient global `fetch`, exactly as it would in a
+		// browser; stub it to dispatch into the worker under test instead of the
+		// real network.
+		vi.stubGlobal("fetch", (url: string, init?: RequestInit) => SELF.fetch(url, init));
+
+		const result = await submitFeedback("http://localhost/api/feedback/submit", token, {
+			rating: 1,
+			ratingScale: "thumbs",
+			body: "Docs example works",
+		});
+		expect(result.id).toBeTruthy();
+
+		const row = await env.DB.prepare("SELECT body, rating FROM feedback WHERE id = ?")
+			.bind(result.id)
+			.first<{ body: string; rating: number }>();
+		expect(row?.body).toBe("Docs example works");
+		expect(row?.rating).toBe(1);
+	});
+
+	it("submitFeedback() surfaces a thrown error on rejection (e.g. bad token)", async () => {
+		vi.stubGlobal("fetch", (url: string, init?: RequestInit) => SELF.fetch(url, init));
+
+		await expect(
+			submitFeedback("http://localhost/api/feedback/submit", "not-a-real-token", { body: "x" })
+		).rejects.toThrow(/Feedback submit failed: 401/);
+	});
+});

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -31,6 +31,7 @@ export default defineConfig({
 						{ label: "Live demo", slug: "guides/live-demo" },
 						{ label: "Self-hosting", slug: "guides/self-hosting" },
 						{ label: "Deploying & operating", slug: "guides/deploying" },
+						{ label: "Feedback widget integration", slug: "guides/feedback-widget-integration" },
 						{ label: "Releases & changelog", link: "https://github.com/TAJD/projektor/releases" },
 					],
 				},

--- a/apps/docs/src/content/docs/guides/feedback-widget-integration.md
+++ b/apps/docs/src/content/docs/guides/feedback-widget-integration.md
@@ -1,0 +1,113 @@
+---
+title: "Feedback widget integration"
+description: "Collect end-user feedback from your own site and route it into a projektor project."
+sidebar:
+  order: 4
+---
+> **Note:** the code below is generated from [`apps/api/src/examples/feedback-widget-submit.ts`](https://github.com/TAJD/projektor/blob/main/apps/api/src/examples/feedback-widget-submit.ts) by `scripts/gen-feedback-example-page.ts`, and is executed against a live projektor instance in [`apps/api/src/test/feedback-example.test.ts`](https://github.com/TAJD/projektor/blob/main/apps/api/src/test/feedback-example.test.ts) - edit that source file, not this page, and run `pnpm gen:docs`.
+
+A **feedback source** is a named, independently-credentialed collection point (e.g.
+"Onboarding survey", "In-app rating widget") that a project owner or admin creates once.
+Any number of sources can exist per project. Each source has its own public submit
+token, so you can revoke or rotate one integration without touching another.
+
+## 1. Create a feedback source
+
+Ask an AI agent with MCP access to the workspace to run `create_feedback_source`, or
+call the REST endpoint directly:
+
+```bash
+curl -X POST https://your-projektor-instance/api/projects/<projectId>/feedback-sources \
+  -H "Authorization: Bearer <your workspace API token>" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "In-app rating widget", "allowedOrigins": ["https://your-site.example"]}'
+```
+
+The response includes a one-time `token` - copy it now, it is never shown again. This
+token is the trust boundary for the integration: it's deliberately public and safe to
+ship in client-side code (the same category as a Sentry DSN or a Stripe publishable
+key), narrow in scope (submit-only), and independently revocable/rotatable per source.
+
+## 2. Submit feedback from your site
+
+```ts
+/**
+ * Minimal, framework-agnostic example: submit end-user feedback from your own
+ * product's client code to a projektor feedback source.
+ *
+ * This file is the single source of truth for the code block in
+ * apps/docs/src/content/docs/guides/feedback-widget-integration.md (mirrored
+ * in by scripts/gen-feedback-example-page.ts) and is executed against a real
+ * projektor instance in apps/api/src/test/feedback-example.test.ts. If either
+ * drifts from this file, CI fails — see the "Generated docs are fresh" step.
+ */
+
+export interface FeedbackPayload {
+	/** -1 or 1 for a "thumbs" ratingScale, or 1-5 for "five_star". */
+	rating?: number;
+	ratingScale?: "thumbs" | "five_star";
+	/** Free-text comment. At least one of rating or body is required. */
+	body?: string;
+	/** Optional label for who submitted this (e.g. an email or username). */
+	submitterLabel?: string;
+	/** Optional context URL — e.g. the page or generated-content URL this feedback is about. */
+	sourceUrl?: string;
+	appVersion?: string;
+}
+
+/**
+ * POSTs to a projektor feedback source's public submit endpoint.
+ *
+ * `token` is the public submit token minted for a feedback source (via the
+ * create_feedback_source MCP tool or the feedback-sources REST API) — it is
+ * meant to be embedded in client-side code, the same trust category as a
+ * Sentry DSN or a Stripe publishable key.
+ */
+export async function submitFeedback(
+	endpoint: string,
+	token: string,
+	feedback: FeedbackPayload
+): Promise<{ id: string }> {
+	const res = await fetch(endpoint, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify(feedback),
+	});
+	if (!res.ok) {
+		throw new Error(`Feedback submit failed: ${res.status} ${await res.text()}`);
+	}
+	return res.json();
+}
+```
+
+Call it after whatever moment makes sense for your product - a thumbs up/down after
+generating something, a rating prompt after a task completes, an in-app "send feedback"
+form:
+
+```ts
+await submitFeedback("https://your-projektor-instance/api/feedback/submit", token, {
+  rating: 1,
+  ratingScale: "thumbs",
+  sourceUrl: window.location.href,
+});
+```
+
+`rating` and `body` are both optional, but at least one is required per submission.
+`ratingScale` is required whenever `rating` is present ("thumbs": -1 or 1; "five_star":
+1-5).
+
+## 3. Triage feedback
+
+Submitted feedback shows up on the project's Feedback page
+(`/feedback/?projectId=<projectId>`) for workspace owners/admins, where it can be
+filtered by status/source, marked reviewed, or converted directly into an issue.
+
+## See also
+
+- Design background: [PROJ-378](https://github.com/TAJD/projektor) (direct user feedback
+  ingestion)
+- [MCP tool catalog](/projektor/agents/tool-catalog/) for the full set of
+  feedback-source management tools (create/list/update/rotate/revoke)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "biome format --write .",
     "cofferdam": "cofferdam check",
     "cofferdam:fix": "cofferdam baseline write",
-    "gen:docs": "pnpm --filter @projektor/api gen:catalog && pnpm --filter @projektor/api gen:workflow-spec && tsx scripts/gen-conventions-page.ts",
+    "gen:docs": "pnpm --filter @projektor/api gen:catalog && pnpm --filter @projektor/api gen:workflow-spec && tsx scripts/gen-conventions-page.ts && tsx scripts/gen-feedback-example-page.ts",
     "prepare": "lefthook install"
   },
   "devDependencies": {

--- a/scripts/gen-feedback-example-page.ts
+++ b/scripts/gen-feedback-example-page.ts
@@ -1,0 +1,108 @@
+/**
+ * Generates the feedback widget integration guide by embedding the real,
+ * tested example from apps/api/src/examples/feedback-widget-submit.ts.
+ *
+ * The code shown to readers is never hand-copied - it's read verbatim from
+ * the source file that apps/api/src/test/feedback-example.test.ts actually
+ * executes against a live worker, so the two cannot silently drift apart.
+ * CI fails if the committed page doesn't match a fresh run (see
+ * .github/workflows/ci.yml's "Generated docs are fresh" step).
+ *
+ *   tsx scripts/gen-feedback-example-page.ts
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, ".."); // scripts -> repo root
+const sourcePath = join(
+	repoRoot,
+	"apps",
+	"api",
+	"src",
+	"examples",
+	"feedback-widget-submit.ts"
+);
+const outPath = join(
+	repoRoot,
+	"apps",
+	"docs",
+	"src",
+	"content",
+	"docs",
+	"guides",
+	"feedback-widget-integration.md"
+);
+
+const exampleCode = readFileSync(sourcePath, "utf8").trimEnd();
+
+const PAGE = `---
+title: "Feedback widget integration"
+description: "Collect end-user feedback from your own site and route it into a projektor project."
+sidebar:
+  order: 4
+---
+> **Note:** the code below is generated from [\`apps/api/src/examples/feedback-widget-submit.ts\`](https://github.com/TAJD/projektor/blob/main/apps/api/src/examples/feedback-widget-submit.ts) by \`scripts/gen-feedback-example-page.ts\`, and is executed against a live projektor instance in [\`apps/api/src/test/feedback-example.test.ts\`](https://github.com/TAJD/projektor/blob/main/apps/api/src/test/feedback-example.test.ts) - edit that source file, not this page, and run \`pnpm gen:docs\`.
+
+A **feedback source** is a named, independently-credentialed collection point (e.g.
+"Onboarding survey", "In-app rating widget") that a project owner or admin creates once.
+Any number of sources can exist per project. Each source has its own public submit
+token, so you can revoke or rotate one integration without touching another.
+
+## 1. Create a feedback source
+
+Ask an AI agent with MCP access to the workspace to run \`create_feedback_source\`, or
+call the REST endpoint directly:
+
+\`\`\`bash
+curl -X POST https://your-projektor-instance/api/projects/<projectId>/feedback-sources \\
+  -H "Authorization: Bearer <your workspace API token>" \\
+  -H "Content-Type: application/json" \\
+  -d '{"name": "In-app rating widget", "allowedOrigins": ["https://your-site.example"]}'
+\`\`\`
+
+The response includes a one-time \`token\` - copy it now, it is never shown again. This
+token is the trust boundary for the integration: it's deliberately public and safe to
+ship in client-side code (the same category as a Sentry DSN or a Stripe publishable
+key), narrow in scope (submit-only), and independently revocable/rotatable per source.
+
+## 2. Submit feedback from your site
+
+\`\`\`ts
+${exampleCode}
+\`\`\`
+
+Call it after whatever moment makes sense for your product - a thumbs up/down after
+generating something, a rating prompt after a task completes, an in-app "send feedback"
+form:
+
+\`\`\`ts
+await submitFeedback("https://your-projektor-instance/api/feedback/submit", token, {
+  rating: 1,
+  ratingScale: "thumbs",
+  sourceUrl: window.location.href,
+});
+\`\`\`
+
+\`rating\` and \`body\` are both optional, but at least one is required per submission.
+\`ratingScale\` is required whenever \`rating\` is present ("thumbs": -1 or 1; "five_star":
+1-5).
+
+## 3. Triage feedback
+
+Submitted feedback shows up on the project's Feedback page
+(\`/feedback/?projectId=<projectId>\`) for workspace owners/admins, where it can be
+filtered by status/source, marked reviewed, or converted directly into an issue.
+
+## See also
+
+- Design background: [PROJ-378](https://github.com/TAJD/projektor) (direct user feedback
+  ingestion)
+- [MCP tool catalog](/projektor/agents/tool-catalog/) for the full set of
+  feedback-source management tools (create/list/update/rotate/revoke)
+`;
+
+writeFileSync(outPath, PAGE, "utf8");
+// cofferdam-ignore: Warning.NoConsoleLog: CLI generator script output, not a debug leftover
+console.log(`Updated ${outPath} from ${sourcePath}`);


### PR DESCRIPTION
## Summary
PROJ-399 (child of PROJ-398). There was no "how to add the feedback widget to a new site" guide anywhere — only the PROJ-378 design doc and scattered breadcrumbs in ironvolume's own repo.

- `apps/api/src/examples/feedback-widget-submit.ts` — minimal, framework-agnostic reference implementation of the public submit call. Single source of truth.
- `scripts/gen-feedback-example-page.ts` — mirrors that file's exact content into the new docs guide (same pattern as `gen-conventions-page.ts` for AGENTS.md), wired into `pnpm gen:docs` and the existing "Generated docs are fresh" CI gate, so the doc can't silently drift from working code.
- `apps/api/src/test/feedback-example.test.ts` — imports that exact example and runs it against a live worker (stubs global `fetch` to dispatch into `SELF`), proving the documented example is actually runnable.

## Test plan
- [x] `pnpm --filter @projektor/api test` — new tests pass (submit succeeds + error path)
- [x] `pnpm --filter @projektor/docs build` — new page builds, internal links validate
- [x] `pnpm turbo type-check` — 0 errors across api/web/docs
- [x] `pnpm gen:docs` run twice — idempotent, no diff (freshness check will pass)
- [x] `pnpm lint`

https://claude.ai/code/session_01Fe31KJGn2YMX5JpC1UHSGV