### PR TITLE
PROJ-427: temporary CF Access diagnostic logging

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -257,16 +257,41 @@ async function validateCfAccessJwt(jwt: string, env: Env): Promise<AuthUser | nu
 	// Pre-screen without keys: avoids a JWKS fetch for obviously-invalid tokens.
 	// Mirrors the order of checks in verifyJwtPayload so early exits fire first.
 	const parts = jwt.split(".");
-	if (parts.length !== 3) return null;
+	if (parts.length !== 3) {
+		console.log("[cf-access-debug] deny: malformed-jwt", { partCount: parts.length });
+		return null;
+	}
 	try {
 		const hdr = JSON.parse(base64urlDecode(parts[0]));
-		if (hdr.alg !== "RS256") return null;
+		if (hdr.alg !== "RS256") {
+			console.log("[cf-access-debug] deny: alg-mismatch", { alg: hdr.alg, kid: hdr.kid });
+			return null;
+		}
 		const pld = JSON.parse(base64urlDecode(parts[1]));
-		if (pld.exp < Math.floor(Date.now() / 1000)) return null;
+		if (pld.exp < Math.floor(Date.now() / 1000)) {
+			console.log("[cf-access-debug] deny: expired", {
+				exp: pld.exp,
+				now: Math.floor(Date.now() / 1000),
+			});
+			return null;
+		}
 		const aud = Array.isArray(pld.aud) ? pld.aud : [pld.aud];
-		if (!aud.includes(env.CF_ACCESS_AUDIENCE)) return null;
-		if (pld.iss !== `https://${env.CF_ACCESS_TEAM_DOMAIN}`) return null;
-	} catch {
+		if (!aud.includes(env.CF_ACCESS_AUDIENCE)) {
+			console.log("[cf-access-debug] deny: aud-mismatch", {
+				tokenAud: aud,
+				expectedAud: env.CF_ACCESS_AUDIENCE,
+			});
+			return null;
+		}
+		if (pld.iss !== `https://${env.CF_ACCESS_TEAM_DOMAIN}`) {
+			console.log("[cf-access-debug] deny: iss-mismatch", {
+				tokenIss: pld.iss,
+				expectedIss: `https://${env.CF_ACCESS_TEAM_DOMAIN}`,
+			});
+			return null;
+		}
+	} catch (e) {
+		console.log("[cf-access-debug] deny: decode-error", { message: String(e) });
 		return null;
 	}
 	// All field checks passed — now fetch keys and verify the signature.
@@ -278,6 +303,9 @@ async function validateCfAccessJwt(jwt: string, env: Env): Promise<AuthUser | nu
 		`https://${env.CF_ACCESS_TEAM_DOMAIN}`
 	);
 	if (!result) {
+		console.log("[cf-access-debug] sig-invalid-with-cached-keys", {
+			cachedKids: keys.map((k) => (k as { kid?: string }).kid),
+		});
 		// PROJ-358: claims already passed the pre-screen above, so a null result
 		// here means the signature didn't match any cached key — most likely
 		// Cloudflare rotated its Access signing keys since we cached them. Force
@@ -291,6 +319,13 @@ async function validateCfAccessJwt(jwt: string, env: Env): Promise<AuthUser | nu
 				env.CF_ACCESS_AUDIENCE,
 				`https://${env.CF_ACCESS_TEAM_DOMAIN}`
 			);
+			if (!result) {
+				console.log("[cf-access-debug] deny: sig-invalid-after-forced-refresh", {
+					freshKids: freshKeys.map((k) => (k as { kid?: string }).kid),
+				});
+			}
+		} else {
+			console.log("[cf-access-debug] deny: forced-refresh-skipped-cooldown");
 		}
 	}
 	if (!result) return null;


### PR DESCRIPTION
## Summary
Temporary diagnostic-only change: logs the exact reason `validateCfAccessJwt` rejects a token (decode error, alg/exp/aud/iss mismatch, or signature-invalid + which key IDs were tried). The user is still seeing 401s in production after the PROJ-427 reload fix, even mid-session with a single correctly-scoped `CF_Authorization` cookie — need real evidence from a live repro to find the actual root cause rather than guessing further.

To be reverted once we've captured a repro via `wrangler tail`.

PROJ-427

## Test plan
- [x] `pnpm --filter api test` — 824 passed
- [x] `pnpm turbo type-check --filter=@projektor/api`
- [x] `biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DjSCvRampBsoXiqUwyQGx