### PR TITLE
Feedback: surface structured context from sourceUrl (PROJ-398/PROJ-410)

### DIFF
--- a/apps/web/src/islands/FeedbackList.test.tsx
+++ b/apps/web/src/islands/FeedbackList.test.tsx
@@ -160,3 +160,56 @@ describe("FeedbackList", () => {
 		expect(screen.getByText(/2 selected/i)).toBeTruthy();
 	});
 });
+
+const ROW_WITH_CONTEXT = {
+	...ROW,
+	id: "f3",
+	sourceUrl: "https://ironvolume.example.com/wod?seed=abc123&focus=strength",
+};
+
+const ROW_BARE_URL = {
+	...ROW,
+	id: "f4",
+	sourceUrl: "https://ironvolume.example.com/wod",
+};
+
+const ROW_MALFORMED_URL = {
+	...ROW,
+	id: "f5",
+	sourceUrl: "not a url",
+};
+
+describe("FeedbackList structured context", () => {
+	it("shows a Context toggle with the param count and expands to reveal params + raw link", async () => {
+		stubFetch([ROW_WITH_CONTEXT]);
+		render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />);
+		const toggle = await screen.findByRole("button", { name: /Context \(2\)/i });
+		expect(screen.queryByText(/seed:/i)).toBeNull();
+		fireEvent.click(toggle);
+		expect(screen.getByText(/seed:\s*abc123/i)).toBeTruthy();
+		expect(screen.getByText(/focus:\s*strength/i)).toBeTruthy();
+		expect(screen.getByRole("link", { name: ROW_WITH_CONTEXT.sourceUrl })).toBeTruthy();
+	});
+
+	it("shows a Context (0) toggle for a sourceUrl with no query string, expanding to just the raw link", async () => {
+		stubFetch([ROW_BARE_URL]);
+		render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />);
+		const toggle = await screen.findByRole("button", { name: /Context \(0\)/i });
+		fireEvent.click(toggle);
+		expect(screen.getByRole("link", { name: ROW_BARE_URL.sourceUrl })).toBeTruthy();
+	});
+
+	it("renders no Context toggle when sourceUrl is null", async () => {
+		stubFetch([ROW]);
+		render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />);
+		await screen.findByText("Great onboarding");
+		expect(screen.queryByRole("button", { name: /Context/i })).toBeNull();
+	});
+
+	it("renders no Context toggle for a malformed sourceUrl, without throwing", async () => {
+		stubFetch([ROW_MALFORMED_URL]);
+		expect(() => render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />)).not.toThrow();
+		await screen.findByText("Great onboarding");
+		expect(screen.queryByRole("button", { name: /Context/i })).toBeNull();
+	});
+});

--- a/apps/web/src/islands/FeedbackList.test.tsx
+++ b/apps/web/src/islands/FeedbackList.test.tsx
@@ -179,6 +179,12 @@ const ROW_MALFORMED_URL = {
 	sourceUrl: "not a url",
 };
 
+const ROW_JS_URL = {
+	...ROW,
+	id: "f6",
+	sourceUrl: "javascript:alert(1)",
+};
+
 describe("FeedbackList structured context", () => {
 	it("shows a Context toggle with the param count and expands to reveal params + raw link", async () => {
 		stubFetch([ROW_WITH_CONTEXT]);
@@ -208,6 +214,13 @@ describe("FeedbackList structured context", () => {
 
 	it("renders no Context toggle for a malformed sourceUrl, without throwing", async () => {
 		stubFetch([ROW_MALFORMED_URL]);
+		expect(() => render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />)).not.toThrow();
+		await screen.findByText("Great onboarding");
+		expect(screen.queryByRole("button", { name: /Context/i })).toBeNull();
+	});
+
+	it("renders no Context toggle for a javascript: sourceUrl, without throwing", async () => {
+		stubFetch([ROW_JS_URL]);
 		expect(() => render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />)).not.toThrow();
 		await screen.findByText("Great onboarding");
 		expect(screen.queryByRole("button", { name: /Context/i })).toBeNull();

--- a/apps/web/src/islands/FeedbackList.tsx
+++ b/apps/web/src/islands/FeedbackList.tsx
@@ -35,6 +35,18 @@ function formatDate(ts: number): string {
 	return new Date(ts * 1000).toLocaleDateString();
 }
 
+function parseContext(
+	sourceUrl: string | null
+): { url: string; params: [string, string][] } | null {
+	if (!sourceUrl) return null;
+	try {
+		const parsed = new URL(sourceUrl);
+		return { url: sourceUrl, params: Array.from(parsed.searchParams.entries()) };
+	} catch {
+		return null;
+	}
+}
+
 export default function FeedbackList({ workspaceSlug, projectId: projectIdProp }: Props) {
 	const [projectId, setProjectId] = useState(projectIdProp ?? "");
 	useEffect(() => {
@@ -48,6 +60,7 @@ export default function FeedbackList({ workspaceSlug, projectId: projectIdProp }
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
 	const [selected, setSelected] = useState<Set<string>>(new Set());
+	const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
 	const fetchRows = useCallback(async () => {
 		if (!projectId) return;
@@ -133,6 +146,15 @@ export default function FeedbackList({ workspaceSlug, projectId: projectIdProp }
 
 	function toggleRow(id: string) {
 		setSelected((prev) => {
+			const next = new Set(prev);
+			if (next.has(id)) next.delete(id);
+			else next.add(id);
+			return next;
+		});
+	}
+
+	function toggleExpanded(id: string) {
+		setExpanded((prev) => {
 			const next = new Set(prev);
 			if (next.has(id)) next.delete(id);
 			else next.add(id);
@@ -251,6 +273,38 @@ export default function FeedbackList({ workspaceSlug, projectId: projectIdProp }
 										{r.submitterLabel && (
 											<div class="text-[0.75rem] text-text-muted mt-1">{r.submitterLabel}</div>
 										)}
+										{(() => {
+											const context = parseContext(r.sourceUrl);
+											if (!context) return null;
+											return (
+												<div class="mt-1">
+													<button
+														type="button"
+														class="text-[0.75rem] text-text-muted underline"
+														onClick={() => toggleExpanded(r.id)}
+													>
+														Context ({context.params.length})
+													</button>
+													{expanded.has(r.id) && (
+														<div class="text-[0.75rem] text-text-muted mt-1 flex flex-col gap-0.5">
+															<a
+																href={context.url}
+																target="_blank"
+																rel="noopener noreferrer"
+																class="underline"
+															>
+																{context.url}
+															</a>
+															{context.params.map(([key, value]) => (
+																<div key={key}>
+																	{key}: {value}
+																</div>
+															))}
+														</div>
+													)}
+												</div>
+											);
+										})()}
 									</td>
 									<td class={`${TD} text-text-muted`}>{r.sourceName ?? "—"}</td>
 									<td class={`${TD} text-text-muted`}>{r.status}</td>

--- a/apps/web/src/islands/FeedbackList.tsx
+++ b/apps/web/src/islands/FeedbackList.tsx
@@ -41,6 +41,7 @@ function parseContext(
 	if (!sourceUrl) return null;
 	try {
 		const parsed = new URL(sourceUrl);
+		if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
 		return { url: sourceUrl, params: Array.from(parsed.searchParams.entries()) };
 	} catch {
 		return null;

--- a/docs/superpowers/plans/2026-07-18-feedback-structured-context.md
+++ b/docs/superpowers/plans/2026-07-18-feedback-structured-context.md
@@ -1,0 +1,190 @@
+# Feedback Structured Context Surfacing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface `sourceUrl`'s query-string params generically in the feedback admin table, as a collapsible per-row toggle.
+
+**Architecture:** Pure client-side change to `apps/web/src/islands/FeedbackList.tsx` — parse `sourceUrl` with the native `URL` API, no backend/schema change.
+
+**Tech Stack:** Preact islands, `@testing-library/preact`, Vitest.
+
+## Global Constraints
+
+- No backend/schema change — `sourceUrl` is already returned by `GET /:id/feedback` (see `Feedback` interface, `apps/web/src/islands/FeedbackList.tsx:12`).
+- A malformed `sourceUrl` (fails `new URL(...)`) must render no toggle and must not throw/crash the table.
+- Toggle label is exactly `` `Context (${N})` `` where N is the query-param count (0 is valid — the toggle still renders so the raw-URL link stays reachable).
+
+---
+
+### Task 1: Context toggle + parsing + tests
+
+**Files:**
+- Modify: `apps/web/src/islands/FeedbackList.tsx`
+- Modify: `apps/web/src/islands/FeedbackList.test.tsx`
+
+**Interfaces:**
+- Produces: `parseContext(sourceUrl: string | null): { url: string; params: [string, string][] } | null` — a pure helper (returns `null` for `null` input or an unparseable URL), unit-testable in isolation.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `apps/web/src/islands/FeedbackList.test.tsx` (inside the existing `describe("FeedbackList", ...)` block, after the last test). These reuse the file's existing `ROW`/`ROW_2`/`stubFetch` fixtures — add a third fixture row with a `sourceUrl` carrying query params, and adjust `stubFetch`'s default rows array if needed to include it without changing the fixture identity (`f1`, `f2`) the pre-existing tests already key off of:
+
+```typescript
+const ROW_WITH_CONTEXT = {
+	...ROW,
+	id: "f3",
+	sourceUrl: "https://ironvolume.example.com/wod?seed=abc123&focus=strength",
+};
+
+const ROW_BARE_URL = {
+	...ROW,
+	id: "f4",
+	sourceUrl: "https://ironvolume.example.com/wod",
+};
+
+const ROW_MALFORMED_URL = {
+	...ROW,
+	id: "f5",
+	sourceUrl: "not a url",
+};
+
+describe("FeedbackList structured context", () => {
+	it("shows a Context toggle with the param count and expands to reveal params + raw link", async () => {
+		stubFetch([ROW_WITH_CONTEXT]);
+		render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />);
+		const toggle = await screen.findByRole("button", { name: /Context \(2\)/i });
+		expect(screen.queryByText(/seed:/i)).toBeNull();
+		fireEvent.click(toggle);
+		expect(screen.getByText(/seed:\s*abc123/i)).toBeTruthy();
+		expect(screen.getByText(/focus:\s*strength/i)).toBeTruthy();
+		expect(screen.getByRole("link", { name: ROW_WITH_CONTEXT.sourceUrl })).toBeTruthy();
+	});
+
+	it("shows a Context (0) toggle for a sourceUrl with no query string, expanding to just the raw link", async () => {
+		stubFetch([ROW_BARE_URL]);
+		render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />);
+		const toggle = await screen.findByRole("button", { name: /Context \(0\)/i });
+		fireEvent.click(toggle);
+		expect(screen.getByRole("link", { name: ROW_BARE_URL.sourceUrl })).toBeTruthy();
+	});
+
+	it("renders no Context toggle when sourceUrl is null", async () => {
+		stubFetch([ROW]);
+		render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />);
+		await screen.findByText("Great onboarding");
+		expect(screen.queryByRole("button", { name: /Context/i })).toBeNull();
+	});
+
+	it("renders no Context toggle for a malformed sourceUrl, without throwing", async () => {
+		stubFetch([ROW_MALFORMED_URL]);
+		expect(() => render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />)).not.toThrow();
+		await screen.findByText("Great onboarding");
+		expect(screen.queryByRole("button", { name: /Context/i })).toBeNull();
+	});
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @projektor/web test FeedbackList -- --run`
+Expected: FAIL — no `parseContext` helper, no Context toggle rendered.
+
+- [ ] **Step 3: Implement `parseContext` and the toggle UI**
+
+In `apps/web/src/islands/FeedbackList.tsx`, add the helper after `formatDate` (after line 36):
+
+```typescript
+function parseContext(sourceUrl: string | null): { url: string; params: [string, string][] } | null {
+	if (!sourceUrl) return null;
+	try {
+		const parsed = new URL(sourceUrl);
+		return { url: sourceUrl, params: Array.from(parsed.searchParams.entries()) };
+	} catch {
+		return null;
+	}
+}
+```
+
+Add `expanded` state after the existing `selected` state (after line 50):
+
+```typescript
+	const [expanded, setExpanded] = useState<Set<string>>(new Set());
+```
+
+Add a `toggleExpanded` function after `toggleRow` (after line 141):
+
+```typescript
+	function toggleExpanded(id: string) {
+		setExpanded((prev) => {
+			const next = new Set(prev);
+			if (next.has(id)) next.delete(id);
+			else next.add(id);
+			return next;
+		});
+	}
+```
+
+Replace the feedback-body `<td>` (lines 249-254) to add the context toggle and expanded panel below `submitterLabel`:
+
+```typescript
+									<td class={`${TD} text-text-base`}>
+										<div>{r.body ?? "—"}</div>
+										{r.submitterLabel && (
+											<div class="text-[0.75rem] text-text-muted mt-1">{r.submitterLabel}</div>
+										)}
+										{(() => {
+											const context = parseContext(r.sourceUrl);
+											if (!context) return null;
+											return (
+												<div class="mt-1">
+													<button
+														type="button"
+														class="text-[0.75rem] text-text-muted underline"
+														onClick={() => toggleExpanded(r.id)}
+													>
+														Context ({context.params.length})
+													</button>
+													{expanded.has(r.id) && (
+														<div class="text-[0.75rem] text-text-muted mt-1 flex flex-col gap-0.5">
+															<a
+																href={context.url}
+																target="_blank"
+																rel="noopener noreferrer"
+																class="underline"
+															>
+																{context.url}
+															</a>
+															{context.params.map(([key, value]) => (
+																<div key={key}>
+																	{key}: {value}
+																</div>
+															))}
+														</div>
+													)}
+												</div>
+											);
+										})()}
+									</td>
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @projektor/web test FeedbackList -- --run`
+Expected: PASS (all tests in the file, including the pre-existing 7 from Task 1-3 of the prior bulk-triage plan)
+
+- [ ] **Step 5: Run the full web test suite**
+
+Run: `pnpm --filter @projektor/web test -- --run`
+Expected: all tests pass (no regressions)
+
+- [ ] **Step 6: Type-check and lint**
+
+Run: `pnpm turbo type-check` and `pnpm biome check --changed`
+Expected: no errors/violations (fix inline with `--write`/`--write --unsafe` if any appear, and re-run tests before committing)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/islands/FeedbackList.tsx apps/web/src/islands/FeedbackList.test.tsx
+git commit -m "feat(web): surface structured context from feedback sourceUrl"
+```

--- a/docs/superpowers/specs/2026-07-18-feedback-structured-context-design.md
+++ b/docs/superpowers/specs/2026-07-18-feedback-structured-context-design.md
@@ -1,0 +1,31 @@
+# Feedback Structured Context Surfacing — Design
+
+**Epic:** PROJ-398 (theme 2 of 5: structured context surfacing)
+
+## Problem
+
+`sourceUrl` already carries per-submission context as a query string (e.g. ironvolume's generator config: seed/focus/time/equipment, encoded via its `ShareSpec.buildLink()` permalink), but the admin page doesn't render it at all today — `FeedbackList.tsx` receives `sourceUrl` in its `Feedback` interface but never displays it.
+
+## Scope
+
+Surface `sourceUrl`'s query-string params generically in the feedback table, without projektor's core schema needing to know what any given consumer's fields mean. No backend or schema changes — `sourceUrl` is already stored and returned by `GET /:id/feedback`.
+
+## Design
+
+Pure client-side change to `apps/web/src/islands/FeedbackList.tsx`:
+
+- A row with a non-null `sourceUrl` gets a `"Context (N)"` toggle button rendered under the existing body/submitter block (same place `submitterLabel` renders today), where `N` is the parsed query-param count (0 if the URL has no query string — the toggle still renders so the raw link stays reachable).
+- Clicking the toggle expands to show:
+  1. A link to the raw `sourceUrl` (`target="_blank" rel="noopener noreferrer"`).
+  2. Each query param as a `key: value` row, parsed via `new URL(sourceUrl).searchParams`.
+- Toggle state: `expanded: Set<string>` of row ids, mirroring the existing `selected` (bulk-triage) pattern — a `toggleExpanded(id)` function analogous to `toggleRow`.
+- Malformed `sourceUrl` (fails `new URL(...)`, e.g. a relative path or garbage string): caught, the row renders no toggle at all rather than crashing the table. This is a per-row `try { new URL(r.sourceUrl) } catch { return null }` guard evaluated once per row during render.
+- No new endpoint, no new DB column, no per-source config. Projektor never interprets what `seed`/`focus`/`time`/`equipment` (or any other consumer's param names) mean — it just parses and displays whatever key/value pairs are present. This satisfies the epic's "generic-first" requirement: the URL itself is the declaration.
+
+## Testing
+
+Extend `apps/web/src/islands/FeedbackList.test.tsx`:
+- A row with a `sourceUrl` containing query params renders a `"Context (2)"`-style toggle; clicking it reveals the raw-URL link and each `key: value` pair.
+- A row with a `sourceUrl` that has no query string still renders a `"Context (0)"` toggle; expanding it shows only the raw-URL link.
+- A row with `sourceUrl: null` renders no toggle.
+- A row with a malformed `sourceUrl` (e.g. `"not a url"`) renders no toggle and doesn't throw.


### PR DESCRIPTION
## Summary
- Surfaces sourceUrl's query-string params generically as a collapsible "Context (N)" toggle per feedback row (PROJ-398 theme 2).
- Pure client-side change, no backend/schema change — parses the already-returned sourceUrl via the URL API.
- Security fix included: restricts rendered context links to http(s) schemes only, closing a stored-XSS gap found in review (sourceUrl is attacker-controlled via the public feedback-submit endpoint).

## Test plan
- [x] `apps/web/src/islands/FeedbackList.test.tsx` — 5 new tests (params present, no query string, null sourceUrl, malformed sourceUrl, javascript: scheme rejected)
- [x] Full web suite: 349/349 passing
- [x] Type-check clean
- [x] Went through subagent-driven-development: implemented, reviewed (Opus, found the XSS gap), fixed, re-reviewed and approved

Design spec: `docs/superpowers/specs/2026-07-18-feedback-structured-context-design.md`
Plan: `docs/superpowers/plans/2026-07-18-feedback-structured-context.md`
Tracker: PROJ-410 (child of epic PROJ-398)