### PR TITLE
PROJ-427: revert diagnostic logging, smooth reload-flash, add login/logout

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -257,41 +257,16 @@ async function validateCfAccessJwt(jwt: string, env: Env): Promise<AuthUser | nu
 	// Pre-screen without keys: avoids a JWKS fetch for obviously-invalid tokens.
 	// Mirrors the order of checks in verifyJwtPayload so early exits fire first.
 	const parts = jwt.split(".");
-	if (parts.length !== 3) {
-		console.log("[cf-access-debug] deny: malformed-jwt", { partCount: parts.length });
-		return null;
-	}
+	if (parts.length !== 3) return null;
 	try {
 		const hdr = JSON.parse(base64urlDecode(parts[0]));
-		if (hdr.alg !== "RS256") {
-			console.log("[cf-access-debug] deny: alg-mismatch", { alg: hdr.alg, kid: hdr.kid });
-			return null;
-		}
+		if (hdr.alg !== "RS256") return null;
 		const pld = JSON.parse(base64urlDecode(parts[1]));
-		if (pld.exp < Math.floor(Date.now() / 1000)) {
-			console.log("[cf-access-debug] deny: expired", {
-				exp: pld.exp,
-				now: Math.floor(Date.now() / 1000),
-			});
-			return null;
-		}
+		if (pld.exp < Math.floor(Date.now() / 1000)) return null;
 		const aud = Array.isArray(pld.aud) ? pld.aud : [pld.aud];
-		if (!aud.includes(env.CF_ACCESS_AUDIENCE)) {
-			console.log("[cf-access-debug] deny: aud-mismatch", {
-				tokenAud: aud,
-				expectedAud: env.CF_ACCESS_AUDIENCE,
-			});
-			return null;
-		}
-		if (pld.iss !== `https://${env.CF_ACCESS_TEAM_DOMAIN}`) {
-			console.log("[cf-access-debug] deny: iss-mismatch", {
-				tokenIss: pld.iss,
-				expectedIss: `https://${env.CF_ACCESS_TEAM_DOMAIN}`,
-			});
-			return null;
-		}
-	} catch (e) {
-		console.log("[cf-access-debug] deny: decode-error", { message: String(e) });
+		if (!aud.includes(env.CF_ACCESS_AUDIENCE)) return null;
+		if (pld.iss !== `https://${env.CF_ACCESS_TEAM_DOMAIN}`) return null;
+	} catch {
 		return null;
 	}
 	// All field checks passed — now fetch keys and verify the signature.
@@ -303,9 +278,6 @@ async function validateCfAccessJwt(jwt: string, env: Env): Promise<AuthUser | nu
 		`https://${env.CF_ACCESS_TEAM_DOMAIN}`
 	);
 	if (!result) {
-		console.log("[cf-access-debug] sig-invalid-with-cached-keys", {
-			cachedKids: keys.map((k) => (k as { kid?: string }).kid),
-		});
 		// PROJ-358: claims already passed the pre-screen above, so a null result
 		// here means the signature didn't match any cached key — most likely
 		// Cloudflare rotated its Access signing keys since we cached them. Force
@@ -319,13 +291,6 @@ async function validateCfAccessJwt(jwt: string, env: Env): Promise<AuthUser | nu
 				env.CF_ACCESS_AUDIENCE,
 				`https://${env.CF_ACCESS_TEAM_DOMAIN}`
 			);
-			if (!result) {
-				console.log("[cf-access-debug] deny: sig-invalid-after-forced-refresh", {
-					freshKids: freshKeys.map((k) => (k as { kid?: string }).kid),
-				});
-			}
-		} else {
-			console.log("[cf-access-debug] deny: forced-refresh-skipped-cooldown");
 		}
 	}
 	if (!result) return null;

--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -648,6 +648,8 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
 
         <div class="sidebar-footer">
           <a href="/help" class="theme-toggle" aria-label="Help — glossary of terms" title="Help">?</a>
+          <a href="/" class="theme-toggle" aria-label="Log in — refresh your session" title="Log in">🔑</a>
+          <a href="/cdn-cgi/access/logout" class="theme-toggle" aria-label="Log out" title="Log out">🚪</a>
           <button class="theme-toggle" aria-label="Toggle colour scheme">🌙</button>
         </div>
         <div class="sidebar-version">v{appVersion}</div>

--- a/apps/web/src/utils/api-client.test.ts
+++ b/apps/web/src/utils/api-client.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
-import { ApiOfflineError, apiFetch } from "./api-client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { __resetApiFetchStateForTests, ApiOfflineError, apiFetch } from "./api-client";
 
 describe("apiFetch", () => {
+	beforeEach(() => {
+		__resetApiFetchStateForTests();
+	});
+
 	it("returns parsed JSON on a successful response", async () => {
 		vi.stubGlobal(
 			"fetch",
@@ -47,6 +51,50 @@ describe("apiFetch", () => {
 
 		expect(reload).toHaveBeenCalledTimes(1);
 		expect(settled).toBe(false);
+		Object.defineProperty(window, "location", { configurable: true, value: originalLocation });
+	});
+
+	it("suppresses errors from other in-flight calls once a 401 has triggered a reload", async () => {
+		const reload = vi.fn();
+		const originalLocation = window.location;
+		Object.defineProperty(window, "location", {
+			configurable: true,
+			value: { ...originalLocation, reload },
+		});
+
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401 }));
+		apiFetch("/api/issues/i1");
+		await new Promise((r) => setTimeout(r, 0));
+		expect(reload).toHaveBeenCalledTimes(1);
+
+		// A concurrent request aborted by the same navigation (network error) or
+		// failing for any other reason shouldn't surface — the page is unloading.
+		vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
+		let networkErrorSettled = false;
+		apiFetch("/auth/me").then(
+			() => {
+				networkErrorSettled = true;
+			},
+			() => {
+				networkErrorSettled = true;
+			}
+		);
+
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+		let httpErrorSettled = false;
+		apiFetch("/api/projects").then(
+			() => {
+				httpErrorSettled = true;
+			},
+			() => {
+				httpErrorSettled = true;
+			}
+		);
+
+		await new Promise((r) => setTimeout(r, 0));
+		expect(networkErrorSettled).toBe(false);
+		expect(httpErrorSettled).toBe(false);
+
 		Object.defineProperty(window, "location", { configurable: true, value: originalLocation });
 	});
 });

--- a/apps/web/src/utils/api-client.ts
+++ b/apps/web/src/utils/api-client.ts
@@ -15,6 +15,17 @@ export class ApiOfflineError extends Error {
 	}
 }
 
+// Set once a 401 triggers window.location.reload(). The reload doesn't tear down the
+// page instantly, so other in-flight calls can still land (or get aborted by the
+// navigation) in the meantime — once we're reloading, suppress their errors too rather
+// than flashing an unrelated "failed to load"/offline error right before the page goes away.
+let reauthReloadInFlight = false;
+
+/** Test-only: reset module state between tests (see the module-level flag above). */
+export function __resetApiFetchStateForTests(): void {
+	reauthReloadInFlight = false;
+}
+
 export async function apiFetch<T = unknown>(
 	path: string,
 	opts: {
@@ -40,15 +51,18 @@ export async function apiFetch<T = unknown>(
 				: {}),
 		});
 	} catch {
+		if (reauthReloadInFlight) return new Promise<T>(() => {});
 		throw new ApiOfflineError(path, method);
 	}
 	if (!res.ok) {
 		// A 401 here means the Cloudflare Access session expired mid-use (the app itself
 		// never prompts re-login). Reload so Access can challenge and bounce the user back.
 		if (res.status === 401) {
+			reauthReloadInFlight = true;
 			window.location.reload();
 			return new Promise<T>(() => {});
 		}
+		if (reauthReloadInFlight) return new Promise<T>(() => {});
 		throw new Error(`API ${method} ${path} failed: ${res.status}`);
 	}
 	return res.json() as Promise<T>;


### PR DESCRIPTION
## Summary
- Revert temporary CF Access JWT diagnostic logging added while investigating the 401 issue (PROJ-427).
- Suppress errors from other in-flight requests once a 401 has triggered a session-refresh reload, so a collateral `ApiOfflineError`/"network unavailable" toast no longer flashes right before the page reloads.
- Add Log in / Log out controls to the sidebar footer as a manual escape hatch for refreshing or ending the Cloudflare Access session.

## Test plan
- [x] `pnpm --filter web test` — 381 passed (38 files)
- [x] `pnpm --filter web type-check` (astro check) — 0 errors
- [x] `pnpm --filter api test` — 824 passed (first run had an unrelated Windows workerd hook timeout flake; passed clean on retry)
- [x] `git diff main -- apps/api/src/middleware/auth.ts` confirms diagnostic logging fully reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DjSCvRampBsoXiqUwyQGx