### PR TITLE
PROJ-238, 237, 374, 234: wiki folders, delete semantics, attachments MCP parity, comments authz fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,9 +52,10 @@ mcp/<domain>.ts      (MCP wrapper)   ─┘     (ALL business logic + SQL live h
 The parity audit (PROJ-236) confirmed these surface-only features are intentional, not
 drift — don't re-flag them in future audits:
 
-- **File attachments (`routes/files.ts`)** — REST-only. Binary/multipart upload and
-  streamed download can't cross JSON-RPC. Tracked separately as PROJ-234 (no MCP surface
-  at all for this domain).
+- **File attachment upload/download (`POST /api/files`, `GET /api/files/:id`)** —
+  REST-only. Binary/multipart upload and streamed download can't cross JSON-RPC.
+  Metadata operations (list, get metadata, link-create, delete) have full MCP parity
+  via `mcp/files.ts` (PROJ-234).
 - **Auth (`routes/auth.ts`): login redirect, API token minting/revocation** — REST-only.
   CF Access login is a browser redirect flow; token minting/revocation is a sensitive
   credential operation kept off the MCP surface.
@@ -268,6 +269,7 @@ These are the constraints the fleet skill reads to plan batches. Keep them curre
 | issues | `services/issues.ts` | `schemas/issues.ts` | `routes/issues.ts` | `mcp/issues.ts` | `test/issues.test.ts` |
 | projects | `services/projects.ts` | `schemas/projects.ts` | `routes/projects.ts` | `mcp/projects.ts` | `test/projects.test.ts` |
 | wiki | `services/wiki.ts` | `schemas/wiki.ts` | `routes/wiki.ts` | `mcp/wiki.ts` | `test/wiki.test.ts` |
+| files | `services/files.ts` | `schemas/files.ts` | `routes/files.ts` | `mcp/files.ts` | `test/files.test.ts` |
 | sprints | `services/sprints.ts` | `schemas/sprints.ts` | `routes/sprints.ts` | `mcp/sprints.ts` | `test/sprints.test.ts` |
 | comments | `services/comments.ts` | `schemas/comments.ts` | `routes/comments.ts` | `mcp/comments.ts` | `test/comments.test.ts` |
 | task-types | `services/task-types.ts` | `schemas/task-types.ts` | `routes/task-types.ts` | `mcp/task-types.ts` | `test/task-types.test.ts` |

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ command shown beside it (token + workspace pre-filled). The full walkthrough - A
 setup, first login, token, MCP - is in
 [CONFIGURE.md](https://github.com/TAJD/projektor-deploy-example/blob/main/CONFIGURE.md).
 
-See the **[agent connection guide](https://tajd.github.io/projektor/agents/mcp-connection/)** for the full connection guide, protocol reference, and tool catalog (<!-- gen-mcp-stats:start -->86 tools across 20 domains<!-- gen-mcp-stats:end --> - project data plus agent-coordination primitives).
+See the **[agent connection guide](https://tajd.github.io/projektor/agents/mcp-connection/)** for the full connection guide, protocol reference, and tool catalog (<!-- gen-mcp-stats:start -->90 tools across 21 domains<!-- gen-mcp-stats:end --> - project data plus agent-coordination primitives).
 
 ## Development
 

--- a/apps/api/src/http/error-adapter.ts
+++ b/apps/api/src/http/error-adapter.ts
@@ -1,6 +1,13 @@
 import type { HonoEnv } from "@projektor/types";
 import type { Context } from "hono";
-import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from "../services/errors";
+import {
+	ConflictError,
+	ForbiddenError,
+	NotFoundError,
+	PayloadTooLargeError,
+	UnsupportedMediaTypeError,
+	ValidationError,
+} from "../services/errors";
 
 export function serviceErrToResponse(c: Context<HonoEnv>, err: unknown) {
 	if (err instanceof ValidationError) {
@@ -14,6 +21,12 @@ export function serviceErrToResponse(c: Context<HonoEnv>, err: unknown) {
 	}
 	if (err instanceof ConflictError) {
 		return c.json({ error: err.message }, 409);
+	}
+	if (err instanceof PayloadTooLargeError) {
+		return c.json({ error: err.message }, 413);
+	}
+	if (err instanceof UnsupportedMediaTypeError) {
+		return c.json({ error: err.message }, 415);
 	}
 	throw err;
 }

--- a/apps/api/src/mcp/catalog.ts
+++ b/apps/api/src/mcp/catalog.ts
@@ -6,6 +6,7 @@ import { commentsTools } from "./comments";
 import { customFieldsTools } from "./custom-fields";
 import { feedbackTools } from "./feedback";
 import { fileClaimsTools } from "./file-claims";
+import { filesTools } from "./files";
 import { flowMetricsTools } from "./flow-metrics";
 import { groupsTools } from "./groups";
 import { issueLeasesTools } from "./issue-leases";
@@ -58,6 +59,7 @@ export const TOOL_DOMAINS: ToolDomain[] = [
 	{ domain: "issue-links", title: "Issue links", group: "Project data", tools: issueLinksTools },
 	{ domain: "comments", title: "Comments", group: "Project data", tools: commentsTools },
 	{ domain: "wiki", title: "Wiki", group: "Project data", tools: wikiTools },
+	{ domain: "files", title: "Attachments", group: "Project data", tools: filesTools },
 	{ domain: "task-types", title: "Task types", group: "Project data", tools: taskTypesTools },
 	{
 		domain: "task-statuses",

--- a/apps/api/src/mcp/files.ts
+++ b/apps/api/src/mcp/files.ts
@@ -1,0 +1,80 @@
+import type { MCPTool } from "@projektor/types";
+import {
+	createLinkAttachment,
+	deleteAttachment,
+	getAttachmentMetadata,
+	listAttachments,
+} from "../services/files";
+import type { ServiceCtx } from "../services/types";
+
+// Binary upload and streamed download can't cross JSON-RPC, so those two operations
+// stay REST-only (POST /api/files, GET /api/files/:id) — a deliberate parity exception
+// (AGENTS.md). Everything else (list, metadata, link-create, delete) is metadata-only
+// and gets full MCP parity here (PROJ-234).
+export const filesTools: MCPTool[] = [
+	{
+		name: "list_attachments",
+		description: "List attachments (files, wiki-page links, URLs) on an issue or wiki page",
+		inputSchema: {
+			type: "object",
+			required: ["entityType", "entityId"],
+			properties: {
+				entityType: { type: "string", enum: ["issue", "wiki_page"] },
+				entityId: { type: "string" },
+			},
+		},
+		async handler(input, ctx) {
+			return listAttachments(ctx as unknown as ServiceCtx, input);
+		},
+	},
+	{
+		name: "get_attachment",
+		description:
+			"Get attachment metadata by id. For kind 'file' the bytes themselves are only " +
+			"available over REST (GET /api/files/:id) — binary content can't cross JSON-RPC.",
+		inputSchema: {
+			type: "object",
+			required: ["id"],
+			properties: { id: { type: "string" } },
+		},
+		async handler(input, ctx) {
+			return getAttachmentMetadata(ctx as unknown as ServiceCtx, input);
+		},
+	},
+	{
+		name: "create_link_attachment",
+		description: "Attach a wiki-page reference or an external URL to an issue or wiki page",
+		inputSchema: {
+			type: "object",
+			required: ["kind", "entityType", "entityId"],
+			properties: {
+				kind: { type: "string", enum: ["wiki_ref", "url"] },
+				entityType: { type: "string", enum: ["issue", "wiki_page"] },
+				entityId: { type: "string" },
+				wikiPageId: { type: "string", description: "Required when kind is 'wiki_ref'" },
+				url: { type: "string", description: "Required when kind is 'url'" },
+				label: { type: "string", description: "Optional display label when kind is 'url'" },
+			},
+		},
+		async handler(input, ctx) {
+			return createLinkAttachment(ctx as unknown as ServiceCtx, input);
+		},
+	},
+	{
+		name: "delete_attachment",
+		description: "Delete an attachment by id",
+		inputSchema: {
+			type: "object",
+			required: ["id"],
+			properties: { id: { type: "string" } },
+		},
+		async handler(input, ctx) {
+			const serviceCtx = ctx as unknown as ServiceCtx;
+			const { r2Key } = await deleteAttachment(serviceCtx, input);
+			// R2 object I/O is streaming-specific in the REST route; do the equivalent
+			// cleanup here so the MCP path doesn't leave the blob orphaned in storage.
+			if (r2Key) await serviceCtx.r2.delete(r2Key);
+			return { ok: true };
+		},
+	},
+];

--- a/apps/api/src/mcp/wiki.ts
+++ b/apps/api/src/mcp/wiki.ts
@@ -105,15 +105,24 @@ export const wikiTools: MCPTool[] = [
 	},
 	{
 		name: "delete_wiki_page",
-		description: "Delete a wiki page by slug (not allowed for viewers)",
+		description:
+			"Delete a wiki page by slug (not allowed for viewers). By default any child pages are " +
+			"promoted to the deleted page's parent; pass cascade=true to delete the whole subtree instead.",
 		inputSchema: {
 			type: "object",
 			required: ["slug"],
-			properties: { slug: { type: "string" } },
+			properties: {
+				slug: { type: "string" },
+				cascade: {
+					type: "boolean",
+					default: false,
+					description: "Delete all descendant pages too, instead of promoting them",
+				},
+			},
 		},
 		async handler(input, ctx) {
-			const { slug } = input as { slug: string };
-			return wikiService.deleteWikiPage(ctx as ServiceCtx, slug);
+			const { slug, cascade } = input as { slug: string; cascade?: boolean };
+			return wikiService.deleteWikiPage(ctx as ServiceCtx, slug, { cascade });
 		},
 	},
 	{

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -3,176 +3,35 @@ import type { Context } from "hono";
 import { Hono } from "hono";
 import { z } from "zod";
 import { serviceErrToResponse } from "../http/error-adapter";
-import { wikiPagePath } from "../lib/urls";
-import { visibleProjectSqlFragment } from "../services/access";
-import { NotFoundError } from "../services/errors";
+import * as filesService from "../services/files";
 import { ctxFromHono } from "../services/types";
-import * as wikiService from "../services/wiki";
 
 const router = new Hono<HonoEnv>();
 
 const EntityTypeEnum = z.enum(["issue", "wiki_page"]);
 
-// Only these types may render inline in the browser; everything else forces download.
-// SVG is intentionally excluded (script execution risk).
-const INLINE_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
-
-const MAX_SIZE = 50 * 1024 * 1024; // 50 MB
-
-// file.type is supplied by the client and can be spoofed; this allowlist prevents accidental
-// or casual abuse but is not a hard security boundary on its own.
-const ALLOWED_UPLOAD_TYPES = new Set([
-	"image/png",
-	"image/jpeg",
-	"image/gif",
-	"image/webp",
-	"image/svg+xml",
-	"application/pdf",
-	"text/plain",
-	"text/markdown",
-	"text/csv",
-	"application/zip",
-	"application/json",
-]);
-
-const DEFAULT_STORAGE_QUOTA_BYTES = 1024 * 1024 * 1024; // 1 GiB per workspace
-
-// Resolve the per-workspace storage quota from env (STORAGE_QUOTA_BYTES), falling
-// back to the default for unset/invalid/non-positive values.
-function storageQuotaBytes(env: { STORAGE_QUOTA_BYTES?: string }): number {
-	const n = Number(env.STORAGE_QUOTA_BYTES);
-	return Number.isFinite(n) && n > 0 ? n : DEFAULT_STORAGE_QUOTA_BYTES;
-}
-
 router.get("/", async (c) => {
-	const workspace = c.get("workspace") as { id: string };
-	const entityType = c.req.query("entityType");
-	const entityId = c.req.query("entityId");
-
-	const parsed = EntityTypeEnum.safeParse(entityType);
-	if (!parsed.success) return c.json({ error: "entityType must be issue or wiki_page" }, 400);
-	if (!entityId) return c.json({ error: "entityId is required" }, 400);
-
-	// PROJ-311/PROJ-407: only join in wiki page details the caller is actually allowed to
-	// see (workspace-level pages, or project-scoped pages they have a grant on). A row
-	// referencing a page outside the caller's visibility joins to nothing, same as a
-	// deleted page — the row still lists as an unavailable wiki_ref rather than leaking
-	// the restricted page's title.
 	const ctx = ctxFromHono(c);
-	const visible = visibleProjectSqlFragment(ctx, "w.project_id");
-	const joinCond = visible
-		? `w.id = a.linked_wiki_page_id AND (w.project_id IS NULL OR ${visible.sql})`
-		: "w.id = a.linked_wiki_page_id";
-
-	const rows = await c.env.DB.prepare(
-		`SELECT a.id, a.kind, a.filename, a.content_type, a.size, a.url, a.created_at,
-            w.id AS wiki_page_id, w.slug AS wiki_page_slug, w.title AS wiki_page_title,
-            w.project_id AS wiki_page_project_id
-     FROM attachments a
-     LEFT JOIN wiki_pages w ON ${joinCond}
-     WHERE a.workspace_id = ? AND a.entity_type = ? AND a.entity_id = ?
-     ORDER BY a.created_at ASC`
-	)
-		.bind(...(visible ? visible.params : []), workspace.id, parsed.data, entityId)
-		.all<{
-			id: string;
-			kind: "file" | "wiki_ref" | "url";
-			filename: string;
-			content_type: string;
-			size: number;
-			url: string | null;
-			created_at: number;
-			wiki_page_id: string | null;
-			wiki_page_slug: string | null;
-			wiki_page_title: string | null;
-			wiki_page_project_id: string | null;
-		}>();
-
-	return c.json(
-		(rows.results ?? []).map((r) => ({
-			id: r.id,
-			kind: r.kind,
-			filename: r.filename,
-			contentType: r.content_type,
-			size: r.size,
-			url: r.url,
-			createdAt: r.created_at,
-			wikiPage:
-				r.kind === "wiki_ref" && r.wiki_page_id
-					? {
-							id: r.wiki_page_id,
-							title: r.wiki_page_title,
-							url: wikiPagePath(r.wiki_page_slug ?? "", r.wiki_page_project_id),
-						}
-					: null,
-		}))
-	);
+	try {
+		const list = await filesService.listAttachments(ctx, {
+			entityType: c.req.query("entityType"),
+			entityId: c.req.query("entityId"),
+		});
+		return c.json(list);
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
 });
 
-const CreateLinkAttachmentSchema = z.discriminatedUnion("kind", [
-	z.object({
-		kind: z.literal("wiki_ref"),
-		entityType: EntityTypeEnum,
-		entityId: z.string().min(1),
-		wikiPageId: z.string().min(1),
-	}),
-	z.object({
-		kind: z.literal("url"),
-		entityType: EntityTypeEnum,
-		entityId: z.string().min(1),
-		url: z
-			.string()
-			.url()
-			.refine((u) => /^https?:\/\//i.test(u), "URL must be http or https"),
-		label: z.string().trim().max(200).optional(),
-	}),
-]);
-
 router.post("/links", async (c) => {
-	const workspace = c.get("workspace") as { id: string };
-	const user = c.get("user") as { id: string };
-
+	const ctx = ctxFromHono(c);
 	const body = await c.req.json().catch(() => null);
-	const parsed = CreateLinkAttachmentSchema.safeParse(body);
-	if (!parsed.success)
-		return c.json({ error: parsed.error.issues[0]?.message ?? "Invalid input" }, 400);
-	const input = parsed.data;
-
-	if (input.kind === "wiki_ref") {
-		// PROJ-311: getWikiPage enforces project-grant visibility, not just existence —
-		// a page in a project the caller can't see 404s the same as a nonexistent one.
-		try {
-			await wikiService.getWikiPage(ctxFromHono(c), input.wikiPageId);
-		} catch (e) {
-			if (e instanceof NotFoundError) return serviceErrToResponse(c, e);
-			throw e;
-		}
+	try {
+		const result = await filesService.createLinkAttachment(ctx, body);
+		return c.json(result, 201);
+	} catch (e) {
+		return serviceErrToResponse(c, e);
 	}
-
-	const id = crypto.randomUUID();
-	const now = Math.floor(Date.now() / 1000);
-
-	await c.env.DB.prepare(
-		`INSERT INTO attachments
-       (id, workspace_id, kind, r2_key, filename, content_type, size, url, linked_wiki_page_id,
-        entity_type, entity_id, created_by_id, created_at)
-     VALUES (?, ?, ?, '', ?, '', 0, ?, ?, ?, ?, ?, ?)`
-	)
-		.bind(
-			id,
-			workspace.id,
-			input.kind,
-			input.kind === "url" ? (input.label ?? "") : "",
-			input.kind === "url" ? input.url : null,
-			input.kind === "wiki_ref" ? input.wikiPageId : null,
-			input.entityType,
-			input.entityId,
-			user.id,
-			now
-		)
-		.run();
-
-	return c.json({ id, kind: input.kind }, 201);
 });
 
 async function parseUploadFormData(c: Context<HonoEnv>) {
@@ -199,73 +58,8 @@ function extractUploadInput(c: Context<HonoEnv>, formData: FormData) {
 	return { file, entityType: parsed.data, entityId };
 }
 
-async function checkUploadConstraints(c: Context<HonoEnv>, workspaceId: string, file: File) {
-	if (file.size > MAX_SIZE) return c.json({ error: "File too large (max 50 MB)" }, 413);
-
-	if (!file.type || !ALLOWED_UPLOAD_TYPES.has(file.type)) {
-		return c.json({ error: "File type not allowed" }, 415);
-	}
-
-	const quotaRow = await c.env.DB.prepare(
-		"SELECT COALESCE(SUM(size), 0) AS total FROM attachments WHERE workspace_id = ?"
-	)
-		.bind(workspaceId)
-		.first<{ total: number }>();
-	const bytesUsed = quotaRow?.total ?? 0;
-	const quota = storageQuotaBytes(c.env);
-	if (bytesUsed + file.size > quota) {
-		const quotaMb = Math.round(quota / (1024 * 1024));
-		return c.json({ error: `Workspace storage quota exceeded (${quotaMb} MB)` }, 413);
-	}
-
-	return null;
-}
-
-async function storeUpload(
-	c: Context<HonoEnv>,
-	params: {
-		workspaceId: string;
-		userId: string;
-		file: File;
-		entityType: z.infer<typeof EntityTypeEnum>;
-		entityId: string;
-	}
-) {
-	const id = crypto.randomUUID();
-	const r2Key = `${params.workspaceId}/${id}`;
-	const now = Math.floor(Date.now() / 1000);
-	// cofferdam-ignore: Refactor.PreferNullishCoalescing: file.type is "" for unknown types; `||` should catch that too
-	const contentType = params.file.type || "application/octet-stream";
-
-	await c.env.R2.put(r2Key, await params.file.arrayBuffer(), {
-		httpMetadata: { contentType },
-	});
-
-	await c.env.DB.prepare(
-		`INSERT INTO attachments
-       (id, workspace_id, r2_key, filename, content_type, size, entity_type, entity_id, created_by_id, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-	)
-		.bind(
-			id,
-			params.workspaceId,
-			r2Key,
-			params.file.name,
-			contentType,
-			params.file.size,
-			params.entityType,
-			params.entityId,
-			params.userId,
-			now
-		)
-		.run();
-
-	return { id, contentType };
-}
-
 router.post("/", async (c) => {
-	const workspace = c.get("workspace") as { id: string };
-	const user = c.get("user") as { id: string };
+	const ctx = ctxFromHono(c);
 
 	const formData = await parseUploadFormData(c);
 	if (formData instanceof Response) return formData;
@@ -274,41 +68,56 @@ router.post("/", async (c) => {
 	if (input instanceof Response) return input;
 	const { file, entityType, entityId } = input;
 
-	const constraintError = await checkUploadConstraints(c, workspace.id, file);
-	if (constraintError) return constraintError;
+	try {
+		await filesService.assertUploadAllowed(ctx, {
+			size: file.size,
+			contentType: file.type,
+			quotaBytes: filesService.storageQuotaBytes(c.env),
+		});
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
 
-	const { id, contentType } = await storeUpload(c, {
-		workspaceId: workspace.id,
-		userId: user.id,
-		file,
+	// cofferdam-ignore: Refactor.PreferNullishCoalescing: file.type is "" for unknown types; `||` should catch that too
+	const contentType = file.type || "application/octet-stream";
+	const r2Key = `${ctx.workspaceId}/${crypto.randomUUID()}`;
+
+	// R2 object I/O is streaming-specific and stays here; metadata/quota/authz decisions
+	// live in the service (PROJ-234).
+	await c.env.R2.put(r2Key, await file.arrayBuffer(), { httpMetadata: { contentType } });
+
+	const { id } = await filesService.recordUpload(ctx, {
 		entityType,
 		entityId,
+		filename: file.name,
+		contentType,
+		size: file.size,
+		r2Key,
 	});
 
 	return c.json({ id, filename: file.name, contentType, size: file.size }, 201);
 });
 
 router.get("/:id", async (c) => {
-	const workspace = c.get("workspace") as { id: string };
+	const ctx = ctxFromHono(c);
 	const { id } = c.req.param();
 
-	const row = await c.env.DB.prepare(
-		"SELECT r2_key, filename, content_type FROM attachments WHERE id = ? AND workspace_id = ?"
-	)
-		.bind(id, workspace.id)
-		.first<{ r2_key: string; filename: string; content_type: string }>();
+	let meta: { r2Key: string; filename: string; contentType: string };
+	try {
+		meta = await filesService.getAttachmentForDownload(ctx, id);
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
 
-	if (!row) return c.json({ error: "Not found" }, 404);
-
-	const obj = await c.env.R2.get(row.r2_key);
+	const obj = await c.env.R2.get(meta.r2Key);
 	if (!obj) return c.json({ error: "Object missing from storage" }, 404);
 
-	const safeContentType = INLINE_TYPES.has(row.content_type)
-		? row.content_type
+	const safeContentType = filesService.INLINE_TYPES.has(meta.contentType)
+		? meta.contentType
 		: "application/octet-stream";
-	const disposition = INLINE_TYPES.has(row.content_type) ? "inline" : "attachment";
+	const disposition = filesService.INLINE_TYPES.has(meta.contentType) ? "inline" : "attachment";
 	// Strip CR/LF and quotes to prevent header injection in the filename parameter.
-	const safeFilename = row.filename.replace(/[\r\n"\\]/g, "_");
+	const safeFilename = meta.filename.replace(/[\r\n"\\]/g, "_");
 
 	// Buffer fully so the R2 handle closes before the response is sent.
 	// Streaming obj.body would leave an open handle that conflicts with miniflare's
@@ -326,19 +135,17 @@ router.get("/:id", async (c) => {
 });
 
 router.delete("/:id", async (c) => {
-	const workspace = c.get("workspace") as { id: string };
+	const ctx = ctxFromHono(c);
 	const { id } = c.req.param();
 
-	const row = await c.env.DB.prepare(
-		"SELECT r2_key FROM attachments WHERE id = ? AND workspace_id = ?"
-	)
-		.bind(id, workspace.id)
-		.first<{ r2_key: string }>();
+	let r2Key: string;
+	try {
+		({ r2Key } = await filesService.deleteAttachment(ctx, { id }));
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
 
-	if (!row) return c.json({ error: "Not found" }, 404);
-
-	if (row.r2_key) await c.env.R2.delete(row.r2_key);
-	await c.env.DB.prepare("DELETE FROM attachments WHERE id = ?").bind(id).run();
+	if (r2Key) await c.env.R2.delete(r2Key);
 
 	return new Response(null, { status: 204 });
 });

--- a/apps/api/src/routes/mcp.ts
+++ b/apps/api/src/routes/mcp.ts
@@ -9,6 +9,7 @@ import { customFieldsTools } from "../mcp/custom-fields";
 import { toMcpError } from "../mcp/error-adapter";
 import { feedbackTools } from "../mcp/feedback";
 import { fileClaimsTools } from "../mcp/file-claims";
+import { filesTools } from "../mcp/files";
 import { flowMetricsTools } from "../mcp/flow-metrics";
 import { groupsTools } from "../mcp/groups";
 import { issueLeasesTools } from "../mcp/issue-leases";
@@ -146,6 +147,7 @@ const coreMCPTools: MCPTool[] = [
 	...commentsTools,
 	...feedbackTools,
 	...wikiTools,
+	...filesTools,
 	...taskTypesTools,
 	...taskStatusesTools,
 	...customFieldsTools,

--- a/apps/api/src/routes/wiki.ts
+++ b/apps/api/src/routes/wiki.ts
@@ -90,7 +90,8 @@ router.put("/:slug", async (c) => {
 router.delete("/:slug", async (c) => {
 	const ctx = ctxFromHono(c);
 	try {
-		return c.json(await wikiService.deleteWikiPage(ctx, c.req.param("slug")));
+		const cascade = c.req.query("cascade") === "true";
+		return c.json(await wikiService.deleteWikiPage(ctx, c.req.param("slug"), { cascade }));
 	} catch (e) {
 		return serviceErrToResponse(c, e);
 	}

--- a/apps/api/src/schemas/files.ts
+++ b/apps/api/src/schemas/files.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+export const EntityTypeSchema = z.enum(["issue", "wiki_page"]);
+
+export const ListAttachmentsSchema = z.object({
+	entityType: EntityTypeSchema,
+	entityId: z.string().min(1),
+});
+
+export const CreateLinkAttachmentSchema = z.discriminatedUnion("kind", [
+	z.object({
+		kind: z.literal("wiki_ref"),
+		entityType: EntityTypeSchema,
+		entityId: z.string().min(1),
+		wikiPageId: z.string().min(1),
+	}),
+	z.object({
+		kind: z.literal("url"),
+		entityType: EntityTypeSchema,
+		entityId: z.string().min(1),
+		url: z
+			.string()
+			.url()
+			.refine((u) => /^https?:\/\//i.test(u), "URL must be http or https"),
+		label: z.string().trim().max(200).optional(),
+	}),
+]);
+
+export const RecordFileUploadSchema = z.object({
+	entityType: EntityTypeSchema,
+	entityId: z.string().min(1),
+	filename: z.string().min(1),
+	contentType: z.string(),
+	size: z.number().int().nonnegative(),
+	r2Key: z.string().min(1),
+});
+
+export const GetAttachmentSchema = z.object({ id: z.string().min(1) });
+
+export const DeleteAttachmentSchema = z.object({ id: z.string().min(1) });

--- a/apps/api/src/schemas/wiki.ts
+++ b/apps/api/src/schemas/wiki.ts
@@ -33,3 +33,9 @@ export const SearchWikiInputSchema = z.object({
 	limit: z.number().int().min(1).max(50).optional().default(10),
 	projectId: z.string().uuid().optional(),
 });
+
+export const DeleteWikiPageOptionsSchema = z.object({
+	// Default (false): children are promoted to the deleted page's parent. true: the
+	// deleted page's entire subtree is removed too.
+	cascade: z.boolean().optional().default(false),
+});

--- a/apps/api/src/services/errors.ts
+++ b/apps/api/src/services/errors.ts
@@ -35,3 +35,17 @@ export class ConflictError extends ServiceError {
 		super(message);
 	}
 }
+
+export class PayloadTooLargeError extends ServiceError {
+	readonly kind = "payload_too_large" as const;
+	constructor(message = "Payload too large") {
+		super(message);
+	}
+}
+
+export class UnsupportedMediaTypeError extends ServiceError {
+	readonly kind = "unsupported_media_type" as const;
+	constructor(message = "Unsupported media type") {
+		super(message);
+	}
+}

--- a/apps/api/src/services/files.ts
+++ b/apps/api/src/services/files.ts
@@ -1,0 +1,290 @@
+import { wikiPagePath } from "../lib/urls";
+import {
+	CreateLinkAttachmentSchema,
+	DeleteAttachmentSchema,
+	GetAttachmentSchema,
+	ListAttachmentsSchema,
+	RecordFileUploadSchema,
+} from "../schemas/files";
+import { visibleProjectSqlFragment } from "./access";
+import {
+	NotFoundError,
+	PayloadTooLargeError,
+	UnsupportedMediaTypeError,
+	ValidationError,
+} from "./errors";
+import type { ServiceCtx } from "./types";
+import * as wikiService from "./wiki";
+
+export interface AttachmentDto {
+	id: string;
+	kind: "file" | "wiki_ref" | "url";
+	filename: string;
+	contentType: string;
+	size: number;
+	url: string | null;
+	createdAt: number;
+	wikiPage: { id: string; title: string | null; url: string } | null;
+}
+
+// Only these types may render inline in the browser; everything else forces download.
+// SVG is intentionally excluded (script execution risk).
+export const INLINE_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
+
+export const MAX_UPLOAD_SIZE = 50 * 1024 * 1024; // 50 MB
+
+// file.type is supplied by the client and can be spoofed; this allowlist prevents accidental
+// or casual abuse but is not a hard security boundary on its own.
+const ALLOWED_UPLOAD_TYPES = new Set([
+	"image/png",
+	"image/jpeg",
+	"image/gif",
+	"image/webp",
+	"image/svg+xml",
+	"application/pdf",
+	"text/plain",
+	"text/markdown",
+	"text/csv",
+	"application/zip",
+	"application/json",
+]);
+
+interface AttachmentRow {
+	id: string;
+	kind: "file" | "wiki_ref" | "url";
+	filename: string;
+	content_type: string;
+	size: number;
+	url: string | null;
+	created_at: number;
+	wiki_page_id: string | null;
+	wiki_page_slug: string | null;
+	wiki_page_title: string | null;
+	wiki_page_project_id: string | null;
+}
+
+function toDto(r: AttachmentRow): AttachmentDto {
+	return {
+		id: r.id,
+		kind: r.kind,
+		filename: r.filename,
+		contentType: r.content_type,
+		size: r.size,
+		url: r.url,
+		createdAt: r.created_at,
+		wikiPage:
+			r.kind === "wiki_ref" && r.wiki_page_id
+				? {
+						id: r.wiki_page_id,
+						title: r.wiki_page_title,
+						url: wikiPagePath(r.wiki_page_slug ?? "", r.wiki_page_project_id),
+					}
+				: null,
+	};
+}
+
+export async function listAttachments(ctx: ServiceCtx, input: unknown): Promise<AttachmentDto[]> {
+	const parsed = ListAttachmentsSchema.safeParse(input);
+	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
+	const { entityType, entityId } = parsed.data;
+
+	// PROJ-311/PROJ-407: only join in wiki page details the caller is actually allowed to
+	// see (workspace-level pages, or project-scoped pages they have a grant on). A row
+	// referencing a page outside the caller's visibility joins to nothing, same as a
+	// deleted page — the row still lists as an unavailable wiki_ref rather than leaking
+	// the restricted page's title.
+	const visible = visibleProjectSqlFragment(ctx, "w.project_id");
+	const joinCond = visible
+		? `w.id = a.linked_wiki_page_id AND (w.project_id IS NULL OR ${visible.sql})`
+		: "w.id = a.linked_wiki_page_id";
+
+	const rows = await ctx.db
+		.prepare(
+			`SELECT a.id, a.kind, a.filename, a.content_type, a.size, a.url, a.created_at,
+	            w.id AS wiki_page_id, w.slug AS wiki_page_slug, w.title AS wiki_page_title,
+	            w.project_id AS wiki_page_project_id
+	     FROM attachments a
+	     LEFT JOIN wiki_pages w ON ${joinCond}
+	     WHERE a.workspace_id = ? AND a.entity_type = ? AND a.entity_id = ?
+	     ORDER BY a.created_at ASC`
+		)
+		.bind(...(visible ? visible.params : []), ctx.workspaceId, entityType, entityId)
+		.all<AttachmentRow>();
+
+	return (rows.results ?? []).map(toDto);
+}
+
+export async function createLinkAttachment(
+	ctx: ServiceCtx,
+	input: unknown
+): Promise<{ id: string; kind: "wiki_ref" | "url" }> {
+	const parsed = CreateLinkAttachmentSchema.safeParse(input);
+	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
+	const data = parsed.data;
+
+	if (data.kind === "wiki_ref") {
+		// PROJ-311: getWikiPage enforces project-grant visibility, not just existence —
+		// a page in a project the caller can't see 404s the same as a nonexistent one.
+		await wikiService.getWikiPage(ctx, data.wikiPageId);
+	}
+
+	const id = crypto.randomUUID();
+	const now = Math.floor(Date.now() / 1000);
+
+	await ctx.db
+		.prepare(
+			`INSERT INTO attachments
+	       (id, workspace_id, kind, r2_key, filename, content_type, size, url, linked_wiki_page_id,
+	        entity_type, entity_id, created_by_id, created_at)
+	     VALUES (?, ?, ?, '', ?, '', 0, ?, ?, ?, ?, ?, ?)`
+		)
+		.bind(
+			id,
+			ctx.workspaceId,
+			data.kind,
+			data.kind === "url" ? (data.label ?? "") : "",
+			data.kind === "url" ? data.url : null,
+			data.kind === "wiki_ref" ? data.wikiPageId : null,
+			data.entityType,
+			data.entityId,
+			ctx.userId,
+			now
+		)
+		.run();
+
+	return { id, kind: data.kind };
+}
+
+// Resolve the per-workspace storage quota from env (STORAGE_QUOTA_BYTES), falling
+// back to the default for unset/invalid/non-positive values.
+const DEFAULT_STORAGE_QUOTA_BYTES = 1024 * 1024 * 1024; // 1 GiB per workspace
+
+export function storageQuotaBytes(env: { STORAGE_QUOTA_BYTES?: string }): number {
+	const n = Number(env.STORAGE_QUOTA_BYTES);
+	return Number.isFinite(n) && n > 0 ? n : DEFAULT_STORAGE_QUOTA_BYTES;
+}
+
+async function workspaceStorageUsageBytes(ctx: ServiceCtx): Promise<number> {
+	const row = await ctx.db
+		.prepare("SELECT COALESCE(SUM(size), 0) AS total FROM attachments WHERE workspace_id = ?")
+		.bind(ctx.workspaceId)
+		.first<{ total: number }>();
+	return row?.total ?? 0;
+}
+
+/** Validates size/type/quota for a would-be upload; throws the matching typed error. */
+export async function assertUploadAllowed(
+	ctx: ServiceCtx,
+	params: { size: number; contentType: string; quotaBytes?: number }
+): Promise<void> {
+	if (params.size > MAX_UPLOAD_SIZE) {
+		throw new PayloadTooLargeError("File too large (max 50 MB)");
+	}
+	if (!params.contentType || !ALLOWED_UPLOAD_TYPES.has(params.contentType)) {
+		throw new UnsupportedMediaTypeError("File type not allowed");
+	}
+
+	const quota = params.quotaBytes ?? DEFAULT_STORAGE_QUOTA_BYTES;
+	const bytesUsed = await workspaceStorageUsageBytes(ctx);
+	if (bytesUsed + params.size > quota) {
+		const quotaMb = Math.round(quota / (1024 * 1024));
+		throw new PayloadTooLargeError(`Workspace storage quota exceeded (${quotaMb} MB)`);
+	}
+}
+
+/** Records metadata for a file already written to R2 by the caller (route owns R2 I/O). */
+export async function recordUpload(ctx: ServiceCtx, input: unknown): Promise<{ id: string }> {
+	const parsed = RecordFileUploadSchema.safeParse(input);
+	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
+	const { entityType, entityId, filename, contentType, size, r2Key } = parsed.data;
+
+	const id = crypto.randomUUID();
+	const now = Math.floor(Date.now() / 1000);
+
+	await ctx.db
+		.prepare(
+			`INSERT INTO attachments
+	       (id, workspace_id, r2_key, filename, content_type, size, entity_type, entity_id, created_by_id, created_at)
+	     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		)
+		.bind(
+			id,
+			ctx.workspaceId,
+			r2Key,
+			filename,
+			contentType,
+			size,
+			entityType,
+			entityId,
+			ctx.userId,
+			now
+		)
+		.run();
+
+	return { id };
+}
+
+/** Metadata needed to stream an attachment's bytes back; the route owns the actual R2 read. */
+export async function getAttachmentForDownload(
+	ctx: ServiceCtx,
+	id: string
+): Promise<{ r2Key: string; filename: string; contentType: string }> {
+	const row = await ctx.db
+		.prepare(
+			"SELECT r2_key, filename, content_type FROM attachments WHERE id = ? AND workspace_id = ?"
+		)
+		.bind(id, ctx.workspaceId)
+		.first<{ r2_key: string; filename: string; content_type: string }>();
+
+	if (!row) throw new NotFoundError("Not found");
+	return { r2Key: row.r2_key, filename: row.filename, contentType: row.content_type };
+}
+
+/** Attachment metadata in the same shape `listAttachments` returns, for the MCP get_attachment tool. */
+export async function getAttachmentMetadata(
+	ctx: ServiceCtx,
+	input: unknown
+): Promise<AttachmentDto> {
+	const parsed = GetAttachmentSchema.safeParse(input);
+	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
+
+	const visible = visibleProjectSqlFragment(ctx, "w.project_id");
+	const joinCond = visible
+		? `w.id = a.linked_wiki_page_id AND (w.project_id IS NULL OR ${visible.sql})`
+		: "w.id = a.linked_wiki_page_id";
+
+	const row = await ctx.db
+		.prepare(
+			`SELECT a.id, a.kind, a.filename, a.content_type, a.size, a.url, a.created_at,
+	            w.id AS wiki_page_id, w.slug AS wiki_page_slug, w.title AS wiki_page_title,
+	            w.project_id AS wiki_page_project_id
+	     FROM attachments a
+	     LEFT JOIN wiki_pages w ON ${joinCond}
+	     WHERE a.workspace_id = ? AND a.id = ?`
+		)
+		.bind(...(visible ? visible.params : []), ctx.workspaceId, parsed.data.id)
+		.first<AttachmentRow>();
+
+	if (!row) throw new NotFoundError("Not found");
+	return toDto(row);
+}
+
+/** Deletes the attachment row; returns the R2 key (if any) so the route can clean up storage. */
+export async function deleteAttachment(
+	ctx: ServiceCtx,
+	input: unknown
+): Promise<{ r2Key: string }> {
+	const parsed = DeleteAttachmentSchema.safeParse(input);
+	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
+
+	const row = await ctx.db
+		.prepare("SELECT r2_key FROM attachments WHERE id = ? AND workspace_id = ?")
+		.bind(parsed.data.id, ctx.workspaceId)
+		.first<{ r2_key: string }>();
+
+	if (!row) throw new NotFoundError("Not found");
+
+	await ctx.db.prepare("DELETE FROM attachments WHERE id = ?").bind(parsed.data.id).run();
+
+	return { r2Key: row.r2_key };
+}

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -1,9 +1,10 @@
 import { drizzle, schema } from "@projektor/db";
-import { and, asc, desc, eq, isNull, or } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, or } from "drizzle-orm";
 import { wikiPagePath } from "../lib/urls";
 import { IdSchema } from "../schemas/common";
 import {
 	CreatePageSchema,
+	DeleteWikiPageOptionsSchema,
 	ListPagesInputSchema,
 	SearchWikiInputSchema,
 	UpdatePageSchema,
@@ -18,6 +19,7 @@ import {
 } from "./access";
 import { recordActivity } from "./activity";
 import { ForbiddenError, NotFoundError, ValidationError } from "./errors";
+import { inChunks } from "./sql";
 import type { ServiceCtx } from "./types";
 
 type TreeNode = { id: string; slug: string; title: string; url: string; children: TreeNode[] };
@@ -368,13 +370,49 @@ export async function updateWikiPage(ctx: ServiceCtx, idOrSlug: string, input: u
 	return { ok: true, url: wikiPagePath(page.slug, page.projectId) };
 }
 
-export async function deleteWikiPage(ctx: ServiceCtx, slug: string) {
+// PROJ-238: breadth-first walk of parent_id children, chunked to stay under D1's
+// bound-parameter cap regardless of subtree size.
+async function collectDescendantIds(
+	db: D1Database,
+	rootId: string,
+	workspaceId: string
+): Promise<string[]> {
+	const orm = drizzle(db, { schema });
+	const descendants: string[] = [];
+	let frontier = [rootId];
+	while (frontier.length > 0) {
+		const children = await inChunks(frontier, (chunk) =>
+			orm
+				.select({ id: schema.wikiPages.id })
+				.from(schema.wikiPages)
+				.where(
+					and(
+						inArray(schema.wikiPages.parentId, chunk),
+						eq(schema.wikiPages.workspaceId, workspaceId)
+					)
+				)
+		);
+		frontier = children.map((c) => c.id);
+		descendants.push(...frontier);
+	}
+	return descendants;
+}
+
+export async function deleteWikiPage(ctx: ServiceCtx, slug: string, options?: unknown) {
 	const idCheck = IdSchema.safeParse(slug);
 	if (!idCheck.success)
 		throw new ValidationError({ formErrors: idCheck.error.flatten().formErrors, fieldErrors: {} });
+	const parsedOptions = DeleteWikiPageOptionsSchema.safeParse(options ?? {});
+	if (!parsedOptions.success) throw new ValidationError(parsedOptions.error.flatten());
+	const { cascade } = parsedOptions.data;
+
 	const orm = drizzle(ctx.db, { schema });
 	const page = await orm
-		.select({ id: schema.wikiPages.id, projectId: schema.wikiPages.projectId })
+		.select({
+			id: schema.wikiPages.id,
+			projectId: schema.wikiPages.projectId,
+			parentId: schema.wikiPages.parentId,
+		})
 		.from(schema.wikiPages)
 		.where(and(eq(schema.wikiPages.slug, slug), eq(schema.wikiPages.workspaceId, ctx.workspaceId)))
 		.get();
@@ -390,12 +428,42 @@ export async function deleteWikiPage(ctx: ServiceCtx, slug: string) {
 			throw new ForbiddenError("Insufficient permissions");
 	}
 
+	if (cascade) {
+		const descendantIds = await collectDescendantIds(ctx.db, page.id, ctx.workspaceId);
+		const allIds = [page.id, ...descendantIds];
+		await inChunks(allIds, async (chunk) => {
+			await orm
+				.delete(schema.attachments)
+				.where(inArray(schema.attachments.linkedWikiPageId, chunk));
+			return [];
+		});
+		await inChunks(allIds, async (chunk) => {
+			await orm.delete(schema.wikiPages).where(inArray(schema.wikiPages.id, chunk));
+			return [];
+		});
+		await recordActivity(ctx, {
+			entityType: "wiki_page",
+			entityId: page.id,
+			action: "deleted",
+			diff: { cascade: true, deletedCount: allIds.length },
+		});
+		return { ok: true, deletedCount: allIds.length };
+	}
+
+	// PROJ-238: no FK constraint on parent_id, so a plain delete would otherwise leave
+	// children pointing at a row that no longer exists. Default behavior is to promote
+	// them to the deleted page's own parent (which may be null, i.e. the root).
+	await orm
+		.update(schema.wikiPages)
+		.set({ parentId: page.parentId })
+		.where(eq(schema.wikiPages.parentId, page.id));
+
 	// PROJ-407: mirror the migration's ON DELETE CASCADE at the app level too, since
 	// D1 does not guarantee FK enforcement is on for every connection.
 	await orm.delete(schema.attachments).where(eq(schema.attachments.linkedWikiPageId, page.id));
 	await orm.delete(schema.wikiPages).where(eq(schema.wikiPages.id, page.id));
 	await recordActivity(ctx, { entityType: "wiki_page", entityId: page.id, action: "deleted" });
-	return { ok: true };
+	return { ok: true, deletedCount: 1 };
 }
 
 export async function getWikiTree(ctx: ServiceCtx, projectId?: string): Promise<TreeNode[]> {

--- a/apps/api/src/test/comments.test.ts
+++ b/apps/api/src/test/comments.test.ts
@@ -7,6 +7,7 @@ import {
 	seedGroupGrant,
 	seedProject,
 	seedProjectFixture,
+	seedWorkspaceRoles,
 } from "./helpers";
 
 type JsonRpcResult<T = unknown> = { jsonrpc: "2.0"; id: unknown; result: T };
@@ -116,6 +117,28 @@ describe("Comments REST API", () => {
 			body: JSON.stringify({ body: "" }),
 		});
 		expect(res.status).toBe(400);
+	});
+
+	// PROJ-374: addComment was missing the viewer-role guard every other write path
+	// enforces (comments.ts:76) — a workspace/project viewer could post comments.
+	it("POST returns 403 for a project viewer", async () => {
+		const roles = await seedWorkspaceRoles();
+		const project = await seedProject(roles.workspace.id);
+		await seedGroupGrant(roles.workspace.id, roles.viewer.user.id, project.id, "viewer");
+
+		const issueRes = await SELF.fetch("http://localhost/api/issues", {
+			method: "POST",
+			headers: authHeaders(roles.owner.token, roles.workspace.slug),
+			body: JSON.stringify({ projectId: project.id, title: "Viewer-visible issue" }),
+		});
+		const { id: viewerIssueId } = (await issueRes.json()) as { id: string };
+
+		const res = await SELF.fetch(`http://localhost/api/issues/${viewerIssueId}/comments`, {
+			method: "POST",
+			headers: authHeaders(roles.viewer.token, roles.workspace.slug),
+			body: JSON.stringify({ body: "Viewers shouldn't be able to post this" }),
+		});
+		expect(res.status).toBe(403);
 	});
 
 	it("GET returns 404 for issue in another workspace", async () => {

--- a/apps/api/src/test/files.test.ts
+++ b/apps/api/src/test/files.test.ts
@@ -4,6 +4,38 @@ import { authHeaders, seedFixture, seedMember, seedProject, seedToken, seedUser 
 
 const ENTITY_ID = crypto.randomUUID();
 
+type JsonRpcResult<T = unknown> = { jsonrpc: "2.0"; id: unknown; result: T };
+type JsonRpcError = { jsonrpc: "2.0"; id: unknown; error: { code: number; message: string } };
+
+async function mcpCall<T>(
+	workspaceId: string,
+	method: string,
+	params: unknown,
+	headers: Record<string, string>
+): Promise<JsonRpcResult<T> | JsonRpcError> {
+	const res = await SELF.fetch(`http://localhost/mcp/${workspaceId}`, {
+		method: "POST",
+		headers,
+		body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+	});
+	return res.json();
+}
+
+async function mcpToolResult<T>(
+	workspaceId: string,
+	name: string,
+	toolArgs: unknown,
+	headers: Record<string, string>
+): Promise<T> {
+	const res = (await mcpCall<{ content: Array<{ text: string }> }>(
+		workspaceId,
+		"tools/call",
+		{ name, arguments: toolArgs },
+		headers
+	)) as JsonRpcResult<{ content: Array<{ text: string }> }>;
+	return JSON.parse(res.result.content[0].text) as T;
+}
+
 function makeUploadRequest(
 	token: string,
 	slug: string,
@@ -557,5 +589,135 @@ describe("Files API", () => {
 			const list = (await listRes.json()) as Array<{ kind: string }>;
 			expect(list.find((l) => l.kind === "wiki_ref")).toBeUndefined();
 		});
+	});
+});
+
+// PROJ-234: attachments previously had no MCP surface at all. list/get/create-link/delete
+// are metadata-only (no binary), so they get full MCP parity; upload/download remain
+// REST-only (AGENTS.md exception).
+describe("Files MCP tools", () => {
+	let token: string;
+	let slug: string;
+	let workspaceId: string;
+
+	beforeEach(async () => {
+		const fixture = await seedFixture();
+		token = fixture.token;
+		slug = fixture.workspace.slug;
+		workspaceId = fixture.workspace.id;
+	});
+
+	it("create_link_attachment + list_attachments + get_attachment + delete_attachment round-trip", async () => {
+		const headers = authHeaders(token, slug);
+		const entityId = crypto.randomUUID();
+
+		const created = await mcpToolResult<{ id: string; kind: string }>(
+			workspaceId,
+			"create_link_attachment",
+			{ kind: "url", entityType: "issue", entityId, url: "https://example.com", label: "Docs" },
+			headers
+		);
+		expect(created.kind).toBe("url");
+
+		const list = await mcpToolResult<Array<{ id: string; filename: string; url: string | null }>>(
+			workspaceId,
+			"list_attachments",
+			{ entityType: "issue", entityId },
+			headers
+		);
+		expect(list).toHaveLength(1);
+		expect(list[0].id).toBe(created.id);
+		expect(list[0].url).toBe("https://example.com");
+
+		const meta = await mcpToolResult<{ id: string; filename: string }>(
+			workspaceId,
+			"get_attachment",
+			{ id: created.id },
+			headers
+		);
+		expect(meta.filename).toBe("Docs");
+
+		await mcpToolResult<{ ok: true }>(
+			workspaceId,
+			"delete_attachment",
+			{ id: created.id },
+			headers
+		);
+
+		const afterDelete = await mcpToolResult<unknown[]>(
+			workspaceId,
+			"list_attachments",
+			{ entityType: "issue", entityId },
+			headers
+		);
+		expect(afterDelete).toHaveLength(0);
+	});
+
+	it("get_attachment returns a JSON-RPC error for an unknown id", async () => {
+		const res = (await mcpCall(
+			workspaceId,
+			"tools/call",
+			{ name: "get_attachment", arguments: { id: crypto.randomUUID() } },
+			authHeaders(token, slug)
+		)) as JsonRpcError;
+		expect(res.error).toBeDefined();
+		expect(res.error.code).toBe(-32000);
+	});
+
+	it("create_link_attachment rejects a wiki_ref for a non-existent page", async () => {
+		const res = (await mcpCall(
+			workspaceId,
+			"tools/call",
+			{
+				name: "create_link_attachment",
+				arguments: {
+					kind: "wiki_ref",
+					entityType: "issue",
+					entityId: crypto.randomUUID(),
+					wikiPageId: crypto.randomUUID(),
+				},
+			},
+			authHeaders(token, slug)
+		)) as JsonRpcError;
+		expect(res.error).toBeDefined();
+		expect(res.error.code).toBe(-32000);
+	});
+
+	it("delete_attachment via MCP also removes the underlying R2 object for uploaded files", async () => {
+		const form = new FormData();
+		form.append("file", new File(["mcp delete test"], "mcp.txt", { type: "text/plain" }));
+		form.append("entityType", "issue");
+		form.append("entityId", crypto.randomUUID());
+		const uploadRes = await SELF.fetch("http://localhost/api/files", {
+			method: "POST",
+			headers: { Authorization: `Bearer ${token}`, "X-Workspace-Slug": slug },
+			body: form,
+		});
+		const { id } = (await uploadRes.json()) as { id: string };
+
+		const row = await env.DB.prepare("SELECT r2_key FROM attachments WHERE id = ?")
+			.bind(id)
+			.first<{ r2_key: string }>();
+		expect(await env.R2.get(row?.r2_key ?? "")).not.toBeNull();
+
+		await mcpToolResult<{ ok: true }>(
+			workspaceId,
+			"delete_attachment",
+			{ id },
+			authHeaders(token, slug)
+		);
+
+		expect(await env.R2.get(row?.r2_key ?? "")).toBeNull();
+	});
+
+	it("list_attachments scopes by workspace — another workspace sees no rows for the same entityId", async () => {
+		const other = await seedFixture();
+		const result = await mcpToolResult<unknown[]>(
+			other.workspace.id,
+			"list_attachments",
+			{ entityType: "issue", entityId: ENTITY_ID },
+			authHeaders(other.token, other.workspace.slug)
+		);
+		expect(result).toEqual([]);
 	});
 });

--- a/apps/api/src/test/mcp.test.ts
+++ b/apps/api/src/test/mcp.test.ts
@@ -477,6 +477,71 @@ describe("MCP endpoint", () => {
 		expect(res.error).toBeDefined();
 	});
 
+	it("MCP delete_wiki_page cascade=true removes the page and its subtree (PROJ-238)", async () => {
+		const owner = await seedFixture({ role: "owner" });
+		const ownerHeaders = authHeaders(owner.token, owner.workspace.slug);
+
+		const parentRes = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: ownerHeaders,
+			body: JSON.stringify({ title: "MCP Cascade Parent", content: "" }),
+		});
+		const parent = (await parentRes.json()) as { id: string; slug: string };
+
+		const childRes = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: ownerHeaders,
+			body: JSON.stringify({ title: "MCP Cascade Child", content: "", parentId: parent.id }),
+		});
+		const child = (await childRes.json()) as { slug: string };
+
+		const delRes = (await mcpCall<{ content: Array<{ text: string }> }>(
+			owner.workspace.id,
+			"tools/call",
+			{ name: "delete_wiki_page", arguments: { slug: parent.slug, cascade: true } },
+			ownerHeaders
+		)) as JsonRpcResult<{ content: Array<{ text: string }> }>;
+		expect(JSON.parse(delRes.result.content[0].text)).toEqual({ ok: true, deletedCount: 2 });
+
+		const childRes2 = await SELF.fetch(`http://localhost/api/wiki/${child.slug}`, {
+			headers: ownerHeaders,
+		});
+		expect(childRes2.status).toBe(404);
+	});
+
+	it("MCP delete_wiki_page default promotes children instead of deleting them", async () => {
+		const owner = await seedFixture({ role: "owner" });
+		const ownerHeaders = authHeaders(owner.token, owner.workspace.slug);
+
+		const parentRes = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: ownerHeaders,
+			body: JSON.stringify({ title: "MCP Promote Parent", content: "" }),
+		});
+		const parent = (await parentRes.json()) as { id: string; slug: string };
+
+		const childRes = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: ownerHeaders,
+			body: JSON.stringify({ title: "MCP Promote Child", content: "", parentId: parent.id }),
+		});
+		const child = (await childRes.json()) as { slug: string };
+
+		await mcpCall(
+			owner.workspace.id,
+			"tools/call",
+			{ name: "delete_wiki_page", arguments: { slug: parent.slug } },
+			ownerHeaders
+		);
+
+		const childRes2 = await SELF.fetch(`http://localhost/api/wiki/${child.slug}`, {
+			headers: ownerHeaders,
+		});
+		expect(childRes2.status).toBe(200);
+		const childPage = (await childRes2.json()) as { parent_id: string | null };
+		expect(childPage.parent_id).toBeNull();
+	});
+
 	// --- get_prioritized_issues ---
 
 	it("get_prioritized_issues returns empty list when no open issues", async () => {

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -462,6 +462,86 @@ describe("Wiki API", () => {
 		expect(page.parent_id).toBe(a.id);
 	});
 
+	it("DELETE /api/wiki/:slug (default) promotes children to the deleted page's parent (PROJ-238)", async () => {
+		const owner = await seedFixture({ role: "owner" });
+		const ownerHeaders = authHeaders(owner.token, owner.workspace.slug);
+
+		const grandparentRes = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: ownerHeaders,
+			body: JSON.stringify({ title: "Grandparent", content: "" }),
+		});
+		const grandparent = (await grandparentRes.json()) as { id: string };
+
+		const parentRes = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: ownerHeaders,
+			body: JSON.stringify({ title: "Parent To Delete", content: "", parentId: grandparent.id }),
+		});
+		const parent = (await parentRes.json()) as { id: string; slug: string };
+
+		const childRes = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: ownerHeaders,
+			body: JSON.stringify({ title: "Child", content: "", parentId: parent.id }),
+		});
+		const child = (await childRes.json()) as { id: string; slug: string };
+
+		const delRes = await SELF.fetch(`http://localhost/api/wiki/${parent.slug}`, {
+			method: "DELETE",
+			headers: ownerHeaders,
+		});
+		expect(delRes.status).toBe(200);
+		expect(await delRes.json()).toEqual({ ok: true, deletedCount: 1 });
+
+		const childPageRes = await SELF.fetch(`http://localhost/api/wiki/${child.slug}`, {
+			headers: ownerHeaders,
+		});
+		const childPage = (await childPageRes.json()) as { parent_id: string };
+		expect(childPage.parent_id).toBe(grandparent.id);
+	});
+
+	it("DELETE /api/wiki/:slug?cascade=true removes the page and its whole subtree", async () => {
+		const owner = await seedFixture({ role: "owner" });
+		const ownerHeaders = authHeaders(owner.token, owner.workspace.slug);
+
+		const parentRes = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: ownerHeaders,
+			body: JSON.stringify({ title: "Cascade Parent", content: "" }),
+		});
+		const parent = (await parentRes.json()) as { id: string; slug: string };
+
+		const childRes = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: ownerHeaders,
+			body: JSON.stringify({ title: "Cascade Child", content: "", parentId: parent.id }),
+		});
+		const child = (await childRes.json()) as { id: string; slug: string };
+
+		const grandchildRes = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: ownerHeaders,
+			body: JSON.stringify({ title: "Cascade Grandchild", content: "", parentId: child.id }),
+		});
+		const grandchild = (await grandchildRes.json()) as { slug: string };
+
+		const delRes = await SELF.fetch(`http://localhost/api/wiki/${parent.slug}?cascade=true`, {
+			method: "DELETE",
+			headers: ownerHeaders,
+		});
+		expect(delRes.status).toBe(200);
+		expect(await delRes.json()).toEqual({ ok: true, deletedCount: 3 });
+
+		await env.DB.prepare("DELETE FROM rate_limit").run();
+		for (const s of [parent.slug, child.slug, grandchild.slug]) {
+			const res = await SELF.fetch(`http://localhost/api/wiki/${s}`, {
+				headers: ownerHeaders,
+			});
+			expect(res.status).toBe(404);
+		}
+	});
+
 	it("DELETE /api/wiki/:slug returns 403 for viewer role", async () => {
 		await SELF.fetch("http://localhost/api/wiki", {
 			method: "POST",

--- a/apps/docs/src/content/docs/agents/tool-catalog.md
+++ b/apps/docs/src/content/docs/agents/tool-catalog.md
@@ -11,7 +11,7 @@ running server.
 
 <!-- gen-mcp-catalog:start - generated block; run `pnpm --filter @projektor/api gen:catalog` to refresh -->
 
-**86 tools across 20 domains.**
+**90 tools across 21 domains.**
 
 ## Coordination
 
@@ -141,6 +141,15 @@ running server.
 | `wiki_tree` | Get the wiki page hierarchy as a nested tree, optionally filtered by project |
 | `list_wiki_revisions` | List revision history for a wiki page |
 | `get_wiki_revision` | Get the content of a specific wiki revision by its ID |
+
+### Attachments
+
+| Tool | Description |
+|------|-------------|
+| `list_attachments` | List attachments (files, wiki-page links, URLs) on an issue or wiki page |
+| `get_attachment` | Get attachment metadata by id. For kind 'file' the bytes themselves are only available over REST (GET /api/files/:id) — binary content can't cross JSON-RPC. |
+| `create_link_attachment` | Attach a wiki-page reference or an external URL to an issue or wiki page |
+| `delete_attachment` | Delete an attachment by id |
 
 ### Task types
 

--- a/apps/docs/src/content/docs/agents/tool-catalog.md
+++ b/apps/docs/src/content/docs/agents/tool-catalog.md
@@ -137,7 +137,7 @@ running server.
 | `get_wiki_page` | Get a wiki page by slug, including full content |
 | `create_wiki_page` | Create a new wiki page |
 | `update_wiki_page` | Update a wiki page by id or slug (saves a revision when content changes) |
-| `delete_wiki_page` | Delete a wiki page by slug (not allowed for viewers) |
+| `delete_wiki_page` | Delete a wiki page by slug (not allowed for viewers). By default any child pages are promoted to the deleted page's parent; pass cascade=true to delete the whole subtree instead. |
 | `wiki_tree` | Get the wiki page hierarchy as a nested tree, optionally filtered by project |
 | `list_wiki_revisions` | List revision history for a wiki page |
 | `get_wiki_revision` | Get the content of a specific wiki revision by its ID |

--- a/apps/docs/src/content/docs/contributing/conventions.md
+++ b/apps/docs/src/content/docs/contributing/conventions.md
@@ -58,9 +58,10 @@ mcp/<domain>.ts      (MCP wrapper)   ─┘     (ALL business logic + SQL live h
 The parity audit (PROJ-236) confirmed these surface-only features are intentional, not
 drift — don't re-flag them in future audits:
 
-- **File attachments (`routes/files.ts`)** — REST-only. Binary/multipart upload and
-  streamed download can't cross JSON-RPC. Tracked separately as PROJ-234 (no MCP surface
-  at all for this domain).
+- **File attachment upload/download (`POST /api/files`, `GET /api/files/:id`)** —
+  REST-only. Binary/multipart upload and streamed download can't cross JSON-RPC.
+  Metadata operations (list, get metadata, link-create, delete) have full MCP parity
+  via `mcp/files.ts` (PROJ-234).
 - **Auth (`routes/auth.ts`): login redirect, API token minting/revocation** — REST-only.
   CF Access login is a browser redirect flow; token minting/revocation is a sensitive
   credential operation kept off the MCP surface.
@@ -274,6 +275,7 @@ These are the constraints the fleet skill reads to plan batches. Keep them curre
 | issues | `services/issues.ts` | `schemas/issues.ts` | `routes/issues.ts` | `mcp/issues.ts` | `test/issues.test.ts` |
 | projects | `services/projects.ts` | `schemas/projects.ts` | `routes/projects.ts` | `mcp/projects.ts` | `test/projects.test.ts` |
 | wiki | `services/wiki.ts` | `schemas/wiki.ts` | `routes/wiki.ts` | `mcp/wiki.ts` | `test/wiki.test.ts` |
+| files | `services/files.ts` | `schemas/files.ts` | `routes/files.ts` | `mcp/files.ts` | `test/files.test.ts` |
 | sprints | `services/sprints.ts` | `schemas/sprints.ts` | `routes/sprints.ts` | `mcp/sprints.ts` | `test/sprints.test.ts` |
 | comments | `services/comments.ts` | `schemas/comments.ts` | `routes/comments.ts` | `mcp/comments.ts` | `test/comments.test.ts` |
 | task-types | `services/task-types.ts` | `schemas/task-types.ts` | `routes/task-types.ts` | `mcp/task-types.ts` | `test/task-types.test.ts` |

--- a/apps/docs/src/generated/mcp-stats.json
+++ b/apps/docs/src/generated/mcp-stats.json
@@ -1,4 +1,4 @@
 {
-	"tools": 86,
-	"domains": 20
+	"tools": 90,
+	"domains": 21
 }

--- a/apps/web/src/islands/WikiPage.test.tsx
+++ b/apps/web/src/islands/WikiPage.test.tsx
@@ -96,6 +96,48 @@ describe("WikiPage", () => {
 		render(<WikiPage />);
 		expect(await screen.findByText(/Failed to load page/i)).toBeTruthy();
 	});
+
+	it("shows Move button once the page is loaded", async () => {
+		history.replaceState(null, "", "?slug=my-page");
+		mockFetchWiki(PAGE);
+		render(<WikiPage />);
+		await screen.findByText("My Page");
+		expect(screen.getByRole("button", { name: "Move" })).toBeTruthy();
+	});
+
+	it("moves a page to a new parent via PUT and refetches tree/page", async () => {
+		history.replaceState(null, "", "?slug=my-page");
+		const OTHER_PAGE_NODE = { id: "w2", slug: "other-page", title: "Other Page", children: [] };
+		const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+			const u = String(url);
+			if (u.includes("/revisions")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			}
+			if (u.includes("/tree")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([OTHER_PAGE_NODE]) });
+			}
+			if (init?.method === "PUT") {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({ ...PAGE }) });
+			}
+			return Promise.resolve({ ok: true, json: () => Promise.resolve(PAGE) });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+		render(<WikiPage />);
+		await screen.findByText("My Page");
+
+		fireEvent.click(screen.getByRole("button", { name: "Move" }));
+		fireEvent.click(await screen.findByRole("combobox", { name: /new parent page/i }));
+		fireEvent.click(await screen.findByRole("option", { name: "Other Page" }));
+		const moveButtons = screen.getAllByRole("button", { name: "Move" });
+		fireEvent.click(moveButtons[moveButtons.length - 1]);
+
+		await waitFor(() => {
+			const putCall = fetchMock.mock.calls.find(([, init]) => init?.method === "PUT");
+			expect(putCall).toBeTruthy();
+			expect(putCall?.[0]).toContain("/api/wiki/my-page");
+			expect(JSON.parse(putCall?.[1].body)).toEqual({ parentId: "w2" });
+		});
+	});
 });
 
 describe("WikiPage — project scope control (PROJ-352)", () => {

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -1697,6 +1697,7 @@ function createWikiActions(args: {
 
 	function startCreate(parentId: string | null = null) {
 		setEditing(false);
+		args.cancelMove();
 		args.rawStartCreate(parentId);
 	}
 
@@ -1986,6 +1987,11 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 	const { latestRevision, breadcrumbs, showToc, createParentTitle, wikiPages, moveOptions } =
 		deriveWikiPageState(pageData, pageMap, editState, createForm, toc);
 
+	function startEdit() {
+		move.cancelMove();
+		editState.startEdit();
+	}
+
 	const createProps = buildCreateFormProps({
 		createParentTitle,
 		createTitle: createForm.createTitle,
@@ -2013,7 +2019,7 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 		saving: editState.saving,
 		save: editState.save,
 		cancelEdit: editState.cancelEdit,
-		startEdit: editState.startEdit,
+		startEdit,
 		startCreate,
 		deletePage,
 		latestRevision,

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -438,6 +438,46 @@ function PageBreadcrumbs({
 	);
 }
 
+function MovePageForm({
+	options,
+	value,
+	saving,
+	error,
+	onChange,
+	onSubmit,
+	onCancel,
+}: {
+	options: SelectOption[];
+	value: string;
+	saving: boolean;
+	error: string | null;
+	onChange: (value: string) => void;
+	onSubmit: () => void;
+	onCancel: () => void;
+}) {
+	return (
+		<div class="mb-4 p-3 border border-border rounded bg-surface">
+			<p class="m-0 mb-2 text-sm font-medium text-text-base">Move to a new parent page</p>
+			{error && (
+				<p role="alert" class="text-[var(--danger-text)] mb-2 text-sm">
+					{error}
+				</p>
+			)}
+			<div class="flex flex-wrap gap-2 items-center">
+				<div class="min-w-[220px]">
+					<Select value={value} options={options} ariaLabel="New parent page" onChange={onChange} />
+				</div>
+				<button type="button" onClick={onSubmit} disabled={saving} class="btn btn-primary btn-sm">
+					{saving ? "Moving…" : "Move"}
+				</button>
+				<button type="button" onClick={onCancel} disabled={saving} class="btn btn-outline btn-sm">
+					Cancel
+				</button>
+			</div>
+		</div>
+	);
+}
+
 const TOC_LINK_BASE_CLASS =
 	"block py-[0.2rem] no-underline border-l-2 transition-[color,border-color] duration-150";
 const TOC_LINK_ACTIVE_CLASS = "text-accent border-accent font-medium";
@@ -484,6 +524,7 @@ function PageHeader({
 	onCancelEdit,
 	onStartEdit,
 	onStartCreateChild,
+	onStartMove,
 	onDelete,
 }: {
 	editing: boolean;
@@ -496,6 +537,7 @@ function PageHeader({
 	onCancelEdit: () => void;
 	onStartEdit: () => void;
 	onStartCreateChild: (pageId: string) => void;
+	onStartMove: () => void;
 	onDelete: () => void;
 }) {
 	return (
@@ -531,6 +573,9 @@ function PageHeader({
 							class="btn btn-outline btn-sm"
 						>
 							+ Child page
+						</button>
+						<button type="button" onClick={onStartMove} class="btn btn-outline btn-sm">
+							Move
 						</button>
 						<button type="button" onClick={onStartEdit} class="btn btn-outline">
 							Edit
@@ -768,6 +813,15 @@ interface PageArticleProps {
 	onStartEdit: () => void;
 	onStartCreateChild: (pageId: string) => void;
 	onDelete: () => void;
+	moving: boolean;
+	moveOptions: SelectOption[];
+	moveTargetId: string;
+	moveSaving: boolean;
+	moveError: string | null;
+	onStartMove: () => void;
+	onMoveTargetChange: (value: string) => void;
+	onSubmitMove: () => void;
+	onCancelMove: () => void;
 	latestRevision: WikiRevision | null;
 	saveError: string | null;
 	draftBanner: { title: string; content: string; savedAt: number } | null;
@@ -810,6 +864,15 @@ function PageArticleMeta(
 		| "onStartEdit"
 		| "onStartCreateChild"
 		| "onDelete"
+		| "moving"
+		| "moveOptions"
+		| "moveTargetId"
+		| "moveSaving"
+		| "moveError"
+		| "onStartMove"
+		| "onMoveTargetChange"
+		| "onSubmitMove"
+		| "onCancelMove"
 		| "latestRevision"
 		| "saveError"
 		| "draftBanner"
@@ -843,8 +906,21 @@ function PageArticleMeta(
 				onCancelEdit={props.onCancelEdit}
 				onStartEdit={props.onStartEdit}
 				onStartCreateChild={props.onStartCreateChild}
+				onStartMove={props.onStartMove}
 				onDelete={props.onDelete}
 			/>
+
+			{props.moving && (
+				<MovePageForm
+					options={props.moveOptions}
+					value={props.moveTargetId}
+					saving={props.moveSaving}
+					error={props.moveError}
+					onChange={props.onMoveTargetChange}
+					onSubmit={props.onSubmitMove}
+					onCancel={props.onCancelMove}
+				/>
+			)}
 
 			{props.latestRevision && (
 				<p class="text-[0.8rem] text-text-muted mt-1 mb-5">
@@ -1424,6 +1500,63 @@ function useWikiEditing(
 	};
 }
 
+// PROJ-237: re-parent a page from the page menu. Backend validation (cycle guard,
+// workspace scoping) already exists on PUT /api/wiki/:slug — this is UI-only.
+function useMovePage(
+	workspaceSlug: string | undefined,
+	page: WikiPageData | null,
+	fetchPage: (s: string) => Promise<void>,
+	fetchTree: () => Promise<void>
+) {
+	const [moving, setMoving] = useState(false);
+	const [moveTargetId, setMoveTargetId] = useState("");
+	const [moveSaving, setMoveSaving] = useState(false);
+	const [moveError, setMoveError] = useState<string | null>(null);
+
+	function startMove() {
+		if (!page) return;
+		setMoveTargetId(page.parent_id ?? "");
+		setMoveError(null);
+		setMoving(true);
+	}
+
+	function cancelMove() {
+		setMoving(false);
+		setMoveError(null);
+	}
+
+	async function submitMove() {
+		if (!page) return;
+		setMoveSaving(true);
+		setMoveError(null);
+		try {
+			await apiFetch(`/api/wiki/${encodeURIComponent(page.slug)}`, {
+				method: "PUT",
+				workspaceSlug,
+				body: { parentId: moveTargetId || null },
+			});
+			setMoving(false);
+			await fetchTree();
+			await fetchPage(page.slug);
+		} catch (e) {
+			setMoveError(`Move failed: ${String(e)}`);
+		} finally {
+			setMoveSaving(false);
+		}
+	}
+
+	return {
+		moving,
+		moveTargetId,
+		setMoveTargetId,
+		moveSaving,
+		moveError,
+		startMove,
+		cancelMove,
+		submitMove,
+	};
+}
+
 function useCreatePageForm(
 	workspaceSlug: string | undefined,
 	projectId: string,
@@ -1536,6 +1669,7 @@ function createWikiActions(args: {
 	setToc: (t: TocItem[]) => void;
 	rawStartCreate: (parentId: string | null) => void;
 	rawSubmitCreate: () => Promise<string | undefined>;
+	cancelMove: () => void;
 }) {
 	const {
 		workspaceSlug,
@@ -1547,6 +1681,7 @@ function createWikiActions(args: {
 		setPage,
 		setError,
 		setToc,
+		cancelMove,
 	} = args;
 
 	function navigateTo(s: string) {
@@ -1556,6 +1691,7 @@ function createWikiActions(args: {
 		setError(null);
 		setToc([]);
 		setSlug(s);
+		cancelMove();
 		history.pushState(null, "", `?slug=${encodeURIComponent(s)}`);
 	}
 
@@ -1692,7 +1828,13 @@ function deriveWikiPageState(
 		? (pageMap[createForm.createParentId]?.title ?? null)
 		: null;
 	const wikiPages = Object.values(pageMap);
-	return { latestRevision, breadcrumbs, showToc, createParentTitle, wikiPages };
+	const moveOptions: SelectOption[] = [
+		{ value: "", label: "No parent (root)" },
+		...wikiPages
+			.filter((p) => p.id !== pageData.page?.id)
+			.map((p) => ({ value: p.id, label: p.title })),
+	];
+	return { latestRevision, breadcrumbs, showToc, createParentTitle, wikiPages, moveOptions };
 }
 
 function buildCreateFormProps(create: {
@@ -1752,6 +1894,8 @@ function buildArticleProps(article: {
 	setShowHistory: (updater: (h: boolean) => boolean) => void;
 	attach: ReturnType<typeof useWikiAttachments>;
 	workspaceSlug: string | undefined;
+	move: ReturnType<typeof useMovePage>;
+	moveOptions: SelectOption[];
 }): Omit<PageArticleProps, "page"> {
 	return {
 		breadcrumbs: article.breadcrumbs,
@@ -1791,6 +1935,15 @@ function buildArticleProps(article: {
 		onUpload: article.attach.uploadAttachment,
 		onCancelUpload: article.attach.cancelUpload,
 		onDeleteAttachment: article.attach.deleteAttachment,
+		moving: article.move.moving,
+		moveOptions: article.moveOptions,
+		moveTargetId: article.move.moveTargetId,
+		moveSaving: article.move.moveSaving,
+		moveError: article.move.moveError,
+		onStartMove: article.move.startMove,
+		onMoveTargetChange: article.move.setMoveTargetId,
+		onSubmitMove: article.move.submitMove,
+		onCancelMove: article.move.cancelMove,
 	};
 }
 
@@ -1813,6 +1966,7 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 		pageData.fetchRevisions
 	);
 	const createForm = useCreatePageForm(workspaceSlug, projectId, fetchTree);
+	const move = useMovePage(workspaceSlug, pageData.page, pageData.fetchPage, fetchTree);
 
 	const { navigateTo, startCreate, submitCreate, deletePage } = createWikiActions({
 		workspaceSlug,
@@ -1826,9 +1980,10 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 		setToc,
 		rawStartCreate: createForm.startCreate,
 		rawSubmitCreate: createForm.submitCreate,
+		cancelMove: move.cancelMove,
 	});
 
-	const { latestRevision, breadcrumbs, showToc, createParentTitle, wikiPages } =
+	const { latestRevision, breadcrumbs, showToc, createParentTitle, wikiPages, moveOptions } =
 		deriveWikiPageState(pageData, pageMap, editState, createForm, toc);
 
 	const createProps = buildCreateFormProps({
@@ -1874,6 +2029,8 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 		setShowHistory: pageData.setShowHistory,
 		attach,
 		workspaceSlug,
+		move,
+		moveOptions,
 	});
 
 	if (gate.pending) return <AccessPending />;


### PR DESCRIPTION
## Summary
- **PROJ-374**: adds a regression test for the viewer 403 guard on POST /api/issues/:id/comments (fix already shipped in a prior commit; this closes the coverage gap that kept the ticket open).
- **PROJ-234**: extracts `routes/files.ts`'s business logic into `services/files.ts`; adds `PayloadTooLargeError`/`UnsupportedMediaTypeError` typed errors (413/415); gives attachments MCP parity (`list_attachments`, `get_attachment`, `create_link_attachment`, `delete_attachment`) with R2 cleanup on delete.
- **PROJ-237**: adds a Move (re-parent) UI to the wiki page island — a Move button opens a parent-page picker and PUTs the new `parentId`. Tree nav, create-under, and breadcrumbs were already implemented in prior work.
- **PROJ-238**: fixes a dangling-`parent_id` bug on wiki page delete (no FK constraint exists). Default now promotes children to the deleted page's parent; `cascade=true` (REST query param / MCP arg) deletes the whole subtree, chunked to respect D1's bound-parameter limit.

An Opus-model review pass was run over the full batched diff before merge — no blocking issues found. Two non-blocking findings were filed as follow-up tickets: PROJ-425 (attachments have no viewer/write authz gate, now reachable via the new MCP tools) and PROJ-426 (wiki page delete orphans R2 blobs for file attachments).

## Test plan
- [x] `pnpm --filter @projektor/api test` — 824/824 passed (5 pre-existing todo)
- [x] `pnpm --filter @projektor/web test` — 379/379 passed
- [x] `pnpm turbo type-check` — clean across all packages
- [x] `pnpm --filter @projektor/web build` — succeeds
- [x] `rtk proxy pnpm lint` (biome) — clean
- [x] Opus-model review of the full batched diff — no blocking issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)