### PR TITLE
PROJ-405: implement issue attachments (files, wiki refs, URLs)

### DIFF
--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -2,7 +2,12 @@ import type { HonoEnv } from "@projektor/types";
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { z } from "zod";
+import { serviceErrToResponse } from "../http/error-adapter";
 import { wikiPagePath } from "../lib/urls";
+import { visibleProjectSqlFragment } from "../services/access";
+import { NotFoundError } from "../services/errors";
+import { ctxFromHono } from "../services/types";
+import * as wikiService from "../services/wiki";
 
 const router = new Hono<HonoEnv>();
 
@@ -48,16 +53,27 @@ router.get("/", async (c) => {
 	if (!parsed.success) return c.json({ error: "entityType must be issue or wiki_page" }, 400);
 	if (!entityId) return c.json({ error: "entityId is required" }, 400);
 
+	// PROJ-311/PROJ-407: only join in wiki page details the caller is actually allowed to
+	// see (workspace-level pages, or project-scoped pages they have a grant on). A row
+	// referencing a page outside the caller's visibility joins to nothing, same as a
+	// deleted page — the row still lists as an unavailable wiki_ref rather than leaking
+	// the restricted page's title.
+	const ctx = ctxFromHono(c);
+	const visible = visibleProjectSqlFragment(ctx, "w.project_id");
+	const joinCond = visible
+		? `w.id = a.linked_wiki_page_id AND (w.project_id IS NULL OR ${visible.sql})`
+		: "w.id = a.linked_wiki_page_id";
+
 	const rows = await c.env.DB.prepare(
 		`SELECT a.id, a.kind, a.filename, a.content_type, a.size, a.url, a.created_at,
             w.id AS wiki_page_id, w.slug AS wiki_page_slug, w.title AS wiki_page_title,
             w.project_id AS wiki_page_project_id
      FROM attachments a
-     LEFT JOIN wiki_pages w ON w.id = a.linked_wiki_page_id
+     LEFT JOIN wiki_pages w ON ${joinCond}
      WHERE a.workspace_id = ? AND a.entity_type = ? AND a.entity_id = ?
      ORDER BY a.created_at ASC`
 	)
-		.bind(workspace.id, parsed.data, entityId)
+		.bind(...(visible ? visible.params : []), workspace.id, parsed.data, entityId)
 		.all<{
 			id: string;
 			kind: "file" | "wiki_ref" | "url";
@@ -123,12 +139,14 @@ router.post("/links", async (c) => {
 	const input = parsed.data;
 
 	if (input.kind === "wiki_ref") {
-		const wikiPage = await c.env.DB.prepare(
-			"SELECT id FROM wiki_pages WHERE id = ? AND workspace_id = ?"
-		)
-			.bind(input.wikiPageId, workspace.id)
-			.first<{ id: string }>();
-		if (!wikiPage) return c.json({ error: "Wiki page not found" }, 404);
+		// PROJ-311: getWikiPage enforces project-grant visibility, not just existence —
+		// a page in a project the caller can't see 404s the same as a nonexistent one.
+		try {
+			await wikiService.getWikiPage(ctxFromHono(c), input.wikiPageId);
+		} catch (e) {
+			if (e instanceof NotFoundError) return serviceErrToResponse(c, e);
+			throw e;
+		}
 	}
 
 	const id = crypto.randomUUID();

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -2,6 +2,7 @@ import type { HonoEnv } from "@projektor/types";
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { z } from "zod";
+import { wikiPagePath } from "../lib/urls";
 
 const router = new Hono<HonoEnv>();
 
@@ -48,29 +49,112 @@ router.get("/", async (c) => {
 	if (!entityId) return c.json({ error: "entityId is required" }, 400);
 
 	const rows = await c.env.DB.prepare(
-		`SELECT id, filename, content_type, size, created_at
-     FROM attachments
-     WHERE workspace_id = ? AND entity_type = ? AND entity_id = ?
-     ORDER BY created_at ASC`
+		`SELECT a.id, a.kind, a.filename, a.content_type, a.size, a.url, a.created_at,
+            w.id AS wiki_page_id, w.slug AS wiki_page_slug, w.title AS wiki_page_title,
+            w.project_id AS wiki_page_project_id
+     FROM attachments a
+     LEFT JOIN wiki_pages w ON w.id = a.linked_wiki_page_id
+     WHERE a.workspace_id = ? AND a.entity_type = ? AND a.entity_id = ?
+     ORDER BY a.created_at ASC`
 	)
 		.bind(workspace.id, parsed.data, entityId)
 		.all<{
 			id: string;
+			kind: "file" | "wiki_ref" | "url";
 			filename: string;
 			content_type: string;
 			size: number;
+			url: string | null;
 			created_at: number;
+			wiki_page_id: string | null;
+			wiki_page_slug: string | null;
+			wiki_page_title: string | null;
+			wiki_page_project_id: string | null;
 		}>();
 
 	return c.json(
 		(rows.results ?? []).map((r) => ({
 			id: r.id,
+			kind: r.kind,
 			filename: r.filename,
 			contentType: r.content_type,
 			size: r.size,
+			url: r.url,
 			createdAt: r.created_at,
+			wikiPage:
+				r.kind === "wiki_ref" && r.wiki_page_id
+					? {
+							id: r.wiki_page_id,
+							title: r.wiki_page_title,
+							url: wikiPagePath(r.wiki_page_slug ?? "", r.wiki_page_project_id),
+						}
+					: null,
 		}))
 	);
+});
+
+const CreateLinkAttachmentSchema = z.discriminatedUnion("kind", [
+	z.object({
+		kind: z.literal("wiki_ref"),
+		entityType: EntityTypeEnum,
+		entityId: z.string().min(1),
+		wikiPageId: z.string().min(1),
+	}),
+	z.object({
+		kind: z.literal("url"),
+		entityType: EntityTypeEnum,
+		entityId: z.string().min(1),
+		url: z
+			.string()
+			.url()
+			.refine((u) => /^https?:\/\//i.test(u), "URL must be http or https"),
+		label: z.string().trim().max(200).optional(),
+	}),
+]);
+
+router.post("/links", async (c) => {
+	const workspace = c.get("workspace") as { id: string };
+	const user = c.get("user") as { id: string };
+
+	const body = await c.req.json().catch(() => null);
+	const parsed = CreateLinkAttachmentSchema.safeParse(body);
+	if (!parsed.success)
+		return c.json({ error: parsed.error.issues[0]?.message ?? "Invalid input" }, 400);
+	const input = parsed.data;
+
+	if (input.kind === "wiki_ref") {
+		const wikiPage = await c.env.DB.prepare(
+			"SELECT id FROM wiki_pages WHERE id = ? AND workspace_id = ?"
+		)
+			.bind(input.wikiPageId, workspace.id)
+			.first<{ id: string }>();
+		if (!wikiPage) return c.json({ error: "Wiki page not found" }, 404);
+	}
+
+	const id = crypto.randomUUID();
+	const now = Math.floor(Date.now() / 1000);
+
+	await c.env.DB.prepare(
+		`INSERT INTO attachments
+       (id, workspace_id, kind, r2_key, filename, content_type, size, url, linked_wiki_page_id,
+        entity_type, entity_id, created_by_id, created_at)
+     VALUES (?, ?, ?, '', ?, '', 0, ?, ?, ?, ?, ?, ?)`
+	)
+		.bind(
+			id,
+			workspace.id,
+			input.kind,
+			input.kind === "url" ? (input.label ?? "") : "",
+			input.kind === "url" ? input.url : null,
+			input.kind === "wiki_ref" ? input.wikiPageId : null,
+			input.entityType,
+			input.entityId,
+			user.id,
+			now
+		)
+		.run();
+
+	return c.json({ id, kind: input.kind }, 201);
 });
 
 async function parseUploadFormData(c: Context<HonoEnv>) {
@@ -235,7 +319,7 @@ router.delete("/:id", async (c) => {
 
 	if (!row) return c.json({ error: "Not found" }, 404);
 
-	await c.env.R2.delete(row.r2_key);
+	if (row.r2_key) await c.env.R2.delete(row.r2_key);
 	await c.env.DB.prepare("DELETE FROM attachments WHERE id = ?").bind(id).run();
 
 	return new Response(null, { status: 204 });

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -390,6 +390,9 @@ export async function deleteWikiPage(ctx: ServiceCtx, slug: string) {
 			throw new ForbiddenError("Insufficient permissions");
 	}
 
+	// PROJ-407: mirror the migration's ON DELETE CASCADE at the app level too, since
+	// D1 does not guarantee FK enforcement is on for every connection.
+	await orm.delete(schema.attachments).where(eq(schema.attachments.linkedWikiPageId, page.id));
 	await orm.delete(schema.wikiPages).where(eq(schema.wikiPages.id, page.id));
 	await recordActivity(ctx, { entityType: "wiki_page", entityId: page.id, action: "deleted" });
 	return { ok: true };

--- a/apps/api/src/test/files.test.ts
+++ b/apps/api/src/test/files.test.ts
@@ -311,4 +311,136 @@ describe("Files API", () => {
 		const body = (await res.json()) as { error: string };
 		expect(body.error).toBe("Workspace storage quota exceeded (1024 MB)");
 	});
+
+	describe("POST /api/files/links (wiki_ref and url attachment kinds)", () => {
+		async function createWikiPage(headers: Record<string, string>) {
+			const res = await SELF.fetch("http://localhost/api/wiki", {
+				method: "POST",
+				headers: { ...headers, "Content-Type": "application/json" },
+				body: JSON.stringify({ title: "Linked page", content: "hello" }),
+			});
+			const body = (await res.json()) as { id: string };
+			return body.id;
+		}
+
+		it("attaches a wiki page reference and lists it with title/url", async () => {
+			const headers = { ...authHeaders(token, slug), "Content-Type": "application/json" };
+			const wikiPageId = await createWikiPage(headers);
+
+			const res = await SELF.fetch("http://localhost/api/files/links", {
+				method: "POST",
+				headers,
+				body: JSON.stringify({
+					kind: "wiki_ref",
+					entityType: "issue",
+					entityId: ENTITY_ID,
+					wikiPageId,
+				}),
+			});
+			expect(res.status).toBe(201);
+
+			const listRes = await SELF.fetch(
+				`http://localhost/api/files?entityType=issue&entityId=${ENTITY_ID}`,
+				{ headers: authHeaders(token, slug) }
+			);
+			const list = (await listRes.json()) as Array<{
+				kind: string;
+				wikiPage: { id: string; title: string; url: string } | null;
+			}>;
+			const entry = list.find((l) => l.kind === "wiki_ref");
+			expect(entry?.wikiPage?.title).toBe("Linked page");
+			expect(entry?.wikiPage?.id).toBe(wikiPageId);
+		});
+
+		it("rejects a wiki_ref for a non-existent wiki page → 404", async () => {
+			const res = await SELF.fetch("http://localhost/api/files/links", {
+				method: "POST",
+				headers: { ...authHeaders(token, slug), "Content-Type": "application/json" },
+				body: JSON.stringify({
+					kind: "wiki_ref",
+					entityType: "issue",
+					entityId: ENTITY_ID,
+					wikiPageId: crypto.randomUUID(),
+				}),
+			});
+			expect(res.status).toBe(404);
+		});
+
+		it("attaches a URL with a label and lists it", async () => {
+			const res = await SELF.fetch("http://localhost/api/files/links", {
+				method: "POST",
+				headers: { ...authHeaders(token, slug), "Content-Type": "application/json" },
+				body: JSON.stringify({
+					kind: "url",
+					entityType: "issue",
+					entityId: ENTITY_ID,
+					url: "https://example.com/doc",
+					label: "Design doc",
+				}),
+			});
+			expect(res.status).toBe(201);
+
+			const listRes = await SELF.fetch(
+				`http://localhost/api/files?entityType=issue&entityId=${ENTITY_ID}`,
+				{ headers: authHeaders(token, slug) }
+			);
+			const list = (await listRes.json()) as Array<{
+				kind: string;
+				filename: string;
+				url: string | null;
+			}>;
+			const entry = list.find((l) => l.kind === "url");
+			expect(entry?.filename).toBe("Design doc");
+			expect(entry?.url).toBe("https://example.com/doc");
+		});
+
+		it("rejects a malformed URL → 400", async () => {
+			const res = await SELF.fetch("http://localhost/api/files/links", {
+				method: "POST",
+				headers: { ...authHeaders(token, slug), "Content-Type": "application/json" },
+				body: JSON.stringify({
+					kind: "url",
+					entityType: "issue",
+					entityId: ENTITY_ID,
+					url: "not-a-url",
+				}),
+			});
+			expect(res.status).toBe(400);
+		});
+
+		it("rejects a non-http(s) URL scheme → 400", async () => {
+			const res = await SELF.fetch("http://localhost/api/files/links", {
+				method: "POST",
+				headers: { ...authHeaders(token, slug), "Content-Type": "application/json" },
+				body: JSON.stringify({
+					kind: "url",
+					entityType: "issue",
+					entityId: ENTITY_ID,
+					url: "javascript:alert(1)",
+				}),
+			});
+			expect(res.status).toBe(400);
+		});
+
+		it("DELETE removes a link attachment without touching R2", async () => {
+			const headers = { ...authHeaders(token, slug), "Content-Type": "application/json" };
+			const createRes = await SELF.fetch("http://localhost/api/files/links", {
+				method: "POST",
+				headers,
+				body: JSON.stringify({
+					kind: "url",
+					entityType: "issue",
+					entityId: ENTITY_ID,
+					url: "https://example.com",
+				}),
+			});
+			const { id } = (await createRes.json()) as { id: string };
+
+			const delRes = await SELF.fetch(`http://localhost/api/files/${id}`, {
+				method: "DELETE",
+				headers: authHeaders(token, slug),
+			});
+			expect(delRes.status).toBe(204);
+		});
+	});
 });

--- a/apps/api/src/test/files.test.ts
+++ b/apps/api/src/test/files.test.ts
@@ -1,6 +1,6 @@
 import { env, SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
-import { authHeaders, seedFixture } from "./helpers";
+import { authHeaders, seedFixture, seedMember, seedProject, seedToken, seedUser } from "./helpers";
 
 const ENTITY_ID = crypto.randomUUID();
 
@@ -441,6 +441,121 @@ describe("Files API", () => {
 				headers: authHeaders(token, slug),
 			});
 			expect(delRes.status).toBe(204);
+		});
+
+		it("rejects attaching a project-scoped wiki page the caller cannot see → 404", async () => {
+			// The default fixture user is a plain member with no group grant, so a
+			// freshly created project-scoped page is invisible to them (PROJ-311
+			// default-deny). Bootstrap an admin in the same workspace to create it.
+			const adminUser = await seedUser(`admin-${crypto.randomUUID()}@example.com`);
+			await seedMember(workspaceId, adminUser.id, "admin");
+			const adminToken = await seedToken(workspaceId, adminUser.id);
+
+			const project = await seedProject(workspaceId);
+			const pageRes = await SELF.fetch("http://localhost/api/wiki", {
+				method: "POST",
+				headers: authHeaders(adminToken, slug),
+				body: JSON.stringify({
+					title: "Restricted page",
+					content: "secret",
+					projectId: project.id,
+				}),
+			});
+			const { id: restrictedPageId } = (await pageRes.json()) as { id: string };
+
+			const res = await SELF.fetch("http://localhost/api/files/links", {
+				method: "POST",
+				headers: { ...authHeaders(token, slug), "Content-Type": "application/json" },
+				body: JSON.stringify({
+					kind: "wiki_ref",
+					entityType: "issue",
+					entityId: ENTITY_ID,
+					wikiPageId: restrictedPageId,
+				}),
+			});
+			expect(res.status).toBe(404);
+		});
+
+		it("does not leak a project-scoped wiki page's title to a caller without project access", async () => {
+			const adminUser = await seedUser(`admin-${crypto.randomUUID()}@example.com`);
+			await seedMember(workspaceId, adminUser.id, "admin");
+			const adminToken = await seedToken(workspaceId, adminUser.id);
+			const adminHeaders = { ...authHeaders(adminToken, slug), "Content-Type": "application/json" };
+
+			const project = await seedProject(workspaceId);
+			const pageRes = await SELF.fetch("http://localhost/api/wiki", {
+				method: "POST",
+				headers: adminHeaders,
+				body: JSON.stringify({
+					title: "Secret project page",
+					content: "secret",
+					projectId: project.id,
+				}),
+			});
+			const { id: restrictedPageId } = (await pageRes.json()) as { id: string };
+
+			// Admin attaches it to an entity — the attachment itself is workspace-visible,
+			// only the joined wiki page details should be gated.
+			const entityId = crypto.randomUUID();
+			const linkRes = await SELF.fetch("http://localhost/api/files/links", {
+				method: "POST",
+				headers: adminHeaders,
+				body: JSON.stringify({
+					kind: "wiki_ref",
+					entityType: "issue",
+					entityId,
+					wikiPageId: restrictedPageId,
+				}),
+			});
+			expect(linkRes.status).toBe(201);
+
+			const listRes = await SELF.fetch(
+				`http://localhost/api/files?entityType=issue&entityId=${entityId}`,
+				{ headers: authHeaders(token, slug) }
+			);
+			const list = (await listRes.json()) as Array<{ kind: string; wikiPage: unknown }>;
+			const entry = list.find((l) => l.kind === "wiki_ref");
+			expect(entry?.wikiPage).toBeNull();
+		});
+
+		it("deleting the linked wiki page also removes the wiki_ref attachment", async () => {
+			// Deleting a workspace-level page requires admin/owner, so create+delete
+			// through a dedicated admin rather than the default member fixture.
+			const adminUser = await seedUser(`admin-${crypto.randomUUID()}@example.com`);
+			await seedMember(workspaceId, adminUser.id, "admin");
+			const adminToken = await seedToken(workspaceId, adminUser.id);
+			const adminHeaders = { ...authHeaders(adminToken, slug), "Content-Type": "application/json" };
+
+			const pageRes = await SELF.fetch("http://localhost/api/wiki", {
+				method: "POST",
+				headers: adminHeaders,
+				body: JSON.stringify({ title: "Doomed page", content: "will be deleted" }),
+			});
+			const { id: wikiPageId, slug: wikiPageSlug } = (await pageRes.json()) as {
+				id: string;
+				slug: string;
+			};
+
+			const entityId = crypto.randomUUID();
+			const linkRes = await SELF.fetch("http://localhost/api/files/links", {
+				method: "POST",
+				headers: adminHeaders,
+				body: JSON.stringify({ kind: "wiki_ref", entityType: "issue", entityId, wikiPageId }),
+			});
+			expect(linkRes.status).toBe(201);
+
+			const delRes = await SELF.fetch(`http://localhost/api/wiki/${wikiPageSlug}`, {
+				method: "DELETE",
+				headers: adminHeaders,
+			});
+			expect(delRes.status).toBe(200);
+
+			const listRes = await SELF.fetch(
+				`http://localhost/api/files?entityType=issue&entityId=${entityId}`,
+				{ headers: adminHeaders }
+			);
+			const list = (await listRes.json()) as Array<{ kind: string }>;
+			expect(list.find((l) => l.kind === "wiki_ref")).toBeUndefined();
 		});
 	});
 });

--- a/apps/api/src/test/migrations.ts
+++ b/apps/api/src/test/migrations.ts
@@ -38,6 +38,7 @@ import m0034 from "../../../../packages/db/migrations/0034_issue_needs_audit.sql
 import m0035 from "../../../../packages/db/migrations/0035_project_slug.sql?raw";
 import m0036 from "../../../../packages/db/migrations/0036_feedback.sql?raw";
 import m0037 from "../../../../packages/db/migrations/0037_issue_author_kind.sql?raw";
+import m0038 from "../../../../packages/db/migrations/0038_attachment_kinds.sql?raw";
 
 export const MIGRATIONS = [
 	m0000,
@@ -78,4 +79,5 @@ export const MIGRATIONS = [
 	m0035,
 	m0036,
 	m0037,
+	m0038,
 ];

--- a/apps/web/e2e/issue-attachments.spec.ts
+++ b/apps/web/e2e/issue-attachments.spec.ts
@@ -1,0 +1,236 @@
+/**
+ * PROJ-405/406/407/408: Attachments panel on the issue detail page.
+ *
+ * Covers three attachment kinds surfaced in one unified "Attachments" panel:
+ *  - PROJ-406: uploaded files (upload/download/delete/reject/isolation)
+ *  - PROJ-407: wiki page references
+ *  - PROJ-408: external URLs
+ *
+ * Prerequisites: globalSetup must have written e2e/.e2e-ctx.json.
+ * Target: E2E_BASE_URL pointing at a dev deployment (ENVIRONMENT=development,
+ * DEV_USER_EMAIL set for the server-side auth bypass).
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+import type { E2EContext } from "./global-setup";
+
+function readCtx(): E2EContext {
+	const file = path.resolve(process.cwd(), "e2e", ".e2e-ctx.json");
+	if (!fs.existsSync(file)) {
+		throw new Error(
+			"e2e/.e2e-ctx.json not found — did globalSetup succeed?\n" +
+				"Run with E2E_BASE_URL set to a dev deployment.",
+		);
+	}
+	return JSON.parse(fs.readFileSync(file, "utf-8")) as E2EContext;
+}
+
+async function createIssue(request: APIRequestContext, ctx: E2EContext, title: string) {
+	const res = await request.post("/api/issues", {
+		headers: { "X-Workspace-Slug": ctx.workspaceSlug },
+		data: { projectId: ctx.grantedProjectId, title, priority: "medium" },
+	});
+	expect(res.status()).toBe(201);
+	return (await res.json()) as { id: string };
+}
+
+async function openIssue(page: Page, ctx: E2EContext, issueId: string) {
+	await page.goto(`/issues/view?id=${issueId}`);
+	await page.evaluate(
+		({ slug }: { slug: string }) => {
+			localStorage.setItem("workspace-slug", slug);
+		},
+		{ slug: ctx.workspaceSlug },
+	);
+	await page.reload();
+	await expect(page.locator("h1")).toBeVisible({ timeout: 15_000 });
+}
+
+test.describe("Issue attachments panel", () => {
+	test("file: upload, persist across reload, and delete", async ({ page, request }) => {
+		test.skip(!process.env.E2E_BASE_URL, "E2E_BASE_URL not set — skipping live deployment test");
+
+		const ctx = readCtx();
+		const issue = await createIssue(request, ctx, "E2E attachments — file happy path");
+		await openIssue(page, ctx, issue.id);
+
+		await page.locator("button", { hasText: "Attach file" }).click();
+		const fileInput = page.locator('input[type="file"]');
+		await fileInput.setInputFiles({
+			name: "e2e-note.txt",
+			mimeType: "text/plain",
+			buffer: Buffer.from("hello from e2e"),
+		});
+		await page.locator("button", { hasText: "Upload" }).click();
+
+		const row = page.locator("a", { hasText: "e2e-note.txt" });
+		await expect(row).toBeVisible({ timeout: 10_000 });
+		await expect(page.getByText(/^\d+(\.\d+)?\s?(B|KB|MB)$/)).toBeVisible();
+
+		await page.reload();
+		await expect(page.locator("a", { hasText: "e2e-note.txt" })).toBeVisible({ timeout: 10_000 });
+
+		await page.locator(`[aria-label="Remove e2e-note.txt"]`).click();
+		await expect(page.locator("a", { hasText: "e2e-note.txt" })).toHaveCount(0, { timeout: 10_000 });
+	});
+
+	test("file: disallowed type shows inline error and adds no entry", async ({ page, request }) => {
+		test.skip(!process.env.E2E_BASE_URL, "E2E_BASE_URL not set — skipping live deployment test");
+
+		const ctx = readCtx();
+		const issue = await createIssue(request, ctx, "E2E attachments — reject path");
+		await openIssue(page, ctx, issue.id);
+
+		await page.locator("button", { hasText: "Attach file" }).click();
+		await page.locator('input[type="file"]').setInputFiles({
+			name: "malware.exe",
+			mimeType: "application/x-msdownload",
+			buffer: Buffer.from("not really a virus"),
+		});
+		await page.locator("button", { hasText: "Upload" }).click();
+
+		await expect(page.getByRole("alert")).toBeVisible({ timeout: 10_000 });
+		await expect(page.locator("a", { hasText: "malware.exe" })).toHaveCount(0);
+	});
+
+	test("file: attachments are scoped per-issue", async ({ page, request }) => {
+		test.skip(!process.env.E2E_BASE_URL, "E2E_BASE_URL not set — skipping live deployment test");
+
+		const ctx = readCtx();
+		const issueA = await createIssue(request, ctx, "E2E attachments — isolation A");
+		const issueB = await createIssue(request, ctx, "E2E attachments — isolation B");
+
+		await openIssue(page, ctx, issueA.id);
+		await page.locator("button", { hasText: "Attach file" }).click();
+		await page.locator('input[type="file"]').setInputFiles({
+			name: "only-on-a.txt",
+			mimeType: "text/plain",
+			buffer: Buffer.from("scoped to issue A"),
+		});
+		await page.locator("button", { hasText: "Upload" }).click();
+		await expect(page.locator("a", { hasText: "only-on-a.txt" })).toBeVisible({ timeout: 10_000 });
+
+		await openIssue(page, ctx, issueB.id);
+		await expect(page.locator("a", { hasText: "only-on-a.txt" })).toHaveCount(0);
+	});
+
+	test("wiki page reference: attach, follow link, and remove", async ({ page, request }) => {
+		test.skip(!process.env.E2E_BASE_URL, "E2E_BASE_URL not set — skipping live deployment test");
+
+		const ctx = readCtx();
+		const pageTitle = `E2E attachment target ${Date.now()}`;
+		const wikiRes = await request.post("/api/wiki", {
+			headers: { "X-Workspace-Slug": ctx.workspaceSlug },
+			data: { title: pageTitle, content: "linked from an issue" },
+		});
+		expect(wikiRes.status()).toBe(201);
+		const wikiPage = (await wikiRes.json()) as { id: string; slug: string };
+
+		const issue = await createIssue(request, ctx, "E2E attachments — wiki ref");
+		await openIssue(page, ctx, issue.id);
+
+		await page.locator("button", { hasText: "Link wiki page" }).click();
+		await page.locator('input[placeholder="Search wiki pages…"]').fill(pageTitle);
+		const resultBtn = page.locator("button", { hasText: pageTitle });
+		await expect(resultBtn).toBeVisible({ timeout: 10_000 });
+		await resultBtn.click();
+
+		const link = page.locator("a", { hasText: pageTitle });
+		await expect(link).toBeVisible({ timeout: 10_000 });
+		await expect(link).toHaveAttribute("href", new RegExp(`slug=${wikiPage.slug}`));
+
+		await link.click();
+		await expect(page.locator("h1", { hasText: pageTitle })).toBeVisible({ timeout: 10_000 });
+		await page.goBack();
+
+		await expect(page.locator("a", { hasText: pageTitle })).toBeVisible({ timeout: 10_000 });
+		await page.locator(`[aria-label="Remove ${pageTitle}"]`).click();
+		await expect(page.locator("a", { hasText: pageTitle })).toHaveCount(0, { timeout: 10_000 });
+
+		// The wiki page itself must survive removal of the reference.
+		const checkRes = await request.get(`/api/wiki/${wikiPage.slug}`, {
+			headers: { "X-Workspace-Slug": ctx.workspaceSlug },
+		});
+		expect(checkRes.status()).toBe(200);
+	});
+
+	test("external URL: add with label, add without label, remove, and reject malformed input", async ({
+		page,
+		request,
+	}) => {
+		test.skip(!process.env.E2E_BASE_URL, "E2E_BASE_URL not set — skipping live deployment test");
+
+		const ctx = readCtx();
+		const issue = await createIssue(request, ctx, "E2E attachments — url");
+		await openIssue(page, ctx, issue.id);
+
+		// Labeled URL
+		await page.locator("button", { hasText: "Add URL" }).click();
+		await page.locator('input[type="url"]').fill("https://example.com/design-doc");
+		await page.locator('input[placeholder="Label (optional)"]').fill("Design doc");
+		await page.locator("button", { hasText: /^Add$/ }).click();
+
+		const labeledLink = page.locator("a", { hasText: "Design doc" });
+		await expect(labeledLink).toBeVisible({ timeout: 10_000 });
+		await expect(labeledLink).toHaveAttribute("target", "_blank");
+		await expect(labeledLink).toHaveAttribute("href", "https://example.com/design-doc");
+
+		// Unlabeled URL — shown as the raw URL text
+		await page.locator("button", { hasText: "Add URL" }).click();
+		await page.locator('input[type="url"]').fill("https://example.com/no-label");
+		await page.locator("button", { hasText: /^Add$/ }).click();
+		await expect(page.locator("a", { hasText: "https://example.com/no-label" })).toBeVisible({
+			timeout: 10_000,
+		});
+
+		// Malformed URL rejected
+		await page.locator("button", { hasText: "Add URL" }).click();
+		await page.locator('input[type="url"]').fill("not-a-url");
+		await page.locator("button", { hasText: /^Add$/ }).click();
+		await expect(page.getByRole("alert")).toBeVisible({ timeout: 10_000 });
+		await page.locator("button", { hasText: "Cancel" }).click();
+
+		// Remove the labeled entry
+		await page.locator(`[aria-label="Remove Design doc"]`).click();
+		await expect(page.locator("a", { hasText: "Design doc" })).toHaveCount(0, { timeout: 10_000 });
+	});
+});
+
+test.describe("Issue attachments panel — mobile (375×812)", () => {
+	test("attach controls stack full-width and stay within the viewport", async ({
+		page,
+		request,
+	}) => {
+		test.skip(!process.env.E2E_BASE_URL, "E2E_BASE_URL not set — skipping live deployment test");
+
+		const ctx = readCtx();
+		const issue = await createIssue(request, ctx, "E2E attachments — mobile layout");
+		await openIssue(page, ctx, issue.id);
+
+		const innerWidth = await page.evaluate(() => window.innerWidth);
+		expect(innerWidth).toBeLessThan(640);
+
+		const attachBtn = page.locator("button", { hasText: "Attach file" });
+		await expect(attachBtn).toBeVisible();
+		await attachBtn.click();
+
+		const chooseFile = page.locator("label span", { hasText: "Choose file" });
+		const chooseBox = await chooseFile.boundingBox();
+		const viewportSize = page.viewportSize();
+		if (!chooseBox || !viewportSize) throw new Error("boundingBox()/viewportSize() null");
+
+		// Full-width control leaves only the page's horizontal padding on either side.
+		expect(chooseBox.width).toBeGreaterThan(viewportSize.width * 0.7);
+		expect(chooseBox.x + chooseBox.width).toBeLessThanOrEqual(viewportSize.width);
+
+		// Touch targets meet the 44px minimum.
+		expect(chooseBox.height).toBeGreaterThanOrEqual(44);
+
+		const uploadBtn = page.locator("button", { hasText: "Upload" });
+		const uploadBox = await uploadBtn.boundingBox();
+		if (!uploadBox) throw new Error("boundingBox() returned null");
+		expect(uploadBox.height).toBeGreaterThanOrEqual(44);
+	});
+});

--- a/apps/web/src/islands/IssueDetailParts.tsx
+++ b/apps/web/src/islands/IssueDetailParts.tsx
@@ -1,4 +1,4 @@
-import { useState } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
 import { formatIssueRef, isValidIssueRef, normalizeIssueRef } from "../lib/issue-ref";
 import { parseStoryPoints } from "../lib/story-points";
 import { apiFetch } from "../utils/api-client";
@@ -723,6 +723,60 @@ export function RelationsSection({
 	);
 }
 
+const FileIcon = () => (
+	<svg
+		width="14"
+		height="14"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		class="shrink-0"
+	>
+		<title>File</title>
+		<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+		<path d="M14 2v6h6" />
+	</svg>
+);
+
+const WikiIcon = () => (
+	<svg
+		width="14"
+		height="14"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		class="shrink-0"
+	>
+		<title>Wiki page</title>
+		<path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+		<path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+	</svg>
+);
+
+const LinkIcon = () => (
+	<svg
+		width="14"
+		height="14"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		class="shrink-0"
+	>
+		<title>External link</title>
+		<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+		<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+	</svg>
+);
+
 function AttachmentRow({
 	attachment,
 	workspaceSlug,
@@ -733,22 +787,46 @@ function AttachmentRow({
 	onDelete: () => void;
 }) {
 	const qs = workspaceSlug ? `?workspace=${workspaceSlug}` : "";
+
+	let icon: preact.ComponentChildren;
+	let href: string;
+	let label: string;
+	let meta: string | null = null;
+	let external = false;
+
+	if (attachment.kind === "wiki_ref" && attachment.wikiPage) {
+		icon = <WikiIcon />;
+		href = attachment.wikiPage.url;
+		label = attachment.wikiPage.title;
+	} else if (attachment.kind === "url" && attachment.url) {
+		icon = <LinkIcon />;
+		href = attachment.url;
+		label = attachment.filename || attachment.url;
+		external = true;
+	} else {
+		icon = <FileIcon />;
+		href = `/api/files/${attachment.id}${qs}`;
+		label = attachment.filename;
+		meta = formatBytes(attachment.size);
+		external = true;
+	}
+
 	return (
-		<div class="flex items-center gap-3 px-3 py-2 border border-border rounded-md bg-surface">
+		<div class="flex items-center gap-3 px-3 py-2 border border-border rounded-md bg-surface min-h-[44px]">
+			<span class="text-text-muted">{icon}</span>
 			<a
-				href={`/api/files/${attachment.id}${qs}`}
-				target="_blank"
-				rel="noreferrer"
+				href={href}
+				{...(external ? { target: "_blank", rel: "noreferrer" } : {})}
 				class="text-accent text-sm no-underline hover:underline flex-1 min-w-0 truncate"
 			>
-				{attachment.filename}
+				{label}
 			</a>
-			<span class="text-xs text-text-muted shrink-0">{formatBytes(attachment.size)}</span>
+			{meta && <span class="text-xs text-text-muted shrink-0">{meta}</span>}
 			<button
 				type="button"
 				onClick={onDelete}
-				aria-label={`Delete ${attachment.filename}`}
-				class="btn btn-sm bg-transparent border-none text-text-muted px-[0.125rem] leading-none"
+				aria-label={`Remove ${label}`}
+				class="btn btn-sm bg-transparent border-none text-text-muted px-[0.125rem] leading-none min-h-[44px] min-w-[44px]"
 			>
 				×
 			</button>
@@ -774,8 +852,8 @@ function AttachmentUploadForm({
 	onCancel: () => void;
 }) {
 	return (
-		<div class="flex flex-wrap gap-2 items-center">
-			<label class="relative cursor-pointer">
+		<div class="flex flex-wrap gap-2 items-center max-sm:flex-col max-sm:items-stretch">
+			<label class="relative cursor-pointer max-sm:w-full">
 				<input
 					type="file"
 					class="sr-only"
@@ -785,19 +863,27 @@ function AttachmentUploadForm({
 						setUploadError(null);
 					}}
 				/>
-				<span class="btn btn-outline btn-sm">{uploadFile ? uploadFile.name : "Choose file"}</span>
+				<span class="btn btn-outline btn-sm max-sm:w-full max-sm:min-h-[44px] truncate block text-center">
+					{uploadFile ? uploadFile.name : "Choose file"}
+				</span>
 			</label>
-			<button
-				type="button"
-				onClick={onUpload}
-				disabled={!uploadFile || uploading}
-				class="btn btn-primary"
-			>
-				{uploading ? "Uploading…" : "Upload"}
-			</button>
-			<button type="button" onClick={onCancel} class="btn btn-outline">
-				Cancel
-			</button>
+			<div class="flex gap-2 max-sm:w-full">
+				<button
+					type="button"
+					onClick={onUpload}
+					disabled={!uploadFile || uploading}
+					class="btn btn-primary max-sm:flex-1 max-sm:min-h-[44px]"
+				>
+					{uploading ? "Uploading…" : "Upload"}
+				</button>
+				<button
+					type="button"
+					onClick={onCancel}
+					class="btn btn-outline max-sm:flex-1 max-sm:min-h-[44px]"
+				>
+					Cancel
+				</button>
+			</div>
 			{uploadError && (
 				<span role="alert" class="text-[0.8rem] text-[var(--danger-text)] self-center">
 					{uploadError}
@@ -806,6 +892,191 @@ function AttachmentUploadForm({
 		</div>
 	);
 }
+
+interface WikiSearchResult {
+	id: string;
+	slug: string;
+	title: string;
+	project_id: string | null;
+}
+
+function WikiPageLinkForm({
+	workspaceSlug,
+	linking,
+	linkError,
+	setLinkError,
+	onLink,
+	onCancel,
+}: {
+	workspaceSlug?: string;
+	linking: boolean;
+	linkError: string | null;
+	setLinkError: (e: string | null) => void;
+	onLink: (wikiPageId: string) => void;
+	onCancel: () => void;
+}) {
+	const [query, setQuery] = useState("");
+	const [results, setResults] = useState<WikiSearchResult[]>([]);
+	const [searching, setSearching] = useState(false);
+
+	useEffect(() => {
+		if (!query.trim()) {
+			setResults([]);
+			return;
+		}
+		let cancelled = false;
+		setSearching(true);
+		const timer = setTimeout(async () => {
+			try {
+				const qs = new URLSearchParams({ q: query.trim() });
+				const data = await apiFetch<WikiSearchResult[]>(`/api/wiki/search?${qs}`, {
+					workspaceSlug,
+				});
+				if (!cancelled) setResults(Array.isArray(data) ? data : []);
+			} catch {
+				if (!cancelled) setResults([]);
+			} finally {
+				if (!cancelled) setSearching(false);
+			}
+		}, 250);
+		return () => {
+			cancelled = true;
+			clearTimeout(timer);
+		};
+	}, [query, workspaceSlug]);
+
+	return (
+		<div class="flex flex-col gap-2 max-w-sm max-sm:max-w-none">
+			<input
+				type="text"
+				value={query}
+				onInput={(e) => {
+					setQuery((e.target as HTMLInputElement).value);
+					setLinkError(null);
+				}}
+				onKeyDown={(e) => {
+					if (e.key === "Escape") onCancel();
+				}}
+				placeholder="Search wiki pages…"
+				// biome-ignore lint/a11y/noAutofocus: intentional focus when the inline picker opens
+				autoFocus
+				disabled={linking}
+				class="px-[0.625rem] py-[0.5rem] border border-border rounded text-sm bg-bg text-text-base min-h-[44px]"
+			/>
+			{searching && <p class="text-xs text-text-muted m-0">Searching…</p>}
+			{results.length > 0 && (
+				<ul class="list-none m-0 p-0 flex flex-col gap-1 max-h-56 overflow-y-auto">
+					{results.map((r) => (
+						<li key={r.id}>
+							<button
+								type="button"
+								disabled={linking}
+								onClick={() => onLink(r.id)}
+								class="w-full text-left px-[0.625rem] py-2 border border-border rounded text-sm
+									bg-surface hover:bg-bg transition-colors min-h-[44px]"
+							>
+								{r.title}
+							</button>
+						</li>
+					))}
+				</ul>
+			)}
+			<div class="flex gap-2">
+				<button type="button" onClick={onCancel} disabled={linking} class="btn btn-outline btn-sm">
+					Cancel
+				</button>
+			</div>
+			{linkError && (
+				<span role="alert" class="text-[0.8rem] text-[var(--danger-text)]">
+					{linkError}
+				</span>
+			)}
+		</div>
+	);
+}
+
+function UrlLinkForm({
+	urlValue,
+	setUrlValue,
+	labelValue,
+	setLabelValue,
+	linkError,
+	setLinkError,
+	linking,
+	onAdd,
+	onCancel,
+}: {
+	urlValue: string;
+	setUrlValue: (v: string) => void;
+	labelValue: string;
+	setLabelValue: (v: string) => void;
+	linkError: string | null;
+	setLinkError: (e: string | null) => void;
+	linking: boolean;
+	onAdd: () => void;
+	onCancel: () => void;
+}) {
+	return (
+		<div class="flex flex-wrap gap-2 items-start max-sm:flex-col">
+			<input
+				type="url"
+				value={urlValue}
+				onInput={(e) => {
+					setUrlValue((e.target as HTMLInputElement).value);
+					setLinkError(null);
+				}}
+				onKeyDown={(e) => {
+					if (e.key === "Enter") onAdd();
+					if (e.key === "Escape") onCancel();
+				}}
+				placeholder="https://example.com/…"
+				// biome-ignore lint/a11y/noAutofocus: intentional focus when the inline editor opens
+				autoFocus
+				disabled={linking}
+				class="px-[0.625rem] py-[0.375rem] border border-border rounded text-sm flex-1 min-w-[10rem]
+					max-sm:w-full bg-bg text-text-base min-h-[44px]"
+			/>
+			<input
+				type="text"
+				value={labelValue}
+				onInput={(e) => setLabelValue((e.target as HTMLInputElement).value)}
+				onKeyDown={(e) => {
+					if (e.key === "Enter") onAdd();
+					if (e.key === "Escape") onCancel();
+				}}
+				placeholder="Label (optional)"
+				disabled={linking}
+				class="px-[0.625rem] py-[0.375rem] border border-border rounded text-sm w-40
+					max-sm:w-full bg-bg text-text-base min-h-[44px]"
+			/>
+			<div class="flex gap-2 max-sm:w-full">
+				<button
+					type="button"
+					onClick={onAdd}
+					disabled={linking || !urlValue.trim()}
+					class="btn btn-primary max-sm:flex-1 max-sm:min-h-[44px]"
+				>
+					{linking ? "Adding…" : "Add"}
+				</button>
+				<button
+					type="button"
+					onClick={onCancel}
+					disabled={linking}
+					class="btn btn-outline max-sm:flex-1 max-sm:min-h-[44px]"
+				>
+					Cancel
+				</button>
+			</div>
+			{linkError && (
+				<span role="alert" class="text-[0.8rem] text-[var(--danger-text)] self-center">
+					{linkError}
+				</span>
+			)}
+		</div>
+	);
+}
+
+type AttachMode = "none" | "file" | "wiki" | "url";
 
 export function AttachmentsSection({
 	issueId,
@@ -818,10 +1089,25 @@ export function AttachmentsSection({
 	attachments: Attachment[];
 	fetchAttachments: () => Promise<void>;
 }) {
-	const [uploadFormOpen, setUploadFormOpen] = useState(false);
+	const [mode, setMode] = useState<AttachMode>("none");
+
 	const [uploadFile, setUploadFile] = useState<File | null>(null);
 	const [uploading, setUploading] = useState(false);
 	const [uploadError, setUploadError] = useState<string | null>(null);
+
+	const [linking, setLinking] = useState(false);
+	const [linkError, setLinkError] = useState<string | null>(null);
+	const [urlValue, setUrlValue] = useState("");
+	const [labelValue, setLabelValue] = useState("");
+
+	function resetForms() {
+		setMode("none");
+		setUploadFile(null);
+		setUploadError(null);
+		setLinkError(null);
+		setUrlValue("");
+		setLabelValue("");
+	}
 
 	async function uploadAttachment() {
 		if (!uploadFile) return;
@@ -833,13 +1119,55 @@ export function AttachmentsSection({
 			form.append("entityType", "issue");
 			form.append("entityId", issueId);
 			await apiFetch("/api/files", { workspaceSlug, method: "POST", body: form });
-			setUploadFile(null);
-			setUploadFormOpen(false);
+			resetForms();
 			await fetchAttachments();
 		} catch (e) {
 			setUploadError(String(e));
 		} finally {
 			setUploading(false);
+		}
+	}
+
+	async function linkWikiPage(wikiPageId: string) {
+		setLinking(true);
+		setLinkError(null);
+		try {
+			await apiFetch("/api/files/links", {
+				workspaceSlug,
+				method: "POST",
+				body: { kind: "wiki_ref", entityType: "issue", entityId: issueId, wikiPageId },
+			});
+			resetForms();
+			await fetchAttachments();
+		} catch (e) {
+			setLinkError(String(e));
+		} finally {
+			setLinking(false);
+		}
+	}
+
+	async function addUrl() {
+		if (!urlValue.trim()) return;
+		setLinking(true);
+		setLinkError(null);
+		try {
+			await apiFetch("/api/files/links", {
+				workspaceSlug,
+				method: "POST",
+				body: {
+					kind: "url",
+					entityType: "issue",
+					entityId: issueId,
+					url: urlValue.trim(),
+					label: labelValue.trim() || undefined,
+				},
+			});
+			resetForms();
+			await fetchAttachments();
+		} catch (e) {
+			setLinkError(String(e));
+		} finally {
+			setLinking(false);
 		}
 	}
 
@@ -871,7 +1199,7 @@ export function AttachmentsSection({
 				</div>
 			)}
 
-			{uploadFormOpen ? (
+			{mode === "file" && (
 				<AttachmentUploadForm
 					uploadFile={uploadFile}
 					setUploadFile={setUploadFile}
@@ -879,21 +1207,60 @@ export function AttachmentsSection({
 					setUploadError={setUploadError}
 					uploading={uploading}
 					onUpload={uploadAttachment}
-					onCancel={() => {
-						setUploadFormOpen(false);
-						setUploadFile(null);
-						setUploadError(null);
-					}}
+					onCancel={resetForms}
 				/>
-			) : (
-				<button
-					type="button"
-					onClick={() => setUploadFormOpen(true)}
-					class="text-sm text-text-muted hover:text-text-base transition-colors flex items-center gap-1"
-				>
-					<span class="text-base leading-none">+</span>
-					<span>Attach file</span>
-				</button>
+			)}
+			{mode === "wiki" && (
+				<WikiPageLinkForm
+					workspaceSlug={workspaceSlug}
+					linking={linking}
+					linkError={linkError}
+					setLinkError={setLinkError}
+					onLink={linkWikiPage}
+					onCancel={resetForms}
+				/>
+			)}
+			{mode === "url" && (
+				<UrlLinkForm
+					urlValue={urlValue}
+					setUrlValue={setUrlValue}
+					labelValue={labelValue}
+					setLabelValue={setLabelValue}
+					linkError={linkError}
+					setLinkError={setLinkError}
+					linking={linking}
+					onAdd={addUrl}
+					onCancel={resetForms}
+				/>
+			)}
+
+			{mode === "none" && (
+				<div class="flex flex-wrap gap-x-4 gap-y-2 max-sm:flex-col max-sm:gap-2">
+					<button
+						type="button"
+						onClick={() => setMode("file")}
+						class="text-sm text-text-muted hover:text-text-base transition-colors flex items-center gap-1 max-sm:min-h-[44px]"
+					>
+						<span class="text-base leading-none">+</span>
+						<span>Attach file</span>
+					</button>
+					<button
+						type="button"
+						onClick={() => setMode("wiki")}
+						class="text-sm text-text-muted hover:text-text-base transition-colors flex items-center gap-1 max-sm:min-h-[44px]"
+					>
+						<span class="text-base leading-none">+</span>
+						<span>Link wiki page</span>
+					</button>
+					<button
+						type="button"
+						onClick={() => setMode("url")}
+						class="text-sm text-text-muted hover:text-text-base transition-colors flex items-center gap-1 max-sm:min-h-[44px]"
+					>
+						<span class="text-base leading-none">+</span>
+						<span>Add URL</span>
+					</button>
+				</div>
 			)}
 		</section>
 	);

--- a/apps/web/src/islands/IssueDetailParts.tsx
+++ b/apps/web/src/islands/IssueDetailParts.tsx
@@ -789,7 +789,7 @@ function AttachmentRow({
 	const qs = workspaceSlug ? `?workspace=${workspaceSlug}` : "";
 
 	let icon: preact.ComponentChildren;
-	let href: string;
+	let href: string | null;
 	let label: string;
 	let meta: string | null = null;
 	let external = false;
@@ -803,24 +803,34 @@ function AttachmentRow({
 		href = attachment.url;
 		label = attachment.filename || attachment.url;
 		external = true;
-	} else {
+	} else if (attachment.kind === "file") {
 		icon = <FileIcon />;
 		href = `/api/files/${attachment.id}${qs}`;
 		label = attachment.filename;
 		meta = formatBytes(attachment.size);
 		external = true;
+	} else {
+		// A wiki_ref whose target page was deleted, or is no longer visible to this
+		// user (project access revoked) — the join comes back empty either way.
+		icon = <WikiIcon />;
+		href = null;
+		label = "Wiki page unavailable";
 	}
 
 	return (
 		<div class="flex items-center gap-3 px-3 py-2 border border-border rounded-md bg-surface min-h-[44px]">
 			<span class="text-text-muted">{icon}</span>
-			<a
-				href={href}
-				{...(external ? { target: "_blank", rel: "noreferrer" } : {})}
-				class="text-accent text-sm no-underline hover:underline flex-1 min-w-0 truncate"
-			>
-				{label}
-			</a>
+			{href ? (
+				<a
+					href={href}
+					{...(external ? { target: "_blank", rel: "noreferrer" } : {})}
+					class="text-accent text-sm no-underline hover:underline flex-1 min-w-0 truncate"
+				>
+					{label}
+				</a>
+			) : (
+				<span class="text-text-muted text-sm italic flex-1 min-w-0 truncate">{label}</span>
+			)}
 			{meta && <span class="text-xs text-text-muted shrink-0">{meta}</span>}
 			<button
 				type="button"
@@ -982,7 +992,12 @@ function WikiPageLinkForm({
 				</ul>
 			)}
 			<div class="flex gap-2">
-				<button type="button" onClick={onCancel} disabled={linking} class="btn btn-outline btn-sm">
+				<button
+					type="button"
+					onClick={onCancel}
+					disabled={linking}
+					class="btn btn-outline btn-sm max-sm:flex-1 max-sm:min-h-[44px]"
+				>
 					Cancel
 				</button>
 			</div>

--- a/apps/web/src/islands/issue-detail-helpers.ts
+++ b/apps/web/src/islands/issue-detail-helpers.ts
@@ -27,10 +27,13 @@ export interface IssueLink {
 
 export interface Attachment {
 	id: string;
+	kind: "file" | "wiki_ref" | "url";
 	filename: string;
 	contentType: string;
 	size: number;
+	url: string | null;
 	createdAt: number;
+	wikiPage: { id: string; title: string; url: string } | null;
 }
 
 export interface IssueData {

--- a/docs/superpowers/specs/2026-07-18-issue-attachments-design.md
+++ b/docs/superpowers/specs/2026-07-18-issue-attachments-design.md
@@ -1,0 +1,71 @@
+# Attach items to issues
+
+## Context
+
+Projektor issues currently support two attachment-like mechanisms that already ship: uploaded **file attachments** (`packages/db/src/schema/attachments.ts`, `apps/api/src/routes/files.ts`, surfaced in `apps/web/src/islands/IssueDetail.tsx`, with backend coverage in `apps/api/src/test/files.test.ts`) and **issue-to-issue links** (`issue_links` table, `create_issue_link` MCP tool). Neither has been checked recently against the request "let people attach items to issues" without first confirming what exists — this spec is the result of that check.
+
+Two gaps remain:
+1. File attachments have zero Playwright (e2e) coverage — only backend integration tests.
+2. There is no way to attach a **reference** to a wiki page or an **external URL** to an issue. (Uploading a wiki page as a *file* is technically possible via the existing `entityType: wiki_page` attachment, but that's unrelated — it attaches a file to a wiki page, not a wiki-page link to an issue.)
+
+## Scope
+
+One epic, three sub-tickets, filed under project **PROJ** (Projektor), workspace `ws-projektor`.
+
+### 1. E2E coverage: file attachments (no new product code)
+
+The feature already works. This ticket adds Playwright coverage only.
+
+**Acceptance criteria** (documents existing behavior the e2e suite must verify):
+1. From an issue detail page, a user can click "Attach file", choose a file, and upload it — it appears in the Attachments list with filename + size.
+2. Clicking an attachment's filename opens/downloads it (image types render inline, other types download).
+3. A user can delete an attachment via its remove control; it disappears from the list immediately.
+4. Uploading a disallowed file type or an oversized file shows an inline error (`role="alert"`) and does not add a list entry.
+5. Attachments are scoped to the issue — switching to a different issue shows a different, non-overlapping attachment list.
+
+**Playwright test plan** (`apps/web/e2e/issue-attachments.spec.ts`, following `wiki-flow.spec.ts` conventions — `E2E_BASE_URL`-gated, reads `.e2e-ctx.json`):
+1. Happy path: open an issue → attach a file → assert it appears with correct filename/size → reload the page → assert it persists → delete it → assert it's gone.
+2. Reject path: attempt to upload a disallowed file type → assert inline error, no list entry added.
+3. Isolation: attach a file to issue A, open issue B, assert A's attachment is not visible on B.
+
+### 2. Attach a wiki page reference to an issue
+
+**Acceptance criteria:**
+1. From the issue's Attachments panel, a user can search/pick a wiki page from the workspace and attach it as a reference (no file upload involved).
+2. The reference appears in the same Attachments list as files, with a distinguishing icon and the wiki page's title.
+3. Clicking the reference navigates to the wiki page.
+4. Any workspace member can remove the reference from the issue; it disappears immediately and does not delete the underlying wiki page.
+5. References are scoped per-issue, same as file attachments.
+
+**Playwright test plan** (extends `issue-attachments.spec.ts` or a sibling file):
+1. Attach a wiki page → assert list entry with correct title → click through to the wiki page → navigate back → assert entry still present.
+2. Remove the reference → assert it's gone from the list and the wiki page itself still exists (unaffected).
+
+### 3. Attach an external URL to an issue
+
+**Acceptance criteria:**
+1. From the issue's Attachments panel, a user can add an external URL with an optional label.
+2. The entry appears in the Attachments list showing the label if provided, otherwise the URL itself; opens in a new tab (`target="_blank"`).
+3. Submitting a malformed URL (not `http://`/`https://`) shows an inline error and does not add an entry.
+4. Any workspace member can remove the URL entry; it disappears immediately.
+5. URL attachments are scoped per-issue, same as file attachments.
+
+**Playwright test plan:**
+1. Add a URL with a label → assert entry shows the label and links to the correct `target="_blank"` URL.
+2. Add a URL without a label → assert the URL itself is shown as the entry text.
+3. Remove an entry → assert it's gone.
+4. Submit a malformed URL → assert inline error, no entry added.
+
+## Data model note
+
+Sub-tickets 2 and 3 extend the existing unified Attachments panel rather than introducing separate UI sections. This likely means extending `attachments.entityType`/adding a `kind` discriminator (`file | wiki_ref | url`) so all three render from one list, keyed by `(workspaceId, entityType, entityId)` as today. The exact schema shape (new column vs. new table) is left to the implementation plan for each sub-ticket, not fixed here.
+
+## Permissions
+
+Any workspace member can add or remove any attachment kind on an issue they can view — consistent with projektor's existing collaborative model (matches commenting).
+
+## Out of scope
+
+- Issue-to-issue linking as an "attachment" — already covered by the existing `issue_links` feature; not duplicated here.
+- Versioning/history of attachments (e.g. re-uploading a file to replace one) — not requested.
+- Per-file or per-attachment-kind granular permissions beyond "any workspace member" — not requested.

--- a/packages/db/migrations/0038_attachment_kinds.sql
+++ b/packages/db/migrations/0038_attachment_kinds.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `attachments` ADD `kind` text DEFAULT 'file' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `attachments` ADD `url` text;
+--> statement-breakpoint
+ALTER TABLE `attachments` ADD `linked_wiki_page_id` text REFERENCES wiki_pages(id);

--- a/packages/db/migrations/0038_attachment_kinds.sql
+++ b/packages/db/migrations/0038_attachment_kinds.sql
@@ -2,4 +2,4 @@ ALTER TABLE `attachments` ADD `kind` text DEFAULT 'file' NOT NULL;
 --> statement-breakpoint
 ALTER TABLE `attachments` ADD `url` text;
 --> statement-breakpoint
-ALTER TABLE `attachments` ADD `linked_wiki_page_id` text REFERENCES wiki_pages(id);
+ALTER TABLE `attachments` ADD `linked_wiki_page_id` text REFERENCES wiki_pages(id) ON DELETE CASCADE;

--- a/packages/db/src/schema/attachments.ts
+++ b/packages/db/src/schema/attachments.ts
@@ -1,5 +1,6 @@
 import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { users, workspaces } from "./core";
+import { wikiPages } from "./wiki";
 
 export const attachments = sqliteTable(
 	"attachments",
@@ -8,10 +9,21 @@ export const attachments = sqliteTable(
 		workspaceId: text("workspace_id")
 			.notNull()
 			.references(() => workspaces.id, { onDelete: "cascade" }),
+		// "file" = uploaded to R2 (r2Key/contentType/size populated); "wiki_ref" = reference to a
+		// wiki page (linkedWikiPageId populated); "url" = external link (url populated, filename
+		// holds the optional display label). Unused columns for a given kind are "" / 0, not null,
+		// since D1/SQLite can't cheaply relax NOT NULL on existing columns via ALTER TABLE.
+		kind: text("kind", { enum: ["file", "wiki_ref", "url"] })
+			.notNull()
+			.default("file"),
 		r2Key: text("r2_key").notNull(),
 		filename: text("filename").notNull(),
 		contentType: text("content_type").notNull(),
 		size: integer("size").notNull(),
+		url: text("url"),
+		linkedWikiPageId: text("linked_wiki_page_id").references(() => wikiPages.id, {
+			onDelete: "cascade",
+		}),
 		entityType: text("entity_type", { enum: ["issue", "wiki_page"] }).notNull(),
 		entityId: text("entity_id").notNull(),
 		createdById: text("created_by_id")


### PR DESCRIPTION
## Summary
- Add attachment support to issues/wiki pages: file uploads (R2-backed), links to other wiki pages, and external URLs (PROJ-405/406/407/408).
- Enforce PROJ-311 project-visibility rules on wiki-page attachment links (both listing and creation), and cascade-delete attachments when the linked wiki page is deleted.
- Mobile-friendly attachment UI (touch targets, layout) in the issue detail view.

## Test plan
- [x] Backend integration tests (`apps/api`): 805 passed, including new coverage for wiki-ref visibility enforcement and cascade delete on wiki page deletion.
- [x] Frontend unit tests (`apps/web`): 341 passed.
- [x] Typecheck clean across the workspace.
- [x] Manual click-through of all three attachment kinds (file, wiki_ref, url) in a deployed dev instance, including mobile viewport.
- [x] Opus review pass completed; all CONFIRMED findings addressed in follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhKPsjCkj3BpGm9egv1frj