### PR TITLE
PROJ-416: add tap-to-open status menu to the mobile board view

### DIFF
--- a/apps/web/src/islands/issue-list/BoardView.test.tsx
+++ b/apps/web/src/islands/issue-list/BoardView.test.tsx
@@ -101,3 +101,35 @@ describe("BoardView — mobile viewport", () => {
 		expect(changeStatus).not.toHaveBeenCalled();
 	});
 });
+
+describe("BoardView — mobile status menu (PROJ-416)", () => {
+	it("renders a tap-to-open status menu on each card", () => {
+		const changeStatus = vi.fn();
+		render(<BoardView issues={[TODO_ISSUE]} statuses={STATUSES} changeStatus={changeStatus} />);
+		expect(screen.getByRole("combobox", { name: "Change status for issue PROJ-1" })).toBeTruthy();
+	});
+
+	it("changes status when a different option is chosen from the menu", () => {
+		const changeStatus = vi.fn();
+		render(<BoardView issues={[TODO_ISSUE]} statuses={STATUSES} changeStatus={changeStatus} />);
+
+		fireEvent.click(screen.getByRole("combobox", { name: "Change status for issue PROJ-1" }));
+		fireEvent.click(screen.getByRole("option", { name: "In Progress" }));
+
+		expect(changeStatus).toHaveBeenCalledWith("i1", "st-in-progress");
+	});
+
+	it("renders the status menu outside the card's link, not nested inside it", () => {
+		// The whole card body is a draggable <a> (desktop DnD target); nesting an
+		// interactive Select inside it would be invalid HTML (no interactive
+		// descendants in an <a>) and would risk taps on the menu also triggering
+		// navigation. The status menu must be a sibling of the <a>, not a child.
+		const changeStatus = vi.fn();
+		render(<BoardView issues={[TODO_ISSUE]} statuses={STATUSES} changeStatus={changeStatus} />);
+
+		const link = screen.getByText("Move me").closest("a") as HTMLElement;
+		const trigger = screen.getByRole("combobox", { name: "Change status for issue PROJ-1" });
+
+		expect(link.contains(trigger)).toBe(false);
+	});
+});

--- a/apps/web/src/islands/issue-list/BoardView.tsx
+++ b/apps/web/src/islands/issue-list/BoardView.tsx
@@ -9,60 +9,82 @@ import {
 	type Issue,
 	type TaskStatus,
 } from "../board-utils";
-import { getStoryPoints, priorityBadge, spBadge } from "./issue-render-helpers";
+import { getStoryPoints, priorityBadge, StatusSelect, spBadge } from "./issue-render-helpers";
 
 function BoardCard({
 	issue,
+	statuses,
 	dragIssueId,
 	setDragIssueId,
+	changeStatus,
 }: {
 	issue: Issue;
+	statuses: TaskStatus[];
 	dragIssueId: string | null;
 	setDragIssueId: (id: string | null) => void;
+	changeStatus: (issueId: string, statusId: string) => void;
 }) {
 	const pts = getStoryPoints(issue);
 	return (
-		<a
+		<div
 			key={issue.id}
-			href={issueUrl(issue.project_key, issue.number, issue.title, issue.id)}
 			class={[
-				"block bg-surface border border-border rounded-md px-3 py-2.5 no-underline shadow-sm select-none",
+				"bg-surface border border-border rounded-md px-3 py-2.5 shadow-sm select-none",
 				"transition-all duration-150 hover:shadow-md hover:border-accent hover:-translate-y-px",
 			].join(" ")}
-			draggable={true}
-			onDragStart={(e: DragEvent) => {
-				if (window.innerWidth < 640) {
-					e.preventDefault();
-					return;
-				}
-				e.dataTransfer?.setData("text/plain", issue.id);
-				setDragIssueId(issue.id);
-			}}
-			onDragEnd={() => setDragIssueId(null)}
 			style={{ opacity: dragIssueId === issue.id ? 0.4 : 1 }}
 		>
-			<div class="font-mono text-[0.72rem] text-text-muted mb-1">
-				{issue.project_key ? `${issue.project_key}-${issue.number}` : `#${issue.number}`}
-			</div>
-			<div class="text-sm font-medium text-text-base leading-[1.35] mb-2">{issue.title}</div>
-			<div class="flex justify-between items-center gap-2">
-				<div class="flex items-center gap-1.5">
-					{priorityBadge(issue)}
-					{pts && spBadge(pts)}
+			<a
+				href={issueUrl(issue.project_key, issue.number, issue.title, issue.id)}
+				class="block no-underline"
+				draggable={true}
+				onDragStart={(e: DragEvent) => {
+					if (window.innerWidth < 640) {
+						e.preventDefault();
+						return;
+					}
+					e.dataTransfer?.setData("text/plain", issue.id);
+					setDragIssueId(issue.id);
+				}}
+				onDragEnd={() => setDragIssueId(null)}
+			>
+				<div class="font-mono text-[0.72rem] text-text-muted mb-1">
+					{issue.project_key ? `${issue.project_key}-${issue.number}` : `#${issue.number}`}
 				</div>
-				{issue.assignee_name && (
-					<span
-						title={issue.assignee_name}
-						class={[
-							"w-6 h-6 rounded-full bg-accent text-white text-[0.68rem] font-bold flex items-center",
-							"justify-center shrink-0 uppercase",
-						].join(" ")}
-					>
-						{assigneeInitials(issue.assignee_name)}
-					</span>
-				)}
+				<div class="text-sm font-medium text-text-base leading-[1.35] mb-2">{issue.title}</div>
+				<div class="flex justify-between items-center gap-2">
+					<div class="flex items-center gap-1.5">
+						{priorityBadge(issue)}
+						{pts && spBadge(pts)}
+					</div>
+					{issue.assignee_name && (
+						<span
+							title={issue.assignee_name}
+							class={[
+								"w-6 h-6 rounded-full bg-accent text-white text-[0.68rem] font-bold flex items-center",
+								"justify-center shrink-0 uppercase",
+							].join(" ")}
+						>
+							{assigneeInitials(issue.assignee_name)}
+						</span>
+					)}
+				</div>
+			</a>
+			{/* Mobile-only: native HTML5 drag-and-drop (used above 640px) doesn't
+			    work on touch devices, so narrow viewports get a tap-to-open status
+			    menu instead (PROJ-416). Rendered as a sibling of the <a>, not
+			    nested inside it, so the interactive Select never lands inside
+			    anchor content (matching the ListSection desktop-table/mobile-card
+			    convention, and avoiding an invalid interactive-in-anchor nesting). */}
+			<div class="hidden max-sm:block mt-2">
+				<StatusSelect
+					issue={issue}
+					statuses={statuses}
+					busy={false}
+					onChange={(statusId) => changeStatus(issue.id, statusId)}
+				/>
 			</div>
-		</a>
+		</div>
 	);
 }
 
@@ -139,8 +161,10 @@ export default function BoardView({
 									<BoardCard
 										key={issue.id}
 										issue={issue}
+										statuses={statuses}
 										dragIssueId={dragIssueId}
 										setDragIssueId={setDragIssueId}
+										changeStatus={changeStatus}
 									/>
 								))
 							)}


### PR DESCRIPTION
## Summary
- `BoardView.tsx` uses native HTML5 drag-and-drop to move issues between status columns — already disabled below 640px since native DnD doesn't work on touch devices, leaving the mobile board read-only.
- Design decision: reuse the existing `StatusSelect` helper (already used by `ListSection.tsx` for the same purpose) as a mobile-only, tap-to-open status menu rendered on each board card.
- Split `BoardCard` into an outer non-anchor wrapper (visual card styling) + inner `<a>` (navigable/draggable desktop content), so the interactive `StatusSelect` renders as a sibling of the `<a>`, not nested inside it — avoids invalid interactive-in-anchor HTML and matches the desktop-table/mobile-card convention used elsewhere (e.g. `ListSection.tsx` keeps its Selects outside row/card anchors too).
- Desktop drag-and-drop is unchanged.

Reviewed by an Opus agent twice: the first pass (an earlier draft that used a `preventDefault`-on-wrapping-div hack to suppress anchor navigation) was sent back with two findings — the interactive-in-anchor nesting was invalid HTML, and the inline Select duplicated the existing `StatusSelect` helper. Both addressed in this version by restructuring the card and reusing `StatusSelect`.

Last child of epic PROJ-411 (mobile coverage hardening).

## Test plan
- [x] `pnpm --filter @projektor/web test -- --run` — 371 tests pass, including 3 new BoardView tests (menu renders, changes status, and — the key regression test — is *not* nested inside the card's `<a>`)
- [x] `pnpm --filter @projektor/web type-check` (after `rm -rf apps/web/dist`) — 0 errors
- [x] `pnpm biome check --write` on changed files
- [x] Full pre-push hook (lint + monorepo test incl. `apps/api`, test-web) passed on the 3rd attempt — the first two hit transient `apps/api` test flakes under pre-push resource contention (D1/workerd timing), confirmed unrelated by a clean standalone `pnpm --filter @projektor/api test` run (812/812)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNaaRLdg4nYs7GpEReiCc2