### PR TITLE
PROJ-417: mobile-viewport test harness for islands

### DIFF
--- a/apps/web/src/islands/issue-list/BoardView.test.tsx
+++ b/apps/web/src/islands/issue-list/BoardView.test.tsx
@@ -1,0 +1,97 @@
+// BoardView — mobile viewport tests (PROJ-417).
+//
+// BoardView disables HTML5 drag-and-drop below 640px (native DnD doesn't work
+// on touch devices) by checking `window.innerWidth` directly in its drag
+// handlers. This exercises that branch with the shared viewport helper,
+// rather than relying on the `max-sm:` CSS classes alone.
+import { fireEvent, render, screen } from "@testing-library/preact";
+import { describe, expect, it, vi } from "vitest";
+import type { Issue, TaskStatus } from "../board-utils";
+import { MOBILE_WIDTH, setViewportWidth } from "../../test/viewport";
+import BoardView from "./BoardView";
+
+const TODO_ISSUE: Issue = {
+	id: "i1",
+	number: 1,
+	title: "Move me",
+	priority: "high",
+	assignee_id: null,
+	assignee_name: null,
+	parent_id: null,
+	project_key: "PROJ",
+	project_name: "Projektor",
+	type_key: null,
+	type_name: null,
+	status_id: "st-todo",
+	status_key: "todo",
+	status_name: "Todo",
+	status_category: "todo",
+	sprint_id: null,
+	updated_at: 1000,
+	created_at: 1000,
+};
+
+const STATUSES: TaskStatus[] = [
+	{ id: "st-todo", key: "todo", name: "Todo", category: "todo", color: null },
+	{ id: "st-in-progress", key: "in_progress", name: "In Progress", category: "in_progress", color: null },
+];
+
+function fakeDataTransfer() {
+	const store = new Map<string, string>();
+	return {
+		setData: (type: string, val: string) => store.set(type, val),
+		getData: (type: string) => store.get(type) ?? "",
+	};
+}
+
+describe("BoardView — mobile viewport", () => {
+	it("blocks drag-and-drop status changes below 640px", () => {
+		const changeStatus = vi.fn();
+		setViewportWidth(MOBILE_WIDTH);
+		render(<BoardView issues={[TODO_ISSUE]} statuses={STATUSES} changeStatus={changeStatus} />);
+
+		const card = screen.getByText("Move me").closest("a")!;
+		const dataTransfer = fakeDataTransfer();
+		fireEvent.dragStart(card, { dataTransfer });
+
+		const inProgressColumn = screen.getByRole("region", { name: "In Progress column" });
+		fireEvent.drop(inProgressColumn, { dataTransfer });
+
+		expect(changeStatus).not.toHaveBeenCalled();
+	});
+
+	it("allows drag-and-drop status changes at desktop widths", () => {
+		const changeStatus = vi.fn();
+		setViewportWidth(1024);
+		render(<BoardView issues={[TODO_ISSUE]} statuses={STATUSES} changeStatus={changeStatus} />);
+
+		const card = screen.getByText("Move me").closest("a")!;
+		const dataTransfer = fakeDataTransfer();
+		fireEvent.dragStart(card, { dataTransfer });
+
+		const inProgressColumn = screen.getByRole("region", { name: "In Progress column" });
+		fireEvent.drop(inProgressColumn, { dataTransfer });
+
+		expect(changeStatus).toHaveBeenCalledWith("i1", "st-in-progress");
+	});
+
+	it("blocks the drop itself below 640px, even with data already set", () => {
+		// onDragStart already blocks setData below 640px, so the desktop/mobile
+		// tests above can't tell whether the drop handler's own width guard does
+		// anything. Seed dataTransfer at desktop width, then drop at mobile width
+		// to isolate that guard.
+		const changeStatus = vi.fn();
+		setViewportWidth(1024);
+		render(<BoardView issues={[TODO_ISSUE]} statuses={STATUSES} changeStatus={changeStatus} />);
+
+		const card = screen.getByText("Move me").closest("a")!;
+		const dataTransfer = fakeDataTransfer();
+		fireEvent.dragStart(card, { dataTransfer });
+
+		setViewportWidth(MOBILE_WIDTH);
+		const inProgressColumn = screen.getByRole("region", { name: "In Progress column" });
+		fireEvent.drop(inProgressColumn, { dataTransfer });
+
+		expect(changeStatus).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/islands/issue-list/BoardView.test.tsx
+++ b/apps/web/src/islands/issue-list/BoardView.test.tsx
@@ -6,8 +6,8 @@
 // rather than relying on the `max-sm:` CSS classes alone.
 import { fireEvent, render, screen } from "@testing-library/preact";
 import { describe, expect, it, vi } from "vitest";
-import type { Issue, TaskStatus } from "../board-utils";
 import { MOBILE_WIDTH, setViewportWidth } from "../../test/viewport";
+import type { Issue, TaskStatus } from "../board-utils";
 import BoardView from "./BoardView";
 
 const TODO_ISSUE: Issue = {
@@ -33,7 +33,13 @@ const TODO_ISSUE: Issue = {
 
 const STATUSES: TaskStatus[] = [
 	{ id: "st-todo", key: "todo", name: "Todo", category: "todo", color: null },
-	{ id: "st-in-progress", key: "in_progress", name: "In Progress", category: "in_progress", color: null },
+	{
+		id: "st-in-progress",
+		key: "in_progress",
+		name: "In Progress",
+		category: "in_progress",
+		color: null,
+	},
 ];
 
 function fakeDataTransfer() {
@@ -50,7 +56,7 @@ describe("BoardView — mobile viewport", () => {
 		setViewportWidth(MOBILE_WIDTH);
 		render(<BoardView issues={[TODO_ISSUE]} statuses={STATUSES} changeStatus={changeStatus} />);
 
-		const card = screen.getByText("Move me").closest("a")!;
+		const card = screen.getByText("Move me").closest("a") as HTMLElement;
 		const dataTransfer = fakeDataTransfer();
 		fireEvent.dragStart(card, { dataTransfer });
 
@@ -65,7 +71,7 @@ describe("BoardView — mobile viewport", () => {
 		setViewportWidth(1024);
 		render(<BoardView issues={[TODO_ISSUE]} statuses={STATUSES} changeStatus={changeStatus} />);
 
-		const card = screen.getByText("Move me").closest("a")!;
+		const card = screen.getByText("Move me").closest("a") as HTMLElement;
 		const dataTransfer = fakeDataTransfer();
 		fireEvent.dragStart(card, { dataTransfer });
 
@@ -84,7 +90,7 @@ describe("BoardView — mobile viewport", () => {
 		setViewportWidth(1024);
 		render(<BoardView issues={[TODO_ISSUE]} statuses={STATUSES} changeStatus={changeStatus} />);
 
-		const card = screen.getByText("Move me").closest("a")!;
+		const card = screen.getByText("Move me").closest("a") as HTMLElement;
 		const dataTransfer = fakeDataTransfer();
 		fireEvent.dragStart(card, { dataTransfer });
 

--- a/apps/web/src/test/viewport.ts
+++ b/apps/web/src/test/viewport.ts
@@ -1,0 +1,25 @@
+// Test helper for islands that branch on `window.innerWidth` directly in JS
+// (e.g. BoardView disabling HTML5 drag below 640px). jsdom doesn't evaluate CSS,
+// so this can't prove a `max-sm:` class actually hides/shows anything at
+// runtime — it only fakes the JS-visible viewport signal. For CSS-only
+// responsive behavior there's nothing to assert here beyond the class names
+// themselves.
+import { afterEach } from "vitest";
+
+export const MOBILE_WIDTH = 375;
+export const DESKTOP_WIDTH = 1024;
+
+export function setViewportWidth(width: number): void {
+	Object.defineProperty(window, "innerWidth", {
+		writable: true,
+		configurable: true,
+		value: width,
+	});
+	window.dispatchEvent(new Event("resize"));
+}
+
+// Reset to a desktop width after every test so viewport state never leaks
+// between test files.
+afterEach(() => {
+	setViewportWidth(DESKTOP_WIDTH);
+});


### PR DESCRIPTION
## Summary
- Adds `apps/web/src/test/viewport.ts` — a shared vitest helper (`setViewportWidth`, `MOBILE_WIDTH`, `DESKTOP_WIDTH`) for islands that branch on `window.innerWidth` in JS, with a documented limitation that jsdom doesn't evaluate CSS so `max-sm:` classes can't be proven at runtime this way.
- Proves the helper against `BoardView`'s real drag-and-drop disable logic (native HTML5 DnD doesn't work on touch, so BoardView guards both `onDragStart` and `onDrop` on `window.innerWidth`), including an isolating case for the drop guard itself.
- Reviewed by an Opus agent: approved, with one optional gap closed (the drop-guard isolation test) before merge.

## Test plan
- [x] `pnpm --filter @projektor/web test BoardView -- --run` — 3/3 pass
- [x] `pnpm --filter @projektor/web test -- --run` — full web suite, 33 files / 352 tests pass
- [x] `pnpm --filter @projektor/web type-check` — 0 errors
- [x] `pnpm biome check` clean on new files

Child of PROJ-411 (mobile coverage epic). Closes PROJ-417.