### PR TITLE
PROJ-395/396/397/401/402: contextual help, issue author tracking, mobile issue-list fixes

### DIFF
--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -283,6 +283,7 @@ export async function listIssues(ctx: ServiceCtx, raw: unknown) {
 			status_category: schema.taskStatuses.category,
 			sprint_id: schema.issues.sprintId,
 			created_by_id: schema.issues.createdById,
+			author_kind: schema.issues.authorKind,
 			created_at: schema.issues.createdAt,
 			updated_at: schema.issues.updatedAt,
 			completed_at: schema.issues.completedAt,
@@ -341,6 +342,7 @@ const issueColumns = {
 	status_category: schema.taskStatuses.category,
 	sprint_id: schema.issues.sprintId,
 	created_by_id: schema.issues.createdById,
+	author_kind: schema.issues.authorKind,
 	created_at: schema.issues.createdAt,
 	updated_at: schema.issues.updatedAt,
 	completed_at: schema.issues.completedAt,
@@ -552,10 +554,10 @@ async function insertIssueRow(
 			`INSERT INTO issues
 			   (id, workspace_id, project_id, number, title, body, status, status_id,
 			    status_category, priority, assignee_id, labels, parent_id, type_id,
-			    created_by_id, created_at, updated_at)
+			    created_by_id, author_kind, created_at, updated_at)
 			 VALUES
 			   (?, ?, ?, (SELECT COALESCE(MAX(number), 0) + 1 FROM issues WHERE project_id = ?),
-			    ?, ?, ?, ?, '', ?, ?, ?, ?, ?, ?, ?, ?)`
+			    ?, ?, ?, ?, '', ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		)
 		.bind(
 			params.id,
@@ -572,6 +574,9 @@ async function insertIssueRow(
 			params.parentId ?? null,
 			params.resolvedTypeId,
 			ctx.userId,
+			// PROJ-396: stamped from the authenticated principal type, not a caller-supplied
+			// field — see ServiceCtx.authKind and the issueComments.authorKind precedent (PROJ-328).
+			ctx.authKind ?? null,
 			params.now,
 			params.now
 		)

--- a/apps/api/src/test/issues.test.ts
+++ b/apps/api/src/test/issues.test.ts
@@ -59,6 +59,24 @@ describe("Issues API", () => {
 		expect(body.id).toBeTruthy();
 	});
 
+	// PROJ-396: author_kind is stamped from the authenticated principal type, not a
+	// caller-supplied field — same convention as issue_comments.author_kind (PROJ-328).
+	// Tests authenticate over Bearer tokens (see authHeaders), same as agents.
+	it("stamps author_kind from the auth transport, not a caller-supplied field", async () => {
+		const res = await SELF.fetch("http://localhost/api/issues", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ projectId, title: "Author kind test", authorKind: "human" }),
+		});
+		expect(res.status).toBe(201);
+		const body = (await res.json()) as { id: string };
+
+		const row = await env.DB.prepare("SELECT author_kind FROM issues WHERE id = ?")
+			.bind(body.id)
+			.first<{ author_kind: string | null }>();
+		expect(row?.author_kind).toBe("agent");
+	});
+
 	it("POST then GET returns the created issue", async () => {
 		await SELF.fetch("http://localhost/api/issues", {
 			method: "POST",

--- a/apps/api/src/test/migrations.ts
+++ b/apps/api/src/test/migrations.ts
@@ -37,6 +37,7 @@ import m0033 from "../../../../packages/db/migrations/0033_custom_field_is_inter
 import m0034 from "../../../../packages/db/migrations/0034_issue_needs_audit.sql?raw";
 import m0035 from "../../../../packages/db/migrations/0035_project_slug.sql?raw";
 import m0036 from "../../../../packages/db/migrations/0036_feedback.sql?raw";
+import m0037 from "../../../../packages/db/migrations/0037_issue_author_kind.sql?raw";
 
 export const MIGRATIONS = [
 	m0000,
@@ -76,4 +77,5 @@ export const MIGRATIONS = [
 	m0034,
 	m0035,
 	m0036,
+	m0037,
 ];

--- a/apps/web/e2e/mobile-issue-list.spec.ts
+++ b/apps/web/e2e/mobile-issue-list.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * PROJ-397: Mobile issue-list layout regression tests.
+ *
+ * Covers two bugs found in a reported screenshot at 375×812 (see PROJ-397):
+ * 1. The issue count label ("N issues (of M)") could wrap to multiple lines
+ *    and visually overlap the "+ New issue" button / list-board-backlog
+ *    toggle, since the header row never dropped to a second line on mobile.
+ * 2. The filter dropdowns in the toolbar wrapped into a ragged, uneven grid
+ *    instead of stacking full-width.
+ *
+ * Also covers the mobile navigation drawer (hamburger menu), which has no
+ * existing coverage.
+ *
+ * Run with: pnpm --filter @projektor/web exec playwright test --project=mobile mobile-issue-list
+ *
+ * Prerequisites: globalSetup must have written e2e/.e2e-ctx.json.
+ * Target: E2E_BASE_URL pointing at a dev deployment (ENVIRONMENT=development,
+ * DEV_USER_EMAIL set for the server-side auth bypass).
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { expect, test, type Page } from "@playwright/test";
+import type { E2EContext } from "./global-setup";
+
+function readCtx(): E2EContext {
+	const file = path.resolve(process.cwd(), "e2e", ".e2e-ctx.json");
+	if (!fs.existsSync(file)) {
+		throw new Error(
+			"e2e/.e2e-ctx.json not found — did globalSetup succeed?\n" +
+				"Run with E2E_BASE_URL set to a dev deployment.",
+		);
+	}
+	return JSON.parse(fs.readFileSync(file, "utf-8")) as E2EContext;
+}
+
+async function openIssues(page: Page, ctx: E2EContext) {
+	await page.goto("/issues");
+	await page.evaluate(
+		({ slug }: { slug: string }) => {
+			localStorage.setItem("workspace-slug", slug);
+		},
+		{ slug: ctx.workspaceSlug },
+	);
+	await page.reload();
+	await page.waitForSelector("text=/\\d+ issues?/", { timeout: 15_000 });
+}
+
+test.describe("Mobile issue list layout (375×812)", () => {
+	test("header row: New issue button and view toggle never overlap the count label", async ({
+		page,
+	}) => {
+		test.skip(
+			!process.env.E2E_BASE_URL,
+			"E2E_BASE_URL not set — skipping live deployment test",
+		);
+
+		const ctx = readCtx();
+		await openIssues(page, ctx);
+
+		const innerWidth = await page.evaluate(() => window.innerWidth);
+		expect(innerWidth).toBeLessThan(640);
+
+		const countLabel = page.locator("p", { hasText: /issues?/ }).first();
+		const newIssueBtn = page.locator("button", { hasText: "+ New issue" });
+		await expect(countLabel).toBeVisible();
+		await expect(newIssueBtn).toBeVisible();
+
+		const labelBox = await countLabel.boundingBox();
+		const btnBox = await newIssueBtn.boundingBox();
+		if (!labelBox || !btnBox) throw new Error("boundingBox() returned null");
+
+		// The two elements must not intersect vertically at all — on mobile the
+		// button row must sit entirely below the (possibly multi-line) count
+		// label, not overlap it.
+		const labelBottom = labelBox.y + labelBox.height;
+		expect(btnBox.y).toBeGreaterThanOrEqual(labelBottom);
+	});
+
+	test("filter dropdowns stack full-width instead of wrapping raggedly", async ({ page }) => {
+		test.skip(
+			!process.env.E2E_BASE_URL,
+			"E2E_BASE_URL not set — skipping live deployment test",
+		);
+
+		const ctx = readCtx();
+		await openIssues(page, ctx);
+
+		const projectSelect = page.locator('[aria-label="Filter by project"]');
+		await expect(projectSelect).toBeVisible();
+
+		const selectBox = await projectSelect.boundingBox();
+		const viewportSize = page.viewportSize();
+		if (!selectBox || !viewportSize) throw new Error("boundingBox()/viewportSize() null");
+
+		// Full-width dropdowns leave only the page's horizontal padding on
+		// either side — assert the select spans the large majority of the
+		// viewport rather than shrink-wrapping to its label text.
+		expect(selectBox.width).toBeGreaterThan(viewportSize.width * 0.7);
+	});
+
+	test("hamburger opens the navigation drawer, and tapping a link closes it", async ({
+		page,
+	}) => {
+		test.skip(
+			!process.env.E2E_BASE_URL,
+			"E2E_BASE_URL not set — skipping live deployment test",
+		);
+
+		await page.goto("/");
+
+		const hamburger = page.locator('[aria-label="Open navigation menu"]');
+		await expect(hamburger).toBeVisible();
+
+		const sidebar = page.locator("#app-sidebar");
+		await expect(sidebar).not.toBeInViewport();
+
+		await hamburger.click();
+		await expect(sidebar).toBeInViewport();
+		await expect(page.locator('[aria-label="Close navigation menu"]')).toBeVisible();
+
+		await sidebar.locator("a", { hasText: "My Issues" }).click();
+		await expect(page).toHaveURL(/\/my-issues/);
+		await expect(sidebar).not.toBeInViewport();
+	});
+
+	test("New issue modal opens and creates an issue from the mobile toolbar", async ({
+		page,
+	}) => {
+		test.skip(
+			!process.env.E2E_BASE_URL,
+			"E2E_BASE_URL not set — skipping live deployment test",
+		);
+
+		const ctx = readCtx();
+		await openIssues(page, ctx);
+
+		const newIssueBtn = page.locator("button", { hasText: "+ New issue" });
+		await expect(newIssueBtn).toBeVisible();
+		await newIssueBtn.click();
+
+		const dialog = page.locator('[role="dialog"][aria-label="Create new issue"]');
+		await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+		// The modal must fit within the mobile viewport, not overflow it.
+		const dialogBox = await dialog.boundingBox();
+		const viewportSize = page.viewportSize();
+		if (!dialogBox || !viewportSize) throw new Error("boundingBox()/viewportSize() null");
+		expect(dialogBox.width).toBeLessThanOrEqual(viewportSize.width);
+
+		await dialog.locator('input[placeholder="Issue title"]').fill("E2E Mobile Test Issue");
+		await dialog.locator('button[type="submit"]', { hasText: "Create issue" }).click();
+
+		await expect(dialog).not.toBeVisible({ timeout: 10_000 });
+		await expect(
+			page.locator("a", { hasText: "E2E Mobile Test Issue" }).first(),
+		).toBeVisible({ timeout: 10_000 });
+	});
+});

--- a/apps/web/src/islands/GlossaryHelp.test.tsx
+++ b/apps/web/src/islands/GlossaryHelp.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from "@testing-library/preact";
+import { describe, expect, it } from "vitest";
+import { GlossaryHelp } from "./GlossaryHelp";
+
+describe("GlossaryHelp", () => {
+	it("shows the trigger but not the definition until clicked", () => {
+		render(<GlossaryHelp id="sprint" />);
+		expect(screen.getByRole("button", { name: "About Sprint" })).toBeTruthy();
+		expect(screen.queryByRole("dialog")).toBeNull();
+	});
+
+	it("toggles the definition popover open and closed on click", () => {
+		render(<GlossaryHelp id="sprint" />);
+		const trigger = screen.getByRole("button", { name: "About Sprint" });
+
+		fireEvent.click(trigger);
+		expect(screen.getByRole("dialog", { name: "Sprint definition" })).toBeTruthy();
+
+		fireEvent.click(trigger);
+		expect(screen.queryByRole("dialog")).toBeNull();
+	});
+
+	it("closes on Escape", () => {
+		render(<GlossaryHelp id="epic" />);
+		fireEvent.click(screen.getByRole("button", { name: "About Epic" }));
+		expect(screen.getByRole("dialog")).toBeTruthy();
+
+		fireEvent.keyDown(document, { key: "Escape" });
+		expect(screen.queryByRole("dialog")).toBeNull();
+	});
+
+	it("closes on an outside click", () => {
+		render(<GlossaryHelp id="groups" />);
+		fireEvent.click(screen.getByRole("button", { name: "About Groups" }));
+		expect(screen.getByRole("dialog")).toBeTruthy();
+
+		fireEvent.mouseDown(document.body);
+		expect(screen.queryByRole("dialog")).toBeNull();
+	});
+});

--- a/apps/web/src/islands/GlossaryHelp.tsx
+++ b/apps/web/src/islands/GlossaryHelp.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useId, useRef, useState } from "preact/hooks";
+import { GLOSSARY_TERMS, type GlossaryTermId } from "./glossary-definitions";
+
+// PROJ-395: a toggletip explaining SDLC/PM jargon (Sprint, Epic, Groups, Tokens) inline
+// next to nav labels, for users unfamiliar with this kind of tool. Same interaction
+// pattern (and CSS classes) as MetricHelp.tsx (PROJ-335) — reused rather than duplicated
+// since the toggletip visuals are identical, only the content source differs.
+export function GlossaryHelp({ id }: { id: GlossaryTermId }) {
+	const term = GLOSSARY_TERMS[id];
+	const [open, setOpen] = useState(false);
+	const rootRef = useRef<HTMLSpanElement>(null);
+	const popoverId = useId();
+
+	useEffect(() => {
+		if (!open) return;
+		function onPointerDown(e: MouseEvent) {
+			if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+		}
+		function onKeyDown(e: KeyboardEvent) {
+			if (e.key === "Escape") setOpen(false);
+		}
+		document.addEventListener("mousedown", onPointerDown);
+		document.addEventListener("keydown", onKeyDown);
+		return () => {
+			document.removeEventListener("mousedown", onPointerDown);
+			document.removeEventListener("keydown", onKeyDown);
+		};
+	}, [open]);
+
+	return (
+		<span class="metric-help" ref={rootRef}>
+			<button
+				type="button"
+				class="metric-help-trigger"
+				aria-label={`About ${term.label}`}
+				aria-expanded={open}
+				aria-describedby={open ? popoverId : undefined}
+				onClick={(e) => {
+					e.preventDefault();
+					setOpen((o) => !o);
+				}}
+			>
+				<span aria-hidden="true">ⓘ</span>
+			</button>
+			{open && (
+				<div
+					id={popoverId}
+					role="dialog"
+					aria-modal="false"
+					aria-label={`${term.label} definition`}
+					class="metric-help-popover"
+				>
+					<p class="m-0 text-[0.8rem] text-text-base">{term.definition}</p>
+				</div>
+			)}
+		</span>
+	);
+}

--- a/apps/web/src/islands/ProjectNav.tsx
+++ b/apps/web/src/islands/ProjectNav.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "preact/hooks";
 import { apiFetch } from "../utils/api-client";
+import { GlossaryHelp } from "./GlossaryHelp";
+import type { GlossaryTermId } from "./glossary-definitions";
 
 interface Project {
 	id: string;
@@ -13,12 +15,15 @@ interface Props {
 	pageLabel?: string;
 }
 
-const TABS = [
+// PROJ-395: glossaryId flags tabs whose label is SDLC jargon a newcomer wouldn't know
+// (Sprints, Epics) — those get an inline GlossaryHelp toggletip; self-explanatory tabs
+// don't, so the nav doesn't get cluttered with icons for power users/agents.
+const TABS: Array<{ label: string; path: string; glossaryId?: GlossaryTermId }> = [
 	{ label: "Overview", path: "/projects/view" },
 	{ label: "Issues", path: "/issues" },
 	{ label: "Wiki", path: "/wiki" },
-	{ label: "Sprints", path: "/sprints" },
-	{ label: "Epics", path: "/epics" },
+	{ label: "Sprints", path: "/sprints", glossaryId: "sprint" },
+	{ label: "Epics", path: "/epics", glossaryId: "epic" },
 	{ label: "Metrics", path: "/metrics" },
 	{ label: "Feedback", path: "/feedback" },
 ];
@@ -139,14 +144,16 @@ export default function ProjectNav({ workspaceSlug, pageLabel }: Props) {
 							? activePath === "/projects/view" || activePath.startsWith("/projects/view/")
 							: activePath === tab.path;
 					return (
-						<a
-							key={tab.path}
-							href={tab.href}
-							class={tabClass(active)}
-							aria-current={active ? "page" : undefined}
-						>
-							{tab.label}
-						</a>
+						<span key={tab.path} class="inline-flex items-center shrink-0">
+							<a
+								href={tab.href}
+								class={tabClass(active)}
+								aria-current={active ? "page" : undefined}
+							>
+								{tab.label}
+							</a>
+							{tab.glossaryId && <GlossaryHelp id={tab.glossaryId} />}
+						</span>
 					);
 				})}
 			</nav>

--- a/apps/web/src/islands/glossary-definitions.ts
+++ b/apps/web/src/islands/glossary-definitions.ts
@@ -1,0 +1,31 @@
+// PROJ-395: plain-language definitions for SDLC/PM jargon shown next to nav items and
+// project tabs, for users unfamiliar with team-collaboration tooling. Same shape as
+// metric-definitions.ts (PROJ-335) but a separate map — these terms describe app concepts,
+// not computed metrics, so a shared "computation" field wouldn't apply.
+
+export type GlossaryTermId = "sprint" | "epic" | "groups" | "tokens";
+
+export interface GlossaryTerm {
+	label: string;
+	definition: string;
+}
+
+export const GLOSSARY_TERMS: Record<GlossaryTermId, GlossaryTerm> = {
+	sprint: {
+		label: "Sprint",
+		definition:
+			"A fixed time window (often 1-2 weeks) used to plan and track a batch of issues together.",
+	},
+	epic: {
+		label: "Epic",
+		definition: "A large body of work broken down into several smaller, related issues.",
+	},
+	groups: {
+		label: "Groups",
+		definition: "Teams of members that share the same project access permissions.",
+	},
+	tokens: {
+		label: "Tokens",
+		definition: "API keys that let external tools or AI agents act on your behalf.",
+	},
+};

--- a/apps/web/src/islands/issue-list/HeaderRow.tsx
+++ b/apps/web/src/islands/issue-list/HeaderRow.tsx
@@ -42,10 +42,10 @@ export default function HeaderRow({
 			: countLabel(view, filtered, totalIssues);
 
 	return (
-		<div class="flex justify-between items-center mb-3">
+		<div class="flex justify-between items-center gap-2 mb-3 max-sm:flex-col max-sm:items-stretch">
 			<p class="text-sm text-text-muted m-0">{label}</p>
 
-			<div class="flex gap-2 items-center">
+			<div class="flex gap-2 items-center max-sm:justify-between">
 				{projectsCount > 0 && (
 					<button type="button" onClick={openCreateModal} class="btn btn-primary btn-sm">
 						+ New issue

--- a/apps/web/src/islands/issue-list/SearchBox.tsx
+++ b/apps/web/src/islands/issue-list/SearchBox.tsx
@@ -12,7 +12,7 @@ export default function SearchBox({
 	searchInputRef: RefObject<HTMLInputElement>;
 }) {
 	return (
-		<div class="flex items-center gap-1">
+		<div class="flex items-center gap-1 max-sm:w-full">
 			<input
 				ref={searchInputRef}
 				type="search"
@@ -20,8 +20,10 @@ export default function SearchBox({
 				onInput={(e) => setSearchQuery((e.target as HTMLInputElement).value)}
 				placeholder="Search…"
 				aria-label="Search issues"
-				class="py-1 px-[0.625rem] border border-border rounded bg-bg text-text-base text-[0.8rem] outline-none"
-				style={{ width: isSearchActive ? "12rem" : "7rem", transition: "width 0.2s" }}
+				class={`py-1 px-[0.625rem] border border-border rounded bg-bg text-text-base text-[0.8rem] outline-none max-sm:w-full ${
+					isSearchActive ? "w-48" : "w-28"
+				}`}
+				style={{ transition: "width 0.2s" }}
 			/>
 			{isSearchActive && (
 				<button

--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -1,5 +1,7 @@
 ---
 import { ClientRouter } from 'astro:transitions';
+import { GlossaryHelp } from '../islands/GlossaryHelp';
+import type { GlossaryTermId } from '../islands/glossary-definitions';
 import pkg from '../../package.json';
 
 interface Props {
@@ -12,12 +14,14 @@ const path = Astro.url.pathname;
 const isActive = (href: string): boolean =>
   href === '/' ? path === '/' : path === href || path.startsWith(`${href}/`);
 
-const navItems = [
+// PROJ-395: glossaryId flags nav items whose label is jargon a newcomer wouldn't
+// know (Groups, Tokens) — those get an inline GlossaryHelp toggletip.
+const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId }> = [
   { href: '/', label: 'Projects' },
   { href: '/my-issues', label: 'My Issues' },
-  { href: '/settings/groups', label: 'Groups' },
-  { href: '/settings/tokens', label: 'Tokens' },
-] as const;
+  { href: '/settings/groups', label: 'Groups', glossaryId: 'groups' },
+  { href: '/settings/tokens', label: 'Tokens', glossaryId: 'tokens' },
+];
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -330,6 +334,11 @@ const navItems = [
         flex-direction: column;
         gap: 0.125rem;
       }
+      .sidebar-link-row {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+      }
       .sidebar-link {
         display: flex;
         align-items: center;
@@ -341,6 +350,8 @@ const navItems = [
         font-size: 0.875rem;
         font-weight: 500;
         line-height: 1.25;
+        flex: 1;
+        min-width: 0;
         transition: background 0.1s, color 0.1s;
       }
       .sidebar-link svg { flex-shrink: 0; }
@@ -464,6 +475,13 @@ const navItems = [
         input, textarea, select {
           font-size: 16px;
         }
+
+        /* PROJ-397: the hand-rolled Select (islands/Select.tsx) shrink-wraps to
+           its label by default, producing a ragged, uneven grid when several
+           sit in a wrapping toolbar. Full-width + stacked (each forces its own
+           line inside the toolbar's flex-wrap row) reads as a tidy list. */
+        .select { width: 100%; }
+        .select-button { width: 100%; justify-content: space-between; }
       }
 
       /* ── Custom Select (islands) ───────────────────────────────────── */
@@ -589,31 +607,35 @@ const navItems = [
 
         <nav class="sidebar-nav" aria-label="Primary">
           {navItems.map((item) => (
-            <a
-              href={item.href}
-              class:list={['sidebar-link', { active: isActive(item.href) }]}
-              aria-current={isActive(item.href) ? 'page' : undefined}
-            >
-              {item.label === 'Projects' && (
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
-              )}
-              {item.label === 'My Issues' && (
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg>
-              )}
-              {item.label === 'Groups' && (
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
-              )}
-              {item.label === 'Tokens' && (
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
-              )}
-              <span class="link-label">{item.label}</span>
-            </a>
+            <span class="sidebar-link-row">
+              <a
+                href={item.href}
+                class:list={['sidebar-link', { active: isActive(item.href) }]}
+                aria-current={isActive(item.href) ? 'page' : undefined}
+              >
+                {item.label === 'Projects' && (
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+                )}
+                {item.label === 'My Issues' && (
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg>
+                )}
+                {item.label === 'Groups' && (
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+                )}
+                {item.label === 'Tokens' && (
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+                )}
+                <span class="link-label">{item.label}</span>
+              </a>
+              {item.glossaryId && <GlossaryHelp client:load id={item.glossaryId} />}
+            </span>
           ))}
         </nav>
 
         <div class="sidebar-spacer"></div>
 
         <div class="sidebar-footer">
+          <a href="/help" class="theme-toggle" aria-label="Help — glossary of terms" title="Help">?</a>
           <button class="theme-toggle" aria-label="Toggle colour scheme">🌙</button>
         </div>
         <div class="sidebar-version">v{appVersion}</div>
@@ -682,7 +704,7 @@ const navItems = [
         }
 
         function bindThemeToggle() {
-          var themeBtn = document.querySelector('.theme-toggle');
+          var themeBtn = document.querySelector('button.theme-toggle');
           if (!themeBtn) return;
           updateThemeIcon(themeBtn);
           themeBtn.addEventListener('click', function () {

--- a/apps/web/src/pages/help.astro
+++ b/apps/web/src/pages/help.astro
@@ -1,0 +1,84 @@
+---
+// PROJ-395: a low-priority, opt-in reference page (not a mandatory onboarding gate —
+// contextual help at the point of confusion, e.g. GlossaryHelp toggletips, does more of
+// the work; see the industry research cited in the PR). Purely static content, so no
+// workspaceSlug/API calls needed.
+import Base from '../layouts/Base.astro';
+
+const sections = [
+  {
+    term: 'Project',
+    body: "A named body of work (e.g. “Website Redesign”). Every issue lives inside a project.",
+  },
+  {
+    term: 'Issue',
+    body: 'A single piece of work — a bug to fix, a feature to build, a task to do. The basic unit everything else is organised around.',
+  },
+  {
+    term: 'Status',
+    body: 'Where an issue is in its life: Backlog (not started) → Todo (ready to start) → In Progress (being worked on) → In Review (done, being checked) → Done.',
+  },
+  {
+    term: 'Sprint',
+    body: 'A fixed time window (often 1–2 weeks) used to plan and track a batch of issues together.',
+  },
+  {
+    term: 'Epic',
+    body: 'A large body of work broken down into several smaller, related issues.',
+  },
+  {
+    term: 'Priority',
+    body: 'How urgent an issue is: Urgent, High, Medium, Low, or None.',
+  },
+  {
+    term: 'Groups',
+    body: 'Teams of members that share the same project access permissions.',
+  },
+  {
+    term: 'Tokens',
+    body: 'API keys that let external tools or AI agents act on your behalf.',
+  },
+  {
+    term: 'Comments',
+    body: 'Discussion and updates attached to an issue — including the completion report an agent or teammate leaves when their work is ready to check.',
+  },
+];
+---
+<Base title="Help — Projektor">
+  <div class="page-container" style="max-width: 42rem;">
+    <header style="margin-bottom: 1.5rem;">
+      <h1 style="margin: 0 0 0.5rem; font-size: 1.5rem; font-weight: 700; color: var(--text);">
+        Getting started
+      </h1>
+      <p style="margin: 0; color: var(--text-muted); font-size: 0.9375rem;">
+        A quick reference for the terms used around Projektor — useful if you're new to
+        this kind of team-planning tool.
+      </p>
+    </header>
+
+    <section style="margin-bottom: 2rem;">
+      <h2 style="font-size: 1.0625rem; margin: 0 0 0.75rem;">Key concepts</h2>
+      <dl style="margin: 0; display: grid; gap: 1rem;">
+        {sections.map((s) => (
+          <div>
+            <dt style="font-weight: 600; color: var(--text-strong);">{s.term}</dt>
+            <dd style="margin: 0.25rem 0 0; color: var(--text); font-size: 0.9375rem; line-height: 1.5;">
+              {s.body}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+
+    <section>
+      <h2 style="font-size: 1.0625rem; margin: 0 0 0.75rem;">Typical workflow</h2>
+      <ol style="margin: 0; padding-left: 1.25rem; color: var(--text); font-size: 0.9375rem; line-height: 1.7;">
+        <li>Someone creates an issue describing work to do.</li>
+        <li>Issues are triaged and moved out of the Backlog once they're ready to start.</li>
+        <li>Someone — or an AI agent — picks it up and works on it (In Progress).</li>
+        <li>When the work's done, it moves to In Review for a check.</li>
+        <li>Once accepted, it's marked Done.</li>
+      </ol>
+    </section>
+  </div>
+</Base>

--- a/packages/db/migrations/0037_issue_author_kind.sql
+++ b/packages/db/migrations/0037_issue_author_kind.sql
@@ -1,0 +1,7 @@
+-- PROJ-396: issue author kind, same convention as issue_comments.author_kind (0029,
+-- PROJ-328) — stamped from the authenticated principal type at write time (Cloudflare
+-- Access JWT => human, Bearer API token => agent — see middleware/auth.ts). NULL for
+-- issues created before this column existed; there's no reliable signal to backfill
+-- principal type for those, so they're excluded from human/agent breakdowns rather
+-- than guessed.
+ALTER TABLE issues ADD COLUMN author_kind TEXT;

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -101,6 +101,11 @@ export const issues = sqliteTable(
 		createdById: text("created_by_id")
 			.notNull()
 			.references(() => users.id),
+		// PROJ-396: the authenticated principal type at write time ("human" = Cloudflare
+		// Access JWT, "agent" = Bearer API token — see middleware/auth.ts), same convention
+		// as issueComments.authorKind (PROJ-328). NULL for issues created before this column
+		// existed — no reliable signal to backfill, so they're excluded rather than guessed.
+		authorKind: text("author_kind", { enum: ["human", "agent"] }),
 		createdAt: integer("created_at").notNull(),
 		updatedAt: integer("updated_at").notNull(),
 		// Stamped when the issue enters a done-category status, cleared when it


### PR DESCRIPTION
## Summary
- **PROJ-396**: record `author_kind` (human/agent) on issues, mirroring the existing `issue_comments.author_kind` convention (PROJ-328) — derived server-side from the auth transport, never caller-supplied.
- **PROJ-395**: onboarding help page (`/help`) + inline `GlossaryHelp` toggletips on jargon nav/tab labels (Sprints, Epics, Groups, Tokens).
- **PROJ-397 / PROJ-401**: fix the mobile issue-list header row overlapping the "+ New issue" button when the issue-count label wraps to multiple lines, and make toolbar filter dropdowns full-width/stacked on mobile instead of a ragged grid.
- **PROJ-402**: add `apps/web/e2e/mobile-issue-list.spec.ts` (targets the existing `mobile` Playwright project, 375×812) covering the header-row overlap, dropdown tidiness, the mobile nav drawer, and the mobile create-issue workflow.

Reviewed by an independent Opus pass; one finding (invalid `<button>` nested inside `<a href>` in `ProjectNav.tsx`/`Base.astro`) fixed, plus a `.theme-toggle` class collision caught while fixing it.

## Test plan
- [x] `astro check` — 0 errors
- [x] `biome check` — clean
- [x] `apps/web` vitest — 336/336 passing
- [x] `apps/api` vitest — 789/789 passing (5 todo)
- [x] `playwright test --list --project=mobile mobile-issue-list` — 4 new tests parse correctly
- [ ] Live Playwright run against a dev deployment (`E2E_BASE_URL`) — not run in this environment; needs manual/CI run against a deployed instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APtmN2NhJiVFdBLCDGo9Qx