### PR TITLE
chore(web): bump version to 0.4.2 for release

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@projektor/web",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
## Summary
- Bump `apps/web` version to 0.4.2 ahead of tagging the release, bundling PROJ-405/406/407/408 (issue attachments), PROJ-404 (feedback aggregate summary), PROJ-396/395/397/401/402 (author tracking, contextual help, mobile issue-list fixes), and PROJ-399 (feedback widget guide).

## Test plan
- [x] Lint clean
- [x] Backend tests: 805 passed
- [x] Frontend tests: 341 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhKPsjCkj3BpGm9egv1frj