### PR TITLE
PROJ-418: wire up PWA service worker registration on Astro pages

### DIFF
--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -14,6 +14,11 @@ export default defineConfig({
     VitePWA({
       registerType: 'autoUpdate',
       manifest: false,
+      // @vite-pwa/astro doesn't inject a registration <script> into Astro's
+      // built pages the way vite-plugin-pwa does for a plain Vite index.html
+      // (PROJ-418) — registration is wired up manually in Base.astro instead,
+      // via the `virtual:pwa-register` module.
+      injectRegister: null,
       workbox: {
         navigateFallback: '/index.html',
         globPatterns: ['**/*.{html,css,js,svg,png,ico,json}'],

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,7 +23,8 @@
     "marked": "^15.0.0",
     "mermaid": "^11.0.0",
     "preact": "^10.25.0",
-    "uplot": "^1.6.32"
+    "uplot": "^1.6.32",
+    "workbox-window": "^7.4.1"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.0",
@@ -37,6 +38,7 @@
     "jsdom": "^25.0.0",
     "tailwindcss": "^3.4.19",
     "typescript": "^5.5.0",
+    "vite-plugin-pwa": "0.21.2",
     "vitest": "^3.0.0"
   }
 }

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -1,1 +1,12 @@
 /// <reference types="astro/client" />
+
+// vite-plugin-pwa's own `vite-plugin-pwa/vanillajs` ambient types aren't picked
+// up via a triple-slash reference inside Base.astro's <script> block by
+// `astro check` (PROJ-418), so the declaration is inlined here instead.
+declare module "virtual:pwa-register" {
+	import type { RegisterSWOptions } from "vite-plugin-pwa/types";
+
+	export type { RegisterSWOptions };
+
+	export function registerSW(options?: RegisterSWOptions): (reloadPage?: boolean) => Promise<void>;
+}

--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -35,6 +35,15 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
     <link rel="manifest" href="/manifest.json" />
     <title>{title}</title>
     <ClientRouter />
+    <!-- PROJ-418: @vite-pwa/astro's generateSW strategy builds dist/sw.js and
+         dist/registerSW.js but never references either from a rendered page -
+         unlike a plain Vite app's index.html, Astro's build has no injection
+         point for it. Registering here via the virtual module is the
+         documented workaround for meta-frameworks (see vite-pwa-org.netlify.app/frameworks/astro). -->
+    <script>
+      import { registerSW } from 'virtual:pwa-register';
+      registerSW({ immediate: true });
+    </script>
     <!-- safe-ls: 'theme' is a cosmetic preference (dark/light). No API dependency - a
          stale or missing value falls back to the system color-scheme media query.
          Astro's ClientRouter swaps <html>'s attributes to match the incoming (server-

--- a/apps/web/src/layouts/Base.pwa-register.test.ts
+++ b/apps/web/src/layouts/Base.pwa-register.test.ts
@@ -1,0 +1,20 @@
+// Base.astro isn't a Preact component, so it can't be rendered with
+// @testing-library/preact — this asserts directly on the source instead
+// (see Base.mobile-viewport.test.ts for the same pattern).
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(join(__dirname, "Base.astro"), "utf-8");
+const configSource = readFileSync(join(__dirname, "../../astro.config.mjs"), "utf-8");
+
+describe("Base layout — PWA service worker registration (PROJ-418)", () => {
+	it("registers the service worker via the virtual:pwa-register module", () => {
+		expect(source).toMatch(/import\s*\{\s*registerSW\s*\}\s*from\s*['"]virtual:pwa-register['"]/);
+		expect(source).toMatch(/registerSW\(/);
+	});
+
+	it("disables vite-plugin-pwa's own (non-functional-on-Astro) auto-injection", () => {
+		expect(configSource).toMatch(/injectRegister:\s*null/);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       uplot:
         specifier: ^1.6.32
         version: 1.6.32
+      workbox-window:
+        specifier: ^7.4.1
+        version: 7.4.1
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.0
@@ -157,7 +160,7 @@ importers:
         version: 3.2.0
       '@vite-pwa/astro':
         specifier: ^0.5.1
-        version: 0.5.1(astro@5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(vite-plugin-pwa@0.21.2(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1))
+        version: 0.5.1(astro@5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(vite-plugin-pwa@0.21.2(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1))
       '@vitest/coverage-v8':
         specifier: ^3.0.0
         version: 3.2.7(vitest@3.2.6(@types/debug@4.1.13)(@types/node@26.0.0)(happy-dom@15.11.7)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -170,6 +173,9 @@ importers:
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
+      vite-plugin-pwa:
+        specifier: 0.21.2
+        version: 0.21.2(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
       vitest:
         specifier: ^3.0.0
         version: 3.2.6(@types/debug@4.1.13)(@types/node@26.0.0)(happy-dom@15.11.7)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -9324,10 +9330,10 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vite-pwa/astro@0.5.1(astro@5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(vite-plugin-pwa@0.21.2(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1))':
+  '@vite-pwa/astro@0.5.1(astro@5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(vite-plugin-pwa@0.21.2(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1))':
     dependencies:
       astro: 5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
-      vite-plugin-pwa: 0.21.2(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
+      vite-plugin-pwa: 0.21.2(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
 
   '@vitest/coverage-istanbul@4.1.10(vitest@4.1.9)':
     dependencies:
@@ -13555,12 +13561,12 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-pwa@0.21.2(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1):
+  vite-plugin-pwa@0.21.2(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1):
     dependencies:
       debug: 4.4.3
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.17
-      vite: 6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       workbox-build: 7.4.1
       workbox-window: 7.4.1
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- `@vite-pwa/astro`'s `generateSW` mode builds `dist/sw.js` and `dist/registerSW.js`, but Astro's static build has no page-injection point for either (unlike a plain Vite app's `index.html`) — confirmed the service worker was built but never referenced from any rendered page.
- Registers manually via `virtual:pwa-register` from `Base.astro`'s `<head>`; since it's a real module script (not `is:inline`), Astro/Vite bundles it into a real chunk that's referenced from every built page's head.
- `injectRegister: null` in `astro.config.mjs` makes explicit that we're not relying on vite-plugin-pwa's non-functional-for-Astro auto-injection.
- Added `workbox-window` as a runtime dependency (required by `virtual:pwa-register`, build failed without it) and `vite-plugin-pwa` as an explicit devDependency (previously only resolvable transitively via `@vite-pwa/astro`, a soft edge an Opus review flagged).
- No change to the existing workbox caching rules (`navigateFallback`, `NetworkOnly` for `/api`/`/mcp`) — registration-wiring only, per the ticket's scope.

## Verification
- `pnpm --filter @projektor/web test -- --run` — 373/373 passing, including new `Base.pwa-register.test.ts`.
- `pnpm turbo type-check --filter=@projektor/web` — 0 errors.
- Manual: built (`pnpm --filter @projektor/web build`) and inspected `dist/index.html` — confirmed the registration script tag is present in every page's head, and the referenced chunk contains real `Workbox` registration code targeting `/sw.js` scope `/`.
- Reviewed by an Opus agent: PASS, no blocking issues. One nit (undeclared transitive `vite-plugin-pwa` type dependency) addressed by pinning it as an explicit devDependency.

## Test plan
- [x] `pnpm --filter @projektor/web test -- --run`
- [x] `pnpm turbo type-check --filter=@projektor/web`
- [x] Manual build + dist inspection confirming SW registration wiring

Closes PROJ-418 (the previously-unaccounted-for 7th child of epic PROJ-411).