### PR TITLE
PROJ-404: feedback aggregate summary by source and app version

### DIFF
--- a/apps/api/src/routes/feedback.ts
+++ b/apps/api/src/routes/feedback.ts
@@ -6,6 +6,7 @@ import { bumpRateCounter } from "../middleware/rate-limit";
 import { ForbiddenError, NotFoundError, ValidationError } from "../services/errors";
 import {
 	convertFeedbackToIssue,
+	getFeedbackSummary,
 	hashFeedbackToken,
 	listFeedback,
 	submitFeedback,
@@ -88,6 +89,16 @@ authedRouter.get("/:id/feedback", async (c) => {
 	const sourceId = c.req.query("sourceId");
 	try {
 		return c.json(await listFeedback(ctx, { projectId, status, sourceId }));
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
+});
+
+authedRouter.get("/:id/feedback/summary", async (c) => {
+	const ctx = ctxFromHono(c);
+	const projectId = c.req.param("id");
+	try {
+		return c.json(await getFeedbackSummary(ctx, { projectId }));
 	} catch (e) {
 		return serviceErrToResponse(c, e);
 	}

--- a/apps/api/src/services/feedback.ts
+++ b/apps/api/src/services/feedback.ts
@@ -241,3 +241,81 @@ export async function convertFeedbackToIssue(
 
 	return issue;
 }
+
+export interface FeedbackVersionSummary {
+	appVersion: string | null;
+	totalCount: number;
+	withCommentCount: number;
+	thumbsUpPct: number | null;
+	avgFiveStar: number | null;
+	lastSeenAt: number;
+}
+
+export interface FeedbackSourceSummary {
+	sourceId: string;
+	sourceName: string | null;
+	totalCount: number;
+	versions: FeedbackVersionSummary[];
+}
+
+interface FeedbackSummaryRow {
+	source_id: string;
+	source_name: string | null;
+	app_version: string | null;
+	total: number;
+	thumbs_up: number;
+	thumbs_total: number;
+	five_star_avg: number | null;
+	five_star_total: number;
+	with_comment_count: number;
+	last_seen_at: number;
+}
+
+export async function getFeedbackSummary(
+	ctx: ServiceCtx,
+	input: { projectId: string }
+): Promise<FeedbackSourceSummary[]> {
+	const { projectId } = input;
+
+	await requireProjectInWorkspace(ctx, projectId);
+	await requireProjectAccess(ctx, projectId);
+
+	const { results } = await ctx.db
+		.prepare(
+			`SELECT
+         f.source_id, s.name AS source_name, f.app_version,
+         COUNT(*) AS total,
+         SUM(CASE WHEN f.rating_scale = 'thumbs' AND f.rating > 0 THEN 1 ELSE 0 END) AS thumbs_up,
+         SUM(CASE WHEN f.rating_scale = 'thumbs' THEN 1 ELSE 0 END) AS thumbs_total,
+         AVG(CASE WHEN f.rating_scale = 'five_star' THEN f.rating END) AS five_star_avg,
+         SUM(CASE WHEN f.rating_scale = 'five_star' THEN 1 ELSE 0 END) AS five_star_total,
+         SUM(CASE WHEN f.body IS NOT NULL AND f.body != '' THEN 1 ELSE 0 END) AS with_comment_count,
+         MAX(f.created_at) AS last_seen_at
+       FROM feedback f
+       LEFT JOIN feedback_sources s ON s.id = f.source_id
+       WHERE f.project_id = ? AND f.workspace_id = ?
+       GROUP BY f.source_id, f.app_version
+       ORDER BY last_seen_at DESC`
+		)
+		.bind(projectId, ctx.workspaceId)
+		.all<FeedbackSummaryRow>();
+
+	const bySource = new Map<string, FeedbackSourceSummary>();
+	for (const r of results ?? []) {
+		let src = bySource.get(r.source_id);
+		if (!src) {
+			src = { sourceId: r.source_id, sourceName: r.source_name, totalCount: 0, versions: [] };
+			bySource.set(r.source_id, src);
+		}
+		src.totalCount += r.total;
+		src.versions.push({
+			appVersion: r.app_version,
+			totalCount: r.total,
+			withCommentCount: r.with_comment_count,
+			thumbsUpPct: r.thumbs_total > 0 ? Math.round((r.thumbs_up / r.thumbs_total) * 100) : null,
+			avgFiveStar: r.five_star_total > 0 ? r.five_star_avg : null,
+			lastSeenAt: r.last_seen_at,
+		});
+	}
+	return Array.from(bySource.values());
+}

--- a/apps/api/src/test/feedback-summary.test.ts
+++ b/apps/api/src/test/feedback-summary.test.ts
@@ -1,0 +1,167 @@
+import { env, SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { authHeaders, seedProjectFixture } from "./helpers";
+
+async function mintSource(
+	f: { projectId: string; token: string; slug: string },
+	body: Record<string, unknown> = { name: "Widget" }
+): Promise<string> {
+	const res = await SELF.fetch(`http://localhost/api/projects/${f.projectId}/feedback-sources`, {
+		method: "POST",
+		headers: authHeaders(f.token, f.slug),
+		body: JSON.stringify(body),
+	});
+	return ((await res.json()) as { token: string }).token;
+}
+
+async function seedFeedbackRow(
+	sourceId: string,
+	workspaceId: string,
+	projectId: string,
+	opts: {
+		rating?: number;
+		ratingScale?: string;
+		body?: string;
+		appVersion?: string;
+		createdAt?: number;
+	} = {}
+): Promise<string> {
+	const id = crypto.randomUUID();
+	const now = opts.createdAt ?? Math.floor(Date.now() / 1000);
+	await env.DB.prepare(
+		`INSERT INTO feedback
+       (id, source_id, workspace_id, project_id, rating, rating_scale, body, app_version, status, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'new', ?)`
+	)
+		.bind(
+			id,
+			sourceId,
+			workspaceId,
+			projectId,
+			opts.rating ?? null,
+			opts.ratingScale ?? null,
+			opts.body ?? null,
+			opts.appVersion ?? null,
+			now
+		)
+		.run();
+	return id;
+}
+
+describe("GET /api/projects/:id/feedback/summary", () => {
+	it("aggregates thumbs %, five-star avg, and comment counts per source+version", async () => {
+		const f = await seedProjectFixture({ role: "owner" });
+		await mintSource(f, { name: "Widget A" });
+		const src = await env.DB.prepare("SELECT id FROM feedback_sources WHERE project_id = ?")
+			.bind(f.projectId)
+			.first<{ id: string }>();
+
+		// v1.0.0: 2 thumbs up, 1 thumbs down, 1 with a comment
+		await seedFeedbackRow(src!.id, f.workspaceId, f.projectId, {
+			rating: 1,
+			ratingScale: "thumbs",
+			appVersion: "v1.0.0",
+			createdAt: 100,
+		});
+		await seedFeedbackRow(src!.id, f.workspaceId, f.projectId, {
+			rating: 1,
+			ratingScale: "thumbs",
+			appVersion: "v1.0.0",
+			body: "Love it",
+			createdAt: 101,
+		});
+		await seedFeedbackRow(src!.id, f.workspaceId, f.projectId, {
+			rating: -1,
+			ratingScale: "thumbs",
+			appVersion: "v1.0.0",
+			createdAt: 102,
+		});
+		// v1.1.0 (more recent): 5-star avg of 4.5
+		await seedFeedbackRow(src!.id, f.workspaceId, f.projectId, {
+			rating: 4,
+			ratingScale: "five_star",
+			appVersion: "v1.1.0",
+			createdAt: 200,
+		});
+		await seedFeedbackRow(src!.id, f.workspaceId, f.projectId, {
+			rating: 5,
+			ratingScale: "five_star",
+			appVersion: "v1.1.0",
+			createdAt: 201,
+		});
+
+		const res = await SELF.fetch(`http://localhost/api/projects/${f.projectId}/feedback/summary`, {
+			headers: authHeaders(f.token, f.slug),
+		});
+		expect(res.status).toBe(200);
+		const summary = (await res.json()) as Array<{
+			sourceId: string;
+			sourceName: string | null;
+			totalCount: number;
+			versions: Array<{
+				appVersion: string | null;
+				totalCount: number;
+				withCommentCount: number;
+				thumbsUpPct: number | null;
+				avgFiveStar: number | null;
+			}>;
+		}>;
+
+		expect(summary).toHaveLength(1);
+		expect(summary[0].sourceName).toBe("Widget A");
+		expect(summary[0].totalCount).toBe(5);
+		expect(summary[0].versions).toHaveLength(2);
+
+		expect(summary[0].versions[0].appVersion).toBe("v1.1.0");
+		expect(summary[0].versions[0].avgFiveStar).toBe(4.5);
+		expect(summary[0].versions[0].thumbsUpPct).toBeNull();
+		expect(summary[0].versions[0].withCommentCount).toBe(0);
+
+		expect(summary[0].versions[1].appVersion).toBe("v1.0.0");
+		expect(summary[0].versions[1].thumbsUpPct).toBe(67);
+		expect(summary[0].versions[1].avgFiveStar).toBeNull();
+		expect(summary[0].versions[1].withCommentCount).toBe(1);
+	});
+
+	it("groups rows with a null app_version under a null bucket", async () => {
+		const f = await seedProjectFixture({ role: "owner" });
+		await mintSource(f);
+		const src = await env.DB.prepare("SELECT id FROM feedback_sources WHERE project_id = ?")
+			.bind(f.projectId)
+			.first<{ id: string }>();
+		await seedFeedbackRow(src!.id, f.workspaceId, f.projectId, { body: "no version here" });
+
+		const res = await SELF.fetch(`http://localhost/api/projects/${f.projectId}/feedback/summary`, {
+			headers: authHeaders(f.token, f.slug),
+		});
+		const summary = (await res.json()) as Array<{ versions: Array<{ appVersion: string | null }> }>;
+		expect(summary[0].versions[0].appVersion).toBeNull();
+	});
+
+	it("404s for a caller with no project access", async () => {
+		const owner = await seedProjectFixture({ role: "owner" });
+		const stranger = await seedProjectFixture({ role: "owner" });
+		const res = await SELF.fetch(
+			`http://localhost/api/projects/${owner.projectId}/feedback/summary`,
+			{ headers: authHeaders(stranger.token, stranger.slug) }
+		);
+		expect(res.status).toBe(404);
+	});
+
+	it("is readable by a viewer", async () => {
+		const f = await seedProjectFixture({ role: "viewer" });
+		const res = await SELF.fetch(`http://localhost/api/projects/${f.projectId}/feedback/summary`, {
+			headers: authHeaders(f.token, f.slug),
+		});
+		expect(res.status).toBe(200);
+	});
+
+	it("returns an empty array for a project with no feedback", async () => {
+		const f = await seedProjectFixture({ role: "owner" });
+		const res = await SELF.fetch(`http://localhost/api/projects/${f.projectId}/feedback/summary`, {
+			headers: authHeaders(f.token, f.slug),
+		});
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual([]);
+	});
+});

--- a/apps/web/src/islands/FeedbackSummary.test.tsx
+++ b/apps/web/src/islands/FeedbackSummary.test.tsx
@@ -61,6 +61,13 @@ describe("FeedbackSummary", () => {
 		expect(screen.getByText(/👍 100%/)).toBeTruthy();
 	});
 
+	it("hides the comment-count badge when a version has no written feedback", async () => {
+		stubFetch();
+		render(<FeedbackSummary workspaceSlug="my-ws" projectId="p1" />);
+		await screen.findByText("Unknown version");
+		expect(screen.queryByText(/0 with comments/)).toBeNull();
+	});
+
 	it("shows an empty state when there is no feedback yet", async () => {
 		stubFetch([]);
 		render(<FeedbackSummary workspaceSlug="my-ws" projectId="p1" />);

--- a/apps/web/src/islands/FeedbackSummary.test.tsx
+++ b/apps/web/src/islands/FeedbackSummary.test.tsx
@@ -29,9 +29,9 @@ const SUMMARY = [
 ];
 
 function stubFetch(data: unknown = SUMMARY) {
-	const fetchMock = vi.fn().mockImplementation(() =>
-		Promise.resolve({ ok: true, json: () => Promise.resolve(data) })
-	);
+	const fetchMock = vi
+		.fn()
+		.mockImplementation(() => Promise.resolve({ ok: true, json: () => Promise.resolve(data) }));
 	vi.stubGlobal("fetch", fetchMock);
 	return fetchMock;
 }

--- a/apps/web/src/islands/FeedbackSummary.test.tsx
+++ b/apps/web/src/islands/FeedbackSummary.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/preact";
+import { describe, expect, it, vi } from "vitest";
+import FeedbackSummary from "./FeedbackSummary";
+
+const SUMMARY = [
+	{
+		sourceId: "s1",
+		sourceName: "Onboarding survey",
+		totalCount: 3,
+		versions: [
+			{
+				appVersion: "v1.1.0",
+				totalCount: 2,
+				withCommentCount: 1,
+				thumbsUpPct: null,
+				avgFiveStar: 4.5,
+				lastSeenAt: 200,
+			},
+			{
+				appVersion: null,
+				totalCount: 1,
+				withCommentCount: 0,
+				thumbsUpPct: 100,
+				avgFiveStar: null,
+				lastSeenAt: 100,
+			},
+		],
+	},
+];
+
+function stubFetch(data: unknown = SUMMARY) {
+	const fetchMock = vi.fn().mockImplementation(() =>
+		Promise.resolve({ ok: true, json: () => Promise.resolve(data) })
+	);
+	vi.stubGlobal("fetch", fetchMock);
+	return fetchMock;
+}
+
+describe("FeedbackSummary", () => {
+	it("renders a card per source with total count", async () => {
+		stubFetch();
+		render(<FeedbackSummary workspaceSlug="my-ws" projectId="p1" />);
+		expect(await screen.findByText("Onboarding survey")).toBeTruthy();
+		expect(screen.getByText(/3 total/i)).toBeTruthy();
+	});
+
+	it("renders avg star rating and comment count for a version", async () => {
+		stubFetch();
+		render(<FeedbackSummary workspaceSlug="my-ws" projectId="p1" />);
+		await screen.findByText("Onboarding survey");
+		expect(screen.getByText(/v1\.1\.0/)).toBeTruthy();
+		expect(screen.getByText(/4\.5★ avg/)).toBeTruthy();
+		expect(screen.getByText(/1 with comments/)).toBeTruthy();
+	});
+
+	it("renders thumbs-up % and falls back to 'Unknown version' for a null appVersion", async () => {
+		stubFetch();
+		render(<FeedbackSummary workspaceSlug="my-ws" projectId="p1" />);
+		await screen.findByText("Onboarding survey");
+		expect(screen.getByText(/Unknown version/i)).toBeTruthy();
+		expect(screen.getByText(/👍 100%/)).toBeTruthy();
+	});
+
+	it("shows an empty state when there is no feedback yet", async () => {
+		stubFetch([]);
+		render(<FeedbackSummary workspaceSlug="my-ws" projectId="p1" />);
+		expect(await screen.findByText(/No feedback yet/i)).toBeTruthy();
+	});
+});

--- a/apps/web/src/islands/FeedbackSummary.tsx
+++ b/apps/web/src/islands/FeedbackSummary.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from "preact/hooks";
+import { apiFetch } from "../utils/api-client";
+
+interface VersionSummary {
+	appVersion: string | null;
+	totalCount: number;
+	withCommentCount: number;
+	thumbsUpPct: number | null;
+	avgFiveStar: number | null;
+	lastSeenAt: number;
+}
+
+interface SourceSummary {
+	sourceId: string;
+	sourceName: string | null;
+	totalCount: number;
+	versions: VersionSummary[];
+}
+
+interface Props {
+	workspaceSlug?: string;
+	projectId?: string;
+}
+
+function versionMetric(v: VersionSummary): string {
+	const parts: string[] = [];
+	if (v.thumbsUpPct !== null) parts.push(`👍 ${v.thumbsUpPct}%`);
+	if (v.avgFiveStar !== null) parts.push(`${v.avgFiveStar.toFixed(1)}★ avg`);
+	if (parts.length === 0) parts.push("No ratings");
+	return parts.join(" · ");
+}
+
+export default function FeedbackSummary({ workspaceSlug, projectId: projectIdProp }: Props) {
+	const [projectId, setProjectId] = useState(projectIdProp ?? "");
+	useEffect(() => {
+		if (projectIdProp) return;
+		const fromUrl = new URLSearchParams(window.location.search).get("projectId");
+		if (fromUrl) setProjectId(fromUrl);
+	}, [projectIdProp]);
+
+	const [sources, setSources] = useState<SourceSummary[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (!projectId) return;
+		let cancelled = false;
+		setLoading(true);
+		setError(null);
+		apiFetch<SourceSummary[]>(`/api/projects/${projectId}/feedback/summary`, { workspaceSlug })
+			.then((data) => {
+				if (!cancelled) setSources(Array.isArray(data) ? data : []);
+			})
+			.catch((e) => {
+				if (!cancelled) setError(String(e));
+			})
+			.finally(() => {
+				if (!cancelled) setLoading(false);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [projectId, workspaceSlug]);
+
+	if (error) {
+		return (
+			<p role="alert" class="text-[var(--danger-text)]">
+				{error}
+			</p>
+		);
+	}
+	if (loading) return <p aria-live="polite">Loading summary…</p>;
+	if (sources.length === 0) {
+		return (
+			<div class="p-6 text-center text-text-muted bg-surface rounded-lg border border-border mb-4">
+				No feedback yet.
+			</div>
+		);
+	}
+
+	return (
+		<section class="mb-6 flex flex-col gap-4">
+			{sources.map((s) => (
+				<div key={s.sourceId} class="bg-surface rounded-lg border border-border p-4">
+					<div class="flex items-baseline gap-2 mb-2">
+						<h3 class="font-semibold text-text-base">{s.sourceName ?? "Untitled source"}</h3>
+						<span class="text-[0.8rem] text-text-muted">{s.totalCount} total</span>
+					</div>
+					<ul class="flex flex-col gap-1">
+						{s.versions.map((v) => (
+							<li
+								key={v.appVersion ?? "unknown"}
+								class="flex flex-wrap gap-x-3 text-[0.875rem] text-text-muted"
+							>
+								<span class="font-medium text-text-base">{v.appVersion ?? "Unknown version"}</span>
+								<span>{versionMetric(v)}</span>
+								<span>{v.withCommentCount} with comments</span>
+							</li>
+						))}
+					</ul>
+				</div>
+			))}
+		</section>
+	);
+}

--- a/apps/web/src/islands/FeedbackSummary.tsx
+++ b/apps/web/src/islands/FeedbackSummary.tsx
@@ -94,7 +94,7 @@ export default function FeedbackSummary({ workspaceSlug, projectId: projectIdPro
 							>
 								<span class="font-medium text-text-base">{v.appVersion ?? "Unknown version"}</span>
 								<span>{versionMetric(v)}</span>
-								<span>{v.withCommentCount} with comments</span>
+								{v.withCommentCount > 0 && <span>{v.withCommentCount} with comments</span>}
 							</li>
 						))}
 					</ul>

--- a/apps/web/src/pages/feedback.astro
+++ b/apps/web/src/pages/feedback.astro
@@ -2,6 +2,7 @@
 import Base from '../layouts/Base.astro';
 import ProjectNav from '../islands/ProjectNav';
 import FeedbackSourceManager from '../islands/FeedbackSourceManager';
+import FeedbackSummary from '../islands/FeedbackSummary';
 import FeedbackList from '../islands/FeedbackList';
 
 const workspaceSlug = import.meta.env.PUBLIC_WORKSPACE_SLUG as string | undefined;
@@ -10,6 +11,7 @@ const workspaceSlug = import.meta.env.PUBLIC_WORKSPACE_SLUG as string | undefine
   <ProjectNav client:load workspaceSlug={workspaceSlug} pageLabel="Feedback" />
   <div class="page-container">
     <FeedbackSourceManager client:load workspaceSlug={workspaceSlug} />
+    <FeedbackSummary client:load workspaceSlug={workspaceSlug} />
     <FeedbackList client:load workspaceSlug={workspaceSlug} />
   </div>
 </Base>


### PR DESCRIPTION
## Summary
- Adds `GET /api/projects/:id/feedback/summary` — a single grouped SQL aggregate (thumbs-up %, avg star rating, written-feedback count) per source × app version, all-time totals.
- Adds `FeedbackSummary.tsx` island rendering that as cards above the existing `/feedback` table, independent of the table's status/source filters.
- Closes PROJ-404 (child of the PROJ-398 feedback UI epic).

Design: `docs/superpowers/specs/2026-07-18-feedback-aggregate-summary-design.md`
Plan: `docs/superpowers/plans/2026-07-18-feedback-aggregate-summary.md`

## Test plan
- [x] `pnpm --filter @projektor/api test` — 796/796 passing (new `feedback-summary.test.ts`: aggregation math, null-version bucketing, access control)
- [x] `pnpm --filter @projektor/web test` — 341/341 passing (new `FeedbackSummary.test.tsx`)
- [x] `pnpm --filter @projektor/web build` — succeeds
- [x] Implemented via subagent-driven-development (3 tasks, each independently reviewed) + a final whole-branch review (opus) — Ready to merge: Yes, no Critical/Important findings
- [ ] Manual check on the dogfood instance post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fe31KJGn2YMX5JpC1UHSGV