### PR TITLE
PROJ-414: distinguish offline failures in apiFetch, add offline banner

### DIFF
--- a/apps/web/src/islands/OfflineBanner.test.tsx
+++ b/apps/web/src/islands/OfflineBanner.test.tsx
@@ -1,0 +1,35 @@
+import { act, render, screen } from "@testing-library/preact";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OfflineBanner } from "./OfflineBanner";
+
+describe("OfflineBanner", () => {
+	let onLineSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		onLineSpy = vi.spyOn(navigator, "onLine", "get").mockReturnValue(true);
+	});
+
+	afterEach(() => {
+		onLineSpy.mockRestore();
+	});
+
+	it("renders nothing while online", () => {
+		render(<OfflineBanner />);
+		expect(screen.queryByRole("status")).toBeNull();
+	});
+
+	it("shows a banner on the offline event and hides it again on online", () => {
+		onLineSpy.mockReturnValue(false);
+		render(<OfflineBanner />);
+		act(() => {
+			window.dispatchEvent(new Event("offline"));
+		});
+
+		expect(screen.getByRole("status").textContent).toMatch(/offline/i);
+
+		act(() => {
+			window.dispatchEvent(new Event("online"));
+		});
+		expect(screen.queryByRole("status")).toBeNull();
+	});
+});

--- a/apps/web/src/islands/OfflineBanner.tsx
+++ b/apps/web/src/islands/OfflineBanner.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "preact/hooks";
+
+/** Minimal offline indicator (PROJ-414) — the app shell loads from the service-worker cache
+ * even offline, but data-fetching islands otherwise fail silently with no shared signal. */
+export function OfflineBanner() {
+	const [online, setOnline] = useState(true);
+
+	useEffect(() => {
+		setOnline(navigator.onLine);
+		const goOnline = () => setOnline(true);
+		const goOffline = () => setOnline(false);
+		window.addEventListener("online", goOnline);
+		window.addEventListener("offline", goOffline);
+		return () => {
+			window.removeEventListener("online", goOnline);
+			window.removeEventListener("offline", goOffline);
+		};
+	}, []);
+
+	if (online) return null;
+
+	return (
+		<div
+			role="status"
+			class="px-3 py-1.5 text-sm font-medium text-center"
+			style={{ background: "var(--danger-bg)", color: "var(--danger-text)" }}
+		>
+			You're offline — changes won't save until your connection returns.
+		</div>
+	);
+}

--- a/apps/web/src/islands/issue-list/useCreateIssueModal.test.tsx
+++ b/apps/web/src/islands/issue-list/useCreateIssueModal.test.tsx
@@ -1,0 +1,56 @@
+// PROJ-414: submitCreate must distinguish an offline (network) failure from a
+// generic HTTP error, since CreateIssueModal shows whatever message createError holds.
+import { fireEvent, render, screen } from "@testing-library/preact";
+import { useEffect, useState } from "preact/hooks";
+import { describe, expect, it, vi } from "vitest";
+import type { Issue } from "../board-utils";
+import CreateIssueModal from "./CreateIssueModal";
+import { useCreateIssueModal } from "./useCreateIssueModal";
+
+const PROJECTS = [{ id: "p1", key: "PROJ", name: "Projektor", description: null }];
+
+function Harness() {
+	const [, setIssues] = useState<Issue[]>([]);
+	const modal = useCreateIssueModal({
+		filterProject: "",
+		projects: PROJECTS,
+		statuses: [],
+		taskTypes: [],
+		setIssues,
+	});
+	// The real flow sets createProjectId via openCreateModal() when the "New issue"
+	// button is clicked; this harness skips that button and opens the modal directly.
+	useEffect(() => {
+		modal.openCreateModal();
+	}, []);
+	return <CreateIssueModal {...modal} projects={PROJECTS} taskTypes={[]} statuses={[]} />;
+}
+
+describe("useCreateIssueModal — offline submit", () => {
+	it("shows an offline-specific message when the create request fails due to network failure", async () => {
+		vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
+
+		render(<Harness />);
+		fireEvent.input(screen.getByPlaceholderText("Issue title"), {
+			target: { value: "Fix the thing" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /create issue/i }));
+
+		const alert = await screen.findByRole("alert");
+		expect(alert.textContent).toMatch(/you're offline/i);
+	});
+
+	it("shows a generic message for a non-offline (HTTP) failure", async () => {
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+
+		render(<Harness />);
+		fireEvent.input(screen.getByPlaceholderText("Issue title"), {
+			target: { value: "Fix the thing" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /create issue/i }));
+
+		const alert = await screen.findByRole("alert");
+		expect(alert.textContent).toMatch(/failed to create issue/i);
+		expect(alert.textContent).not.toMatch(/you're offline/i);
+	});
+});

--- a/apps/web/src/islands/issue-list/useCreateIssueModal.ts
+++ b/apps/web/src/islands/issue-list/useCreateIssueModal.ts
@@ -1,6 +1,6 @@
 import type { Dispatch, StateUpdater } from "preact/hooks";
 import { useEffect, useState } from "preact/hooks";
-import { apiFetch } from "../../utils/api-client";
+import { ApiOfflineError, apiFetch } from "../../utils/api-client";
 import type { Issue, TaskStatus } from "../board-utils";
 import { buildCreateIssuePayload, buildOptimisticIssue } from "../IssueList-helpers";
 import type { ProjectMeta } from "./types";
@@ -85,7 +85,11 @@ export function useCreateIssueModal({
 			setIssues((prev) => [newIssue, ...prev]);
 			setShowCreateModal(false);
 		} catch (err) {
-			setCreateError(`Failed to create issue: ${String(err)}`);
+			setCreateError(
+				err instanceof ApiOfflineError
+					? "You're offline — the issue wasn't created. Try again once your connection returns."
+					: `Failed to create issue: ${String(err)}`
+			);
 		} finally {
 			setSubmittingCreate(false);
 		}

--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -1,6 +1,7 @@
 ---
 import { ClientRouter } from 'astro:transitions';
 import { GlossaryHelp } from '../islands/GlossaryHelp';
+import { OfflineBanner } from '../islands/OfflineBanner';
 import type { GlossaryTermId } from '../islands/glossary-definitions';
 import pkg from '../../package.json';
 
@@ -581,6 +582,7 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
     </style>
   </head>
   <body>
+    <OfflineBanner client:load />
     <div class="app-shell">
       <header class="mobile-topbar">
         <button

--- a/apps/web/src/utils/api-client.test.ts
+++ b/apps/web/src/utils/api-client.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+import { ApiOfflineError, apiFetch } from "./api-client";
+
+describe("apiFetch", () => {
+	it("returns parsed JSON on a successful response", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ id: "i1" }) })
+		);
+
+		await expect(apiFetch("/api/issues/i1")).resolves.toEqual({ id: "i1" });
+	});
+
+	it("throws a plain Error on an HTTP error response", async () => {
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+
+		await expect(apiFetch("/api/issues/i1")).rejects.toThrow(/404/);
+	});
+
+	it("throws ApiOfflineError when fetch itself rejects (network failure)", async () => {
+		vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
+
+		await expect(apiFetch("/api/issues/i1", { method: "POST" })).rejects.toBeInstanceOf(
+			ApiOfflineError
+		);
+	});
+});

--- a/apps/web/src/utils/api-client.ts
+++ b/apps/web/src/utils/api-client.ts
@@ -7,6 +7,14 @@ function buildHeaders(
 	return h;
 }
 
+/** Thrown when `apiFetch`'s underlying `fetch` call rejects (network failure/offline), as opposed to a completed HTTP error response. */
+export class ApiOfflineError extends Error {
+	constructor(path: string, method: string) {
+		super(`API ${method} ${path} failed: network unavailable`);
+		this.name = "ApiOfflineError";
+	}
+}
+
 export async function apiFetch<T = unknown>(
 	path: string,
 	opts: {
@@ -17,17 +25,23 @@ export async function apiFetch<T = unknown>(
 	} = {}
 ): Promise<T> {
 	const isFormData = opts.body instanceof FormData;
-	const res = await fetch(path, {
-		method: opts.method ?? "GET",
-		credentials: "include",
-		headers: {
-			...buildHeaders(opts.workspaceSlug, opts.headers),
-			...(opts.body && !isFormData ? { "Content-Type": "application/json" } : {}),
-		},
-		...(opts.body
-			? { body: isFormData ? (opts.body as FormData) : JSON.stringify(opts.body) }
-			: {}),
-	});
-	if (!res.ok) throw new Error(`API ${opts.method ?? "GET"} ${path} failed: ${res.status}`);
+	const method = opts.method ?? "GET";
+	let res: Response;
+	try {
+		res = await fetch(path, {
+			method,
+			credentials: "include",
+			headers: {
+				...buildHeaders(opts.workspaceSlug, opts.headers),
+				...(opts.body && !isFormData ? { "Content-Type": "application/json" } : {}),
+			},
+			...(opts.body
+				? { body: isFormData ? (opts.body as FormData) : JSON.stringify(opts.body) }
+				: {}),
+		});
+	} catch {
+		throw new ApiOfflineError(path, method);
+	}
+	if (!res.ok) throw new Error(`API ${method} ${path} failed: ${res.status}`);
 	return res.json() as Promise<T>;
 }


### PR DESCRIPTION
## Summary
- `apiFetch` had one failure path (thrown `Error` on a non-ok HTTP response); a raw `fetch()` rejection (offline/network failure) wasn't caught and propagated as an unhandled rejection. No offline-awareness existed anywhere in the app.
- `apiFetch` now catches a `fetch()` rejection and rethrows it as a distinct `ApiOfflineError`.
- New `OfflineBanner` island (mounted in `Base.astro`, first child of `<body>`) shows a `role="status"` banner while `navigator.onLine` is false, clearing on `online`.
- `useCreateIssueModal`'s `submitCreate` shows an offline-specific message on `ApiOfflineError` vs. the generic create-failure message, as the concrete write-path example from the ticket.
- No change to service-worker caching/retry behavior — additive error-path handling only, per scope.
- Reviewed by an Opus agent: approved as-is (confirmed the try/catch doesn't swallow a post-fetch JSON-parse failure, the banner's hydration-safe `navigator.onLine` pattern is correct, and the test harness's `openCreateModal()`-in-`useEffect` faithfully reproduces the real click-before-submit precondition rather than masking anything).

## Test plan
- [x] New `apps/web/src/utils/api-client.test.ts` — 3 tests (success, HTTP error, network-failure → `ApiOfflineError`)
- [x] New `apps/web/src/islands/OfflineBanner.test.tsx` — 2 tests (hidden online, shown/hidden on offline/online events)
- [x] New `apps/web/src/islands/issue-list/useCreateIssueModal.test.tsx` — 2 tests (offline-specific vs. generic create-failure message)
- [x] `pnpm --filter @projektor/web test -- --run` — 37 files / 362 tests pass
- [x] `pnpm --filter @projektor/web type-check` — 0 errors
- [x] `pnpm biome check` clean on changed files

Child of PROJ-411 (mobile coverage epic). Closes PROJ-414.