### PR TITLE
PROJ-427: reload to re-auth via Cloudflare Access on a 401

### DIFF
--- a/apps/web/src/utils/api-client.test.ts
+++ b/apps/web/src/utils/api-client.test.ts
@@ -24,4 +24,29 @@ describe("apiFetch", () => {
 			ApiOfflineError
 		);
 	});
+
+	it("reloads the page and never settles on a 401 (expired Cloudflare Access session)", async () => {
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401 }));
+		const reload = vi.fn();
+		const originalLocation = window.location;
+		Object.defineProperty(window, "location", {
+			configurable: true,
+			value: { ...originalLocation, reload },
+		});
+
+		let settled = false;
+		apiFetch("/api/issues/i1").then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			}
+		);
+		await new Promise((r) => setTimeout(r, 0));
+
+		expect(reload).toHaveBeenCalledTimes(1);
+		expect(settled).toBe(false);
+		Object.defineProperty(window, "location", { configurable: true, value: originalLocation });
+	});
 });

--- a/apps/web/src/utils/api-client.ts
+++ b/apps/web/src/utils/api-client.ts
@@ -42,6 +42,14 @@ export async function apiFetch<T = unknown>(
 	} catch {
 		throw new ApiOfflineError(path, method);
 	}
-	if (!res.ok) throw new Error(`API ${method} ${path} failed: ${res.status}`);
+	if (!res.ok) {
+		// A 401 here means the Cloudflare Access session expired mid-use (the app itself
+		// never prompts re-login). Reload so Access can challenge and bounce the user back.
+		if (res.status === 401) {
+			window.location.reload();
+			return new Promise<T>(() => {});
+		}
+		throw new Error(`API ${method} ${path} failed: ${res.status}`);
+	}
 	return res.json() as Promise<T>;
 }


### PR DESCRIPTION
## Summary
- Fixes user-reported 401 issues on the production deployment: `apiFetch` threw a generic error on any non-2xx response, including a 401 from an expired Cloudflare Access session — leaving the user stuck on stale UI with no way back to a working session short of a manual reload.
- On a 401, `apiFetch` now triggers `window.location.reload()` (and never resolves), forcing a full navigation that Cloudflare Access intercepts at the edge and challenges for fresh login, landing the user back on the same page afterward.

## Investigation
- Confirmed via user report: session was logged in and in active use, then API calls started failing with 401 (root Access app session_duration is 24h).
- Checked Cloudflare Access config directly via the API: `/api/*` and `/mcp/*` each have their own Access Application set to `bypass: everyone` (pre-existing since 2026-06-21, not the cause) — enforcement for those paths is entirely the Worker's own `authMiddleware`, which correctly 401s on a stale/invalid session. The frontend just had no handling for that response.

PROJ-427

## Test plan
- [x] `pnpm --filter web test` — 380 tests pass, including new coverage for the 401 reload path
- [x] `astro check` — 0 errors
- [x] `biome check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DjSCvRampBsoXiqUwyQGx