### PR TITLE
PROJ-419: fix sidebar glossary help popover clipping

### DIFF
--- a/apps/web/src/islands/GlossaryHelp.test.tsx
+++ b/apps/web/src/islands/GlossaryHelp.test.tsx
@@ -37,4 +37,41 @@ describe("GlossaryHelp", () => {
 		fireEvent.mouseDown(document.body);
 		expect(screen.queryByRole("dialog")).toBeNull();
 	});
+
+	it("positions the popover with position: fixed, not absolute (PROJ-419)", () => {
+		// A plain CSS `absolute` popover gets clipped by any ancestor with
+		// non-visible overflow (e.g. the sidebar's `overflow-y: auto`, which
+		// forces overflow-x to `auto` too). `fixed` + a rect computed from the
+		// trigger escapes that clipping — see Select.tsx's dropdown for the
+		// same pattern.
+		render(<GlossaryHelp id="tokens" />);
+		fireEvent.click(screen.getByRole("button", { name: "About Tokens" }));
+		const dialog = screen.getByRole("dialog");
+		expect(dialog.style.position).toBe("fixed");
+	});
+
+	it("closes when an ancestor scrolls, rather than leaving a stale-positioned popover", () => {
+		render(<GlossaryHelp id="tokens" />);
+		fireEvent.click(screen.getByRole("button", { name: "About Tokens" }));
+		expect(screen.getByRole("dialog")).toBeTruthy();
+
+		fireEvent.scroll(window);
+		expect(screen.queryByRole("dialog")).toBeNull();
+	});
+
+	it("portals the popover onto document.body and doesn't self-close on a click inside it (PROJ-419)", () => {
+		// Portalled to escape a transformed ancestor's containing-block trap for
+		// `position: fixed` (the mobile off-canvas drawer applies a CSS
+		// transform to the sidebar, which would otherwise reintroduce clipping).
+		// A click landing on the popover's own content is not "outside" even
+		// though it's no longer a DOM descendant of the trigger's <span>.
+		render(<GlossaryHelp id="tokens" />);
+		fireEvent.click(screen.getByRole("button", { name: "About Tokens" }));
+		const dialog = screen.getByRole("dialog");
+
+		expect(dialog.parentElement).toBe(document.body);
+
+		fireEvent.mouseDown(dialog);
+		expect(screen.queryByRole("dialog")).toBeTruthy();
+	});
 });

--- a/apps/web/src/islands/GlossaryHelp.tsx
+++ b/apps/web/src/islands/GlossaryHelp.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from "preact/compat";
 import { useEffect, useId, useRef, useState } from "preact/hooks";
 import { GLOSSARY_TERMS, type GlossaryTermId } from "./glossary-definitions";
 
@@ -5,31 +6,76 @@ import { GLOSSARY_TERMS, type GlossaryTermId } from "./glossary-definitions";
 // next to nav labels, for users unfamiliar with this kind of tool. Same interaction
 // pattern (and CSS classes) as MetricHelp.tsx (PROJ-335) — reused rather than duplicated
 // since the toggletip visuals are identical, only the content source differs.
+//
+// PROJ-419: the Groups/Tokens triggers live inside the sidebar, which has
+// `overflow-y: auto` (forcing overflow-x to `auto` too - CSS spec: one
+// non-visible axis forces the other) - clipping a plain CSS `position:
+// absolute` popover. A `position: fixed` popover alone isn't enough to escape
+// it: on mobile the sidebar becomes an off-canvas drawer with a CSS
+// `transform`, and a transformed ancestor becomes the containing block for
+// its `position: fixed` descendants too, reintroducing the exact same
+// clipping. Portalling the popover to `document.body` sidesteps both cases
+// (no DOM ancestor to be clipped or transformed by), while the position is
+// still computed from the trigger's rect, same as Select.tsx's dropdown.
+const POPOVER_WIDTH = 256; // 16rem, matches .metric-help-popover's `width`
+const POPOVER_MARGIN = 8;
+
 export function GlossaryHelp({ id }: { id: GlossaryTermId }) {
 	const term = GLOSSARY_TERMS[id];
 	const [open, setOpen] = useState(false);
+	const [popoverPos, setPopoverPos] = useState<{ top: number; left: number } | null>(null);
 	const rootRef = useRef<HTMLSpanElement>(null);
+	const triggerRef = useRef<HTMLButtonElement>(null);
+	const popoverRef = useRef<HTMLDivElement>(null);
 	const popoverId = useId();
+
+	function openPopover() {
+		const rect = triggerRef.current?.getBoundingClientRect();
+		if (rect) {
+			const left = Math.max(
+				POPOVER_MARGIN,
+				Math.min(rect.left, window.innerWidth - POPOVER_WIDTH - POPOVER_MARGIN)
+			);
+			setPopoverPos({ top: rect.bottom + 4, left });
+		}
+		setOpen(true);
+	}
+
+	function isInside(node: Node) {
+		return !!(rootRef.current?.contains(node) || popoverRef.current?.contains(node));
+	}
 
 	useEffect(() => {
 		if (!open) return;
 		function onPointerDown(e: MouseEvent) {
-			if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+			if (!(e.target instanceof Node) || !isInside(e.target)) setOpen(false);
 		}
 		function onKeyDown(e: KeyboardEvent) {
 			if (e.key === "Escape") setOpen(false);
 		}
+		function onScroll(e: Event) {
+			if (e.target instanceof Node && isInside(e.target)) return;
+			setOpen(false);
+		}
+		function onResize() {
+			setOpen(false);
+		}
 		document.addEventListener("mousedown", onPointerDown);
 		document.addEventListener("keydown", onKeyDown);
+		window.addEventListener("scroll", onScroll, true);
+		window.addEventListener("resize", onResize);
 		return () => {
 			document.removeEventListener("mousedown", onPointerDown);
 			document.removeEventListener("keydown", onKeyDown);
+			window.removeEventListener("scroll", onScroll, true);
+			window.removeEventListener("resize", onResize);
 		};
 	}, [open]);
 
 	return (
 		<span class="metric-help" ref={rootRef}>
 			<button
+				ref={triggerRef}
 				type="button"
 				class="metric-help-trigger"
 				aria-label={`About ${term.label}`}
@@ -37,22 +83,28 @@ export function GlossaryHelp({ id }: { id: GlossaryTermId }) {
 				aria-describedby={open ? popoverId : undefined}
 				onClick={(e) => {
 					e.preventDefault();
-					setOpen((o) => !o);
+					if (open) setOpen(false);
+					else openPopover();
 				}}
 			>
 				<span aria-hidden="true">ⓘ</span>
 			</button>
-			{open && (
-				<div
-					id={popoverId}
-					role="dialog"
-					aria-modal="false"
-					aria-label={`${term.label} definition`}
-					class="metric-help-popover"
-				>
-					<p class="m-0 text-[0.8rem] text-text-base">{term.definition}</p>
-				</div>
-			)}
+			{open &&
+				popoverPos &&
+				createPortal(
+					<div
+						id={popoverId}
+						ref={popoverRef}
+						role="dialog"
+						aria-modal="false"
+						aria-label={`${term.label} definition`}
+						class="metric-help-popover"
+						style={{ position: "fixed", top: `${popoverPos.top}px`, left: `${popoverPos.left}px` }}
+					>
+						<p class="m-0 text-[0.8rem] text-text-base">{term.definition}</p>
+					</div>,
+					document.body
+				)}
 		</span>
 	);
 }


### PR DESCRIPTION
## Summary
- `GlossaryHelp.tsx`'s toggletip popover (the ⓘ next to "Groups"/"Tokens" in the sidebar) was `position: absolute` relative to its own trigger span, inside `.sidebar` — which has `overflow-y: auto`, forcing `overflow-x` to `auto` too (CSS spec: one non-visible axis forces the other) and clipping the popover against the sidebar's edge.
- Fixed by portalling the popover to `document.body` via `preact/compat`'s `createPortal`, with position computed from the trigger's `getBoundingClientRect()` (same idea as `Select.tsx`'s existing dropdown fix).
- Portalling (not just `position: fixed`) matters because the mobile off-canvas drawer applies a CSS `transform` to `.sidebar` below 640px — a transformed ancestor becomes the containing block for its `position: fixed` descendants, which would reintroduce the same clipping there. An Opus review caught this gap in an earlier iteration that used `position: fixed` alone.
- Outside-click detection now checks containment against both the trigger's root span and the portalled popover itself, since the popover is no longer a DOM descendant of the trigger after portalling.
- `MetricHelp.tsx` shares the identical pattern but isn't currently rendered inside any clipping/transformed ancestor, so it's out of scope here (noted in the ticket as a candidate for the same fix + logic-sharing if that changes).

## Verification
- `pnpm --filter @projektor/web test -- --run` — 376/376 passing, including new tests for fixed positioning, scroll-close, and portal-without-self-close.
- `pnpm turbo type-check --filter=@projektor/web` — 0 errors.
- Opus-reviewed (two passes): first pass caught the mobile-drawer transform gap in the position:fixed-only approach; addressed by portalling.

## Test plan
- [x] `pnpm --filter @projektor/web test -- --run`
- [x] `pnpm turbo type-check --filter=@projektor/web`
- [ ] Manual: open Groups/Tokens sidebar info icon (desktop and mobile drawer) and confirm the definition renders unclipped

Closes PROJ-419.