### PR TITLE
PROJ-415: add mobile-card fallback to admin data tables

### DIFF
--- a/apps/web/src/islands/EpicList.test.tsx
+++ b/apps/web/src/islands/EpicList.test.tsx
@@ -160,7 +160,7 @@ describe("EpicList", () => {
 		render(<EpicList />);
 
 		// Sensible default rendered: falls back to the first project and loads its epics.
-		expect(await screen.findByText("Big Epic")).toBeTruthy();
+		expect((await screen.findAllByText("Big Epic")).length).toBeGreaterThan(0);
 
 		// The stale id never reached an API call.
 		expect(calledUrls.some((u) => u.includes("stale-deleted-project"))).toBe(false);
@@ -174,15 +174,23 @@ describe("EpicList", () => {
 		history.replaceState(null, "", "?projectId=p1");
 		mockFetchEpics([EPIC_ISSUE]);
 		render(<EpicList />);
-		expect(await screen.findByText("Big Epic")).toBeTruthy();
-		expect(screen.getByText("High")).toBeTruthy();
+		expect((await screen.findAllByText("Big Epic")).length).toBeGreaterThan(0);
+		expect(screen.getAllByText("High").length).toBeGreaterThan(0);
+	});
+
+	it("renders a mobile-card fallback alongside the desktop table", async () => {
+		history.replaceState(null, "", "?projectId=p1");
+		mockFetchEpics([EPIC_ISSUE]);
+		render(<EpicList />);
+		// Desktop table + mobile card both render (CSS hides one per viewport).
+		expect((await screen.findAllByText("Big Epic")).length).toBe(2);
 	});
 
 	it("shows '+ New Epic' button when the epic task type is available", async () => {
 		history.replaceState(null, "", "?projectId=p1");
 		mockFetchEpics([EPIC_ISSUE]);
 		render(<EpicList />);
-		await screen.findByText("Big Epic");
+		await screen.findAllByText("Big Epic");
 		expect(screen.getByRole("button", { name: /New Epic/i })).toBeTruthy();
 	});
 
@@ -214,7 +222,7 @@ describe("EpicList", () => {
 			})
 		);
 		render(<EpicList />);
-		await screen.findByText("Big Epic");
+		await screen.findAllByText("Big Epic");
 		const issuesCall = calledUrls.find((u) => u.includes("/api/issues?"));
 		expect(issuesCall).toContain("completedAfter=");
 		expect(issuesCall).toContain("completedBefore=");
@@ -228,7 +236,7 @@ describe("EpicList", () => {
 		);
 		mockFetchEpics([EPIC_ISSUE]);
 		render(<EpicList />);
-		await screen.findByText("Big Epic");
+		await screen.findAllByText("Big Epic");
 		expect(screen.getByRole("button", { name: /Filters \(1\)/i })).toBeTruthy();
 	});
 
@@ -263,7 +271,7 @@ describe("EpicList — priority sort", () => {
 		render(<EpicList />);
 
 		// Wait for render
-		await screen.findByText("Urgent Epic");
+		await screen.findAllByText("Urgent Epic");
 
 		// Click the Priority column header to sort ascending
 		fireEvent.click(screen.getByRole("columnheader", { name: /Priority/i }));
@@ -279,7 +287,7 @@ describe("EpicList — priority sort", () => {
 		mockFetchEpics([URGENT_EPIC, MEDIUM_EPIC, LOW_EPIC]);
 		render(<EpicList />);
 
-		await screen.findByText("Urgent Epic");
+		await screen.findAllByText("Urgent Epic");
 
 		const header = screen.getByRole("columnheader", { name: /Priority/i });
 		fireEvent.click(header); // asc
@@ -296,7 +304,7 @@ describe("EpicList — priority sort", () => {
 		mockFetchEpics([URGENT_EPIC, MEDIUM_EPIC, LOW_EPIC]);
 		render(<EpicList />);
 
-		await screen.findByText("Urgent Epic");
+		await screen.findAllByText("Urgent Epic");
 
 		const header = screen.getByRole("columnheader", { name: /Priority/i });
 

--- a/apps/web/src/islands/EpicList.tsx
+++ b/apps/web/src/islands/EpicList.tsx
@@ -564,28 +564,61 @@ function EpicsTable({
 	if (filteredEpics.length === 0) {
 		return <p class="text-text-muted text-sm">No epics match the active filters.</p>;
 	}
+	const sorted = sortIssues(filteredEpics, sortBy, sortDir);
 	return (
-		<div class="overflow-x-auto">
-			<table class="w-full border-collapse text-sm" aria-label="Epics">
-				<thead>
-					<tr>
-						<th class={TH_CLASS}>Title</th>
-						<th class={TH_CLASS}>Status</th>
-						<th
-							class={`${TH_CLASS} cursor-pointer select-none hover:text-text-base`}
-							onClick={() => toggleSort("priority")}
-						>
-							Priority{sortIndicator("priority", sortBy, sortDir)}
-						</th>
-						<th class={TH_CLASS}>Children</th>
-					</tr>
-				</thead>
-				<tbody>
-					{sortIssues(filteredEpics, sortBy, sortDir).map((ep) => (
-						<EpicRow key={ep.id} ep={ep} rollup={epicRollups[ep.id]} />
-					))}
-				</tbody>
-			</table>
+		<>
+			<div class="overflow-x-auto max-sm:hidden">
+				<table class="w-full border-collapse text-sm" aria-label="Epics">
+					<thead>
+						<tr>
+							<th class={TH_CLASS}>Title</th>
+							<th class={TH_CLASS}>Status</th>
+							<th
+								class={`${TH_CLASS} cursor-pointer select-none hover:text-text-base`}
+								onClick={() => toggleSort("priority")}
+							>
+								Priority{sortIndicator("priority", sortBy, sortDir)}
+							</th>
+							<th class={TH_CLASS}>Children</th>
+						</tr>
+					</thead>
+					<tbody>
+						{sorted.map((ep) => (
+							<EpicRow key={ep.id} ep={ep} rollup={epicRollups[ep.id]} />
+						))}
+					</tbody>
+				</table>
+			</div>
+			<div class="hidden max-sm:flex max-sm:flex-col max-sm:gap-3">
+				{sorted.map((ep) => (
+					<EpicMobileCard key={ep.id} ep={ep} rollup={epicRollups[ep.id]} />
+				))}
+			</div>
+		</>
+	);
+}
+
+function EpicMobileCard({ ep, rollup }: EpicRowProps) {
+	const statusColor = CATEGORY_COLORS[ep.status_category ?? ""] ?? "var(--text-muted)";
+	return (
+		<div class="py-3 px-4 border border-border rounded-md bg-surface">
+			<a
+				href={issueUrl(ep.project_key, ep.number, ep.title, ep.id)}
+				class="text-text-base no-underline font-medium hover:underline"
+			>
+				{ep.title}
+			</a>
+			<div class="flex justify-between items-center gap-2 mt-1">
+				<span class="font-medium text-[0.8rem]" style={{ color: statusColor }}>
+					{statusDisplayName(ep.status_name, ep.status_key)}
+				</span>
+				<span class="text-xs font-medium">{PRIORITY_LABEL[ep.priority] ?? ep.priority}</span>
+			</div>
+			<div class="text-xs text-text-muted mt-1">
+				{!rollup || rollup.total === 0
+					? "—"
+					: `${rollup.done} done · ${rollup.remaining} remaining`}
+			</div>
 		</div>
 	);
 }

--- a/apps/web/src/islands/FeedbackList.test.tsx
+++ b/apps/web/src/islands/FeedbackList.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/preact";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/preact";
 import { describe, expect, it, vi } from "vitest";
+import { MOBILE_WIDTH, setViewportWidth } from "../test/viewport";
 import FeedbackList from "./FeedbackList";
 
 const ROW = {
@@ -63,18 +64,26 @@ function stubFetch(rows: unknown[] = [ROW, ROW_2], bulkConvertStatus = 201) {
 	return fetchMock;
 }
 
+// Table interactions are scoped to the desktop table via `within`, since the
+// mobile-card fallback (PROJ-415) renders the same controls a second time —
+// both are always in the DOM, CSS picks which is visible per viewport (jsdom
+// doesn't evaluate CSS, see apps/web/src/test/viewport.ts).
+function table() {
+	return within(screen.getByRole("table"));
+}
+
 describe("FeedbackList", () => {
 	it("renders feedback rows with body and source name", async () => {
 		stubFetch([ROW]);
 		render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />);
-		expect(await screen.findByText("Great onboarding")).toBeTruthy();
-		expect(screen.getByText(/Onboarding survey/)).toBeTruthy();
+		expect((await screen.findAllByText("Great onboarding")).length).toBeGreaterThan(0);
+		expect(screen.getAllByText(/Onboarding survey/).length).toBeGreaterThan(0);
 	});
 
 	it("changing the status filter refetches with the status query param", async () => {
 		const fetchMock = stubFetch();
 		render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />);
-		await screen.findByText("Great onboarding");
+		await screen.findAllByText("Great onboarding");
 		fireEvent.change(screen.getByLabelText(/Status/i), { target: { value: "reviewed" } });
 		await waitFor(() => {
 			expect(fetchMock.mock.calls.some((call) => String(call[0]).includes("status=reviewed"))).toBe(
@@ -86,8 +95,8 @@ describe("FeedbackList", () => {
 	it("mark-reviewed PATCHes with status reviewed and refetches", async () => {
 		const fetchMock = stubFetch([ROW]);
 		render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />);
-		await screen.findByText("Great onboarding");
-		fireEvent.click(screen.getByRole("button", { name: /Mark reviewed/i }));
+		await screen.findAllByText("Great onboarding");
+		fireEvent.click(table().getByRole("button", { name: /Mark reviewed/i }));
 		await waitFor(() => {
 			expect(
 				fetchMock.mock.calls.some((call) => {
@@ -105,8 +114,8 @@ describe("FeedbackList", () => {
 	it("convert-to-issue POSTs and refetches", async () => {
 		const fetchMock = stubFetch([ROW]);
 		render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />);
-		await screen.findByText("Great onboarding");
-		fireEvent.click(screen.getByRole("button", { name: /Convert to issue/i }));
+		await screen.findAllByText("Great onboarding");
+		fireEvent.click(table().getByRole("button", { name: /Convert to issue/i }));
 		await waitFor(() => {
 			expect(
 				fetchMock.mock.calls.some(
@@ -119,7 +128,7 @@ describe("FeedbackList", () => {
 	it("select-all then bulk mark-reviewed POSTs both ids and refetches", async () => {
 		const fetchMock = stubFetch();
 		render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />);
-		await screen.findByText("Great onboarding");
+		await screen.findAllByText("Great onboarding");
 		fireEvent.click(screen.getByLabelText(/select all/i));
 		fireEvent.click(screen.getByRole("button", { name: /^Mark all reviewed$/i }));
 		await waitFor(() => {
@@ -136,7 +145,7 @@ describe("FeedbackList", () => {
 	it("select-all then bulk convert-to-issue POSTs both ids and refetches", async () => {
 		const fetchMock = stubFetch();
 		render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />);
-		await screen.findByText("Great onboarding");
+		await screen.findAllByText("Great onboarding");
 		fireEvent.click(screen.getByLabelText(/select all/i));
 		fireEvent.click(screen.getByRole("button", { name: /^Convert all to issue$/i }));
 		await waitFor(() => {
@@ -153,11 +162,21 @@ describe("FeedbackList", () => {
 	it("shows an error and keeps the selection when bulk convert-to-issue conflicts", async () => {
 		stubFetch([ROW, ROW_2], 409);
 		render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />);
-		await screen.findByText("Great onboarding");
+		await screen.findAllByText("Great onboarding");
 		fireEvent.click(screen.getByLabelText(/select all/i));
 		fireEvent.click(screen.getByRole("button", { name: /^Convert all to issue$/i }));
 		expect(await screen.findByRole("alert")).toBeTruthy();
 		expect(screen.getByText(/2 selected/i)).toBeTruthy();
+	});
+});
+
+describe("FeedbackList — mobile viewport", () => {
+	it("renders a mobile-card fallback alongside the desktop table", async () => {
+		setViewportWidth(MOBILE_WIDTH);
+		stubFetch([ROW]);
+		render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />);
+		// Desktop table + mobile card both render (CSS hides one per viewport).
+		expect((await screen.findAllByText("Great onboarding")).length).toBe(2);
 	});
 });
 
@@ -189,40 +208,42 @@ describe("FeedbackList structured context", () => {
 	it("shows a Context toggle with the param count and expands to reveal params + raw link", async () => {
 		stubFetch([ROW_WITH_CONTEXT]);
 		render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />);
-		const toggle = await screen.findByRole("button", { name: /Context \(2\)/i });
+		await screen.findAllByText("Great onboarding");
+		const toggle = table().getByRole("button", { name: /Context \(2\)/i });
 		expect(screen.queryByText(/seed:/i)).toBeNull();
 		fireEvent.click(toggle);
-		expect(screen.getByText(/seed:\s*abc123/i)).toBeTruthy();
-		expect(screen.getByText(/focus:\s*strength/i)).toBeTruthy();
-		expect(screen.getByRole("link", { name: ROW_WITH_CONTEXT.sourceUrl })).toBeTruthy();
+		expect(table().getByText(/seed:\s*abc123/i)).toBeTruthy();
+		expect(table().getByText(/focus:\s*strength/i)).toBeTruthy();
+		expect(table().getByRole("link", { name: ROW_WITH_CONTEXT.sourceUrl })).toBeTruthy();
 	});
 
 	it("shows a Context (0) toggle for a sourceUrl with no query string, expanding to just the raw link", async () => {
 		stubFetch([ROW_BARE_URL]);
 		render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />);
-		const toggle = await screen.findByRole("button", { name: /Context \(0\)/i });
+		await screen.findAllByText("Great onboarding");
+		const toggle = table().getByRole("button", { name: /Context \(0\)/i });
 		fireEvent.click(toggle);
-		expect(screen.getByRole("link", { name: ROW_BARE_URL.sourceUrl })).toBeTruthy();
+		expect(table().getByRole("link", { name: ROW_BARE_URL.sourceUrl })).toBeTruthy();
 	});
 
 	it("renders no Context toggle when sourceUrl is null", async () => {
 		stubFetch([ROW]);
 		render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />);
-		await screen.findByText("Great onboarding");
-		expect(screen.queryByRole("button", { name: /Context/i })).toBeNull();
+		await screen.findAllByText("Great onboarding");
+		expect(table().queryByRole("button", { name: /Context/i })).toBeNull();
 	});
 
 	it("renders no Context toggle for a malformed sourceUrl, without throwing", async () => {
 		stubFetch([ROW_MALFORMED_URL]);
 		expect(() => render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />)).not.toThrow();
-		await screen.findByText("Great onboarding");
-		expect(screen.queryByRole("button", { name: /Context/i })).toBeNull();
+		await screen.findAllByText("Great onboarding");
+		expect(table().queryByRole("button", { name: /Context/i })).toBeNull();
 	});
 
 	it("renders no Context toggle for a javascript: sourceUrl, without throwing", async () => {
 		stubFetch([ROW_JS_URL]);
 		expect(() => render(<FeedbackList workspaceSlug="my-ws" projectId="p1" />)).not.toThrow();
-		await screen.findByText("Great onboarding");
-		expect(screen.queryByRole("button", { name: /Context/i })).toBeNull();
+		await screen.findAllByText("Great onboarding");
+		expect(table().queryByRole("button", { name: /Context/i })).toBeNull();
 	});
 });

--- a/apps/web/src/islands/FeedbackList.tsx
+++ b/apps/web/src/islands/FeedbackList.tsx
@@ -48,6 +48,122 @@ function parseContext(
 	}
 }
 
+function FeedbackContext({
+	row,
+	expanded,
+	onToggle,
+}: {
+	row: Feedback;
+	expanded: boolean;
+	onToggle: () => void;
+}) {
+	const context = parseContext(row.sourceUrl);
+	if (!context) return null;
+	return (
+		<div class="mt-1">
+			<button type="button" class="text-[0.75rem] text-text-muted underline" onClick={onToggle}>
+				Context ({context.params.length})
+			</button>
+			{expanded && (
+				<div class="text-[0.75rem] text-text-muted mt-1 flex flex-col gap-0.5">
+					<a href={context.url} target="_blank" rel="noopener noreferrer" class="underline">
+						{context.url}
+					</a>
+					{context.params.map(([key, value]) => (
+						<div key={key}>
+							{key}: {value}
+						</div>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function FeedbackRowActions({
+	row,
+	onMarkReviewed,
+	onConvert,
+}: {
+	row: Feedback;
+	onMarkReviewed: (id: string) => void;
+	onConvert: (id: string) => void;
+}) {
+	return (
+		<div class="flex gap-2 flex-wrap">
+			{row.status === "new" && (
+				<button type="button" class="btn btn-outline btn-sm" onClick={() => onMarkReviewed(row.id)}>
+					Mark reviewed
+				</button>
+			)}
+			{row.linkedIssueId ? (
+				<span class="text-[0.8rem] text-text-muted">Linked</span>
+			) : (
+				<button type="button" class="btn btn-outline btn-sm" onClick={() => onConvert(row.id)}>
+					Convert to issue
+				</button>
+			)}
+		</div>
+	);
+}
+
+interface FeedbackMobileCardsProps {
+	rows: Feedback[];
+	selected: Set<string>;
+	expanded: Set<string>;
+	onToggleRow: (id: string) => void;
+	onToggleExpanded: (id: string) => void;
+	onMarkReviewed: (id: string) => void;
+	onConvert: (id: string) => void;
+}
+
+function FeedbackMobileCards({
+	rows,
+	selected,
+	expanded,
+	onToggleRow,
+	onToggleExpanded,
+	onMarkReviewed,
+	onConvert,
+}: FeedbackMobileCardsProps) {
+	return (
+		<div class="hidden max-sm:flex max-sm:flex-col max-sm:gap-3">
+			{rows.map((r) => (
+				<div key={r.id} class="py-3 px-4 border border-border rounded-md bg-surface">
+					<div class="flex items-start gap-2 mb-2">
+						<input
+							type="checkbox"
+							aria-label={`select row ${r.id}`}
+							checked={selected.has(r.id)}
+							onChange={() => onToggleRow(r.id)}
+							class="mt-1"
+						/>
+						<div class="flex-1">
+							<div class="flex justify-between items-center gap-2 mb-1">
+								<span class="text-[0.9rem]">{ratingDisplay(r.rating, r.ratingScale)}</span>
+								<span class="text-[0.75rem] text-text-muted">{formatDate(r.createdAt)}</span>
+							</div>
+							<div class="text-[0.875rem] text-text-base">{r.body ?? "—"}</div>
+							{r.submitterLabel && (
+								<div class="text-[0.75rem] text-text-muted mt-1">{r.submitterLabel}</div>
+							)}
+							<FeedbackContext
+								row={r}
+								expanded={expanded.has(r.id)}
+								onToggle={() => onToggleExpanded(r.id)}
+							/>
+							<div class="text-[0.75rem] text-text-muted mt-1">
+								{r.sourceName ?? "—"} · {r.status}
+							</div>
+						</div>
+					</div>
+					<FeedbackRowActions row={r} onMarkReviewed={onMarkReviewed} onConvert={onConvert} />
+				</div>
+			))}
+		</div>
+	);
+}
+
 export default function FeedbackList({ workspaceSlug, projectId: projectIdProp }: Props) {
 	const [projectId, setProjectId] = useState(projectIdProp ?? "");
 	useEffect(() => {
@@ -237,108 +353,75 @@ export default function FeedbackList({ workspaceSlug, projectId: projectIdProp }
 					No feedback yet.
 				</div>
 			) : (
-				<div class="overflow-x-auto">
-					<table class="w-full border-collapse text-[0.9rem]">
-						<thead>
-							<tr>
-								<th class={TH}>
-									<input
-										type="checkbox"
-										aria-label="select all"
-										checked={rows.length > 0 && selected.size === rows.length}
-										onChange={toggleSelectAll}
-									/>
-								</th>
-								<th class={TH}>Rating</th>
-								<th class={TH}>Feedback</th>
-								<th class={TH}>Source</th>
-								<th class={TH}>Status</th>
-								<th class={TH}>Received</th>
-								<th class={TH}></th>
-							</tr>
-						</thead>
-						<tbody>
-							{rows.map((r) => (
-								<tr key={r.id}>
-									<td class={TD}>
+				<>
+					<div class="overflow-x-auto max-sm:hidden">
+						<table class="w-full border-collapse text-[0.9rem]">
+							<thead>
+								<tr>
+									<th class={TH}>
 										<input
 											type="checkbox"
-											aria-label={`select row ${r.id}`}
-											checked={selected.has(r.id)}
-											onChange={() => toggleRow(r.id)}
+											aria-label="select all"
+											checked={rows.length > 0 && selected.size === rows.length}
+											onChange={toggleSelectAll}
 										/>
-									</td>
-									<td class={TD}>{ratingDisplay(r.rating, r.ratingScale)}</td>
-									<td class={`${TD} text-text-base`}>
-										<div>{r.body ?? "—"}</div>
-										{r.submitterLabel && (
-											<div class="text-[0.75rem] text-text-muted mt-1">{r.submitterLabel}</div>
-										)}
-										{(() => {
-											const context = parseContext(r.sourceUrl);
-											if (!context) return null;
-											return (
-												<div class="mt-1">
-													<button
-														type="button"
-														class="text-[0.75rem] text-text-muted underline"
-														onClick={() => toggleExpanded(r.id)}
-													>
-														Context ({context.params.length})
-													</button>
-													{expanded.has(r.id) && (
-														<div class="text-[0.75rem] text-text-muted mt-1 flex flex-col gap-0.5">
-															<a
-																href={context.url}
-																target="_blank"
-																rel="noopener noreferrer"
-																class="underline"
-															>
-																{context.url}
-															</a>
-															{context.params.map(([key, value]) => (
-																<div key={key}>
-																	{key}: {value}
-																</div>
-															))}
-														</div>
-													)}
-												</div>
-											);
-										})()}
-									</td>
-									<td class={`${TD} text-text-muted`}>{r.sourceName ?? "—"}</td>
-									<td class={`${TD} text-text-muted`}>{r.status}</td>
-									<td class={`${TD} text-text-muted`}>{formatDate(r.createdAt)}</td>
-									<td class={`${TD} whitespace-nowrap`}>
-										<div class="flex gap-2">
-											{r.status === "new" && (
-												<button
-													type="button"
-													class="btn btn-outline btn-sm"
-													onClick={() => markReviewed(r.id)}
-												>
-													Mark reviewed
-												</button>
-											)}
-											{r.linkedIssueId ? (
-												<span class="text-[0.8rem] text-text-muted">Linked</span>
-											) : (
-												<button
-													type="button"
-													class="btn btn-outline btn-sm"
-													onClick={() => convert(r.id)}
-												>
-													Convert to issue
-												</button>
-											)}
-										</div>
-									</td>
+									</th>
+									<th class={TH}>Rating</th>
+									<th class={TH}>Feedback</th>
+									<th class={TH}>Source</th>
+									<th class={TH}>Status</th>
+									<th class={TH}>Received</th>
+									<th class={TH}></th>
 								</tr>
-							))}
-						</tbody>
-					</table>
-				</div>
+							</thead>
+							<tbody>
+								{rows.map((r) => (
+									<tr key={r.id}>
+										<td class={TD}>
+											<input
+												type="checkbox"
+												aria-label={`select row ${r.id}`}
+												checked={selected.has(r.id)}
+												onChange={() => toggleRow(r.id)}
+											/>
+										</td>
+										<td class={TD}>{ratingDisplay(r.rating, r.ratingScale)}</td>
+										<td class={`${TD} text-text-base`}>
+											<div>{r.body ?? "—"}</div>
+											{r.submitterLabel && (
+												<div class="text-[0.75rem] text-text-muted mt-1">{r.submitterLabel}</div>
+											)}
+											<FeedbackContext
+												row={r}
+												expanded={expanded.has(r.id)}
+												onToggle={() => toggleExpanded(r.id)}
+											/>
+										</td>
+										<td class={`${TD} text-text-muted`}>{r.sourceName ?? "—"}</td>
+										<td class={`${TD} text-text-muted`}>{r.status}</td>
+										<td class={`${TD} text-text-muted`}>{formatDate(r.createdAt)}</td>
+										<td class={`${TD} whitespace-nowrap`}>
+											<FeedbackRowActions
+												row={r}
+												onMarkReviewed={markReviewed}
+												onConvert={convert}
+											/>
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+					<FeedbackMobileCards
+						rows={rows}
+						selected={selected}
+						expanded={expanded}
+						onToggleRow={toggleRow}
+						onToggleExpanded={toggleExpanded}
+						onMarkReviewed={markReviewed}
+						onConvert={convert}
+					/>
+				</>
 			)}
 		</section>
 	);

--- a/apps/web/src/islands/FeedbackSourceManager.test.tsx
+++ b/apps/web/src/islands/FeedbackSourceManager.test.tsx
@@ -36,8 +36,15 @@ describe("FeedbackSourceManager", () => {
 	it("lists sources with name and token preview after fetch", async () => {
 		stubFetch();
 		render(<FeedbackSourceManager workspaceSlug="my-ws" projectId="p1" />);
-		expect(await screen.findByText("Onboarding survey")).toBeTruthy();
-		expect(screen.getByText(/abcdef012345/)).toBeTruthy();
+		expect((await screen.findAllByText("Onboarding survey")).length).toBeGreaterThan(0);
+		expect(screen.getAllByText(/abcdef012345/).length).toBeGreaterThan(0);
+	});
+
+	it("renders a mobile-card fallback alongside the desktop table", async () => {
+		stubFetch();
+		render(<FeedbackSourceManager workspaceSlug="my-ws" projectId="p1" />);
+		// Desktop table + mobile card both render (CSS hides one per viewport).
+		expect((await screen.findAllByText("Onboarding survey")).length).toBe(2);
 	});
 
 	it("shows the raw token once after minting a source", async () => {
@@ -76,7 +83,7 @@ describe("FeedbackSourceManager", () => {
 		stubFetch();
 		try {
 			render(<FeedbackSourceManager workspaceSlug="my-ws" />);
-			expect(await screen.findByText("Onboarding survey")).toBeTruthy();
+			expect((await screen.findAllByText("Onboarding survey")).length).toBeGreaterThan(0);
 			const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
 			expect(fetchMock.mock.calls[0][0]).toContain("/api/projects/p1/feedback-sources");
 		} finally {

--- a/apps/web/src/islands/FeedbackSourceManager.tsx
+++ b/apps/web/src/islands/FeedbackSourceManager.tsx
@@ -41,6 +41,93 @@ function parseOrigins(raw: string): string[] | undefined {
 	return list.length > 0 ? list : undefined;
 }
 
+function SourceRotateRevokeControl({
+	rotating,
+	onRotateClick,
+	onRotateConfirm,
+	onRotateCancel,
+	onRevoke,
+}: {
+	rotating: boolean;
+	onRotateClick: () => void;
+	onRotateConfirm: () => void;
+	onRotateCancel: () => void;
+	onRevoke: () => void;
+}) {
+	if (rotating) {
+		return (
+			<span class="inline-flex gap-[0.375rem] items-center flex-wrap">
+				<span class="text-[0.8rem] text-text-muted">Rotate? Old token dies.</span>
+				<button type="button" class="btn btn-danger btn-sm" onClick={onRotateConfirm}>
+					Yes
+				</button>
+				<button type="button" class="btn btn-outline btn-sm" onClick={onRotateCancel}>
+					No
+				</button>
+			</span>
+		);
+	}
+	return (
+		<span class="inline-flex gap-[0.375rem]">
+			<button type="button" class="btn btn-outline btn-sm" onClick={onRotateClick}>
+				Rotate
+			</button>
+			<button
+				type="button"
+				class="btn btn-outline btn-sm text-[var(--danger-text)] border-[var(--danger-border)]"
+				onClick={onRevoke}
+			>
+				Revoke
+			</button>
+		</span>
+	);
+}
+
+interface SourceMobileCardsProps {
+	sources: FeedbackSource[];
+	rotateId: string | null;
+	onToggleActive: (s: FeedbackSource) => void;
+	onRotateClick: (id: string) => void;
+	onRotateConfirm: (id: string) => void;
+	onRotateCancel: () => void;
+	onRevoke: (id: string) => void;
+}
+
+function SourceMobileCards({
+	sources,
+	rotateId,
+	onToggleActive,
+	onRotateClick,
+	onRotateConfirm,
+	onRotateCancel,
+	onRevoke,
+}: SourceMobileCardsProps) {
+	return (
+		<div class="hidden max-sm:flex max-sm:flex-col max-sm:gap-3">
+			{sources.map((s) => (
+				<div key={s.id} class="py-3 px-4 border border-border rounded-md bg-surface">
+					<div class="flex justify-between items-start gap-2 mb-2">
+						<span class="font-medium text-text-base">{s.name}</span>
+						<button type="button" class="btn btn-outline btn-sm" onClick={() => onToggleActive(s)}>
+							{s.isActive ? "Active" : "Inactive"}
+						</button>
+					</div>
+					<div class="text-[0.875rem] text-text-muted mb-1">{s.description ?? "—"}</div>
+					<div class="text-[0.75rem] font-mono text-text-muted mb-1">{s.tokenPreview}</div>
+					<div class="text-[0.75rem] text-text-muted mb-2">{formatDate(s.createdAt)}</div>
+					<SourceRotateRevokeControl
+						rotating={rotateId === s.id}
+						onRotateClick={() => onRotateClick(s.id)}
+						onRotateConfirm={() => onRotateConfirm(s.id)}
+						onRotateCancel={onRotateCancel}
+						onRevoke={() => onRevoke(s.id)}
+					/>
+				</div>
+			))}
+		</div>
+	);
+}
+
 export default function FeedbackSourceManager({ workspaceSlug, projectId: projectIdProp }: Props) {
 	const [projectId, setProjectId] = useState(projectIdProp ?? "");
 	useEffect(() => {
@@ -248,77 +335,61 @@ export default function FeedbackSourceManager({ workspaceSlug, projectId: projec
 					No feedback sources yet.
 				</div>
 			) : (
-				<div class="overflow-x-auto">
-					<table class="w-full border-collapse text-[0.9rem]">
-						<thead>
-							<tr>
-								<th class={TH}>Name</th>
-								<th class={TH}>Description</th>
-								<th class={TH}>Active</th>
-								<th class={TH}>Token</th>
-								<th class={TH}>Created</th>
-								<th class={TH}></th>
-							</tr>
-						</thead>
-						<tbody>
-							{sources.map((s) => (
-								<tr key={s.id}>
-									<td class={`${TD} font-medium text-text-base`}>{s.name}</td>
-									<td class={`${TD} text-text-muted`}>{s.description ?? "—"}</td>
-									<td class={TD}>
-										<button
-											type="button"
-											class="btn btn-outline btn-sm"
-											onClick={() => toggleActive(s)}
-										>
-											{s.isActive ? "Active" : "Inactive"}
-										</button>
-									</td>
-									<td class={`${TD} font-mono text-[0.8rem] text-text-muted`}>{s.tokenPreview}</td>
-									<td class={`${TD} text-text-muted`}>{formatDate(s.createdAt)}</td>
-									<td class={`${TD} whitespace-nowrap`}>
-										{rotateId === s.id ? (
-											<span class="inline-flex gap-[0.375rem] items-center">
-												<span class="text-[0.8rem] text-text-muted">Rotate? Old token dies.</span>
-												<button
-													type="button"
-													class="btn btn-danger btn-sm"
-													onClick={() => confirmRotate(s.id)}
-												>
-													Yes
-												</button>
-												<button
-													type="button"
-													class="btn btn-outline btn-sm"
-													onClick={() => setRotateId(null)}
-												>
-													No
-												</button>
-											</span>
-										) : (
-											<span class="inline-flex gap-[0.375rem]">
-												<button
-													type="button"
-													class="btn btn-outline btn-sm"
-													onClick={() => setRotateId(s.id)}
-												>
-													Rotate
-												</button>
-												<button
-													type="button"
-													class="btn btn-outline btn-sm text-[var(--danger-text)] border-[var(--danger-border)]"
-													onClick={() => revoke(s.id)}
-												>
-													Revoke
-												</button>
-											</span>
-										)}
-									</td>
+				<>
+					<div class="overflow-x-auto max-sm:hidden">
+						<table class="w-full border-collapse text-[0.9rem]">
+							<thead>
+								<tr>
+									<th class={TH}>Name</th>
+									<th class={TH}>Description</th>
+									<th class={TH}>Active</th>
+									<th class={TH}>Token</th>
+									<th class={TH}>Created</th>
+									<th class={TH}></th>
 								</tr>
-							))}
-						</tbody>
-					</table>
-				</div>
+							</thead>
+							<tbody>
+								{sources.map((s) => (
+									<tr key={s.id}>
+										<td class={`${TD} font-medium text-text-base`}>{s.name}</td>
+										<td class={`${TD} text-text-muted`}>{s.description ?? "—"}</td>
+										<td class={TD}>
+											<button
+												type="button"
+												class="btn btn-outline btn-sm"
+												onClick={() => toggleActive(s)}
+											>
+												{s.isActive ? "Active" : "Inactive"}
+											</button>
+										</td>
+										<td class={`${TD} font-mono text-[0.8rem] text-text-muted`}>
+											{s.tokenPreview}
+										</td>
+										<td class={`${TD} text-text-muted`}>{formatDate(s.createdAt)}</td>
+										<td class={`${TD} whitespace-nowrap`}>
+											<SourceRotateRevokeControl
+												rotating={rotateId === s.id}
+												onRotateClick={() => setRotateId(s.id)}
+												onRotateConfirm={() => confirmRotate(s.id)}
+												onRotateCancel={() => setRotateId(null)}
+												onRevoke={() => revoke(s.id)}
+											/>
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+					<SourceMobileCards
+						sources={sources}
+						rotateId={rotateId}
+						onToggleActive={toggleActive}
+						onRotateClick={(id) => setRotateId(id)}
+						onRotateConfirm={(id) => confirmRotate(id)}
+						onRotateCancel={() => setRotateId(null)}
+						onRevoke={(id) => revoke(id)}
+					/>
+				</>
 			)}
 		</section>
 	);

--- a/apps/web/src/islands/GroupManager.test.tsx
+++ b/apps/web/src/islands/GroupManager.test.tsx
@@ -41,7 +41,9 @@ function mockFetch() {
 }
 
 async function openEditor() {
-	fireEvent.click(await screen.findByRole("button", { name: "Engineering" }));
+	await screen.findByRole("table");
+	const nameButtons = await screen.findAllByRole("button", { name: "Engineering" });
+	fireEvent.click(nameButtons[0]);
 	return (await screen.findByLabelText(/Group name/i)) as HTMLInputElement;
 }
 
@@ -123,7 +125,7 @@ describe("GroupManager tabs", () => {
 		expect(groupsTab.getAttribute("aria-selected")).toBe("true");
 		expect(membersTab.getAttribute("aria-selected")).toBe("false");
 
-		expect(screen.getByText("Engineering")).toBeTruthy();
+		expect(screen.getAllByText("Engineering").length).toBeGreaterThan(0);
 		expect(screen.queryByText("Mo Member")).toBeNull();
 	});
 
@@ -131,10 +133,10 @@ describe("GroupManager tabs", () => {
 		mockFetchForTabs({ role: "admin" });
 		render(<GroupManager workspaceSlug="my-ws" />);
 
-		await screen.findByText("Engineering");
+		await screen.findAllByText("Engineering");
 		fireEvent.click(screen.getByRole("tab", { name: "Members" }));
 
-		expect(await screen.findByText("Mo Member")).toBeTruthy();
+		expect((await screen.findAllByText("Mo Member")).length).toBeGreaterThan(0);
 		expect(screen.queryByPlaceholderText("New group name")).toBeNull();
 		expect(screen.getByRole("tab", { name: "Members" }).getAttribute("aria-selected")).toBe("true");
 	});
@@ -146,5 +148,20 @@ describe("GroupManager tabs", () => {
 		await screen.findByText("Your groups");
 		expect(screen.queryByRole("tab", { name: "Members" })).toBeNull();
 		expect(screen.queryByRole("tablist")).toBeNull();
+	});
+
+	it("renders a mobile-card fallback for the groups table", async () => {
+		mockFetchForTabs({ role: "admin" });
+		render(<GroupManager workspaceSlug="my-ws" />);
+		// Desktop table + mobile card both render (CSS hides one per viewport).
+		expect((await screen.findAllByText("Engineering")).length).toBe(2);
+	});
+
+	it("renders a mobile-card fallback for the members table", async () => {
+		mockFetchForTabs({ role: "admin" });
+		render(<GroupManager workspaceSlug="my-ws" />);
+		await screen.findAllByText("Engineering");
+		fireEvent.click(screen.getByRole("tab", { name: "Members" }));
+		expect((await screen.findAllByText("Mo Member")).length).toBe(2);
 	});
 });

--- a/apps/web/src/islands/GroupManager.tsx
+++ b/apps/web/src/islands/GroupManager.tsx
@@ -150,12 +150,52 @@ function RoleBanner(props: { role: string; isAdmin: boolean }) {
 // Members overview — group chips + pending badge
 // ---------------------------------------------------------------------------
 
+function MemberGroupsCell(props: {
+	member: WsMember;
+	groups: Array<{ id: string; name: string }>;
+}) {
+	const isAdmin = props.member.role === "owner" || props.member.role === "admin";
+	if (isAdmin) {
+		return <span class="text-[0.78rem] text-text-muted">All projects (bypasses groups)</span>;
+	}
+	if (props.groups.length === 0) return <span class={BADGE_PENDING}>Pending — no access</span>;
+	return (
+		<>
+			{props.groups.map((g) => (
+				<span key={g.id} class={CHIP}>
+					{g.name}
+				</span>
+			))}
+		</>
+	);
+}
+
+function MembersMobileCards(props: {
+	members: WsMember[];
+	groupsByUser: Map<string, Array<{ id: string; name: string }>>;
+}) {
+	return (
+		<div class="hidden max-sm:flex max-sm:flex-col max-sm:gap-3">
+			{props.members.map((m) => (
+				<div key={m.id} class="py-3 px-4 border border-border rounded-md bg-surface">
+					<div class="font-medium text-text-base">{m.name || m.email}</div>
+					<div class="text-[0.75rem] text-text-muted mb-1">{m.email}</div>
+					<div class="text-[0.75rem] text-text-muted mb-2">Role: {m.role}</div>
+					<div>
+						<MemberGroupsCell member={m} groups={props.groupsByUser.get(m.id) ?? []} />
+					</div>
+				</div>
+			))}
+		</div>
+	);
+}
+
 function MembersOverview(props: { members: WsMember[]; memberGroups: MemberGroupsRow[] }) {
 	const groupsByUser = new Map(props.memberGroups.map((r) => [r.userId, r.groups]));
 	return (
 		<section class={CARD}>
 			<h2 class={H2}>Members</h2>
-			<div class="overflow-x-auto">
+			<div class="overflow-x-auto max-sm:hidden">
 				<table class="w-full border-collapse">
 					<thead>
 						<tr>
@@ -165,37 +205,22 @@ function MembersOverview(props: { members: WsMember[]; memberGroups: MemberGroup
 						</tr>
 					</thead>
 					<tbody>
-						{props.members.map((m) => {
-							const isAdmin = m.role === "owner" || m.role === "admin";
-							const groups = groupsByUser.get(m.id) ?? [];
-							return (
-								<tr key={m.id}>
-									<td class={TD}>
-										<div class="font-medium text-text-base">{m.name || m.email}</div>
-										<div class="text-[0.75rem] text-text-muted">{m.email}</div>
-									</td>
-									<td class={TD}>{m.role}</td>
-									<td class={TD}>
-										{isAdmin ? (
-											<span class="text-[0.78rem] text-text-muted">
-												All projects (bypasses groups)
-											</span>
-										) : groups.length > 0 ? (
-											groups.map((g) => (
-												<span key={g.id} class={CHIP}>
-													{g.name}
-												</span>
-											))
-										) : (
-											<span class={BADGE_PENDING}>Pending — no access</span>
-										)}
-									</td>
-								</tr>
-							);
-						})}
+						{props.members.map((m) => (
+							<tr key={m.id}>
+								<td class={TD}>
+									<div class="font-medium text-text-base">{m.name || m.email}</div>
+									<div class="text-[0.75rem] text-text-muted">{m.email}</div>
+								</td>
+								<td class={TD}>{m.role}</td>
+								<td class={TD}>
+									<MemberGroupsCell member={m} groups={groupsByUser.get(m.id) ?? []} />
+								</td>
+							</tr>
+						))}
 					</tbody>
 				</table>
 			</div>
+			<MembersMobileCards members={props.members} groupsByUser={groupsByUser} />
 		</section>
 	);
 }
@@ -602,51 +627,85 @@ export default function GroupManager({ workspaceSlug }: Props) {
 							: "You don't belong to any groups yet. An owner or admin can add you to one."}
 					</div>
 				) : (
-					<div class="overflow-x-auto">
-						<table class="w-full border-collapse">
-							<thead>
-								<tr>
-									<th class={TH}>Name</th>
-									<th class={TH}>Members</th>
-									<th class={TH}>Projects</th>
-									{isAdmin && <th class={TH} />}
-								</tr>
-							</thead>
-							<tbody>
-								{data.groups.map((g) => (
-									<tr key={g.id}>
-										<td class={TD}>
-											{isAdmin ? (
-												<button
-													type="button"
-													class="text-accent font-medium bg-transparent border-0 cursor-pointer p-0"
-													onClick={() => setSelected(g.id)}
-												>
-													{g.name}
-												</button>
-											) : (
-												<span class="font-medium text-text-base">{g.name}</span>
-											)}
-										</td>
-										<td class={TD}>{g.memberCount}</td>
-										<td class={TD}>{g.grantCount}</td>
-										{isAdmin && (
-											<td class={TD}>
-												<button
-													type="button"
-													class={BTN_DANGER}
-													disabled={busy}
-													onClick={() => deleteGroup(g.id)}
-												>
-													Delete
-												</button>
-											</td>
-										)}
+					<>
+						<div class="overflow-x-auto max-sm:hidden">
+							<table class="w-full border-collapse">
+								<thead>
+									<tr>
+										<th class={TH}>Name</th>
+										<th class={TH}>Members</th>
+										<th class={TH}>Projects</th>
+										{isAdmin && <th class={TH} />}
 									</tr>
-								))}
-							</tbody>
-						</table>
-					</div>
+								</thead>
+								<tbody>
+									{data.groups.map((g) => (
+										<tr key={g.id}>
+											<td class={TD}>
+												{isAdmin ? (
+													<button
+														type="button"
+														class="text-accent font-medium bg-transparent border-0 cursor-pointer p-0"
+														onClick={() => setSelected(g.id)}
+													>
+														{g.name}
+													</button>
+												) : (
+													<span class="font-medium text-text-base">{g.name}</span>
+												)}
+											</td>
+											<td class={TD}>{g.memberCount}</td>
+											<td class={TD}>{g.grantCount}</td>
+											{isAdmin && (
+												<td class={TD}>
+													<button
+														type="button"
+														class={BTN_DANGER}
+														disabled={busy}
+														onClick={() => deleteGroup(g.id)}
+													>
+														Delete
+													</button>
+												</td>
+											)}
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+						<div class="hidden max-sm:flex max-sm:flex-col max-sm:gap-3">
+							{data.groups.map((g) => (
+								<div key={g.id} class="py-3 px-4 border border-border rounded-md bg-surface">
+									<div class="flex justify-between items-center gap-2 mb-1">
+										{isAdmin ? (
+											<button
+												type="button"
+												class="text-accent font-medium bg-transparent border-0 cursor-pointer p-0"
+												onClick={() => setSelected(g.id)}
+											>
+												{g.name}
+											</button>
+										) : (
+											<span class="font-medium text-text-base">{g.name}</span>
+										)}
+										{isAdmin && (
+											<button
+												type="button"
+												class={BTN_DANGER}
+												disabled={busy}
+												onClick={() => deleteGroup(g.id)}
+											>
+												Delete
+											</button>
+										)}
+									</div>
+									<div class="text-[0.75rem] text-text-muted">
+										{g.memberCount} members · {g.grantCount} projects
+									</div>
+								</div>
+							))}
+						</div>
+					</>
 				)}
 			</section>
 

--- a/apps/web/src/islands/TokenManager.test.tsx
+++ b/apps/web/src/islands/TokenManager.test.tsx
@@ -52,8 +52,16 @@ describe("TokenManager", () => {
 	it("renders token names and scope after fetch resolves", async () => {
 		mockFetchTokens([TOKEN]);
 		render(<TokenManager workspaceSlug="my-ws" />);
-		expect(await screen.findByText("Claude agent")).toBeTruthy();
-		expect(screen.getByText("Read + Write")).toBeTruthy();
+		expect(await screen.findAllByText("Claude agent")).not.toHaveLength(0);
+		expect(screen.getAllByText("Read + Write").length).toBeGreaterThan(0);
+	});
+
+	it("renders a mobile-card fallback alongside the desktop table", async () => {
+		mockFetchTokens([TOKEN]);
+		render(<TokenManager workspaceSlug="my-ws" />);
+		// Desktop table + mobile card both render (CSS hides one per viewport;
+		// jsdom doesn't evaluate CSS, see apps/web/src/test/viewport.ts).
+		expect((await screen.findAllByText("Claude agent")).length).toBe(2);
 	});
 
 	it("shows empty state when no tokens exist", async () => {

--- a/apps/web/src/islands/TokenManager.tsx
+++ b/apps/web/src/islands/TokenManager.tsx
@@ -477,38 +477,104 @@ function TokenTableRow({
 			</td>
 			<td class={TD_MUTED}>{formatDate(tok.lastUsedAt)}</td>
 			<td class={`${TD_BASE} whitespace-nowrap`}>
-				{revokeId === tok.id ? (
-					<span class="inline-flex gap-[0.375rem] items-center">
-						<span class="text-[0.8rem] text-text-muted">Revoke?</span>
-						<button
-							type="button"
-							class="btn btn-danger btn-sm"
-							disabled={revoking}
-							onClick={() => onConfirmRevoke(tok.id)}
-						>
-							{revoking ? "…" : "Yes"}
-						</button>
-						<button
-							type="button"
-							class="btn btn-outline btn-sm"
-							disabled={revoking}
-							onClick={onCancelRevoke}
-						>
-							No
-						</button>
-						{revokeError && <span class="text-[var(--danger-text)] text-xs">{revokeError}</span>}
-					</span>
-				) : (
-					<button
-						type="button"
-						class="btn btn-outline btn-sm text-[var(--danger-text)] border-[var(--danger-border)]"
-						onClick={() => onSelectRevoke(tok.id)}
-					>
-						Revoke
-					</button>
-				)}
+				<TokenRevokeControl
+					tok={tok}
+					revokeId={revokeId}
+					revoking={revoking}
+					revokeError={revokeError}
+					onSelectRevoke={onSelectRevoke}
+					onCancelRevoke={onCancelRevoke}
+					onConfirmRevoke={onConfirmRevoke}
+				/>
 			</td>
 		</tr>
+	);
+}
+
+function TokenRevokeControl({
+	tok,
+	revokeId,
+	revoking,
+	revokeError,
+	onSelectRevoke,
+	onCancelRevoke,
+	onConfirmRevoke,
+}: TokenTableRowProps) {
+	if (revokeId === tok.id) {
+		return (
+			<span class="inline-flex gap-[0.375rem] items-center flex-wrap">
+				<span class="text-[0.8rem] text-text-muted">Revoke?</span>
+				<button
+					type="button"
+					class="btn btn-danger btn-sm"
+					disabled={revoking}
+					onClick={() => onConfirmRevoke(tok.id)}
+				>
+					{revoking ? "…" : "Yes"}
+				</button>
+				<button
+					type="button"
+					class="btn btn-outline btn-sm"
+					disabled={revoking}
+					onClick={onCancelRevoke}
+				>
+					No
+				</button>
+				{revokeError && <span class="text-[var(--danger-text)] text-xs">{revokeError}</span>}
+			</span>
+		);
+	}
+	return (
+		<button
+			type="button"
+			class="btn btn-outline btn-sm text-[var(--danger-text)] border-[var(--danger-border)]"
+			onClick={() => onSelectRevoke(tok.id)}
+		>
+			Revoke
+		</button>
+	);
+}
+
+function TokenMobileCards({
+	tokens,
+	revokeId,
+	revoking,
+	revokeError,
+	onSelectRevoke,
+	onCancelRevoke,
+	onConfirmRevoke,
+}: TokenTableProps) {
+	return (
+		<div class="hidden max-sm:flex max-sm:flex-col max-sm:gap-3">
+			{tokens.map((tok) => (
+				<div key={tok.id} class="py-3 px-4 border border-border rounded-md bg-surface">
+					<div class="text-[0.9rem] text-text-base font-medium mb-2">{tok.name}</div>
+					<dl class="grid grid-cols-[auto_1fr] gap-x-2 gap-y-1 text-[0.8rem] text-text-muted mb-3">
+						<dt class="font-semibold">Scope</dt>
+						<dd class="m-0">{formatScopes(tok.scopes)}</dd>
+						<dt class="font-semibold">Created</dt>
+						<dd class="m-0">{formatDate(tok.createdAt)}</dd>
+						<dt class="font-semibold">Expires</dt>
+						<dd
+							class={`m-0 ${tok.expiresAt && tok.expiresAt < Date.now() / 1000 ? "text-[var(--danger-text)]" : ""}`}
+						>
+							{tok.expiresAt === null ? "No expiry" : formatDate(tok.expiresAt)}
+						</dd>
+						<dt class="font-semibold">Last used</dt>
+						<dd class="m-0">{formatDate(tok.lastUsedAt)}</dd>
+					</dl>
+					<TokenRevokeControl
+						tok={tok}
+						revokeId={revokeId}
+						revoking={revoking}
+						revokeError={revokeError}
+						onSelectRevoke={onSelectRevoke}
+						onCancelRevoke={onCancelRevoke}
+						onConfirmRevoke={onConfirmRevoke}
+					/>
+				</div>
+			))}
+		</div>
 	);
 }
 
@@ -540,34 +606,45 @@ function TokenTable({
 		);
 	}
 	return (
-		<div class="overflow-x-auto">
-			<table class="w-full border-collapse text-[0.9rem]">
-				<thead>
-					<tr>
-						<th class={TH_CLASS}>Name</th>
-						<th class={TH_CLASS}>Scope</th>
-						<th class={TH_CLASS}>Created</th>
-						<th class={TH_CLASS}>Expires</th>
-						<th class={TH_CLASS}>Last used</th>
-						<th class={TH_CLASS}></th>
-					</tr>
-				</thead>
-				<tbody>
-					{tokens.map((tok) => (
-						<TokenTableRow
-							key={tok.id}
-							tok={tok}
-							revokeId={revokeId}
-							revoking={revoking}
-							revokeError={revokeError}
-							onSelectRevoke={onSelectRevoke}
-							onCancelRevoke={onCancelRevoke}
-							onConfirmRevoke={onConfirmRevoke}
-						/>
-					))}
-				</tbody>
-			</table>
-		</div>
+		<>
+			<div class="overflow-x-auto max-sm:hidden">
+				<table class="w-full border-collapse text-[0.9rem]">
+					<thead>
+						<tr>
+							<th class={TH_CLASS}>Name</th>
+							<th class={TH_CLASS}>Scope</th>
+							<th class={TH_CLASS}>Created</th>
+							<th class={TH_CLASS}>Expires</th>
+							<th class={TH_CLASS}>Last used</th>
+							<th class={TH_CLASS}></th>
+						</tr>
+					</thead>
+					<tbody>
+						{tokens.map((tok) => (
+							<TokenTableRow
+								key={tok.id}
+								tok={tok}
+								revokeId={revokeId}
+								revoking={revoking}
+								revokeError={revokeError}
+								onSelectRevoke={onSelectRevoke}
+								onCancelRevoke={onCancelRevoke}
+								onConfirmRevoke={onConfirmRevoke}
+							/>
+						))}
+					</tbody>
+				</table>
+			</div>
+			<TokenMobileCards
+				tokens={tokens}
+				revokeId={revokeId}
+				revoking={revoking}
+				revokeError={revokeError}
+				onSelectRevoke={onSelectRevoke}
+				onCancelRevoke={onCancelRevoke}
+				onConfirmRevoke={onConfirmRevoke}
+			/>
+		</>
 	);
 }
 


### PR DESCRIPTION
## Summary
- Adds a card-based fallback for narrow viewports to the 6 admin data tables across 5 islands: TokenManager, FeedbackList, FeedbackSourceManager, GroupManager (members + groups), EpicList.
- Follows the desktop-table/mobile-card convention established in PROJ-412 (MyIssues.tsx's ProjectIssuesSection): desktop table wrapped in `max-sm:hidden`, mobile cards in `hidden max-sm:flex max-sm:flex-col max-sm:gap-3`, individual cards styled `py-3 px-4 border border-border rounded-md bg-surface`.
- Extracted shared row-action sub-components (TokenRevokeControl, FeedbackContext/FeedbackRowActions, SourceRotateRevokeControl, MemberGroupsCell) so desktop and mobile share handler logic instead of duplicating it.
- Reviewed by an Opus agent: approved with minor non-blocking follow-ups (addressed the cosmetic one — dropped no-op `setViewportWidth` calls in two tests where there's no JS-level viewport branch to prove).

Part of epic PROJ-411 (mobile coverage hardening).

## Test plan
- [x] `pnpm --filter @projektor/web test -- --run` — 368 tests pass across all islands
- [x] `pnpm --filter @projektor/web type-check` (after `rm -rf apps/web/dist`) — 0 errors
- [x] `pnpm biome check --write` on all changed files
- [x] Full pre-push hook (lint + full monorepo test incl. apps/api + test-web) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNaaRLdg4nYs7GpEReiCc2