### PR TITLE
PROJ-431: cut mobile time-to-content on the issue page by ~60%

### DIFF
--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -33,6 +33,26 @@ export default defineConfig({
         // never left the device — an expired tab just 401ed and reloaded forever.
         // Assets stay precached; navigations must hit the network.
         globPatterns: ['**/*.{css,js,svg,png,ico,json}'],
+        // PROJ-431: these are all dynamically imported and reached by a minority of
+        // sessions (mermaid/cytoscape/katex render wiki diagrams and maths; the editor
+        // only mounts on Edit). Precaching them cost 4.17 MiB on install and a
+        // re-download on every deploy. They still load on demand over the network —
+        // this only removes them from the install-time payload.
+        // The real guard against regression is the precache budget asserted in
+        // astro.config.precache.test.ts, not these patterns.
+        globIgnores: [
+          '**/mermaid*.js',
+          '**/cytoscape*.js',
+          '**/katex*.js',
+          '**/cynefin*.js',
+          '**/MarkdownEditor*.js',
+          '**/*Diagram-*.js',
+          '**/swimlanes-*.js',
+          '**/cose-bilkent-*.js',
+          '**/flow-charts*.js',
+          '**/dagre-*.js',
+          '**/ordinal-*.js',
+        ],
         runtimeCaching: [
           {
             urlPattern: /^\/(?:api|mcp)\//,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,12 +4,13 @@
   "private": true,
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "astro build && node scripts/assert-sw.mjs",
     "type-check": "astro check",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test --grep-invert @long",
-    "test:e2e:long": "playwright test --grep @long"
+    "test:e2e:long": "playwright test --grep @long",
+    "verify:sw": "node scripts/assert-sw.mjs"
   },
   "dependencies": {
     "@astrojs/preact": "^4.0.0",

--- a/apps/web/scripts/assert-sw.mjs
+++ b/apps/web/scripts/assert-sw.mjs
@@ -1,0 +1,99 @@
+// Asserts the *built* service worker, not the config.
+//
+// PROJ-430 was caused by a Workbox default that the config never mentions:
+// vite-plugin-pwa hard-codes navigateFallback: 'index.html' and merges with
+// Object.assign, so the generated sw.js can register a cache-first navigation route
+// that no line of astro.config.mjs asked for. That is only visible after a build,
+// which is why this runs as a post-build step rather than as a vitest case (CI runs
+// the unit tests before the build, so a dist-reading test would just skip).
+//
+// PROJ-431 adds the precache budget: the install payload had grown to 4.17 MiB of
+// mostly lazy vendor chunks.
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const dist = join(dirname(fileURLToPath(import.meta.url)), '..', 'dist');
+const swPath = join(dist, 'sw.js');
+
+const PRECACHE_BUDGET_BYTES = 1024 * 1024;
+
+const failures = [];
+const notes = [];
+
+if (!existsSync(swPath)) {
+  console.error(`assert-sw: ${swPath} not found — run the build first.`);
+  process.exit(1);
+}
+
+const sw = readFileSync(swPath, 'utf8');
+
+// ── PROJ-430 invariants ──────────────────────────────────────────────────────
+// Navigations must reach the network, or Cloudflare Access can never re-challenge
+// an expired session and the app reload-loops.
+for (const marker of ['NavigationRoute', 'createHandlerBoundToURL']) {
+  if (sw.includes(marker)) {
+    failures.push(
+      `sw.js contains ${marker}: navigations would be answered from cache. ` +
+        `See PROJ-430 — this caused an all-night reload loop. If reintroducing an ` +
+        `offline shell deliberately, it must be NetworkFirst with ` +
+        `cacheableResponse: { statuses: [200] } so Access's login redirect is never cached.`,
+    );
+  }
+}
+
+if (!sw.includes('NetworkOnly')) {
+  failures.push('sw.js has no NetworkOnly handler — /api and /mcp must never be cached.');
+}
+if (!/\/\^\\\/\(\?:api\|mcp\)\\\//.test(sw)) {
+  failures.push('sw.js has no /^\\/(?:api|mcp)\\// route — API traffic may be cached.');
+}
+
+// ── PROJ-431 precache budget ─────────────────────────────────────────────────
+// Workbox emits the manifest minified as `url:"_astro/foo.js",revision:...` —
+// entries are relative and unquoted-key, so match that shape specifically.
+const urls = [...new Set([...sw.matchAll(/url:"([^"]+)"/g)].map((m) => m[1]))];
+if (urls.length === 0) {
+  failures.push(
+    'could not parse any precache entries out of sw.js — the manifest format changed, ' +
+      'so the budget check below is not actually checking anything. Fix the parser.',
+  );
+}
+let total = 0;
+const entries = [];
+for (const u of urls) {
+  const p = join(dist, u.replace(/^\//, ''));
+  if (!existsSync(p)) continue;
+  const size = statSync(p).size;
+  total += size;
+  entries.push({ u, size });
+}
+
+if (urls.some((u) => u.endsWith('.html'))) {
+  failures.push('sw.js precaches HTML — navigations must reach the network (PROJ-430).');
+}
+
+entries.sort((a, b) => b.size - a.size);
+notes.push(
+  `precache: ${entries.length} entries, ${(total / 1024 / 1024).toFixed(2)} MiB ` +
+    `(budget ${(PRECACHE_BUDGET_BYTES / 1024 / 1024).toFixed(2)} MiB)`,
+);
+for (const e of entries.slice(0, 5)) {
+  notes.push(`  ${(e.size / 1024).toFixed(1).padStart(8)} KiB  ${e.u}`);
+}
+
+if (total > PRECACHE_BUDGET_BYTES) {
+  failures.push(
+    `precache is ${(total / 1024 / 1024).toFixed(2)} MiB, over the ` +
+      `${(PRECACHE_BUDGET_BYTES / 1024 / 1024).toFixed(2)} MiB budget. Heavy chunks that are ` +
+      `dynamically imported (mermaid, cytoscape, katex, the editor) belong in globIgnores ` +
+      `in astro.config.mjs — they still load on demand.`,
+  );
+}
+
+for (const n of notes) console.log(`assert-sw: ${n}`);
+if (failures.length) {
+  for (const f of failures) console.error(`assert-sw: FAIL — ${f}`);
+  process.exit(1);
+}
+console.log('assert-sw: OK');

--- a/apps/web/scripts/perf/README.md
+++ b/apps/web/scripts/perf/README.md
@@ -1,0 +1,41 @@
+# Mobile performance harness (PROJ-431)
+
+Two scripts for measuring the built app on a mobile profile against a real API. Neither
+runs in CI; both are for producing numbers when changing load performance.
+
+Both serve `apps/web/dist/` from a local server and proxy `/api`, `/auth` and `/mcp` to a
+deployed Worker, so measurements include real API latency. The static server applies
+brotli/gzip — without that the mobile JS figures are roughly 3× what production ships —
+and replicates the Worker's fallback for pretty issue URLs, which have no prerendered
+page.
+
+```sh
+pnpm --filter @projektor/web build
+cd apps/web
+PROJEKTOR_API_TOKEN=<token> node scripts/perf/measure-load.mjs
+PROJEKTOR_API_TOKEN=<token> node scripts/perf/check-interactive.mjs
+```
+
+The token is an app bearer token. `/api` and `/mcp` are Cloudflare Access bypass apps, so
+they are reachable with a bearer token alone — no Access service token needed.
+
+## `measure-load.mjs`
+
+Chromium via Playwright on two profiles: Pixel 5 with Lighthouse mobile throttling
+(1.6 Mbps down, 750 Kbps up, 150 ms RTT, 4× CPU) and unthrottled desktop. Median of 3
+runs per page. Reports FCP, LCP, DCL, JS transfer, when the last JS and last API request
+finished, long-task time, and time until real content replaces the loading placeholder.
+Pass paths as arguments to override the defaults — without a leading slash, which Git
+Bash mangles.
+
+Compare runs back to back. API latency drifts by several hundred ms between sessions, so
+a before/after pair measured an hour apart is not comparable; the JS-side figures are
+deterministic and can be trusted on their own.
+
+## `check-interactive.mjs`
+
+Functional checks of the PROJ-431 editing changes at 375 px and 1440 px: draft
+persistence across reload, the fallback textarea while the editor chunk loads and
+CodeMirror adopting what was typed into it, 16 px inputs on mobile (below that iOS Safari
+zooms the viewport on focus), and 44 px toolbar touch targets on mobile while desktop
+stays compact. Exits non-zero on any failure.

--- a/apps/web/scripts/perf/check-interactive.mjs
+++ b/apps/web/scripts/perf/check-interactive.mjs
@@ -1,0 +1,108 @@
+// PROJ-431 throwaway: exercises the interactive changes in a real browser at both
+// mobile and desktop widths. Reuses the static+proxy server from perf-measure.mjs.
+import { createServer } from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import { extname, join, normalize } from 'node:path';
+import { chromium, devices } from '@playwright/test';
+
+const ORIGIN = 'https://projektor.tajdickson.workers.dev';
+const TOKEN = process.env.PROJEKTOR_API_TOKEN;
+const DIST = new URL('../../dist/', import.meta.url).pathname.replace(/^\//, '');
+const PORT = 4400;
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.svg': 'image/svg+xml', '.png': 'image/png', '.ico': 'image/x-icon', '.json': 'application/json', '.woff2': 'font/woff2' };
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+  if (/^\/(api|auth|mcp)/.test(url.pathname)) {
+    const up = await fetch(ORIGIN + req.url, {
+      method: req.method,
+      headers: { Authorization: `Bearer ${TOKEN}`, 'X-Workspace-Slug': 'projektor', ...(req.headers['content-type'] ? { 'content-type': req.headers['content-type'] } : {}) },
+      body: ['GET', 'HEAD'].includes(req.method) ? undefined : await new Promise((r) => { const c = []; req.on('data', (d) => c.push(d)); req.on('end', () => r(Buffer.concat(c))); }),
+      redirect: 'manual',
+    });
+    const buf = Buffer.from(await up.arrayBuffer());
+    res.writeHead(up.status, { 'content-type': up.headers.get('content-type') ?? 'application/json' });
+    return res.end(buf);
+  }
+  const pathname = /^\/projects\/[^/]+\/issues\/\d+\//.test(url.pathname) ? '/issues/view' : url.pathname;
+  let p = normalize(join(DIST, decodeURIComponent(pathname)));
+  try {
+    const s = await stat(p).catch(() => null);
+    if (!s || s.isDirectory()) p = join(p, 'index.html');
+    res.writeHead(200, { 'content-type': MIME[extname(p)] ?? 'application/octet-stream', 'cache-control': 'no-store' });
+    res.end(await readFile(p));
+  } catch { res.writeHead(404).end('nf'); }
+});
+await new Promise((r) => server.listen(PORT, r));
+
+const ISSUE = '/issues/view?id=49053198-9ea1-4f14-a3bf-0d1ce9766aa0';
+const results = [];
+const check = (profile, name, pass, detail = '') => {
+  results.push({ profile, name, pass, detail });
+  console.log(`  ${pass ? 'PASS' : 'FAIL'}  ${name}${detail ? `  — ${detail}` : ''}`);
+};
+
+for (const [profile, ctxOpts] of [
+  ['mobile 375x812', { ...devices['Pixel 5'] }],
+  ['desktop 1440x900', { viewport: { width: 1440, height: 900 } }],
+]) {
+  console.log(`\n=== ${profile} ===`);
+  const browser = await chromium.launch();
+  const ctx = await browser.newContext({ ...ctxOpts, serviceWorkers: 'block' });
+  const page = await ctx.newPage();
+  const isMobile = profile.startsWith('mobile');
+
+  await page.goto(`http://localhost:${PORT}${ISSUE}`);
+  await page.waitForSelector('article', { timeout: 30000 });
+
+  // ── comment textarea: 16px on mobile so iOS doesn't zoom on focus ──
+  const ta = page.locator('textarea[placeholder="Add a comment…"]');
+  await ta.waitFor();
+  const taFont = await ta.evaluate((el) => getComputedStyle(el).fontSize);
+  check(profile, 'comment textarea font-size', isMobile ? taFont === '16px' : taFont === '14px', taFont);
+
+  // ── draft persistence ──
+  await ta.fill('a half-typed thought from PROJ-431');
+  await page.waitForTimeout(150);
+  await page.reload();
+  await page.waitForSelector('article', { timeout: 30000 });
+  const restored = await page.locator('textarea[placeholder="Add a comment…"]').inputValue();
+  check(profile, 'comment draft survives reload', restored === 'a half-typed thought from PROJ-431', JSON.stringify(restored.slice(0, 40)));
+
+  await page.locator('textarea[placeholder="Add a comment…"]').fill('');
+  await page.waitForTimeout(150);
+  await page.reload();
+  await page.waitForSelector('article', { timeout: 30000 });
+  const cleared = await page.locator('textarea[placeholder="Add a comment…"]').inputValue();
+  check(profile, 'cleared draft does not come back', cleared === '', JSON.stringify(cleared));
+
+  // ── lazy editor: fallback textarea first, then CodeMirror ──
+  await page.route('**/_astro/MarkdownEditor*.js', async (r) => { await new Promise((x) => setTimeout(x, 1500)); await r.continue(); });
+  await page.locator('button[title="Edit description"]').click();
+  const fallback = await page.locator('textarea[aria-label="Markdown editor"]').isVisible().catch(() => false);
+  check(profile, 'fallback textarea shown while editor chunk loads', fallback);
+
+  if (fallback) {
+    await page.locator('textarea[aria-label="Markdown editor"]').fill('typed before CodeMirror arrived');
+  }
+  await page.waitForSelector('.cm-content', { timeout: 30000 });
+  const adopted = (await page.locator('.cm-content').innerText()).includes('typed before CodeMirror arrived');
+  check(profile, 'CodeMirror adopts text typed into the fallback', adopted);
+
+  const cmFont = await page.locator('.cm-content').evaluate((el) => getComputedStyle(el).fontSize);
+  check(profile, 'editor font-size', isMobile ? cmFont === '16px' : cmFont === '14px', cmFont);
+
+  // ── toolbar tap targets ──
+  const boxes = await page.locator('button[title="Bold (Ctrl+B)"], button[title="Heading 1"], button[title="Link"]').evaluateAll(
+    (els) => els.map((e) => { const r = e.getBoundingClientRect(); return { w: Math.round(r.width), h: Math.round(r.height) }; }),
+  );
+  const okTargets = isMobile ? boxes.every((b) => b.w >= 44 && b.h >= 44) : boxes.every((b) => b.h < 44);
+  check(profile, isMobile ? 'toolbar buttons are >=44px touch targets' : 'toolbar stays compact on desktop', okTargets, JSON.stringify(boxes));
+
+  await browser.close();
+}
+
+const failed = results.filter((r) => !r.pass);
+console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
+server.close();
+process.exit(failed.length ? 1 : 0);

--- a/apps/web/scripts/perf/measure-load.mjs
+++ b/apps/web/scripts/perf/measure-load.mjs
@@ -1,0 +1,203 @@
+// PROJ-431 throwaway measurement harness. Serves the built dist/ locally and
+// proxies /api + /auth to the live dogfood Worker so the numbers include real
+// API latency, then drives Chromium on a Lighthouse-equivalent mobile profile.
+import { createServer } from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import { extname, join, normalize } from 'node:path';
+import { brotliCompressSync, gzipSync } from 'node:zlib';
+import { chromium, devices } from '@playwright/test';
+
+const ORIGIN = 'https://projektor.tajdickson.workers.dev';
+const TOKEN = process.env.PROJEKTOR_API_TOKEN;
+const SLUG = 'projektor';
+const DIST = new URL('../../dist/', import.meta.url).pathname.replace(/^\//, '');
+const PORT = 4399;
+
+const MIME = {
+  '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css',
+  '.svg': 'image/svg+xml', '.png': 'image/png', '.ico': 'image/x-icon',
+  '.json': 'application/json', '.woff2': 'font/woff2', '.webmanifest': 'application/manifest+json',
+};
+
+const apiTimings = [];
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+
+  if (url.pathname.startsWith('/api') || url.pathname.startsWith('/auth') || url.pathname.startsWith('/mcp')) {
+    const t0 = performance.now();
+    try {
+      const upstream = await fetch(ORIGIN + req.url, {
+        method: req.method,
+        headers: { Authorization: `Bearer ${TOKEN}`, 'X-Workspace-Slug': SLUG },
+        redirect: 'manual',
+      });
+      const buf = Buffer.from(await upstream.arrayBuffer());
+      apiTimings.push({ path: url.pathname + url.search, ms: performance.now() - t0, status: upstream.status, bytes: buf.length });
+      res.writeHead(upstream.status, { 'content-type': upstream.headers.get('content-type') ?? 'application/json' });
+      res.end(buf);
+    } catch (e) {
+      res.writeHead(502).end(JSON.stringify({ error: String(e) }));
+    }
+    return;
+  }
+
+  // Pretty issue URLs have no prerendered page (getStaticPaths returns []); the Worker
+  // serves the /issues/view document and the island resolves from the pathname.
+  const pathname = /^\/projects\/[^/]+\/issues\/\d+\//.test(url.pathname)
+    ? '/issues/view'
+    : url.pathname;
+
+  // static
+  let p = normalize(join(DIST, decodeURIComponent(pathname)));
+  try {
+    const s = await stat(p).catch(() => null);
+    if (!s || s.isDirectory()) p = join(p, 'index.html');
+    const raw = await readFile(p);
+    // Cloudflare serves these assets brotli/gzip-encoded; without this the mobile
+    // profile measures ~3x the JS bytes that production actually ships.
+    const compressible = /\.(js|css|html|json|svg)$/.test(p);
+    const accepts = String(req.headers['accept-encoding'] ?? '');
+    const useBr = compressible && accepts.includes('br');
+    const useGz = compressible && !useBr && accepts.includes('gzip');
+    const body = useBr ? brotliCompressSync(raw) : useGz ? gzipSync(raw, { level: 9 }) : raw;
+    res.writeHead(200, {
+      'content-type': MIME[extname(p)] ?? 'application/octet-stream',
+      'cache-control': 'no-store',
+      ...(useBr ? { 'content-encoding': 'br' } : useGz ? { 'content-encoding': 'gzip' } : {}),
+    });
+    res.end(body);
+  } catch {
+    res.writeHead(404).end('not found');
+  }
+});
+
+await new Promise((r) => server.listen(PORT, r));
+
+// Leading slashes get mangled by Git Bash path conversion, so args are passed
+// without one and normalised here.
+const TARGETS = (
+  process.argv.slice(2).length
+    ? process.argv.slice(2)
+    : ['', 'issues/view?id=49053198-9ea1-4f14-a3bf-0d1ce9766aa0', 'projects/PROJ/issues/431/x']
+).map((t) => '/' + t.replace(/^\/+/, ''));
+
+const PROFILES = {
+  // Lighthouse "mobile" defaults: 1.6 Mbps down / 750 Kbps up / 150ms RTT, 4x CPU slowdown.
+  'mobile (Slow 4G, 4x CPU)': { down: (1.6 * 1024 * 1024) / 8, up: (750 * 1024) / 8, latency: 150, cpu: 4, mobile: true },
+  'desktop (unthrottled)': { down: -1, up: -1, latency: 0, cpu: 1, mobile: false },
+};
+
+const results = [];
+
+for (const [profileName, prof] of Object.entries(PROFILES)) {
+  for (const target of TARGETS) {
+    for (let run = 0; run < 3; run++) {
+      const browser = await chromium.launch();
+      const ctx = await browser.newContext(
+        prof.mobile
+          ? { ...devices['Pixel 5'], serviceWorkers: 'allow' }
+          : { viewport: { width: 1440, height: 900 }, serviceWorkers: 'allow' },
+      );
+      const page = await ctx.newPage();
+      await page.addInitScript(() => {
+        window.__lcp = null; window.__long = [];
+        try {
+          new PerformanceObserver((l) => { window.__lcp = l.getEntries().at(-1).startTime; })
+            .observe({ type: 'largest-contentful-paint', buffered: true });
+        } catch {}
+        try {
+          new PerformanceObserver((l) => { for (const e of l.getEntries()) window.__long.push(e.duration); })
+            .observe({ type: 'longtask', buffered: true });
+        } catch {}
+      });
+      const cdp = await ctx.newCDPSession(page);
+      await cdp.send('Network.enable');
+      await cdp.send('Network.emulateNetworkConditions', {
+        offline: false, downloadThroughput: prof.down, uploadThroughput: prof.up, latency: prof.latency,
+      });
+      await cdp.send('Emulation.setCPUThrottlingRate', { rate: prof.cpu });
+
+      let jsBytes = 0, reqCount = 0;
+      page.on('response', async (r) => {
+        reqCount++;
+        const cl = Number(r.headers()['content-length'] ?? 0);
+        if (r.url().endsWith('.js')) jsBytes += cl;
+      });
+
+      const t0 = Date.now();
+      await page.goto(`http://localhost:${PORT}${target}`, { waitUntil: 'commit' });
+
+      // Time until real content (not the "Loading…" placeholder) is on screen.
+      let contentMs = null;
+      try {
+        await page.waitForFunction(() => {
+          const t = document.body?.innerText ?? '';
+          return t.length > 120 && !/^\s*Loading…?\s*$/m.test(t.trim()) && !t.trim().startsWith('Loading');
+        }, undefined, { timeout: 30000 });
+        contentMs = Date.now() - t0;
+      } catch { /* stayed on placeholder */ }
+
+      await page.waitForLoadState('networkidle').catch(() => {});
+
+      const vitals = await page.evaluate(() => {
+        const nav = performance.getEntriesByType('navigation')[0];
+        const paints = Object.fromEntries(performance.getEntriesByType('paint').map((p) => [p.name, p.startTime]));
+        const res = performance.getEntriesByType('resource');
+        const js = res.filter((r) => r.name.endsWith('.js'));
+        const api = res.filter((r) => r.name.includes('/api/') || r.name.includes('/auth/'));
+        return {
+          fcp: paints['first-contentful-paint'] ?? null,
+          lcp: window.__lcp ?? null,
+          dcl: nav?.domContentLoadedEventEnd ?? null,
+          load: nav?.loadEventEnd ?? null,
+          longTasks: (window.__long ?? []).length,
+          longTaskMs: (window.__long ?? []).reduce((a, d) => a + d, 0),
+          jsBytes: js.reduce((a, r) => a + (r.encodedBodySize || r.transferSize || 0), 0),
+          jsDoneAt: js.length ? Math.max(...js.map((r) => r.responseEnd)) : null,
+          apiFirstAt: api.length ? Math.min(...api.map((r) => r.startTime)) : null,
+          apiDoneAt: api.length ? Math.max(...api.map((r) => r.responseEnd)) : null,
+          apiCount: api.length,
+        };
+      });
+
+      results.push({ profile: profileName, target, run, contentMs, reqCount, ...vitals });
+      await browser.close();
+    }
+  }
+}
+
+const med = (xs) => { const a = xs.filter((x) => x != null).sort((x, y) => x - y); return a.length ? a[Math.floor(a.length / 2)] : null; };
+const fmt = (n) => (n == null ? '   n/a' : `${Math.round(n)}`.padStart(6));
+
+console.log('\n=== PROJ-431 measured page load (median of 3) ===\n');
+console.log('profile                    target                       FCP    LCP    DCL  content  JSdone  api1st apidone   JSKiB  napi longTask');
+for (const profile of Object.keys(PROFILES)) {
+  for (const target of TARGETS) {
+    const rs = results.filter((r) => r.profile === profile && r.target === target);
+    if (!rs.length) continue;
+    console.log(
+      profile.padEnd(26) + target.slice(0, 28).padEnd(29) +
+      fmt(med(rs.map((r) => r.fcp))) + fmt(med(rs.map((r) => r.lcp))) +
+      fmt(med(rs.map((r) => r.dcl))) + fmt(med(rs.map((r) => r.contentMs))) +
+      fmt(med(rs.map((r) => r.jsDoneAt))) + fmt(med(rs.map((r) => r.apiFirstAt))) +
+      fmt(med(rs.map((r) => r.apiDoneAt))) +
+      fmt(med(rs.map((r) => r.jsBytes / 1024))) + fmt(med(rs.map((r) => r.apiCount))) +
+      fmt(med(rs.map((r) => r.longTaskMs))),
+    );
+  }
+}
+
+console.log('\n=== upstream API calls observed (ms, as seen by the proxy) ===');
+const byPath = new Map();
+for (const t of apiTimings) {
+  const k = t.path.replace(/[0-9a-f]{8}-[0-9a-f-]{27}/g, '{id}').split('&entityId')[0];
+  if (!byPath.has(k)) byPath.set(k, []);
+  byPath.get(k).push(t.ms);
+}
+for (const [k, v] of [...byPath.entries()].sort((a, b) => med(b[1]) - med(a[1]))) {
+  console.log(`${fmt(med(v))} ms median  (n=${v.length})  ${k}`);
+}
+
+server.close();
+process.exit(0);

--- a/apps/web/src/islands/AccountMenu.tsx
+++ b/apps/web/src/islands/AccountMenu.tsx
@@ -1,6 +1,7 @@
 import { createPortal } from "preact/compat";
 import { useEffect, useId, useRef, useState } from "preact/hooks";
 import { apiFetch } from "../utils/api-client";
+import { clearAllDrafts } from "../utils/drafts";
 import { resolveWorkspaceSlug } from "../utils/workspace";
 
 interface Props {
@@ -161,7 +162,13 @@ export function AccountMenu({ workspaceSlug }: Props) {
 							>
 								Refresh session
 							</a>
-							<a role="menuitem" class="account-menu-item" href="/cdn-cgi/access/logout">
+							<a
+								role="menuitem"
+								class="account-menu-item"
+								href="/cdn-cgi/access/logout"
+								// PROJ-431: don't leave one user's unsent drafts on a shared device.
+								onClick={() => clearAllDrafts()}
+							>
 								Log out
 							</a>
 						</div>

--- a/apps/web/src/islands/IssueDetail.test.tsx
+++ b/apps/web/src/islands/IssueDetail.test.tsx
@@ -359,3 +359,112 @@ describe("workspace-slug header contract (PROJ-98)", () => {
 		}
 	});
 });
+
+// ─── PROJ-431: first-paint path ───────────────────────────────────────────────
+
+describe("PROJ-431 — first paint", () => {
+	// /api/issues/KEY-N returns the same payload as /api/issues/{uuid}, so the resolve
+	// step already holds a complete issue. Refetching by UUID before rendering put a
+	// second serial round trip (~1.3s on mobile) in front of first paint.
+	it("renders from the resolve response without waiting for the UUID-keyed refetch", async () => {
+		history.replaceState(null, "", "/projects/PROJ/issues/7/plain-task");
+
+		let releaseRefetch: (() => void) | undefined;
+		const refetchGate = new Promise<void>((r) => {
+			releaseRefetch = r;
+		});
+		let uuidFetches = 0;
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation((url: string) => {
+				const u = String(url);
+				if (u.includes("/comments") || u.includes("/links")) {
+					return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+				}
+				if (u.includes("task-statuses") || u.includes("/api/files")) {
+					return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+				}
+				if (u.endsWith("/api/issues/PROJ-7")) {
+					return Promise.resolve({ ok: true, json: () => Promise.resolve(PLAIN_ISSUE_DATA) });
+				}
+				if (u.endsWith("/api/issues/plain-1")) {
+					uuidFetches++;
+					// Never settles until released — if render waited on it, nothing would paint.
+					return refetchGate.then(() => ({
+						ok: true,
+						json: () => Promise.resolve(PLAIN_ISSUE_DATA),
+					}));
+				}
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+			})
+		);
+
+		render(<IssueDetail />);
+
+		await waitFor(() => expect(screen.getByText("Plain Task")).toBeDefined());
+		expect(uuidFetches).toBe(1);
+		releaseRefetch?.();
+	});
+
+	// The page used to gate on Promise.all over all seven requests, so title and body
+	// waited behind /api/files, /api/task-statuses and /api/workspaces/{slug}.
+	it("paints the issue before the secondary requests settle", async () => {
+		let releaseSecondary: (() => void) | undefined;
+		const secondaryGate = new Promise<void>((r) => {
+			releaseSecondary = r;
+		});
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation((url: string) => {
+				const u = String(url);
+				if (u.endsWith("/api/issues/plain-1")) {
+					return Promise.resolve({ ok: true, json: () => Promise.resolve(PLAIN_ISSUE_DATA) });
+				}
+				// Everything else — statuses, files, links, comments, members — hangs.
+				return secondaryGate.then(() => ({ ok: true, json: () => Promise.resolve([]) }));
+			})
+		);
+
+		render(<IssueDetail issueId="plain-1" />);
+
+		// The full view is on screen (title + breadcrumb), not the page-level placeholder.
+		// Individual sections may still show their own loading state — that's the point.
+		await waitFor(() => expect(screen.getByText("Plain Task")).toBeDefined());
+		expect(screen.getByRole("article")).toBeDefined();
+		releaseSecondary?.();
+	});
+
+	// issueId is empty for the whole resolve round trip, so the "no issue ID" branch
+	// used to render as a ~1.3s error flash on the canonical pretty URL.
+	it("shows a loading state, not 'No issue ID provided', while resolving a pretty URL", async () => {
+		history.replaceState(null, "", "/projects/PROJ/issues/7/plain-task");
+
+		let release: ((v: unknown) => void) | undefined;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation(
+				() =>
+					new Promise((r) => {
+						release = r;
+					})
+			)
+		);
+
+		render(<IssueDetail />);
+
+		await waitFor(() => expect(screen.getByText(/Loading/)).toBeDefined());
+		expect(screen.queryByText(/No issue ID provided/)).toBeNull();
+		release?.({ ok: true, json: () => Promise.resolve(PLAIN_ISSUE_DATA) });
+	});
+
+	it("still reports 'No issue ID provided' when there is genuinely nothing to resolve", async () => {
+		history.replaceState(null, "", "/issues/view");
+		vi.stubGlobal("fetch", vi.fn());
+
+		render(<IssueDetail />);
+
+		await waitFor(() => expect(screen.getByText(/No issue ID provided/)).toBeDefined());
+	});
+});

--- a/apps/web/src/islands/IssueDetail.tsx
+++ b/apps/web/src/islands/IssueDetail.tsx
@@ -38,33 +38,52 @@ function useResolvedIssueId(
 ) {
 	const [issueId, setIssueId] = useState(issueIdProp ?? "");
 	const [resolveError, setResolveError] = useState<string | null>(null);
+	// PROJ-431: /api/issues/KEY-N returns the *whole* issue, byte-identical to
+	// /api/issues/{uuid}. Keeping only `.id` and letting useIssueCore refetch by UUID
+	// put a second serial round trip in front of first paint — ~1.3s on mobile, on the
+	// canonical URL form. Hand the payload on as seed state instead; the UUID-keyed
+	// fetch still runs and revalidates, just no longer blocking anything.
+	const [resolvedIssue, setResolvedIssue] = useState<IssueData | null>(null);
+	// Whether an id is still being worked out. Without it the component's "no issue ID
+	// provided" branch renders for the whole resolve round trip — a ~1.3s error flash on
+	// mobile, on the canonical pretty URL. It can't be derived during render: the island
+	// is prerendered at build time, so `window` is only safe to touch from an effect.
+	const [resolving, setResolving] = useState(!issueIdProp);
 
 	useEffect(() => {
-		if (!issueIdProp) {
-			setIssueId(new URLSearchParams(window.location.search).get("id") ?? "");
+		if (issueIdProp) return;
+
+		const fromQuery = new URLSearchParams(window.location.search).get("id");
+		if (fromQuery) {
+			setIssueId(fromQuery);
+			setResolving(false);
+			return;
 		}
-	}, [issueIdProp]);
 
-	// Resolve issueNumber+projectSlug to UUID via the KEY-NUMBER API format (e.g. PROJ-42)
-	useEffect(() => {
-		if (issueIdProp || !projectSlug || issueNumber === undefined) return;
-		apiFetch<{ id: string }>(`/api/issues/${projectSlug}-${issueNumber}`, { workspaceSlug })
-			.then((data) => setIssueId(data.id))
-			.catch((e) => setResolveError(String(e)));
+		// Either handed in as props, or — when this page is served as the fallback for a
+		// pretty-URL route (/projects/KEY/issues/N/title) — parsed back off the pathname.
+		const pretty = window.location.pathname.match(/^\/projects\/([^/]+)\/issues\/(\d+)\//);
+		const ref =
+			projectSlug && issueNumber !== undefined
+				? `${projectSlug}-${issueNumber}`
+				: pretty
+					? `${pretty[1]}-${pretty[2]}`
+					: null;
+		if (!ref) {
+			setResolving(false);
+			return;
+		}
+
+		apiFetch<IssueData>(`/api/issues/${ref}`, { workspaceSlug })
+			.then((data) => {
+				setResolvedIssue(data);
+				setIssueId(data.id);
+			})
+			.catch((e) => setResolveError(String(e)))
+			.finally(() => setResolving(false));
 	}, [issueIdProp, projectSlug, issueNumber, workspaceSlug]);
 
-	// When served as fallback for pretty-URL issue routes (/projects/KEY/issues/N/title),
-	// extract KEY and N from the pathname and resolve to a UUID via the API.
-	useEffect(() => {
-		if (issueIdProp || projectSlug || issueNumber !== undefined) return;
-		const m = window.location.pathname.match(/^\/projects\/([^/]+)\/issues\/(\d+)\//);
-		if (!m) return;
-		apiFetch<{ id: string }>(`/api/issues/${m[1]}-${m[2]}`, { workspaceSlug })
-			.then((data) => setIssueId(data.id))
-			.catch((e) => setResolveError(String(e)));
-	}, [issueIdProp, projectSlug, issueNumber, workspaceSlug]);
-
-	return { issueId, resolveError };
+	return { issueId, resolveError, resolvedIssue, resolving };
 }
 
 function useBackHref() {
@@ -168,15 +187,23 @@ function useIssueCore(
 	issueId: string,
 	workspaceSlug: string | undefined,
 	fetchLinks: () => Promise<void>,
-	fetchAttachments: () => Promise<void>
+	fetchAttachments: () => Promise<void>,
+	seedIssue: IssueData | null
 ) {
-	const [issue, setIssue] = useState<IssueData | null>(null);
+	const [issue, setIssue] = useState<IssueData | null>(seedIssue);
 	const [comments, setComments] = useState<Comment[]>([]);
 	const [statuses, setStatuses] = useState<TaskStatus[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
 	const [members, setMembers] = useState<Member[]>([]);
 	const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+
+	// The seed resolves asynchronously, so it can't just be the useState initial value.
+	// Only ever fills the gap before the first real fetch lands — never clobbers fresher
+	// data, or a local optimistic update made while that fetch was in flight.
+	useEffect(() => {
+		if (seedIssue) setIssue((prev) => prev ?? seedIssue);
+	}, [seedIssue]);
 
 	const fetchIssue = useCallback(async () => {
 		try {
@@ -505,7 +532,7 @@ export default function IssueDetail({
 	projectSlug,
 	workspaceSlug,
 }: Props) {
-	const { issueId, resolveError } = useResolvedIssueId(
+	const { issueId, resolveError, resolvedIssue, resolving } = useResolvedIssueId(
 		issueIdProp,
 		issueNumber,
 		projectSlug,
@@ -527,7 +554,7 @@ export default function IssueDetail({
 		currentUserId,
 		fetchIssue,
 		fetchComments,
-	} = useIssueCore(issueId, workspaceSlug, fetchLinks, fetchAttachments);
+	} = useIssueCore(issueId, workspaceSlug, fetchLinks, fetchAttachments, resolvedIssue);
 
 	const { parentEpic, childIssues } = useEpicRelations(issue, workspaceSlug);
 
@@ -540,13 +567,8 @@ export default function IssueDetail({
 		changeAssignee,
 	} = useIssueMutations({ issue, setIssue, issueId, workspaceSlug, statuses, members, fetchIssue });
 
-	if (!issueId)
-		return (
-			<p class="text-text-muted">
-				No issue ID provided. Add <code>?id=…</code> to the URL.
-			</p>
-		);
-	if (loading) return <p aria-live="polite">Loading…</p>;
+	// Error first: a failed resolve leaves issueId empty, so this has to be checked
+	// before the branches below or it would show as a permanent "Loading…".
 	const loadError = error ?? resolveError;
 	if (loadError)
 		return (
@@ -554,6 +576,17 @@ export default function IssueDetail({
 				Failed to load issue: {loadError}
 			</p>
 		);
+	if (!issueId && !resolving)
+		return (
+			<p class="text-text-muted">
+				No issue ID provided. Add <code>?id=…</code> to the URL.
+			</p>
+		);
+	// PROJ-431: paint as soon as the core issue is known rather than waiting on the
+	// whole seven-request fan-out (statuses, members, files, links…). Every section
+	// below already degrades on empty data and upgrades when it arrives — e.g.
+	// StatusField renders a read-only label until `statuses` lands, then a <Select>.
+	if (loading && !issue) return <p aria-live="polite">Loading…</p>;
 	if (!issue) return null;
 
 	const issueRef = formatIssueRef(issue.project_key, issue.number);

--- a/apps/web/src/islands/IssueDetailParts.tsx
+++ b/apps/web/src/islands/IssueDetailParts.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "preact/hooks";
 import { formatIssueRef, isValidIssueRef, normalizeIssueRef } from "../lib/issue-ref";
 import { parseStoryPoints } from "../lib/story-points";
 import { apiFetch } from "../utils/api-client";
+import { clearDraft, draftKey, loadDraft, saveDraft } from "../utils/drafts";
 import { issueUrl } from "../utils/issue-url";
 import { PRIORITY_OPTIONS } from "../utils/issue-utils";
 import { renderMd } from "../utils/markdown";
@@ -22,7 +23,7 @@ import {
 	PRIORITY_COLORS,
 	relativeTime,
 } from "./issue-detail-helpers";
-import MarkdownEditor from "./MarkdownEditor";
+import MarkdownEditor from "./LazyMarkdownEditor";
 import Select from "./Select";
 
 const PencilIcon = () => (
@@ -346,16 +347,32 @@ export function BodySection({
 	const [editBody, setEditBody] = useState("");
 	const [savingBody, setSavingBody] = useState(false);
 	const [saveBodyError, setSaveBodyError] = useState<string | null>(null);
+	const key = draftKey(workspaceSlug, issueId, "body");
+	const [hasDraft, setHasDraft] = useState(false);
 
-	function startEditBody() {
-		setEditBody(issue.body ?? "");
+	// Surface an unsaved edit from a previous visit, rather than silently reopening the
+	// editor — the user may have moved on, and the issue may have changed since.
+	useEffect(() => {
+		setHasDraft(loadDraft(key) !== null);
+	}, [key]);
+
+	function startEditBody(fromDraft = false) {
+		setEditBody((fromDraft ? loadDraft(key) : null) ?? issue.body ?? "");
 		setSaveBodyError(null);
 		setEditingBody(true);
+	}
+
+	function updateBody(value: string) {
+		setEditBody(value);
+		saveDraft(key, value);
+		setHasDraft(!!value.trim());
 	}
 
 	function cancelEditBody() {
 		setEditingBody(false);
 		setSaveBodyError(null);
+		clearDraft(key);
+		setHasDraft(false);
 	}
 
 	async function saveBody() {
@@ -367,6 +384,9 @@ export function BodySection({
 				method: "PATCH",
 				body: { body: editBody },
 			});
+			// Only discard once the server has it — a failed save keeps the text.
+			clearDraft(key);
+			setHasDraft(false);
 			await fetchIssue();
 			setEditingBody(false);
 		} catch (e) {
@@ -386,7 +406,7 @@ export function BodySection({
 				{!editingBody && (
 					<button
 						type="button"
-						onClick={startEditBody}
+						onClick={() => startEditBody()}
 						title="Edit description"
 						class="text-text-muted hover:text-text-base transition-colors rounded p-0.5"
 					>
@@ -401,10 +421,23 @@ export function BodySection({
 				</p>
 			)}
 
+			{!editingBody && hasDraft && (
+				<p class="mb-3 text-sm text-text-muted">
+					You have an unsaved description edit.{" "}
+					<button
+						type="button"
+						onClick={() => startEditBody(true)}
+						class="underline bg-transparent border-0 p-0 text-inherit cursor-pointer font-[inherit]"
+					>
+						Resume editing
+					</button>
+				</p>
+			)}
+
 			{editingBody ? (
 				<div>
 					<div class="mb-2">
-						<MarkdownEditor value={editBody} onChange={setEditBody} minHeight="240px" />
+						<MarkdownEditor value={editBody} onChange={updateBody} minHeight="240px" />
 					</div>
 					<div class="flex gap-2">
 						<button type="button" onClick={saveBody} disabled={savingBody} class="btn btn-primary">
@@ -1437,6 +1470,18 @@ function useNewCommentForm(
 	const [newComment, setNewComment] = useState("");
 	const [postingComment, setPostingComment] = useState(false);
 	const [commentError, setCommentError] = useState<string | null>(null);
+	const key = draftKey(workspaceSlug, issueId, "comment");
+
+	// Restore any unsent comment. Keyed on issueId so switching issues picks up that
+	// issue's own draft rather than carrying text across.
+	useEffect(() => {
+		setNewComment(loadDraft(key) ?? "");
+	}, [key]);
+
+	function updateComment(value: string) {
+		setNewComment(value);
+		saveDraft(key, value);
+	}
 
 	async function submitComment(e: Event) {
 		e.preventDefault();
@@ -1449,6 +1494,8 @@ function useNewCommentForm(
 				method: "POST",
 				body: { body: newComment.trim() },
 			});
+			// Only discard the draft once the server has it — a failed post keeps the text.
+			clearDraft(key);
 			setNewComment("");
 			await fetchComments();
 		} catch (e) {
@@ -1458,7 +1505,7 @@ function useNewCommentForm(
 		}
 	}
 
-	return { newComment, setNewComment, postingComment, commentError, submitComment };
+	return { newComment, setNewComment: updateComment, postingComment, commentError, submitComment };
 }
 
 export function CommentsSection({
@@ -1527,7 +1574,9 @@ export function CommentsSection({
 					onInput={(e) => setNewComment((e.target as HTMLTextAreaElement).value)}
 					placeholder="Add a comment…"
 					rows={4}
-					class="w-full px-3 py-2 border border-border rounded text-sm resize-y box-border mb-2 bg-bg text-text-base"
+					// text-base (16px) on phones: below 16px iOS Safari zooms the viewport
+					// when the field takes focus. sm:text-sm keeps desktop as it was.
+					class="w-full px-3 py-2 border border-border rounded text-base sm:text-sm resize-y box-border mb-2 bg-bg text-text-base"
 				/>
 				<button
 					type="submit"

--- a/apps/web/src/islands/LazyMarkdownEditor.test.tsx
+++ b/apps/web/src/islands/LazyMarkdownEditor.test.tsx
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/preact";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import LazyMarkdownEditor from "./LazyMarkdownEditor";
+
+afterEach(cleanup);
+
+// PROJ-431: MarkdownEditor pulls in CodeMirror — 168 KiB gzip, 76% of the JS on
+// /issues/view and /wiki — but only renders after the user taps Edit.
+describe("LazyMarkdownEditor (PROJ-431)", () => {
+	it("does not import MarkdownEditor statically at any call site", () => {
+		for (const f of [
+			"IssueDetailParts.tsx",
+			"WikiPage.tsx",
+			join("issue-list", "CreateIssueModal.tsx"),
+		]) {
+			const source = readFileSync(join(__dirname, f), "utf-8");
+			expect(source, `${f} must not statically import MarkdownEditor`).not.toMatch(
+				/from\s+"\.\.?\/MarkdownEditor"/
+			);
+			expect(source).toMatch(/from\s+"\.\.?\/LazyMarkdownEditor"/);
+		}
+	});
+
+	it("loads the real editor through a dynamic import", () => {
+		const source = readFileSync(join(__dirname, "LazyMarkdownEditor.tsx"), "utf-8");
+		expect(source).toMatch(/import\("\.\/MarkdownEditor"\)/);
+	});
+
+	// Importing preact/compat anywhere in an island's graph switches Preact to React's
+	// event semantics for that whole island. Using compat's lazy/Suspense here broke
+	// native <select> onChange in IssueList, via CreateIssueModal.
+	it("does not pull preact/compat into the editor call sites", () => {
+		const source = readFileSync(join(__dirname, "LazyMarkdownEditor.tsx"), "utf-8");
+		// An actual import, not the mention of it in the comment explaining why.
+		expect(source).not.toMatch(/^import\s[^;]*"preact\/compat"/m);
+	});
+
+	// A spinner would mean staring at nothing for seconds on a phone. The fallback is a
+	// working field on the same controlled contract, so typing starts immediately and the
+	// text is already in `value` when CodeMirror mounts.
+	it("renders a usable textarea while the editor chunk is in flight", async () => {
+		const onChange = vi.fn();
+		render(<LazyMarkdownEditor value="seed text" onChange={onChange} minHeight="240px" />);
+
+		const field = await screen.findByLabelText("Markdown editor");
+		expect((field as HTMLTextAreaElement).value).toBe("seed text");
+
+		fireEvent.input(field, { target: { value: "typed while loading" } });
+		await waitFor(() => expect(onChange).toHaveBeenCalledWith("typed while loading"));
+	});
+
+	// Below 16px iOS Safari zooms the viewport on focus, and the viewport meta sets no
+	// maximum-scale — so the fallback must not be smaller than that on a phone.
+	it("uses a 16px font on mobile so iOS does not zoom on focus", () => {
+		const source = readFileSync(join(__dirname, "LazyMarkdownEditor.tsx"), "utf-8");
+		expect(source).toMatch(/text-base sm:text-sm/);
+	});
+});

--- a/apps/web/src/islands/LazyMarkdownEditor.tsx
+++ b/apps/web/src/islands/LazyMarkdownEditor.tsx
@@ -1,0 +1,63 @@
+import type { ComponentType } from "preact";
+import { useEffect, useState } from "preact/hooks";
+
+interface Props {
+	value: string;
+	onChange: (value: string) => void;
+	minHeight?: string;
+}
+
+// PROJ-431: MarkdownEditor pulls in CodeMirror — 486 KiB raw / 168 KiB gzip, 76% of
+// the JS on /issues/view and /wiki. As a static import every *reader* of an issue paid
+// for it, though it only renders after tapping Edit. Loading it on demand takes those
+// pages from 221 KiB to ~53 KiB gzip.
+//
+// Deliberately a plain dynamic import rather than preact/compat's lazy + Suspense.
+// Importing preact/compat anywhere in an island's graph switches Preact to React's
+// event semantics for that whole island — which silently broke native <select>
+// onChange handling in IssueList (CreateIssueModal is one of the three call sites).
+// Not worth a global behaviour change to save a few lines here.
+
+// Shown while the chunk is in flight. Deliberately a working textarea rather than a
+// spinner: on a slow mobile connection the chunk can take seconds, and the whole point
+// of tapping Edit is to type. Same controlled contract as the real editor, so whatever
+// is typed here is already in `value` when CodeMirror mounts and adopts it.
+function EditorFallback({ value, onChange, minHeight }: Props) {
+	return (
+		<div class="flex flex-col border border-border rounded overflow-hidden bg-bg normal-case">
+			<div
+				class={
+					"px-2 py-[2px] text-[0.7rem] text-text-muted bg-surface border-b border-border " +
+					"shrink-0 uppercase tracking-[0.06em]"
+				}
+			>
+				Loading editor…
+			</div>
+			<textarea
+				value={value}
+				onInput={(e) => onChange((e.target as HTMLTextAreaElement).value)}
+				aria-label="Markdown editor"
+				style={{ minHeight }}
+				class="w-full px-3 py-2 border-0 resize-y box-border bg-bg text-text-base font-mono
+					text-base sm:text-sm leading-[1.6] focus:outline-none"
+			/>
+		</div>
+	);
+}
+
+export default function LazyMarkdownEditor(props: Props) {
+	const [Editor, setEditor] = useState<ComponentType<Props> | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		import("./MarkdownEditor").then((m) => {
+			// Wrapped in a thunk: a bare component would be read as a state updater.
+			if (!cancelled) setEditor(() => m.default);
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	return Editor ? <Editor {...props} /> : <EditorFallback {...props} />;
+}

--- a/apps/web/src/islands/MarkdownEditor.test.tsx
+++ b/apps/web/src/islands/MarkdownEditor.test.tsx
@@ -3,6 +3,8 @@
 // MarkdownEditor has no network dependency. It mounts a CodeMirror editor and
 // renders a live preview pane. The pattern: render with props, assert on the
 // toolbar buttons and preview pane content. cleanup runs via setup.ts afterEach.
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { fireEvent, render, screen, waitFor } from "@testing-library/preact";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import MarkdownEditor from "./MarkdownEditor";
@@ -124,5 +126,30 @@ describe("MarkdownEditor", () => {
 		// After click the Edit button loses its active styles (class contains bg-transparent)
 		const editToggle = buttons.find((b) => b.textContent === "Edit");
 		expect(editToggle?.className).toContain("border-border");
+	});
+});
+
+// ─── PROJ-431: mobile editing ────────────────────────────────────────────────
+
+describe("MarkdownEditor — mobile ergonomics (PROJ-431)", () => {
+	const source = readFileSync(join(__dirname, "MarkdownEditor.tsx"), "utf-8");
+
+	// Toolbar buttons were ~24px tall (py-[2px] at 0.8rem), well under the 44px
+	// accessible touch target. Desktop keeps the original compact sizing.
+	it("gives toolbar buttons a 44px touch target on small screens only", () => {
+		expect(source).toMatch(/min-w-\[44px\] min-h-\[44px\] sm:min-w-0 sm:min-h-0/);
+	});
+
+	it("gives the mobile Edit/Preview toggle a 44px touch target", () => {
+		expect(source).toMatch(/min-h-\[44px\][^"]*px-\[14px\]/);
+	});
+
+	// Below 16px, iOS Safari zooms the viewport when the field takes focus, and the
+	// viewport meta sets no maximum-scale.
+	it("sets a 16px editor font on phones and restores 0.875rem from 640px up", () => {
+		expect(source).toMatch(/fontSize:\s*"1rem"/);
+		expect(source).toMatch(
+			/"@media \(min-width: 640px\)":\s*\{\s*"\.cm-content":\s*\{\s*fontSize:\s*"0\.875rem"\s*\}/
+		);
 	});
 });

--- a/apps/web/src/islands/MarkdownEditor.tsx
+++ b/apps/web/src/islands/MarkdownEditor.tsx
@@ -11,13 +11,16 @@ interface Props {
 	minHeight?: string;
 }
 
+// Sub-640px gets a 44px-square touch target (the toolbar was ~24px tall, well under
+// the accessible minimum on a phone). Desktop keeps the original compact sizing.
 const TOOLBAR_BUTTON_CLASS =
+	"min-w-[44px] min-h-[44px] sm:min-w-0 sm:min-h-0 inline-flex items-center justify-center " +
 	"px-[7px] py-[2px] border border-transparent rounded-[3px] bg-transparent text-text-base " +
 	"cursor-pointer text-[0.8rem] font-[inherit] leading-[1.5] hover:bg-border";
 
 function mobileToggleClass(active: boolean): string {
 	const base =
-		"px-[10px] py-[2px] border rounded-[3px] text-[0.8rem] font-[inherit] cursor-pointer";
+		"min-h-[44px] px-[14px] py-[2px] border rounded-[3px] text-[0.8rem] font-[inherit] cursor-pointer";
 	const state = active
 		? " bg-accent text-white border-accent"
 		: " border-border bg-transparent text-text-base";
@@ -220,10 +223,16 @@ function useMarkdownEditorView(
 					"&": { background: "var(--bg)", color: "var(--text)" },
 					".cm-content": {
 						fontFamily: "ui-monospace, 'Cascadia Code', Menlo, Monaco, 'Courier New', monospace",
-						fontSize: "0.875rem",
+						// 16px on phones. Below 16px, iOS Safari zooms the viewport when a
+						// field takes focus, and the viewport meta sets no maximum-scale —
+						// so tapping into the editor used to jump the whole page.
+						fontSize: "1rem",
 						padding: "0.5rem 0.75rem",
 						minHeight,
 						caretColor: "var(--text)",
+					},
+					"@media (min-width: 640px)": {
+						".cm-content": { fontSize: "0.875rem" },
 					},
 					".cm-line": { lineHeight: "1.6" },
 					".cm-focused": { outline: "none" },

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -5,7 +5,7 @@ import { useAccessGate } from "../utils/access-gate";
 import { apiFetch } from "../utils/api-client";
 import { renderMdWithWikilinks, renderMermaidDiagrams } from "../utils/markdown";
 import AccessPending from "./AccessPending";
-import MarkdownEditor from "./MarkdownEditor";
+import MarkdownEditor from "./LazyMarkdownEditor";
 import Select, { type SelectOption } from "./Select";
 
 interface ProjectOption {

--- a/apps/web/src/islands/issue-list/CreateIssueModal.tsx
+++ b/apps/web/src/islands/issue-list/CreateIssueModal.tsx
@@ -1,7 +1,7 @@
 import type { Dispatch, StateUpdater } from "preact/hooks";
 import { PRIORITY_OPTIONS } from "../../utils/issue-utils";
 import type { TaskStatus } from "../board-utils";
-import MarkdownEditor from "../MarkdownEditor";
+import MarkdownEditor from "../LazyMarkdownEditor";
 import Select from "../Select";
 import type { ProjectMeta } from "./types";
 

--- a/apps/web/src/layouts/Base.pwa-register.test.ts
+++ b/apps/web/src/layouts/Base.pwa-register.test.ts
@@ -40,3 +40,27 @@ describe("PWA service worker — navigations must reach the network (PROJ-430)",
 		expect(configSource).toMatch(/handler:\s*['"]NetworkOnly['"]/);
 	});
 });
+
+// PROJ-431: the precache had grown to 4.17 MiB / 111 entries, dominated by chunks
+// that are dynamically imported and reached by a minority of sessions (mermaid,
+// cytoscape and katex render wiki diagrams and maths; the editor mounts only on Edit).
+// They still load on demand — this only keeps them out of the install-time payload.
+describe("PWA precache — keep the install payload small (PROJ-431)", () => {
+	it("excludes the heavy dynamically-imported vendor chunks", () => {
+		const globIgnores = configSource.match(/globIgnores:\s*\[([\s\S]*?)\]/)?.[1] ?? "";
+		for (const chunk of ["mermaid", "cytoscape", "katex", "MarkdownEditor", "Diagram-"]) {
+			expect(globIgnores, `${chunk} should not be precached`).toContain(chunk);
+		}
+	});
+
+	// The config patterns above are brittle to chunk renames; the byte budget asserted
+	// against the built sw.js is the guard that actually holds. It runs as part of the
+	// build (astro build && node scripts/assert-sw.mjs) because CI runs unit tests
+	// before the build, so a dist-reading test here would just skip.
+	it("enforces the precache budget from the build, against the built sw.js", () => {
+		const pkg = JSON.parse(
+			readFileSync(join(__dirname, "../../package.json"), "utf-8")
+		) as { scripts: Record<string, string> };
+		expect(pkg.scripts.build).toContain("scripts/assert-sw.mjs");
+	});
+});

--- a/apps/web/src/utils/drafts.test.ts
+++ b/apps/web/src/utils/drafts.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearAllDrafts, clearDraft, draftKey, loadDraft, saveDraft } from "./drafts";
+
+describe("drafts (PROJ-431)", () => {
+	beforeEach(() => {
+		localStorage.clear();
+		vi.useRealTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("round-trips a draft", () => {
+		const k = draftKey("projektor", "issue-1", "comment");
+		saveDraft(k, "half a thought");
+		expect(loadDraft(k)).toBe("half a thought");
+	});
+
+	it("returns null when there is no draft", () => {
+		expect(loadDraft(draftKey("projektor", "issue-1", "comment"))).toBeNull();
+	});
+
+	// Cached *fetched* data is deliberately not persisted; drafts are the user's own
+	// unsent input. Tenant scoping still has to hold so text can't surface elsewhere.
+	it("scopes keys by workspace so one workspace's draft can't surface in another", () => {
+		const a = draftKey("alpha", "issue-1", "comment");
+		const b = draftKey("beta", "issue-1", "comment");
+		expect(a).not.toBe(b);
+		saveDraft(a, "alpha text");
+		expect(loadDraft(b)).toBeNull();
+	});
+
+	it("keys distinct fields on the same issue separately", () => {
+		const c = draftKey("projektor", "issue-1", "comment");
+		const b = draftKey("projektor", "issue-1", "body");
+		saveDraft(c, "a comment");
+		saveDraft(b, "a body");
+		expect(loadDraft(c)).toBe("a comment");
+		expect(loadDraft(b)).toBe("a body");
+	});
+
+	it("treats an empty or whitespace-only value as a clear", () => {
+		const k = draftKey("projektor", "issue-1", "comment");
+		saveDraft(k, "something");
+		saveDraft(k, "   ");
+		expect(loadDraft(k)).toBeNull();
+		expect(localStorage.getItem(k)).toBeNull();
+	});
+
+	it("expires drafts older than 7 days, and removes the entry", () => {
+		const k = draftKey("projektor", "issue-1", "comment");
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-07-01T00:00:00Z"));
+		saveDraft(k, "stale");
+		vi.setSystemTime(new Date("2026-07-08T00:00:01Z"));
+		expect(loadDraft(k)).toBeNull();
+		expect(localStorage.getItem(k)).toBeNull();
+	});
+
+	it("keeps a draft that is just inside the 7-day window", () => {
+		const k = draftKey("projektor", "issue-1", "comment");
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-07-01T00:00:00Z"));
+		saveDraft(k, "fresh enough");
+		vi.setSystemTime(new Date("2026-07-07T23:00:00Z"));
+		expect(loadDraft(k)).toBe("fresh enough");
+	});
+
+	it("discards a malformed entry instead of throwing", () => {
+		const k = draftKey("projektor", "issue-1", "comment");
+		localStorage.setItem(k, "not json");
+		expect(loadDraft(k)).toBeNull();
+	});
+
+	it("clearAllDrafts removes drafts but leaves unrelated keys alone", () => {
+		saveDraft(draftKey("projektor", "issue-1", "comment"), "one");
+		saveDraft(draftKey("other", "issue-2", "body"), "two");
+		localStorage.setItem("theme", "dark");
+		clearAllDrafts();
+		expect(loadDraft(draftKey("projektor", "issue-1", "comment"))).toBeNull();
+		expect(loadDraft(draftKey("other", "issue-2", "body"))).toBeNull();
+		expect(localStorage.getItem("theme")).toBe("dark");
+	});
+
+	it("clearDraft removes a single entry", () => {
+		const k = draftKey("projektor", "issue-1", "comment");
+		saveDraft(k, "x");
+		clearDraft(k);
+		expect(loadDraft(k)).toBeNull();
+	});
+
+	// Private mode / quota. Persistence is a convenience, never a precondition for editing.
+	it("degrades silently when storage throws", () => {
+		const k = draftKey("projektor", "issue-1", "comment");
+		vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+			throw new Error("QuotaExceededError");
+		});
+		expect(() => saveDraft(k, "x")).not.toThrow();
+		vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+			throw new Error("blocked");
+		});
+		expect(loadDraft(k)).toBeNull();
+	});
+});

--- a/apps/web/src/utils/drafts.ts
+++ b/apps/web/src/utils/drafts.ts
@@ -1,0 +1,73 @@
+// PROJ-431: losing a half-typed comment on a phone — backgrounded tab, dropped
+// connection, accidental back — is a real pain point. Drafts are the user's own
+// *unsent* input, which is why they're persisted while fetched issue data deliberately
+// isn't (see the ticket's caching recommendation).
+
+const PREFIX = "projektor:draft:";
+const TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface StoredDraft {
+	value: string;
+	at: number;
+}
+
+/**
+ * Build a storage key for one editable field. Scoped by workspace so a draft can never
+ * surface under a different tenant.
+ */
+export function draftKey(workspaceSlug: string | undefined, scope: string, field: string): string {
+	return `${PREFIX}${workspaceSlug ?? "-"}:${scope}:${field}`;
+}
+
+/** Returns the stored draft, or null if absent, expired or unreadable. */
+export function loadDraft(key: string): string | null {
+	try {
+		const raw = localStorage.getItem(key);
+		if (raw === null) return null;
+		const parsed = JSON.parse(raw) as StoredDraft;
+		if (typeof parsed?.value !== "string" || typeof parsed?.at !== "number") {
+			localStorage.removeItem(key);
+			return null;
+		}
+		if (Date.now() - parsed.at > TTL_MS) {
+			localStorage.removeItem(key);
+			return null;
+		}
+		return parsed.value;
+	} catch {
+		// Unreadable, blocked (private mode) or malformed — behave as if there's no draft.
+		return null;
+	}
+}
+
+/** Persists a draft. Empty/whitespace-only values clear the entry rather than storing it. */
+export function saveDraft(key: string, value: string): void {
+	try {
+		if (!value.trim()) {
+			localStorage.removeItem(key);
+			return;
+		}
+		localStorage.setItem(key, JSON.stringify({ value, at: Date.now() } satisfies StoredDraft));
+	} catch {
+		// Quota exceeded or storage blocked. Draft persistence is a convenience, never a
+		// precondition for editing — degrade silently.
+	}
+}
+
+export function clearDraft(key: string): void {
+	try {
+		localStorage.removeItem(key);
+	} catch {}
+}
+
+/**
+ * Drop every stored draft. Intended for logout, so one user's unsent text isn't left
+ * behind for the next person on a shared device.
+ */
+export function clearAllDrafts(): void {
+	try {
+		for (const k of Object.keys(localStorage)) {
+			if (k.startsWith(PREFIX)) localStorage.removeItem(k);
+		}
+	} catch {}
+}

--- a/docs/superpowers/specs/2026-07-26-proj-431-pwa-mobile-design.md
+++ b/docs/superpowers/specs/2026-07-26-proj-431-pwa-mobile-design.md
@@ -36,14 +36,23 @@ On a single warm reused connection to the dogfood Worker:
 | `/api/issues/{uuid}/comments` | 957 ms |
 
 Network RTT to the edge is ~110 ms, so ~620–990 ms is server time, for payloads
-of 5.7 KiB. The cause is visible in the middleware chain: `rate-limit.ts` does a
-`DELETE` + upsert + `SELECT`, `auth.ts` does a `SELECT` on `api_tokens` plus an
-`UPDATE last_used_at`, `workspace.ts` does a workspace `SELECT` plus a membership
-`SELECT` — roughly **seven sequential D1 round trips before the route handler runs
-its first query**.
+of 5.7 KiB. Counting only *blocking* D1 round trips before the route handler runs
+its first query, on the browser (CF Access) path with warm isolate caches:
+
+- `rate-limit.ts` — 2 (upsert, then a separate count `SELECT`), plus a prune
+  `DELETE` at 1% probability.
+- `auth.ts` → `provisionUserOnLogin` — 3. It runs on *every* request despite the
+  name, and for an admin its cost is `2 + N` for N workspaces, sequentially.
+- `workspace.ts` — 2 (workspace by slug, then membership).
+
+**Seven sequential round trips**, each paying full D1 latency. Two things that are
+*not* the cause, checked so they aren't re-investigated: `api_tokens.last_used_at`
+is already throttled and `waitUntil`-wrapped (PROJ-360), and the JWKS keys and
+`upsertUserByEmail` are served from isolate-local caches (PROJ-354).
 
 This is the single largest lever and no frontend change fixes it; caching only
-hides it. It lives in `apps/api`, outside this ticket's scope. Raise separately.
+hides it. It lives in `apps/api`, outside this ticket's scope. Raised as PROJ-432,
+with the provisioning finding as PROJ-433.
 
 ### 2. `/issues/view` ships CodeMirror to readers
 
@@ -173,9 +182,14 @@ teardown on 401/logout, a workspace-scoped database name, a schema version, and
 leaves private data at rest on a phone that may be shared or lost. Not worth it
 while offline means logged out.
 
+Raised as PROJ-434. Worth re-measuring whether it still pays for itself once
+PROJ-432 lands — if authenticated requests drop from ~1s to ~200ms, the perceived
+win shrinks. Sequence it second.
+
 ### API middleware round trips
 
-See "1. The API is the floor". Largest available win, `apps/api`, separate ticket.
+See "1. The API is the floor". Largest available win. PROJ-432, with PROJ-433
+under it.
 
 ## Verification
 

--- a/docs/superpowers/specs/2026-07-26-proj-431-pwa-mobile-design.md
+++ b/docs/superpowers/specs/2026-07-26-proj-431-pwa-mobile-design.md
@@ -1,0 +1,189 @@
+# PROJ-431 — PWA mobile performance: design
+
+Date: 2026-07-26
+Ticket: PROJ-431
+Prior context that constrains this work: PROJ-430 (`fe2eb16`), PROJ-427, PROJ-414.
+
+## What is slow today, measured
+
+Harness: `apps/web/perf-measure.mjs` (throwaway). Serves the built `dist/` over a
+local server with brotli/gzip — matching how Cloudflare serves these assets — and
+proxies `/api` and `/auth` to the live dogfood Worker, so the numbers include real
+API latency. Chromium via Playwright, Pixel 5 device profile, Lighthouse mobile
+throttling (1.6 Mbps down / 750 Kbps up / 150 ms RTT, 4× CPU). Median of 3 runs.
+"content" is time until the page shows something other than the `Loading…`
+placeholder.
+
+| profile | page | FCP | LCP | JS done | API done | content |
+|---|---|---|---|---|---|---|
+| mobile | `/issues/view` | 604 ms | 5976 ms | 3653 ms | 5641 ms | **6160 ms** |
+| mobile | `/` (projects) | 812 ms | 2312 ms | 1200 ms | 3114 ms | **3065 ms** |
+| desktop, unthrottled | `/issues/view` | 196 ms | 2500 ms | 1326 ms | 2440 ms | 2512 ms |
+| desktop, unthrottled | `/` | 196 ms | 772 ms | 235 ms | 2172 ms | 766 ms |
+
+Three independent causes.
+
+### 1. The API is the floor (~1 s per authenticated request)
+
+On a single warm reused connection to the dogfood Worker:
+
+| request | TTFB |
+|---|---|
+| static asset (`/favicon.svg`) | 109 ms |
+| `/api/health` | 115 ms |
+| `/api/task-statuses` | 1098 ms |
+| `/api/issues/{uuid}` | 734 ms, 737 ms |
+| `/api/issues/{uuid}/comments` | 957 ms |
+
+Network RTT to the edge is ~110 ms, so ~620–990 ms is server time, for payloads
+of 5.7 KiB. The cause is visible in the middleware chain: `rate-limit.ts` does a
+`DELETE` + upsert + `SELECT`, `auth.ts` does a `SELECT` on `api_tokens` plus an
+`UPDATE last_used_at`, `workspace.ts` does a workspace `SELECT` plus a membership
+`SELECT` — roughly **seven sequential D1 round trips before the route handler runs
+its first query**.
+
+This is the single largest lever and no frontend change fixes it; caching only
+hides it. It lives in `apps/api`, outside this ticket's scope. Raise separately.
+
+### 2. `/issues/view` ships CodeMirror to readers
+
+Static module closure of the built page: 637 KiB raw / **221 KiB gzip**, of which
+`MarkdownEditor` is **486 KiB raw / 168 KiB gzip — 76%**. It is a static import in
+`IssueDetailParts.tsx:25`, so every reader pays for it even though it only renders
+after tapping Edit. `/wiki` has the same 221 KiB gzip closure for the same reason.
+
+### 3. First paint waits on all seven requests
+
+`IssueDetail.tsx:203-236` gates render on `Promise.all([...]).finally(() =>
+setLoading(false))`. Title and body need one request but wait behind `/api/files`,
+`/api/task-statuses` and `/api/workspaces/{slug}`.
+
+Compounding it, `useResolvedIssueId` turns a pretty URL into a UUID with a
+*separate* prior request. `/api/issues/PROJ-431` and `/api/issues/{uuid}` were
+verified to return byte-identical 31-key payloads, so that first response is a
+complete issue that is discarded except for `.id` — a fully wasted serial round
+trip on the canonical URL form.
+
+### 4. The service worker precaches 4.17 MiB
+
+111 entries, 4.17 MiB, including `mermaid.core` (579 K), `cytoscape.esm` (433 K),
+`katex` (255 K), `cynefin` (672 K) and every diagram chunk. All are already
+dynamically imported and used only by the wiki. This downloads on install and
+re-downloads changed entries on every deploy.
+
+## Constraints carried forward from PROJ-430
+
+Non-negotiable, and asserted by tests:
+
+- No `navigateFallback`. The explicit `navigateFallback: undefined` stays, because
+  `vite-plugin-pwa`'s `defaultWorkbox` hard-codes `'index.html'` and merges with
+  `Object.assign` — omitting the key re-enables it.
+- No HTML in the precache; navigations must reach the network so Cloudflare Access
+  can challenge.
+- `/api` and `/mcp` stay `NetworkOnly`.
+- Verified against the built `dist/sw.js`, not the config.
+
+No offline app shell is reintroduced. For an Access-gated app, offline means
+logged out, and PROJ-414's offline banner already covers that state.
+
+## Changes
+
+### C1 — Seed issue state from the resolve response (`IssueDetail.tsx`)
+
+`useResolvedIssueId` returns the full issue it already fetched, not just the id.
+`useIssueCore` accepts it as initial state. The UUID-keyed fetch still runs and
+revalidates; it is simply no longer in front of first paint.
+
+### C2 — Render on the core request (`IssueDetail.tsx`)
+
+`if (loading) return <Loading/>` becomes `if (loading && !issue)`. Downstream
+components already degrade: `StatusField` renders a read-only label when
+`statuses` is empty and upgrades to a `<Select>` when it arrives.
+
+### C3 — Lazy-load the editor (new `LazyMarkdownEditor.tsx`)
+
+`preact/compat` `lazy` + `Suspense`, substituted at the three static import sites
+(`IssueDetailParts.tsx`, `issue-list/CreateIssueModal.tsx`, `WikiPage.tsx`).
+
+The `Suspense` fallback is a real `<textarea>` bound to the same `value`/`onChange`
+contract, not a spinner, so typing works immediately on a slow connection.
+`MarkdownEditor`'s existing external-`value` sync effect handles the handoff when
+the chunk lands.
+
+Known edge, accepted: caret position and focus are lost at the swap.
+
+### C4 — Trim the precache (`astro.config.mjs`)
+
+`globIgnores` for the lazy vendor chunks. They still load on demand over the
+network. Target: install payload under 1 MiB, from 4.17 MiB.
+
+Guarded by a **precache byte-budget test** against the built `sw.js`, which is what
+actually prevents regression — glob patterns alone are brittle to chunk renames.
+
+### C5 — Two mobile editing defects
+
+- Toolbar buttons are `py-[2px]` at `0.8rem` — roughly 24 px tall, against a 44 px
+  touch-target guideline. Raised to a 44 px target on small screens only, so the
+  desktop toolbar is unchanged.
+- Editor content is `0.875rem` (14 px) and the comment textarea is `text-sm`. Below
+  16 px, iOS Safari zooms the viewport on focus, and the viewport meta sets no
+  `maximum-scale`. Raised to 16 px on small screens only.
+
+### C6 — Draft persistence (new `utils/drafts.ts`)
+
+Debounced save of in-progress comment and issue-body text to `localStorage`,
+restored on return, cleared on successful submit.
+
+- Keys are namespaced and **workspace-scoped**: `projektor:draft:<workspace>:<scope>`.
+- Entries carry a timestamp and **expire after 7 days**.
+- Storage failures (private mode, quota) degrade silently to no persistence.
+
+Trade-off, stated explicitly: this puts user-typed text on disk, which is in mild
+tension with the "nothing private at rest" reasoning behind the in-memory cache
+decision below. Treated differently because a draft is the user's own *unsent*
+input and losing it is the concrete pain the ticket names, whereas cached issue
+data is *fetched* private data carrying tenant-leak and staleness surface.
+
+## Recommended, deliberately not built
+
+### Local caching of issues/projects — in-memory stale-while-revalidate
+
+The recommendation is a module-scoped SWR cache that **dies with the tab**, not
+IndexedDB.
+
+Rationale. The measurements show the API costs ~1 s per request, so the win from
+caching is real — but it is a *within-session* win: instant back-navigation and
+instant re-open of a recently viewed issue. Surviving a cold start buys much less
+here, because a cold start is exactly when an Access session may need re-challenging.
+
+It also answers the ticket's three auth questions for free rather than by
+mechanism:
+
+- **Logout / expiry** — nothing is written to disk, so nothing outlives the tab.
+  No teardown path to get wrong.
+- **Workspace scoping** — cache keys include the workspace slug; a tab only ever
+  holds one workspace's data anyway.
+- **Staleness** — stale-while-revalidate always issues the network request and
+  repaints on the response, so a cached issue is a head start, never a final
+  answer.
+
+IndexedDB is the alternative worth naming. It wins on cold start and is the right
+answer if the app ever needs to be genuinely usable offline. It costs an explicit
+teardown on 401/logout, a workspace-scoped database name, a schema version, and
+leaves private data at rest on a phone that may be shared or lost. Not worth it
+while offline means logged out.
+
+### API middleware round trips
+
+See "1. The API is the floor". Largest available win, `apps/api`, separate ticket.
+
+## Verification
+
+- `cd apps/web && pnpm vitest run` — full web suite green
+- `pnpm turbo type-check` — 7/7
+- `pnpm biome check` — clean (invoke biome directly; rtk rewrites `pnpm biome`)
+- `pnpm --filter @projektor/web build`, then assert against `dist/sw.js`:
+  no `NavigationRoute`, no `createHandlerBoundToURL`, `NetworkOnly` on `/api|/mcp`,
+  precache under budget
+- Re-run `perf-measure.mjs` before/after and report both mobile and desktop
+- Interactive changes exercised at 375 px and desktop widths


### PR DESCRIPTION
Investigation and fixes for PWA mobile performance. Ticket: PROJ-431.

## Measured

Harness in `apps/web/scripts/perf/` (see its README). Serves the built `dist/` locally with brotli/gzip — matching how Cloudflare serves these assets — and proxies `/api` to the live dogfood Worker, so numbers include real API latency. Chromium via Playwright, Pixel 5, Lighthouse mobile throttling (1.6 Mbps down, 750 Kbps up, 150 ms RTT, 4× CPU). Median of 3. Before/after runs taken back to back.

**Time until content replaces the loading placeholder:**

| page | mobile before | mobile after | desktop before | desktop after |
|---|---|---|---|---|
| `/projects/PROJ/issues/N/…` (canonical) | 7876 ms | **3314 ms** | 6357 ms | **2028 ms** |
| `/issues/view?id=` | 8008 ms | **2989 ms** | 4555 ms | **1478 ms** |
| `/` (projects) | 3108 ms | **2105 ms** | 1020 ms | 868 ms |

Deterministic figures:

| | before | after |
|---|---|---|
| eager JS, `/issues/view` | 221 KiB gz | **54.6 KiB gz** |
| eager JS, `/wiki` | 221 KiB gz | **54.4 KiB gz** |
| JS finished downloading (mobile) | 3693 ms | **1579 ms** |
| service worker precache | 4265 KiB / 111 entries | **683 KiB / 71 entries** |

API latency drifts several hundred ms between sessions, so part of the wall-clock delta is noise; the JS-side figures are deterministic.

## What was slow, and what changed

**CodeMirror shipped to readers.** `MarkdownEditor` was a static import, so everyone viewing an issue downloaded 486 KiB raw / 168 KiB gzip — 76% of the page's JS — for an editor that only mounts on Edit. Now loaded on demand.

The loading fallback is a working `<textarea>` on the same controlled contract rather than a spinner, so typing starts immediately on a slow connection and CodeMirror adopts the text when it arrives. Caret position is lost at the swap.

Deliberately a plain dynamic import, **not** `preact/compat`'s `lazy` + `Suspense`: importing `preact/compat` anywhere in an island's graph switches Preact to React's event semantics for that whole island, which silently broke native `<select>` `onChange` in `IssueList` via `CreateIssueModal`. Caught by the existing suite; there's a regression test.

**A wasted round trip in front of first paint.** `/api/issues/KEY-N` returns a payload byte-identical to `/api/issues/{uuid}`, but the resolve step kept only `.id` and let `useIssueCore` refetch. It now seeds issue state. The same path also rendered "No issue ID provided" for the whole resolve, since `issueId` is empty until it completes — a ~1.3 s error flash on the canonical URL.

**First paint gated on all seven requests.** `Promise.all(...).finally(...)` meant title and body waited behind `/api/files`, `/api/task-statuses` and `/api/workspaces/{slug}`. Sections already degrade on empty data and upgrade when it arrives (`StatusField` renders a read-only label, then a `<Select>`).

**4.17 MiB precache** across 111 entries, mostly dynamically imported chunks a minority of sessions reach (mermaid 579 K, cytoscape 433 K, katex 255 K, cynefin 672 K, the editor). They still load on demand.

**Two mobile editing defects.** Toolbar buttons were ~24 px against a 44 px touch target. The editor and comment inputs were 14 px — below 16 px iOS Safari zooms the viewport on focus, and the viewport meta sets no `maximum-scale`. Both scoped to small screens; desktop is byte-identical in behaviour.

**Draft persistence.** Comment and description drafts go to `localStorage`, workspace-scoped, expiring after 7 days, cleared on successful submit and on logout. A description draft surfaces a "Resume editing" affordance rather than silently reopening the editor.

## PROJ-430 invariants

No offline shell is reintroduced. `navigateFallback: undefined` and the HTML-free precache are untouched.

`apps/web/scripts/assert-sw.mjs` now asserts these against the **built** `dist/sw.js` — no `NavigationRoute`, no `createHandlerBoundToURL`, no precached HTML, `NetworkOnly` on `/api|/mcp`, precache under a 1 MiB budget. It runs as part of `build`, because CI runs unit tests *before* the build, so a `dist`-reading vitest case would only ever skip. All three failure modes were verified to actually trip, including a guard against the manifest parser silently matching zero entries.

## Recommended, not built

- **Local caching of issues/projects — in-memory stale-while-revalidate, not IndexedDB.** Dying with the tab answers the auth questions structurally: nothing at rest, so logout and expiry need no teardown; keys carry the workspace slug; SWR always revalidates so a cached issue is a head start, never a final answer. IndexedDB wins on cold start and is the right call only if offline should mean *usable*, which it can't while offline means logged out. Full reasoning in the design doc.
- **The API is the real floor, and it's the largest lever.** On a warm connection: static asset 109 ms, `/api/health` 115 ms, but every authenticated D1 endpoint 730–1350 ms for 5.7 KiB payloads. The middleware chain does ~7 sequential D1 round trips before the handler's first query — rate-limit `DELETE` + upsert + `SELECT`, auth `SELECT` + `UPDATE`, workspace `SELECT` + `SELECT`. Belongs in `apps/api` as its own ticket. No frontend change fixes it; caching only hides it.

## Verification

- `pnpm vitest run` — 437/437 web, 825 passed / 5 todo api
- `pnpm turbo type-check` — 7/7, 0 errors
- `pnpm biome check .` — clean (319 files)
- `pnpm --filter @projektor/web build` + `assert-sw` — OK, precache 0.67 MiB
- `node scripts/perf/check-interactive.mjs` — 14/14 at 375 px and 1440 px: draft survives reload, cleared draft stays cleared, fallback textarea appears then CodeMirror adopts its text, 16 px inputs on mobile / 14 px desktop, 44 px touch targets on mobile / compact on desktop

Not done: not deployed to the dogfood instance or clicked through by hand. Per the usual deploy-verify-before-merge rule this should be checked there before merging — the browser verification above is against a local server proxying the real API, not the deployed Worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VyJbysfF5u7ocuJArkY2ZS