### PR TITLE
PROJ-400: fix sprints hang bug; audit + lock in mobile coverage for remaining surfaces

### DIFF
--- a/apps/web/e2e/epics.spec.ts
+++ b/apps/web/e2e/epics.spec.ts
@@ -106,17 +106,19 @@ test.describe("Epics — mobile layout (375×812)", () => {
 		const innerWidth = await page.evaluate(() => window.innerWidth);
 		expect(innerWidth).toBeLessThan(640);
 
-		await expect(page.locator('table[aria-label="Epics"]')).not.toBeVisible();
-
 		const newEpicBtn = page.locator("button", { hasText: "+ New Epic" });
 		await expect(newEpicBtn).toBeVisible({ timeout: 15_000 });
 		await newEpicBtn.click();
 		await page.locator("#create-epic-title").fill(`${EPIC_TITLE} (mobile)`);
 		await page.locator("button", { hasText: "Create Epic" }).click();
 
+		// Assert the table stays hidden even once an epic actually exists to
+		// render — the earlier no-epics empty state renders no table at all, so
+		// checking beforehand would pass vacuously.
 		await expect(
 			page.locator("div", { hasText: `${EPIC_TITLE} (mobile)` }).last(),
 		).toBeVisible({ timeout: 15_000 });
+		await expect(page.locator('table[aria-label="Epics"]')).not.toBeVisible();
 
 		const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
 		expect(scrollWidth).toBeLessThanOrEqual(innerWidth);

--- a/apps/web/e2e/epics.spec.ts
+++ b/apps/web/e2e/epics.spec.ts
@@ -91,3 +91,63 @@ test.describe("Epics page", () => {
 		await expect(epicRow).toBeVisible({ timeout: 10_000 });
 	});
 });
+
+// PROJ-422: epic list + epic detail mobile layout regression coverage. Both
+// were audited and found already responsive (EpicList already renders
+// EpicMobileCard below 640px; the epic detail view reuses IssueDetail's
+// existing max-sm: stacking) — these tests lock that behaviour in.
+test.describe("Epics — mobile layout (375×812)", () => {
+	test("epic list shows mobile cards, not the desktop table", async ({ page }) => {
+		test.skip(!process.env.E2E_BASE_URL, "E2E_BASE_URL not set — skipping live deployment test");
+
+		const ctx = readCtx();
+		await openEpics(page, ctx);
+
+		const innerWidth = await page.evaluate(() => window.innerWidth);
+		expect(innerWidth).toBeLessThan(640);
+
+		await expect(page.locator('table[aria-label="Epics"]')).not.toBeVisible();
+
+		const newEpicBtn = page.locator("button", { hasText: "+ New Epic" });
+		await expect(newEpicBtn).toBeVisible({ timeout: 15_000 });
+		await newEpicBtn.click();
+		await page.locator("#create-epic-title").fill(`${EPIC_TITLE} (mobile)`);
+		await page.locator("button", { hasText: "Create Epic" }).click();
+
+		await expect(
+			page.locator("div", { hasText: `${EPIC_TITLE} (mobile)` }).last(),
+		).toBeVisible({ timeout: 15_000 });
+
+		const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+		expect(scrollWidth).toBeLessThanOrEqual(innerWidth);
+	});
+
+	test("epic detail page stacks the sidebar below the body, no horizontal scroll", async ({
+		page,
+	}) => {
+		test.skip(!process.env.E2E_BASE_URL, "E2E_BASE_URL not set — skipping live deployment test");
+
+		const ctx = readCtx();
+		await openEpics(page, ctx);
+
+		const newEpicBtn = page.locator("button", { hasText: "+ New Epic" });
+		await expect(newEpicBtn).toBeVisible({ timeout: 15_000 });
+		await newEpicBtn.click();
+		const detailTitle = `${EPIC_TITLE} (detail mobile)`;
+		await page.locator("#create-epic-title").fill(detailTitle);
+		await page.locator("button", { hasText: "Create Epic" }).click();
+
+		const epicLink = page
+			.locator("a", { hasText: detailTitle })
+			.or(page.locator("div", { hasText: detailTitle }).locator("a"))
+			.first();
+		await expect(epicLink).toBeVisible({ timeout: 15_000 });
+		await epicLink.click();
+
+		await expect(page.locator("text=Child issues")).toBeVisible({ timeout: 15_000 });
+
+		const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+		const innerWidth = await page.evaluate(() => window.innerWidth);
+		expect(scrollWidth).toBeLessThanOrEqual(innerWidth);
+	});
+});

--- a/apps/web/e2e/sprint.spec.ts
+++ b/apps/web/e2e/sprint.spec.ts
@@ -186,3 +186,36 @@ test.describe("Sprint planning flow", () => {
 		).toBeVisible({ timeout: 10_000 });
 	});
 });
+
+// PROJ-421: sprint list mobile layout regression coverage. SprintManager was
+// audited and found already responsive (flex-wrap throughout, no fixed
+// widths) — these tests lock that behaviour in rather than leaving it
+// unverified.
+test.describe("Sprint list — mobile layout (375×812)", () => {
+	test("header row and sprint cards fit the viewport with no horizontal scroll", async ({
+		page,
+	}) => {
+		test.skip(!process.env.E2E_BASE_URL, "E2E_BASE_URL not set — skipping live deployment test");
+
+		const ctx = readCtx();
+		const base = process.env.E2E_BASE_URL as string;
+		const projectId = await fetchFirstProjectId(base, ctx.workspaceSlug);
+		await openSprints(page, ctx, projectId);
+
+		const innerWidth = await page.evaluate(() => window.innerWidth);
+		expect(innerWidth).toBeLessThan(640);
+
+		const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+		expect(scrollWidth).toBeLessThanOrEqual(innerWidth);
+
+		const countLabel = page.locator("p", { hasText: /sprints?/i }).first();
+		const newSprintBtn = page.locator("button", { hasText: "+ New sprint" });
+		await expect(countLabel).toBeVisible();
+		await expect(newSprintBtn).toBeVisible();
+
+		const labelBox = await countLabel.boundingBox();
+		const btnBox = await newSprintBtn.boundingBox();
+		if (!labelBox || !btnBox) throw new Error("boundingBox() returned null");
+		expect(btnBox.y).toBeGreaterThanOrEqual(labelBox.y + labelBox.height);
+	});
+});

--- a/apps/web/e2e/wiki-flow.spec.ts
+++ b/apps/web/e2e/wiki-flow.spec.ts
@@ -119,3 +119,39 @@ test.describe("Wiki create and edit flow", () => {
 		await expect(page.locator(".prose")).not.toContainText(INITIAL_CONTENT, { timeout: 5_000 });
 	});
 });
+
+// PROJ-423: wiki editor mobile layout regression coverage. MarkdownEditor was
+// audited and found already responsive (toolbar wraps via flex-wrap, and a
+// dedicated Edit/Preview toggle replaces the desktop side-by-side layout
+// below 640px) — these tests lock that behaviour in.
+test.describe("Wiki editor — mobile layout (375×812)", () => {
+	test("editor fits the viewport and shows the mobile Edit/Preview toggle", async ({ page }) => {
+		test.skip(
+			!process.env.E2E_BASE_URL,
+			"E2E_BASE_URL not set — skipping live deployment test",
+		);
+
+		const ctx = readCtx();
+		await openWiki(page, ctx);
+
+		const innerWidth = await page.evaluate(() => window.innerWidth);
+		expect(innerWidth).toBeLessThan(640);
+
+		const newPageBtn = page.locator("button", { hasText: "+ New page" });
+		await expect(newPageBtn).toBeVisible({ timeout: 15_000 });
+		await newPageBtn.click();
+
+		await expect(page.locator("#create-title")).toBeVisible({ timeout: 5_000 });
+
+		// The mobile Edit/Preview toggle only renders below 640px.
+		const previewToggle = page.locator("button", { hasText: "Preview" });
+		await expect(previewToggle).toBeVisible({ timeout: 5_000 });
+
+		await typeInEditor(page, INITIAL_CONTENT);
+		await previewToggle.click();
+		await expect(page.locator(".prose")).toContainText(INITIAL_CONTENT, { timeout: 5_000 });
+
+		const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+		expect(scrollWidth).toBeLessThanOrEqual(innerWidth);
+	});
+});

--- a/apps/web/src/islands/SprintManager.test.tsx
+++ b/apps/web/src/islands/SprintManager.test.tsx
@@ -57,10 +57,18 @@ afterEach(() => {
 });
 
 describe("SprintManager", () => {
-	it("renders loading state initially", () => {
+	it("renders loading state initially when a projectId is present", () => {
 		// loading starts true — visible immediately without any fetch resolving
+		history.replaceState(null, "", "?projectId=p1");
+		mockFetchSprints([]);
 		render(<SprintManager />);
 		expect(screen.getByText(/Loading sprints/i)).toBeTruthy();
+	});
+
+	it("shows 'No project specified' instead of hanging when no projectId is in the URL (PROJ-424)", () => {
+		render(<SprintManager />);
+		expect(screen.getByText(/No project specified/i)).toBeTruthy();
+		expect(screen.queryByText(/Loading sprints/i)).toBeNull();
 	});
 
 	it("renders sprint list after fetch resolves", async () => {

--- a/apps/web/src/islands/SprintManager.tsx
+++ b/apps/web/src/islands/SprintManager.tsx
@@ -289,6 +289,7 @@ function useSprintData(workspaceSlug: string | undefined) {
 	useEffect(() => {
 		const id = new URLSearchParams(window.location.search).get("projectId");
 		setProjectId(id);
+		if (!id) setLoading(false);
 	}, []);
 
 	const fetchSprints = useCallback(


### PR DESCRIPTION
## Summary
- **PROJ-424**: fixes the Sprints page hanging on "Loading sprints…" forever when navigated with no `?projectId=` (e.g. via the plain nav bar link) — `loading` never got cleared in that path.
- **PROJ-420** (Board/Backlog kanban), **PROJ-422** (Epic list + detail), **PROJ-423** (Wiki editor): audited all three at 375×812. Each was already fully responsive via the app's existing `max-sm:`/`flex-wrap` conventions from prior PROJ-411/412 work — no layout fixes were needed. Added mobile Playwright e2e specs to lock in that behaviour (they had none before).
- **PROJ-421** (Sprint list): same audit — already responsive by construction (flex-wrap throughout, no fixed widths). Was blocked on PROJ-424 landing first so the page could even load; added mobile e2e coverage for it too.

## Test plan
- [x] `SprintManager.test.tsx` — updated + new regression test for the no-`projectId` case, all 6 pass
- [x] Full web vitest suite (377 tests) passes
- [x] `astro check` — 0 errors
- [x] biome lint clean
- [x] New/updated e2e specs (`sprint.spec.ts`, `epics.spec.ts`, `wiki-flow.spec.ts`) verified via `playwright test --list` (parse correctly, 14 tests total); they require a live `E2E_BASE_URL` deployment to actually execute, same as all existing specs in this suite
- [x] Verified Board/Backlog/Epics-list/Wiki-editor mobile rendering directly via Playwright mobile-viewport screenshots against a local dev server

https://claude.ai/code/session_01BNaaRLdg4nYs7GpEReiCc2