### PR TITLE
PROJ-412: add mobile-card fallback to search results

### DIFF
--- a/apps/web/src/islands/issue-list/SearchResultsSection.test.tsx
+++ b/apps/web/src/islands/issue-list/SearchResultsSection.test.tsx
@@ -1,0 +1,49 @@
+// SearchResultsSection — mobile viewport test (PROJ-412).
+//
+// Below 640px the desktop table (`max-sm:hidden`) renders nothing, so a
+// mobile-card fallback must render whenever there are results. Only the
+// mobile-card presence is JS-visible in jsdom (see apps/web/src/test/viewport.ts) -
+// the `max-sm:hidden`/`max-sm:flex` CSS itself isn't evaluated here.
+import { render, screen } from "@testing-library/preact";
+import { describe, expect, it } from "vitest";
+import { MOBILE_WIDTH, setViewportWidth } from "../../test/viewport";
+import SearchResultsSection from "./SearchResultsSection";
+import type { SearchResult } from "./useIssueSearch";
+
+const RESULTS: SearchResult[] = [
+	{
+		id: "i1",
+		number: 1,
+		title: "Fix the thing",
+		status: "in_progress",
+		priority: "high",
+		project_id: "p1",
+		project_key: "PROJ",
+		project_name: "Projektor",
+	},
+];
+
+describe("SearchResultsSection — mobile viewport", () => {
+	it("renders mobile cards for non-empty results at narrow widths", () => {
+		setViewportWidth(MOBILE_WIDTH);
+		render(
+			<SearchResultsSection searchLoading={false} searchResults={RESULTS} searchQuery="fix" />
+		);
+
+		expect(screen.getAllByText("Fix the thing")).toHaveLength(2);
+	});
+
+	it("shows the loading state regardless of viewport", () => {
+		setViewportWidth(MOBILE_WIDTH);
+		render(<SearchResultsSection searchLoading={true} searchResults={null} searchQuery="fix" />);
+
+		expect(screen.getByText("Searching…")).toBeTruthy();
+	});
+
+	it("shows the no-results state regardless of viewport", () => {
+		setViewportWidth(MOBILE_WIDTH);
+		render(<SearchResultsSection searchLoading={false} searchResults={[]} searchQuery="fix" />);
+
+		expect(screen.getByText("No results for «fix»")).toBeTruthy();
+	});
+});

--- a/apps/web/src/islands/issue-list/SearchResultsSection.tsx
+++ b/apps/web/src/islands/issue-list/SearchResultsSection.tsx
@@ -2,6 +2,24 @@ import { formatIssueRef } from "../../lib/issue-ref";
 import { issueUrl } from "../../utils/issue-url";
 import type { SearchResult } from "./useIssueSearch";
 
+function priorityBadge(r: SearchResult) {
+	return (
+		<span
+			class="inline-flex items-center px-1.5 py-0.5 rounded text-[0.7rem] font-semibold capitalize whitespace-nowrap"
+			style={{
+				background: `var(--priority-${r.priority}-bg, var(--priority-low-bg))`,
+				color: `var(--priority-${r.priority}-text, var(--text-muted))`,
+			}}
+		>
+			{r.priority === "none" ? "–" : r.priority}
+		</span>
+	);
+}
+
+function statusBadge(r: SearchResult) {
+	return <span class="font-medium text-sm text-text-muted">{r.status.replace(/_/g, " ")}</span>;
+}
+
 function SearchResultsTable({ results }: { results: SearchResult[] }) {
 	return (
 		<div class="overflow-x-auto max-sm:hidden">
@@ -38,26 +56,33 @@ function SearchResultsTable({ results }: { results: SearchResult[] }) {
 									{r.title}
 								</a>
 							</td>
-							<td class="px-3 py-2 align-middle whitespace-nowrap">
-								<span
-									class="inline-flex items-center px-1.5 py-0.5 rounded text-[0.7rem] font-semibold capitalize whitespace-nowrap"
-									style={{
-										background: `var(--priority-${r.priority}-bg, var(--priority-low-bg))`,
-										color: `var(--priority-${r.priority}-text, var(--text-muted))`,
-									}}
-								>
-									{r.priority === "none" ? "–" : r.priority}
-								</span>
-							</td>
-							<td class="px-3 py-2 align-middle whitespace-nowrap">
-								<span class="font-medium text-sm text-text-muted">
-									{r.status.replace(/_/g, " ")}
-								</span>
-							</td>
+							<td class="px-3 py-2 align-middle whitespace-nowrap">{priorityBadge(r)}</td>
+							<td class="px-3 py-2 align-middle whitespace-nowrap">{statusBadge(r)}</td>
 						</tr>
 					))}
 				</tbody>
 			</table>
+		</div>
+	);
+}
+
+function SearchResultsMobileCards({ results }: { results: SearchResult[] }) {
+	return (
+		<div class="hidden max-sm:flex max-sm:flex-col max-sm:gap-3">
+			{results.map((r) => (
+				<div key={r.id} class="py-3 px-4 border border-border rounded-md bg-surface">
+					<span class="inline-block font-mono text-[0.8rem] text-text-muted mb-1">
+						{formatIssueRef(r.project_key, r.number)}
+					</span>
+					<a href={issueUrl(r.project_key, r.number, r.title, r.id)} class="no-underline">
+						<div class="text-[0.9rem] text-text-base font-medium mb-2">{r.title}</div>
+					</a>
+					<div class="flex gap-[0.375rem] flex-wrap items-center">
+						{priorityBadge(r)}
+						{statusBadge(r)}
+					</div>
+				</div>
+			))}
 		</div>
 	);
 }
@@ -82,5 +107,10 @@ export default function SearchResultsSection({
 	if (searchResults.length === 0) {
 		return <p class="text-text-muted">No results for «{searchQuery.trim()}»</p>;
 	}
-	return <SearchResultsTable results={searchResults} />;
+	return (
+		<>
+			<SearchResultsTable results={searchResults} />
+			<SearchResultsMobileCards results={searchResults} />
+		</>
+	);
 }


### PR DESCRIPTION
## Summary
- `SearchResultsSection.tsx` wrapped its only results view in `overflow-x-auto max-sm:hidden` with no mobile alternative — a non-empty search rendered nothing visible below 640px.
- Adds `SearchResultsMobileCards`, following the desktop-table + mobile-cards pairing already used in `MyIssues`/`BacklogView`/`ListSection`. Shared `priorityBadge`/`statusBadge` helpers extracted between the table and the cards.
- Loading and no-results states are unchanged at any viewport.
- Reviewed by an Opus agent: approved as-is.

## Test plan
- [x] `pnpm --filter @projektor/web test SearchResultsSection -- --run` — 3/3 pass
- [x] `pnpm --filter @projektor/web test -- --run` — 34 files / 355 tests pass
- [x] `pnpm --filter @projektor/web type-check` — 0 errors
- [x] `pnpm biome check` clean on changed files

Child of PROJ-411 (mobile coverage epic). Closes PROJ-412.