### PR TITLE
PROJ-430: make re-auth navigations reach Cloudflare Access

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -38,6 +38,20 @@ import { createWorkspace, listUserWorkspaces } from "./services/workspaces";
 
 const app = new Hono<HonoEnv>();
 
+// PROJ-430: Hono's default handler answers an uncaught throw with a bare,
+// unlogged 500, which is why diagnosing the overnight error burst needed
+// temporary instrumentation (PROJ-427/#131). Log the failure with its request
+// context and return the same JSON error shape every other endpoint uses.
+app.onError((err, c) => {
+	console.error("unhandled error", {
+		method: c.req.method,
+		path: c.req.path,
+		err: err instanceof Error ? `${err.name}: ${err.message}` : String(err),
+		stack: err instanceof Error ? err.stack : undefined,
+	});
+	return c.json({ error: "Internal Server Error" }, 500);
+});
+
 // PROJ-378: anonymous feedback ingestion. Mounted ahead of the global logger()
 // and cors() calls below — not merely ahead of auth — the same "register before
 // the .use() you need to skip" technique already used for /api/health (mounted

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -35,6 +35,12 @@ export interface AuthUser {
 
 type AuthOutcome = { kind: "skip" } | { kind: "deny"; response: Response } | { kind: "allow" };
 
+// PROJ-430: separates "we could not check this token" from "this token is bad".
+// The frontend reloads the page to re-authenticate on a 401, so reporting an
+// unreachable JWKS endpoint as 401 sends the user through a login round-trip
+// that cannot fix it — and reloading on a still-broken backend loops.
+class AuthUnavailableError extends Error {}
+
 // 1. Cloudflare Access JWT (header or cookie)
 async function tryCfAccessAuth(c: Context<HonoEnv>): Promise<AuthOutcome> {
 	const cfJwt =
@@ -42,7 +48,16 @@ async function tryCfAccessAuth(c: Context<HonoEnv>): Promise<AuthOutcome> {
 		parseCookie(c.req.header("cookie") ?? "", "CF_Authorization");
 	if (!cfJwt) return { kind: "skip" };
 
-	const user = await validateCfAccessJwt(cfJwt, c.env);
+	let user: AuthUser | null;
+	try {
+		user = await validateCfAccessJwt(cfJwt, c.env);
+	} catch (err) {
+		if (!(err instanceof AuthUnavailableError)) throw err;
+		return {
+			kind: "deny",
+			response: c.json({ error: "Authentication temporarily unavailable" }, 503),
+		};
+	}
 	if (!user) return { kind: "deny", response: c.json({ error: "Invalid Access token" }, 401) };
 
 	await provisionUserOnLogin(c.env, user);
@@ -270,7 +285,7 @@ async function validateCfAccessJwt(jwt: string, env: Env): Promise<AuthUser | nu
 		return null;
 	}
 	// All field checks passed — now fetch keys and verify the signature.
-	const keys = await getCfAccessKeys(env);
+	const keys = await getCfAccessKeysOrUnavailable(env);
 	let result = await verifyJwtPayload(
 		jwt,
 		keys,
@@ -283,7 +298,7 @@ async function validateCfAccessJwt(jwt: string, env: Env): Promise<AuthUser | nu
 		// Cloudflare rotated its Access signing keys since we cached them. Force
 		// one rate-limited refetch and retry before giving up, instead of
 		// leaving every login failing until both cache layers expire.
-		const freshKeys = await getCfAccessKeys(env, { forceRefresh: true });
+		const freshKeys = await getCfAccessKeysOrUnavailable(env, { forceRefresh: true });
 		if (freshKeys !== keys) {
 			result = await verifyJwtPayload(
 				jwt,
@@ -319,6 +334,19 @@ async function fetchAndCacheCfAccessKeys(env: Env): Promise<JsonWebKey[]> {
 	await env.KV.put("cf-access-certs", JSON.stringify(keys), { expirationTtl: 3600 });
 	inMemoryCertsCache = { keys, expiresAt: Date.now() + CERTS_LOCAL_TTL_MS };
 	return keys;
+}
+
+// A cold cache plus an unreachable/erroring JWKS endpoint leaves us unable to
+// verify anything — surface that as its own failure rather than an auth verdict.
+async function getCfAccessKeysOrUnavailable(
+	env: Env,
+	opts?: { forceRefresh?: boolean }
+): Promise<JsonWebKey[]> {
+	try {
+		return await getCfAccessKeys(env, opts);
+	} catch {
+		throw new AuthUnavailableError();
+	}
 }
 
 async function getCfAccessKeys(env: Env, opts?: { forceRefresh?: boolean }): Promise<JsonWebKey[]> {

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -47,7 +47,19 @@ export async function rateLimitMiddleware(
 		limit = parseInt(c.env.RATE_LIMIT_AUTH_MAX ?? "300", 10);
 	}
 
-	const count = await incrementCounter(c.env.DB, key, slot, windowSecs);
+	// PROJ-430: every request writes then reads one hot row, so a burst from a
+	// single key serialises on it. A D1 error here is a limiter outage, not a
+	// client problem — fail open rather than turning it into a 500 for a request
+	// that would otherwise have succeeded.
+	let count: number;
+	try {
+		count = await incrementCounter(c.env.DB, key, slot, windowSecs);
+	} catch (err) {
+		console.error("rate-limit counter unavailable, failing open", { key, err: String(err) });
+		await next();
+		return;
+	}
+
 	if (count > limit) {
 		const windowRemaining = slot + windowSecs - now;
 		c.header("Retry-After", String(windowRemaining > 0 ? windowRemaining : windowSecs));

--- a/apps/api/src/test/auth.test.ts
+++ b/apps/api/src/test/auth.test.ts
@@ -1001,3 +1001,53 @@ describe("PROJ-79: MCP protocol validation", () => {
 		expect(body.jsonrpc).toBe("2.0");
 	});
 });
+
+// ---------------------------------------------------------------------------
+// PROJ-430: an auth *infrastructure* failure (the JWKS endpoint unreachable)
+// must not masquerade as a session problem. The frontend reloads the page to
+// re-authenticate on a 401 (PROJ-427), so answering a certs-fetch failure with
+// a 401 sends the client off to re-login for something re-login cannot fix.
+// It must also not be a bare, unlogged 500.
+// ---------------------------------------------------------------------------
+
+describe("PROJ-430: CF Access certs fetch failure", () => {
+	it("returns 503, not 401 or 500, when the JWKS endpoint is unreachable", async () => {
+		const keyPair = (await crypto.subtle.generateKey(
+			{
+				name: "RSASSA-PKCS1-v1_5",
+				modulusLength: 2048,
+				publicExponent: new Uint8Array([1, 0, 1]),
+				hash: "SHA-256",
+			},
+			true,
+			["sign", "verify"]
+		)) as CryptoKeyPair;
+
+		const domain = "proj-430-unreachable.example.com";
+		const audience = "proj-430-audience";
+		env.CF_ACCESS_TEAM_DOMAIN = domain;
+		env.CF_ACCESS_AUDIENCE = audience;
+
+		// Cold both cache layers so validateCfAccessJwt has to hit the network,
+		// which fails for this domain in the test runtime.
+		resetAuthCachesForTests();
+		await env.KV.delete("cf-access-certs");
+
+		// Claims are entirely valid — only the certs fetch is broken.
+		const jwt = await signTestJwt(keyPair.privateKey, {
+			exp: Math.floor(Date.now() / 1000) + 3600,
+			aud: audience,
+			iss: `https://${domain}`,
+			email: `proj-430-${crypto.randomUUID().slice(0, 8)}@example.com`,
+		});
+
+		const res = await SELF.fetch("http://localhost/auth/me", {
+			headers: { "Cf-Access-Jwt-Assertion": jwt },
+		});
+
+		expect(res.status).toBe(503);
+		expect((await res.json()) as { error: string }).toEqual({
+			error: "Authentication temporarily unavailable",
+		});
+	});
+});

--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -20,8 +20,19 @@ export default defineConfig({
       // via the `virtual:pwa-register` module.
       injectRegister: null,
       workbox: {
-        navigateFallback: '/index.html',
-        globPatterns: ['**/*.{html,css,js,svg,png,ico,json}'],
+        // Load-bearing: vite-plugin-pwa's own defaults set navigateFallback to
+        // 'index.html', so omitting this key silently re-enables the fallback
+        // (and, with no HTML precached, createHandlerBoundToURL then throws at
+        // service-worker install time). It has to be explicitly undefined.
+        navigateFallback: undefined,
+        // PROJ-430: deliberately no navigation fallback and no HTML in the precache.
+        // Every page here sits behind Cloudflare Access, and Access can only
+        // refresh an expired session by challenging a real network navigation.
+        // Precached HTML + navigateFallback answered navigations cache-first, so
+        // reload-to-re-auth (PROJ-427) and the sidebar Log in / Log out links
+        // never left the device — an expired tab just 401ed and reloaded forever.
+        // Assets stay precached; navigations must hit the network.
+        globPatterns: ['**/*.{css,js,svg,png,ico,json}'],
         runtimeCaching: [
           {
             urlPattern: /^\/(?:api|mcp)\//,

--- a/apps/web/src/layouts/Base.pwa-register.test.ts
+++ b/apps/web/src/layouts/Base.pwa-register.test.ts
@@ -18,3 +18,25 @@ describe("Base layout — PWA service worker registration (PROJ-418)", () => {
 		expect(configSource).toMatch(/injectRegister:\s*null/);
 	});
 });
+
+// PROJ-430: the whole re-auth story (PROJ-427/#129's reload-on-401, and the
+// sidebar Log in / Log out links) depends on a navigation reaching Cloudflare
+// Access. A cache-first service worker that answers navigations locally makes
+// every one of those paths inert — the session can never be refreshed.
+describe("PWA service worker — navigations must reach the network (PROJ-430)", () => {
+	it("does not precache HTML", () => {
+		const globPatterns = configSource.match(/globPatterns:\s*\[([^\]]*)\]/)?.[1] ?? "";
+		expect(globPatterns).not.toMatch(/html/);
+	});
+
+	// vite-plugin-pwa defaults navigateFallback to 'index.html', so this has to be
+	// an explicit override — merely omitting the key leaves the fallback enabled.
+	it("explicitly disables vite-plugin-pwa's default navigation fallback", () => {
+		expect(configSource).toMatch(/navigateFallback:\s*undefined/);
+	});
+
+	it("keeps API and MCP traffic off the cache entirely", () => {
+		expect(configSource).toMatch(/urlPattern:\s*\/\^\\\/\(\?:api\|mcp\)\\\/\//);
+		expect(configSource).toMatch(/handler:\s*['"]NetworkOnly['"]/);
+	});
+});

--- a/apps/web/src/utils/api-client.test.ts
+++ b/apps/web/src/utils/api-client.test.ts
@@ -1,8 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { __resetApiFetchStateForTests, ApiOfflineError, apiFetch } from "./api-client";
+import {
+	__resetApiFetchStateForTests,
+	ApiOfflineError,
+	apiFetch,
+	SessionExpiredError,
+} from "./api-client";
 
 describe("apiFetch", () => {
 	beforeEach(() => {
+		sessionStorage.clear();
 		__resetApiFetchStateForTests();
 	});
 
@@ -96,5 +102,88 @@ describe("apiFetch", () => {
 		expect(httpErrorSettled).toBe(false);
 
 		Object.defineProperty(window, "location", { configurable: true, value: originalLocation });
+	});
+});
+
+// PROJ-430: an overnight 401 storm. The re-auth reload only helps if the reload
+// actually reaches Cloudflare Access; when it doesn't, the reloaded page 401s
+// again and reloads again, indefinitely. The guard below is what bounds that,
+// independently of whether any given reload manages to re-authenticate.
+describe("apiFetch — re-auth loop guard (PROJ-430)", () => {
+	let reload: ReturnType<typeof vi.fn>;
+	let originalLocation: Location;
+
+	beforeEach(() => {
+		sessionStorage.clear();
+		__resetApiFetchStateForTests();
+		reload = vi.fn();
+		originalLocation = window.location;
+		Object.defineProperty(window, "location", {
+			configurable: true,
+			value: { ...originalLocation, reload },
+		});
+	});
+
+	const restoreLocation = () =>
+		Object.defineProperty(window, "location", { configurable: true, value: originalLocation });
+
+	it("does not reload a second time when the reloaded page 401s again", async () => {
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401 }));
+
+		apiFetch("/api/issues/i1");
+		await new Promise((r) => setTimeout(r, 0));
+		expect(reload).toHaveBeenCalledTimes(1);
+
+		// Simulate the page actually reloading: module state resets, but the
+		// sessionStorage marker survives the navigation.
+		__resetApiFetchStateForTests();
+
+		await expect(apiFetch("/api/issues/i1")).rejects.toBeInstanceOf(SessionExpiredError);
+		expect(reload).toHaveBeenCalledTimes(1);
+
+		restoreLocation();
+	});
+
+	it("re-arms after a successful response, so a later expiry can re-auth again", async () => {
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401 }));
+		apiFetch("/api/issues/i1");
+		await new Promise((r) => setTimeout(r, 0));
+		expect(reload).toHaveBeenCalledTimes(1);
+
+		// Reload succeeded: fresh module state, and a request now works.
+		__resetApiFetchStateForTests();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ id: "i1" }) })
+		);
+		await expect(apiFetch("/api/issues/i1")).resolves.toEqual({ id: "i1" });
+
+		// A later session expiry is allowed to reload again.
+		__resetApiFetchStateForTests();
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401 }));
+		apiFetch("/api/issues/i1");
+		await new Promise((r) => setTimeout(r, 0));
+		expect(reload).toHaveBeenCalledTimes(2);
+
+		restoreLocation();
+	});
+
+	it("still reloads on a 401 when sessionStorage is unavailable", async () => {
+		const getItem = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+			throw new Error("storage disabled");
+		});
+		const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+			throw new Error("storage disabled");
+		});
+		__resetApiFetchStateForTests();
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401 }));
+
+		apiFetch("/api/issues/i1");
+		await new Promise((r) => setTimeout(r, 0));
+		expect(reload).toHaveBeenCalledTimes(1);
+
+		getItem.mockRestore();
+		setItem.mockRestore();
+		restoreLocation();
 	});
 });

--- a/apps/web/src/utils/api-client.ts
+++ b/apps/web/src/utils/api-client.ts
@@ -15,15 +15,62 @@ export class ApiOfflineError extends Error {
 	}
 }
 
+/** Thrown when the Cloudflare Access session is gone and reloading has already failed to restore it. */
+export class SessionExpiredError extends Error {
+	constructor() {
+		super("Your session has expired. Use Log in to start a new one.");
+		this.name = "SessionExpiredError";
+	}
+}
+
 // Set once a 401 triggers window.location.reload(). The reload doesn't tear down the
 // page instantly, so other in-flight calls can still land (or get aborted by the
 // navigation) in the meantime — once we're reloading, suppress their errors too rather
 // than flashing an unrelated "failed to load"/offline error right before the page goes away.
 let reauthReloadInFlight = false;
 
-/** Test-only: reset module state between tests (see the module-level flag above). */
+// PROJ-430: the reload above only restores a session if the navigation actually
+// reaches Cloudflare Access. When it doesn't, the reloaded page 401s immediately and
+// reloads again — an unattended tab did this all night, thousands of times. Persist the
+// attempt across the navigation (module state doesn't survive it) so the second 401
+// surfaces to the user instead of starting another lap.
+const REAUTH_MARKER_KEY = "projektor:reauth-attempted-at";
+const REAUTH_MARKER_TTL_MS = 60_000;
+
+// Read once per page load rather than on every response: the marker only changes
+// when we set or clear it below.
+let reauthAttemptedAt: number | null = readReauthMarker();
+
+function readReauthMarker(): number | null {
+	try {
+		const raw = sessionStorage.getItem(REAUTH_MARKER_KEY);
+		const at = raw === null ? Number.NaN : Number(raw);
+		return Number.isFinite(at) && Date.now() - at < REAUTH_MARKER_TTL_MS ? at : null;
+	} catch {
+		// Storage blocked (private mode, cookies-off). Degrade to the pre-PROJ-430
+		// behaviour — reload every time — rather than refusing to re-authenticate.
+		return null;
+	}
+}
+
+function markReauthAttempt(): void {
+	reauthAttemptedAt = Date.now();
+	try {
+		sessionStorage.setItem(REAUTH_MARKER_KEY, String(reauthAttemptedAt));
+	} catch {}
+}
+
+function clearReauthMarker(): void {
+	reauthAttemptedAt = null;
+	try {
+		sessionStorage.removeItem(REAUTH_MARKER_KEY);
+	} catch {}
+}
+
+/** Test-only: reset module state between tests (see the module-level state above). */
 export function __resetApiFetchStateForTests(): void {
 	reauthReloadInFlight = false;
+	reauthAttemptedAt = readReauthMarker();
 }
 
 export async function apiFetch<T = unknown>(
@@ -62,6 +109,8 @@ export async function apiFetch<T = unknown>(
 			if (opts.on401 === "throw") {
 				throw new Error(`API ${method} ${path} failed: 401`);
 			}
+			if (reauthAttemptedAt !== null) throw new SessionExpiredError();
+			markReauthAttempt();
 			reauthReloadInFlight = true;
 			window.location.reload();
 			return new Promise<T>(() => {});
@@ -69,5 +118,8 @@ export async function apiFetch<T = unknown>(
 		if (reauthReloadInFlight) return new Promise<T>(() => {});
 		throw new Error(`API ${method} ${path} failed: ${res.status}`);
 	}
+	// A working request proves the session is good again — re-arm the guard so a
+	// later expiry gets its own reload attempt.
+	if (reauthAttemptedAt !== null) clearReauthMarker();
 	return res.json() as Promise<T>;
 }


### PR DESCRIPTION
## Root cause

The overnight 401/429 burst was a **self-sustaining reload loop**, not a token-refresh problem.

PROJ-418's service worker precached HTML and registered a cache-first `navigateFallback`, so navigations were answered from the local cache. PROJ-427/#129's reload-to-re-auth therefore **never left the device**: Cloudflare Access was never asked to challenge, the session was never refreshed, and the reloaded page 401ed and reloaded again — all night.

Evidence from Cloudflare (this account, `projektor` Worker):

| Hour (UTC) | Worker requests | Access logins |
|---|---|---|
| 2026-07-25 20:00 | 302 | 0 |
| 2026-07-25 21:00 | 544 | 0 |
| 2026-07-25 22:00 | 810 | 0 |
| 2026-07-26 13:00 | 25 | **10** |

Escalating traffic with **zero Access login events** all night is the loop; the first login lands only when a human intervened the next day. `errors=0` throughout, so nothing was crashing the Worker — these were *returned* 401/429s.

Two structural facts made the 24h session a hard wall:

- `/api` and `/mcp` are Access **bypass** apps (deliberately — agents authenticate by bearer token). So API traffic never renews the Access session; only real page navigations do.
- The service worker stopped page navigations from happening. That also made #133's sidebar **Log in** (`href="/"`) and **Log out** (`/cdn-cgi/access/logout`) links inert.

## Why not eager token refresh

The ticket asks whether tokens should be refreshed eagerly before expiry. They can't be, client-side: `CF_Authorization` is an HttpOnly cookie minted by Access at the edge, so nothing in JS can renew it. The only renewal mechanism is a top-level navigation through Access — i.e. re-authentication. So the fix is to make **forced re-authentication actually work**, which it never did in production. Eager renewal is possible as a follow-up but needs the Worker to publish the JWT's `exp` (it's the only party that can read it) so the client can navigate through Access *before* expiry rather than after — an ergonomic improvement, not the bug fix.

## Changes

- **`apps/web/astro.config.mjs`** — drop HTML from the precache and explicitly set `navigateFallback: undefined`. The explicit `undefined` is load-bearing: vite-plugin-pwa's `defaultWorkbox` hard-codes `navigateFallback: 'index.html'` and merges with `Object.assign`, so *omitting* the key re-enables the fallback — and with no HTML precached, `createHandlerBoundToURL` then throws at SW install time. Verified in the built `dist/sw.js`: no `NavigationRoute`, no `createHandlerBoundToURL`, `NetworkOnly` on `/api|/mcp` retained. Assets stay precached.
- **`apps/web/src/utils/api-client.ts`** — bound the loop independently of whether any reload succeeds. A re-auth attempt is recorded in `sessionStorage` (module state doesn't survive the navigation), so a reload that fails to re-authenticate raises `SessionExpiredError` instead of starting another lap. Re-arms on the next successful response. Degrades to the old behaviour if storage is blocked.
- **`apps/api/src/middleware/auth.ts`** — an unreachable JWKS endpoint now answers **503**, not 401. A 401 sends the client through a re-login that cannot fix it. This was previously an uncaught throw, so a bare 500 — demonstrated by the new test, which failed with 500 before the change.
- **`apps/api/src/index.ts`** — add `app.onError`: log uncaught throws with request context and return the standard JSON error shape instead of Hono's bare, unlogged 500. Being blind here is why #131 needed temporary instrumentation.
- **`apps/api/src/middleware/rate-limit.ts`** — fail open on a D1 error. Every request writes then reads one hot row, so a burst from a single key serialises on it; a limiter outage shouldn't 500 a request that would otherwise have succeeded.

## Trade-off accepted

No offline app shell: an offline navigation now gets the browser's offline page rather than a cached page. For an Access-gated app, offline effectively means logged out, and the offline banner (PROJ-414) already handles the state. Asset precaching (the repeat-load win) is unchanged. If the offline shell is wanted back, the follow-up is a `NetworkFirst` navigation route with `cacheableResponse: { statuses: [200] }` so Access's cross-origin redirect isn't cached.

## Verification

- `apps/api`: 825 passed / 0 failed on a complete run. New test `PROJ-430: CF Access certs fetch failure` fails with 500 before the fix, passes with 503 after.
- `apps/web`: 387 passed / 0 failed, including 3 new re-auth loop-guard tests and 3 new service-worker navigation tests.
- `turbo type-check`: 7/7 clean. `biome check`: clean.
- `astro build` + inspection of generated `dist/sw.js` (the assertion that actually matters — the config-level tests alone would not have caught the injected plugin default).
- Two full-suite reruns each aborted early with a different unrelated failure (`issues.test.ts`, `agent-messages.test.ts`); both files pass in isolation (85 tests) — the known Windows workerd flake, not a regression.

## Before merging

Not yet deployed or clicked through in a browser. Two things want a real check on the dogfood instance:

1. That an expired session now lands on the Access login page instead of looping, and that the sidebar Log in / Log out links work.
2. **Rollout risk:** clients with the *old* service worker installed must fetch the new `sw.js` to pick this up. That request goes through Access, so a user whose session is already dead may get the login HTML instead of JS and stay stuck on the old worker until they successfully re-authenticate once. A hard reload or clearing the service worker may be needed for anyone currently in the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
