### PR TITLE
PROJ-413: link the PWA manifest and add maskable icons

### DIFF
--- a/apps/web/public/manifest.json
+++ b/apps/web/public/manifest.json
@@ -6,7 +6,9 @@
   "theme_color": "#6366f1",
   "background_color": "#0f1117",
   "icons": [
-    { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png" }
+    { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any" },
+    { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any" },
+    { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "maskable" },
+    { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
   ]
 }

--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -31,6 +31,7 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="theme-color" content="#6366f1" />
     <link rel="apple-touch-icon" href="/icon-192.png" />
+    <link rel="manifest" href="/manifest.json" />
     <title>{title}</title>
     <ClientRouter />
     <!-- safe-ls: 'theme' is a cosmetic preference (dark/light). No API dependency - a


### PR DESCRIPTION
## Summary
- `astro.config.mjs` disables vite-pwa's manifest injection (`manifest: false`), and `Base.astro` had no `<link rel="manifest">`, so the existing valid `public/manifest.json` was never referenced from any page — Chrome/Android's install-prompt criteria were never met.
- Adds `<link rel="manifest" href="/manifest.json">` to `Base.astro`'s `<head>`, keeping the static manifest as the single source of truth (option (b) in the ticket, vite-pwa config and service-worker caching untouched).
- Adds maskable icon entries. The existing `icon-192/512.png` are solid, uniform brand-color squares with no logo/edge detail, so they're safe to reuse as maskable without regenerating new assets (confirmed by viewing both images).
- Reviewed by an Opus agent: approved, with a required follow-up ticket (PROJ-418) for the orphaned `registerSW.js` — a separate pre-existing bug where the built service worker is never actually registered from any page. Confirmed this doesn't block Chrome's installability check (the fetch-handling-SW requirement was dropped in Chrome 89) and is out of scope for this manifest-only ticket.

## Test plan
- [x] `pnpm --filter @projektor/web build` succeeds; built `dist/index.html` contains the manifest link, `dist/manifest.json` has all 4 icon entries
- [x] Manifest checked against the Chromium/W3C installability checklist in code (name, short_name, start_url, display=standalone, 192x192 + 512x512 icons, at least one maskable icon) — all pass
- [x] `pnpm --filter @projektor/web test -- --run` — 34 files / 355 tests pass (unaffected by this change)
- [x] `pnpm --filter @projektor/web type-check` — 0 errors
- No live browser/Lighthouse available in this environment to capture an installability screenshot — the acceptance criteria's Lighthouse/DevTools check should be run against the deployed dogfood instance before/after this merges.

Child of PROJ-411 (mobile coverage epic). Closes PROJ-413. Follow-up: PROJ-418.