### PR TITLE
PROJ-438: take the dead time off the issue page's critical path

### DIFF
--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -2,14 +2,18 @@ import type { HonoEnv } from "@projektor/types";
 import { Hono } from "hono";
 import { serviceErrToResponse } from "../http/error-adapter";
 import { addComment, deleteComment, listComments, updateComment } from "../services/comments";
+import { resolveIssueIdParam } from "../services/issues";
 import { ctxFromHono } from "../services/types";
 
 const router = new Hono<HonoEnv>();
 
+// Reads accept a ref ("PROJ-42") as well as a UUID so the browser doesn't have to
+// resolve one before asking (PROJ-438). Writes stay UUID-only — they're never on a
+// first-paint path, so there's nothing to gain for the extra surface.
 router.get("/:issueId/comments", async (c) => {
 	const ctx = ctxFromHono(c);
-	const issueId = c.req.param("issueId");
 	try {
+		const issueId = await resolveIssueIdParam(ctx, c.req.param("issueId"));
 		return c.json(await listComments(ctx, { issueId }));
 	} catch (e) {
 		return serviceErrToResponse(c, e);

--- a/apps/api/src/routes/issue-links.ts
+++ b/apps/api/src/routes/issue-links.ts
@@ -2,15 +2,18 @@ import type { HonoEnv } from "@projektor/types";
 import { Hono } from "hono";
 import { serviceErrToResponse } from "../http/error-adapter";
 import { createLink, deleteLink, listLinksForIssue } from "../services/issue-links";
+import { resolveIssueIdParam } from "../services/issues";
 import { ctxFromHono } from "../services/types";
 
 const router = new Hono<HonoEnv>();
 
-// GET /api/issues/:issueId/links
+// GET /api/issues/:issueId/links — accepts a ref ("PROJ-42") as well as a UUID, so the
+// browser can ask for these alongside the issue itself rather than after it (PROJ-438).
 router.get("/:issueId/links", async (c) => {
 	const ctx = ctxFromHono(c);
 	try {
-		return c.json(await listLinksForIssue(ctx, { issueId: c.req.param("issueId") }));
+		const issueId = await resolveIssueIdParam(ctx, c.req.param("issueId"));
+		return c.json(await listLinksForIssue(ctx, { issueId }));
 	} catch (e) {
 		return serviceErrToResponse(c, e);
 	}

--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -368,7 +368,10 @@ async function fetchIssueById(orm: ReturnType<typeof drizzle>, ctx: ServiceCtx, 
 	);
 }
 
-export const ISSUE_REF_PATTERN = /^([A-Z]+)-(\d+)$/;
+// Digits are bounded: parseInt("9".repeat(400)) is Infinity, which drizzle would happily
+// bind and D1 would reject as a type error — a 500 where a 404 belongs. Anything longer
+// than this isn't a ref, so it falls through to being treated as an id and 404s.
+export const ISSUE_REF_PATTERN = /^([A-Z]+)-(\d{1,9})$/;
 
 /**
  * Accept either identifier in an `:issueId` path segment.
@@ -378,9 +381,12 @@ export const ISSUE_REF_PATTERN = /^([A-Z]+)-(\d+)$/;
  * and links — a full round trip of dead time on the critical path, per sub-resource.
  *
  * This resolves within `ctx.workspaceId` only, and answers "not found" for a ref that
- * doesn't, so it can't be used to probe for issues in another workspace. It does not
- * check project visibility: callers pass the returned id to a service that already
- * does (PROJ-311), and duplicating that here would be a second way to get it wrong.
+ * doesn't, so it can't be used to probe for issues in another workspace.
+ *
+ * It does NOT check project visibility. Both current callers hand the returned id
+ * straight to a service that does (PROJ-311), and duplicating the check here would be a
+ * second place to get it wrong. If you add a caller, confirm that holds for yours too —
+ * an id from this function is workspace-scoped and nothing more.
  */
 export async function resolveIssueIdParam(ctx: ServiceCtx, param: string): Promise<string> {
 	const m = param.match(ISSUE_REF_PATTERN);

--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -368,6 +368,41 @@ async function fetchIssueById(orm: ReturnType<typeof drizzle>, ctx: ServiceCtx, 
 	);
 }
 
+export const ISSUE_REF_PATTERN = /^([A-Z]+)-(\d+)$/;
+
+/**
+ * Accept either identifier in an `:issueId` path segment.
+ *
+ * PROJ-438: only `GET /api/issues/:id` understood a ref, so a browser landing on
+ * /projects/KEY/N/… had to resolve the UUID and only then ask for that issue's comments
+ * and links — a full round trip of dead time on the critical path, per sub-resource.
+ *
+ * This resolves within `ctx.workspaceId` only, and answers "not found" for a ref that
+ * doesn't, so it can't be used to probe for issues in another workspace. It does not
+ * check project visibility: callers pass the returned id to a service that already
+ * does (PROJ-311), and duplicating that here would be a second way to get it wrong.
+ */
+export async function resolveIssueIdParam(ctx: ServiceCtx, param: string): Promise<string> {
+	const m = param.match(ISSUE_REF_PATTERN);
+	if (!m) return param;
+
+	const orm = drizzle(ctx.db, { schema });
+	const row = await orm
+		.select({ id: schema.issues.id })
+		.from(schema.issues)
+		.innerJoin(schema.projects, eq(schema.issues.projectId, schema.projects.id))
+		.where(
+			and(
+				eq(schema.projects.key, m[1]),
+				eq(schema.issues.number, parseInt(m[2], 10)),
+				eq(schema.issues.workspaceId, ctx.workspaceId)
+			)
+		)
+		.get();
+	if (!row) throw new NotFoundError("Issue not found");
+	return row.id;
+}
+
 async function fetchIssueByRef(orm: ReturnType<typeof drizzle>, ctx: ServiceCtx, ref: string) {
 	const m = ref.match(/^([A-Z]+)-(\d+)$/);
 	if (!m)

--- a/apps/api/src/test/comments.test.ts
+++ b/apps/api/src/test/comments.test.ts
@@ -5,6 +5,7 @@ import {
 	seedComment,
 	seedFixture,
 	seedGroupGrant,
+	seedIssue,
 	seedProject,
 	seedProjectFixture,
 	seedWorkspaceRoles,
@@ -251,5 +252,71 @@ describe("Comments MCP cross-workspace security", () => {
 
 		expect(res.error).toBeDefined();
 		expect(res.error.code).toBe(-32000);
+	});
+});
+
+// PROJ-438: the browser reaches an issue page by ref, so making it resolve the UUID
+// before it can ask for comments put a whole round trip of dead time on the critical
+// path. These reads now take either identifier.
+describe("PROJ-438 — comments accept an issue ref", () => {
+	it("GET /:ref/comments returns the same comments as GET /:uuid/comments", async () => {
+		const fixture = await seedProjectFixture({ role: "owner" });
+		const issue = await seedIssue(fixture.workspaceId, fixture.projectId, fixture.userId, {
+			title: "Referenced issue",
+		});
+		await seedComment(issue.id, fixture.userId, "visible via both identifiers");
+
+		const detail = await SELF.fetch(`http://localhost/api/issues/${issue.id}`, {
+			headers: authHeaders(fixture.token, fixture.slug),
+		});
+		const { project_key: key, number } = (await detail.json()) as {
+			project_key: string;
+			number: number;
+		};
+
+		const byRef = await SELF.fetch(`http://localhost/api/issues/${key}-${number}/comments`, {
+			headers: authHeaders(fixture.token, fixture.slug),
+		});
+		const byUuid = await SELF.fetch(`http://localhost/api/issues/${issue.id}/comments`, {
+			headers: authHeaders(fixture.token, fixture.slug),
+		});
+
+		expect(byRef.status).toBe(200);
+		expect(await byRef.json()).toEqual(await byUuid.json());
+	});
+
+	// The whole point of resolving inside the caller's workspace. A ref is guessable in a
+	// way a UUID isn't — KEY-1 exists almost everywhere — so this is the case that would
+	// turn refs into a cross-tenant read.
+	it("a ref belonging to another workspace is 404, not that workspace's comments", async () => {
+		const mine = await seedProjectFixture({ role: "owner" });
+		const theirs = await seedFixture({ role: "owner" });
+		const theirProject = await seedProject(theirs.workspace.id, "OTHER");
+		const theirIssue = await seedIssue(theirs.workspace.id, theirProject.id, theirs.user.id, {
+			title: "Not yours",
+		});
+		await seedComment(theirIssue.id, theirs.user.id, "secret");
+
+		const res = await SELF.fetch("http://localhost/api/issues/OTHER-1/comments", {
+			headers: authHeaders(mine.token, mine.slug),
+		});
+
+		expect(res.status).toBe(404);
+	});
+
+	// The ref path must not become a way around PROJ-311 project grants.
+	it("a ref for an issue in a project the caller has no grant on is 404", async () => {
+		const fixture = await seedProjectFixture({ role: "member" });
+		const ungranted = await seedProject(fixture.workspaceId, "NOGRANT");
+		const issue = await seedIssue(fixture.workspaceId, ungranted.id, fixture.userId, {
+			title: "Invisible",
+		});
+		await seedComment(issue.id, fixture.userId, "secret");
+
+		const res = await SELF.fetch("http://localhost/api/issues/NOGRANT-1/comments", {
+			headers: authHeaders(fixture.token, fixture.slug),
+		});
+
+		expect(res.status).toBe(404);
 	});
 });

--- a/apps/api/src/test/comments.test.ts
+++ b/apps/api/src/test/comments.test.ts
@@ -288,7 +288,36 @@ describe("PROJ-438 — comments accept an issue ref", () => {
 	// The whole point of resolving inside the caller's workspace. A ref is guessable in a
 	// way a UUID isn't — KEY-1 exists almost everywhere — so this is the case that would
 	// turn refs into a cross-tenant read.
-	it("a ref belonging to another workspace is 404, not that workspace's comments", async () => {
+	//
+	// Both workspaces get the *same* project key and the same issue number deliberately.
+	// With distinct keys this would still pass with the resolver's workspace filter
+	// deleted, because listComments re-filters on workspace and 404s anyway — the test
+	// would be green while the thing it names was broken.
+	it("resolves a colliding ref inside the caller's own workspace, not the other one", async () => {
+		const mine = await seedFixture({ role: "owner" });
+		const myProject = await seedProject(mine.workspace.id, "DUP");
+		const myIssue = await seedIssue(mine.workspace.id, myProject.id, mine.user.id, {
+			title: "Mine",
+		});
+		await seedComment(myIssue.id, mine.user.id, "mine");
+
+		const theirs = await seedFixture({ role: "owner" });
+		const theirProject = await seedProject(theirs.workspace.id, "DUP");
+		const theirIssue = await seedIssue(theirs.workspace.id, theirProject.id, theirs.user.id, {
+			title: "Not yours",
+		});
+		await seedComment(theirIssue.id, theirs.user.id, "secret");
+
+		const res = await SELF.fetch("http://localhost/api/issues/DUP-1/comments", {
+			headers: authHeaders(mine.token, mine.workspace.slug),
+		});
+
+		expect(res.status).toBe(200);
+		const bodies = ((await res.json()) as Array<{ body: string }>).map((c) => c.body);
+		expect(bodies).toEqual(["mine"]);
+	});
+
+	it("a ref that exists only in another workspace is 404", async () => {
 		const mine = await seedProjectFixture({ role: "owner" });
 		const theirs = await seedFixture({ role: "owner" });
 		const theirProject = await seedProject(theirs.workspace.id, "OTHER");

--- a/apps/api/src/test/issue-links.test.ts
+++ b/apps/api/src/test/issue-links.test.ts
@@ -277,7 +277,34 @@ describe("PROJ-438 — links accept an issue ref", () => {
 		expect(await byRef.json()).toEqual(await byUuid.json());
 	});
 
-	it("a ref belonging to another workspace is 404", async () => {
+	// Same key and number in both workspaces on purpose — see the matching test in
+	// comments.test.ts for why distinct keys would let this pass with the resolver's
+	// workspace filter removed.
+	it("resolves a colliding ref inside the caller's own workspace", async () => {
+		const mine = await seedFixture({ role: "owner" });
+		const myProject = await seedProject(mine.workspace.id, "DUP");
+		const a = await seedIssue(mine.workspace.id, myProject.id, mine.user.id, { title: "A" });
+		const b = await seedIssue(mine.workspace.id, myProject.id, mine.user.id, { title: "B" });
+		await SELF.fetch(`http://localhost/api/issues/${a.id}/links`, {
+			method: "POST",
+			headers: authHeaders(mine.token, mine.workspace.slug),
+			body: JSON.stringify({ targetIssueId: b.id, type: "blocks" }),
+		});
+
+		const theirs = await seedFixture({ role: "owner" });
+		const theirProject = await seedProject(theirs.workspace.id, "DUP");
+		await seedIssue(theirs.workspace.id, theirProject.id, theirs.user.id, { title: "Not yours" });
+
+		const res = await SELF.fetch("http://localhost/api/issues/DUP-1/links", {
+			headers: authHeaders(mine.token, mine.workspace.slug),
+		});
+
+		expect(res.status).toBe(200);
+		const links = (await res.json()) as Array<{ linkedIssueId: string }>;
+		expect(links.map((l) => l.linkedIssueId)).toEqual([b.id]);
+	});
+
+	it("a ref that exists only in another workspace is 404", async () => {
 		const mine = await seedFixture({ role: "owner" });
 		const theirs = await seedFixture({ role: "owner" });
 		const theirProject = await seedProject(theirs.workspace.id, "OTHER");

--- a/apps/api/src/test/issue-links.test.ts
+++ b/apps/api/src/test/issue-links.test.ts
@@ -242,3 +242,67 @@ describe("Issue Links role guards", () => {
 		expect(deleteRes.status).toBe(403);
 	});
 });
+
+// PROJ-438: same as comments — the URL carries a ref, so the read takes one.
+describe("PROJ-438 — links accept an issue ref", () => {
+	it("GET /:ref/links returns the same links as GET /:uuid/links", async () => {
+		const fixture = await seedFixture({ role: "owner" });
+		const slug = fixture.workspace.slug;
+		const project = await seedProject(fixture.workspace.id);
+		const a = await seedIssue(fixture.workspace.id, project.id, fixture.user.id, { title: "A" });
+		const b = await seedIssue(fixture.workspace.id, project.id, fixture.user.id, { title: "B" });
+
+		await SELF.fetch(`http://localhost/api/issues/${a.id}/links`, {
+			method: "POST",
+			headers: authHeaders(fixture.token, slug),
+			body: JSON.stringify({ targetIssueId: b.id, type: "blocks" }),
+		});
+
+		const detail = await SELF.fetch(`http://localhost/api/issues/${a.id}`, {
+			headers: authHeaders(fixture.token, slug),
+		});
+		const { project_key: key, number } = (await detail.json()) as {
+			project_key: string;
+			number: number;
+		};
+
+		const byRef = await SELF.fetch(`http://localhost/api/issues/${key}-${number}/links`, {
+			headers: authHeaders(fixture.token, slug),
+		});
+		const byUuid = await SELF.fetch(`http://localhost/api/issues/${a.id}/links`, {
+			headers: authHeaders(fixture.token, slug),
+		});
+
+		expect(byRef.status).toBe(200);
+		expect(await byRef.json()).toEqual(await byUuid.json());
+	});
+
+	it("a ref belonging to another workspace is 404", async () => {
+		const mine = await seedFixture({ role: "owner" });
+		const theirs = await seedFixture({ role: "owner" });
+		const theirProject = await seedProject(theirs.workspace.id, "OTHER");
+		await seedIssue(theirs.workspace.id, theirProject.id, theirs.user.id, { title: "Not yours" });
+
+		const res = await SELF.fetch("http://localhost/api/issues/OTHER-1/links", {
+			headers: authHeaders(mine.token, mine.workspace.slug),
+		});
+
+		expect(res.status).toBe(404);
+	});
+
+	// Writes were deliberately left UUID-only — they're never on a first-paint path.
+	it("POST /:ref/links is still rejected — writes did not widen", async () => {
+		const fixture = await seedFixture({ role: "owner" });
+		const project = await seedProject(fixture.workspace.id);
+		await seedIssue(fixture.workspace.id, project.id, fixture.user.id, { title: "A" });
+		const b = await seedIssue(fixture.workspace.id, project.id, fixture.user.id, { title: "B" });
+
+		const res = await SELF.fetch(`http://localhost/api/issues/${project.key}-1/links`, {
+			method: "POST",
+			headers: authHeaders(fixture.token, fixture.workspace.slug),
+			body: JSON.stringify({ targetIssueId: b.id, type: "blocks" }),
+		});
+
+		expect(res.status).toBe(400);
+	});
+});

--- a/apps/web/src/islands/IssueDetail.test.tsx
+++ b/apps/web/src/islands/IssueDetail.test.tsx
@@ -245,9 +245,9 @@ describe("URL path parsing (pretty-URL fallback)", () => {
 				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
 			if (u.includes("?parentId="))
 				return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [] }) });
-			// Ref lookup: GET /api/issues/PROJ-87 → returns the UUID
+			// Ref lookup: GET /api/issues/PROJ-87 returns the whole issue, not just its id
 			if (u.endsWith("/api/issues/PROJ-87")) {
-				return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: "plain-1" }) });
+				return Promise.resolve({ ok: true, json: () => Promise.resolve(PLAIN_ISSUE_DATA) });
 			}
 			// Full issue fetch by UUID
 			return Promise.resolve({ ok: true, json: () => Promise.resolve(PLAIN_ISSUE_DATA) });
@@ -403,7 +403,9 @@ describe("PROJ-431 — first paint", () => {
 		render(<IssueDetail />);
 
 		await waitFor(() => expect(screen.getByText("Plain Task")).toBeDefined());
-		expect(uuidFetches).toBe(1);
+		// PROJ-438: was 1 — the resolve response already *is* the issue, so the UUID-keyed
+		// fetch was a second copy of a payload we held, 100ms behind the first.
+		expect(uuidFetches).toBe(0);
 		releaseRefetch?.();
 	});
 
@@ -466,5 +468,162 @@ describe("PROJ-431 — first paint", () => {
 		render(<IssueDetail />);
 
 		await waitFor(() => expect(screen.getByText(/No issue ID provided/)).toBeDefined());
+	});
+});
+
+// ─── PROJ-438: critical path ──────────────────────────────────────────────────
+
+describe("PROJ-438 — critical path", () => {
+	function stubFetch(impl?: (url: string) => unknown) {
+		const mock = vi.fn().mockImplementation((url: string) => {
+			const u = String(url);
+			const custom = impl?.(u);
+			if (custom) return custom;
+			if (u.endsWith("/api/issues/PROJ-7")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve(PLAIN_ISSUE_DATA) });
+			}
+			if (u.endsWith("/api/issues/plain-1")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve(PLAIN_ISSUE_DATA) });
+			}
+			return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+		});
+		vi.stubGlobal("fetch", mock);
+		return mock;
+	}
+
+	// Comments and links used to wait for the ref→UUID resolve to come back before they
+	// could name the issue. They accept the ref now, so they go out on it.
+	it("requests comments and links by ref, without waiting for the UUID", async () => {
+		history.replaceState(null, "", "/projects/PROJ/issues/7/plain-task");
+
+		// The resolve never settles: anything that fired anyway did so without the UUID.
+		const mock = stubFetch((u) =>
+			u.endsWith("/api/issues/PROJ-7") ? new Promise(() => {}) : undefined
+		);
+
+		render(<IssueDetail />);
+
+		await waitFor(() => {
+			const calls = (mock.mock.calls as [string][]).map(([u]) => String(u));
+			expect(calls).toContain("/api/issues/PROJ-7/comments");
+			expect(calls).toContain("/api/issues/PROJ-7/links");
+		});
+	});
+
+	// The whole reason readKey is set once and never swapped: keying these on the UUID as
+	// soon as it landed would fetch every one of them a second time.
+	it("does not re-request comments or links once the UUID resolves", async () => {
+		history.replaceState(null, "", "/projects/PROJ/issues/7/plain-task");
+		const mock = stubFetch();
+
+		render(<IssueDetail />);
+		await waitFor(() => expect(screen.getByText("Plain Task")).toBeDefined());
+
+		const calls = (mock.mock.calls as [string][]).map(([u]) => String(u));
+		expect(calls.filter((u) => u.endsWith("/comments"))).toHaveLength(1);
+		expect(calls.filter((u) => u.endsWith("/links"))).toHaveLength(1);
+	});
+
+	// Attachments render below body, children and relations, and were the slowest call in
+	// the mount fan-out. They must not be in flight before the issue paints.
+	it("does not request attachments before the issue is on screen", async () => {
+		history.replaceState(null, "", "/projects/PROJ/issues/7/plain-task");
+		const mock = stubFetch();
+
+		render(<IssueDetail />);
+		await waitFor(() => expect(screen.getByText("Plain Task")).toBeDefined());
+
+		const atFirstPaint = (mock.mock.calls as [string][]).map(([u]) => String(u));
+		expect(atFirstPaint.some((u) => u.includes("/api/files"))).toBe(false);
+
+		// …but they do still arrive.
+		await waitFor(() => {
+			const later = (mock.mock.calls as [string][]).map(([u]) => String(u));
+			expect(later.some((u) => u.includes("/api/files"))).toBe(true);
+		});
+	});
+
+	describe("inline prefetch handoff", () => {
+		afterEach(() => {
+			delete (window as unknown as Record<string, unknown>).__projektorIssuePrefetch;
+		});
+
+		it("uses the prefetched response instead of issuing its own request", async () => {
+			history.replaceState(null, "", "/projects/PROJ/issues/7/plain-task");
+			(window as unknown as Record<string, unknown>).__projektorIssuePrefetch = {
+				key: "PROJ-7",
+				response: Promise.resolve({
+					ok: true,
+					json: () => Promise.resolve(PLAIN_ISSUE_DATA),
+				}),
+			};
+			const mock = stubFetch();
+
+			render(<IssueDetail />);
+			await waitFor(() => expect(screen.getByText("Plain Task")).toBeDefined());
+
+			const calls = (mock.mock.calls as [string][]).map(([u]) => String(u));
+			expect(calls).not.toContain("/api/issues/PROJ-7");
+		});
+
+		// A prefetch that 401s or 404s must not become the user's error. apiFetch owns
+		// re-authentication (PROJ-430); the prefetch deliberately knows nothing about it.
+		it("falls back to a normal fetch when the prefetch came back non-ok", async () => {
+			history.replaceState(null, "", "/projects/PROJ/issues/7/plain-task");
+			(window as unknown as Record<string, unknown>).__projektorIssuePrefetch = {
+				key: "PROJ-7",
+				response: Promise.resolve({ ok: false, status: 401 }),
+			};
+			const mock = stubFetch();
+
+			render(<IssueDetail />);
+			await waitFor(() => expect(screen.getByText("Plain Task")).toBeDefined());
+
+			const calls = (mock.mock.calls as [string][]).map(([u]) => String(u));
+			expect(calls).toContain("/api/issues/PROJ-7");
+		});
+
+		// Stale handoff from a previous page — must never be served for a different issue.
+		it("ignores a prefetch that was issued for a different issue", async () => {
+			history.replaceState(null, "", "/projects/PROJ/issues/7/plain-task");
+			(window as unknown as Record<string, unknown>).__projektorIssuePrefetch = {
+				key: "PROJ-999",
+				response: Promise.resolve({
+					ok: true,
+					json: () => Promise.resolve({ ...PLAIN_ISSUE_DATA, title: "Wrong Issue" }),
+				}),
+			};
+			const mock = stubFetch();
+
+			render(<IssueDetail />);
+			await waitFor(() => expect(screen.getByText("Plain Task")).toBeDefined());
+
+			expect(screen.queryByText("Wrong Issue")).toBeNull();
+			const calls = (mock.mock.calls as [string][]).map(([u]) => String(u));
+			expect(calls).toContain("/api/issues/PROJ-7");
+		});
+	});
+});
+
+// The ?id=<uuid> form gets the same prefetch — the inline script keys on whichever
+// identifier the URL carries, and this is the fetch that would otherwise duplicate it.
+describe("PROJ-438 — prefetch on the ?id= form", () => {
+	afterEach(() => {
+		delete (window as unknown as Record<string, unknown>).__projektorIssuePrefetch;
+	});
+
+	it("claims a prefetch keyed by UUID instead of refetching", async () => {
+		(window as unknown as Record<string, unknown>).__projektorIssuePrefetch = {
+			key: "plain-1",
+			response: Promise.resolve({ ok: true, json: () => Promise.resolve(PLAIN_ISSUE_DATA) }),
+		};
+		const mock = makeFetchForDetail(PLAIN_ISSUE_DATA);
+		vi.stubGlobal("fetch", mock);
+
+		render(<IssueDetail issueId="plain-1" />);
+		await waitFor(() => expect(screen.getByText("Plain Task")).toBeDefined());
+
+		const calls = (mock.mock.calls as [string][]).map(([u]) => String(u));
+		expect(calls).not.toContain("/api/issues/plain-1");
 	});
 });

--- a/apps/web/src/islands/IssueDetail.test.tsx
+++ b/apps/web/src/islands/IssueDetail.test.tsx
@@ -552,6 +552,7 @@ describe("PROJ-438 — critical path", () => {
 			history.replaceState(null, "", "/projects/PROJ/issues/7/plain-task");
 			(window as unknown as Record<string, unknown>).__projektorIssuePrefetch = {
 				key: "PROJ-7",
+				t: Date.now(),
 				response: Promise.resolve({
 					ok: true,
 					json: () => Promise.resolve(PLAIN_ISSUE_DATA),
@@ -572,6 +573,7 @@ describe("PROJ-438 — critical path", () => {
 			history.replaceState(null, "", "/projects/PROJ/issues/7/plain-task");
 			(window as unknown as Record<string, unknown>).__projektorIssuePrefetch = {
 				key: "PROJ-7",
+				t: Date.now(),
 				response: Promise.resolve({ ok: false, status: 401 }),
 			};
 			const mock = stubFetch();
@@ -588,6 +590,7 @@ describe("PROJ-438 — critical path", () => {
 			history.replaceState(null, "", "/projects/PROJ/issues/7/plain-task");
 			(window as unknown as Record<string, unknown>).__projektorIssuePrefetch = {
 				key: "PROJ-999",
+				t: Date.now(),
 				response: Promise.resolve({
 					ok: true,
 					json: () => Promise.resolve({ ...PLAIN_ISSUE_DATA, title: "Wrong Issue" }),
@@ -615,6 +618,7 @@ describe("PROJ-438 — prefetch on the ?id= form", () => {
 	it("claims a prefetch keyed by UUID instead of refetching", async () => {
 		(window as unknown as Record<string, unknown>).__projektorIssuePrefetch = {
 			key: "plain-1",
+			t: Date.now(),
 			response: Promise.resolve({ ok: true, json: () => Promise.resolve(PLAIN_ISSUE_DATA) }),
 		};
 		const mock = makeFetchForDetail(PLAIN_ISSUE_DATA);
@@ -625,5 +629,81 @@ describe("PROJ-438 — prefetch on the ?id= form", () => {
 
 		const calls = (mock.mock.calls as [string][]).map(([u]) => String(u));
 		expect(calls).not.toContain("/api/issues/plain-1");
+	});
+});
+
+// A handoff nobody claims outlives the page that made it — ClientRouter swaps the body,
+// not the window — and a seeded issue skips the refetch, so a stale claim would never be
+// corrected. Bounded by age rather than trusted.
+describe("PROJ-438 — stale prefetch handoff", () => {
+	afterEach(() => {
+		delete (window as unknown as Record<string, unknown>).__projektorIssuePrefetch;
+	});
+
+	it("ignores a handoff older than the freshness bound and fetches instead", async () => {
+		history.replaceState(null, "", "/projects/PROJ/issues/7/plain-task");
+		(window as unknown as Record<string, unknown>).__projektorIssuePrefetch = {
+			key: "PROJ-7",
+			t: Date.now() - 60_000,
+			response: Promise.resolve({
+				ok: true,
+				json: () => Promise.resolve({ ...PLAIN_ISSUE_DATA, title: "Hour-old Title" }),
+			}),
+		};
+		const mock = makeFetchForDetail(PLAIN_ISSUE_DATA);
+		vi.stubGlobal("fetch", mock);
+
+		render(<IssueDetail />);
+		await waitFor(() => expect(screen.getByText("Plain Task")).toBeDefined());
+
+		expect(screen.queryByText("Hour-old Title")).toBeNull();
+		const calls = (mock.mock.calls as [string][]).map(([u]) => String(u));
+		expect(calls).toContain("/api/issues/PROJ-7");
+	});
+
+	it("still uses a handoff issued moments ago", async () => {
+		history.replaceState(null, "", "/projects/PROJ/issues/7/plain-task");
+		(window as unknown as Record<string, unknown>).__projektorIssuePrefetch = {
+			key: "PROJ-7",
+			t: Date.now() - 200,
+			response: Promise.resolve({ ok: true, json: () => Promise.resolve(PLAIN_ISSUE_DATA) }),
+		};
+		const mock = makeFetchForDetail(PLAIN_ISSUE_DATA);
+		vi.stubGlobal("fetch", mock);
+
+		render(<IssueDetail />);
+		await waitFor(() => expect(screen.getByText("Plain Task")).toBeDefined());
+
+		const calls = (mock.mock.calls as [string][]).map(([u]) => String(u));
+		expect(calls).not.toContain("/api/issues/PROJ-7");
+	});
+});
+
+// The inline script is the half these tests can't execute, so pin its contract against
+// the source: it must survive ClientRouter's script de-duplication, agree with the
+// island on which identifier wins, and stamp the handoff so it can go stale.
+describe("PROJ-438 — inline prefetch script contract", () => {
+	const source = readFileSync(join(__dirname, "../pages/issues/view.astro"), "utf-8");
+
+	it("opts out of ClientRouter's run-once script de-duplication", () => {
+		expect(source).toMatch(/<script is:inline data-astro-rerun/);
+	});
+
+	it("stamps the handoff with a timestamp", () => {
+		expect(source).toMatch(/t: Date\.now\(\)/);
+	});
+
+	it("clears a leftover handoff before the router swaps in a new page", () => {
+		expect(source).toMatch(/astro:before-swap/);
+		expect(source).toMatch(/delete window\.__projektorIssuePrefetch/);
+	});
+
+	// Both sides must agree, or a URL carrying both forms is prefetched under one key
+	// and claimed under the other.
+	it("prefers ?id= over the pretty path, matching the island", () => {
+		const idFirst = source.indexOf("URLSearchParams(location.search).get('id')");
+		const pathFallback = source.indexOf("pretty[1] + '-' + pretty[2]");
+		expect(idFirst).toBeGreaterThan(-1);
+		expect(pathFallback).toBeGreaterThan(idFirst);
 	});
 });

--- a/apps/web/src/islands/IssueDetail.tsx
+++ b/apps/web/src/islands/IssueDetail.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "preact/hooks";
 import { formatIssueRef } from "../lib/issue-ref";
 import { apiFetch } from "../utils/api-client";
+import { claimPrefetchedIssue } from "../utils/issue-prefetch";
 import { issueUrl } from "../utils/issue-url";
 import {
 	AttachmentsSection,
@@ -37,12 +38,17 @@ function useResolvedIssueId(
 	workspaceSlug: string | undefined
 ) {
 	const [issueId, setIssueId] = useState(issueIdProp ?? "");
+	// Whatever identifier this page was reached by — a ref ("PROJ-42") from the pretty
+	// URL, or a UUID from ?id= / props. PROJ-438: the reads that accept either (the
+	// issue, its comments, its links) key off this instead of `issueId`, so they no
+	// longer queue behind the ref→UUID resolve. It is set once and never swapped for
+	// the UUID afterwards, which is what stops them all firing a second time.
+	const [readKey, setReadKey] = useState(issueIdProp ?? "");
 	const [resolveError, setResolveError] = useState<string | null>(null);
 	// PROJ-431: /api/issues/KEY-N returns the *whole* issue, byte-identical to
 	// /api/issues/{uuid}. Keeping only `.id` and letting useIssueCore refetch by UUID
 	// put a second serial round trip in front of first paint — ~1.3s on mobile, on the
-	// canonical URL form. Hand the payload on as seed state instead; the UUID-keyed
-	// fetch still runs and revalidates, just no longer blocking anything.
+	// canonical URL form. Hand the payload on as seed state instead.
 	const [resolvedIssue, setResolvedIssue] = useState<IssueData | null>(null);
 	// Whether an id is still being worked out. Without it the component's "no issue ID
 	// provided" branch renders for the whole resolve round trip — a ~1.3s error flash on
@@ -56,6 +62,7 @@ function useResolvedIssueId(
 		const fromQuery = new URLSearchParams(window.location.search).get("id");
 		if (fromQuery) {
 			setIssueId(fromQuery);
+			setReadKey(fromQuery);
 			setResolving(false);
 			return;
 		}
@@ -73,8 +80,9 @@ function useResolvedIssueId(
 			setResolving(false);
 			return;
 		}
+		setReadKey(ref);
 
-		apiFetch<IssueData>(`/api/issues/${ref}`, { workspaceSlug })
+		loadIssue(ref, workspaceSlug)
 			.then((data) => {
 				setResolvedIssue(data);
 				setIssueId(data.id);
@@ -83,7 +91,25 @@ function useResolvedIssueId(
 			.finally(() => setResolving(false));
 	}, [issueIdProp, projectSlug, issueNumber, workspaceSlug]);
 
-	return { issueId, resolveError, resolvedIssue, resolving };
+	return { issueId, readKey, resolveError, resolvedIssue, resolving };
+}
+
+/**
+ * The issue, from the inline prefetch if that beat us to it (PROJ-438) or over the
+ * network if not. A prefetch that missed — expired session, offline, a 404 — is not
+ * treated as a failure: it just falls through to `apiFetch`, which is where 401
+ * re-authentication and offline reporting live.
+ */
+async function loadIssue(ref: string, workspaceSlug: string | undefined): Promise<IssueData> {
+	const prefetched = claimPrefetchedIssue<IssueData>(ref);
+	if (prefetched) {
+		try {
+			return await prefetched;
+		} catch {
+			// fall through
+		}
+	}
+	return apiFetch<IssueData>(`/api/issues/${ref}`, { workspaceSlug });
 }
 
 function useBackHref() {
@@ -105,22 +131,22 @@ function useBackHref() {
 	return backHref;
 }
 
-function useIssueLinks(issueId: string, workspaceSlug: string | undefined) {
+function useIssueLinks(readKey: string, workspaceSlug: string | undefined) {
 	const [links, setLinks] = useState<IssueLink[]>([]);
 	const [fetchingLinks, setFetchingLinks] = useState(false);
 
 	const fetchLinks = useCallback(async () => {
-		if (!issueId) return;
+		if (!readKey) return;
 		setFetchingLinks(true);
 		try {
-			const data = await apiFetch<IssueLink[]>(`/api/issues/${issueId}/links`, { workspaceSlug });
+			const data = await apiFetch<IssueLink[]>(`/api/issues/${readKey}/links`, { workspaceSlug });
 			setLinks(Array.isArray(data) ? data : []);
 		} catch {
 			// non-fatal
 		} finally {
 			setFetchingLinks(false);
 		}
-	}, [issueId, workspaceSlug]);
+	}, [readKey, workspaceSlug]);
 
 	return { links, fetchingLinks, fetchLinks };
 }
@@ -185,6 +211,7 @@ function useEpicRelations(issue: IssueData | null, workspaceSlug: string | undef
 
 function useIssueCore(
 	issueId: string,
+	readKey: string,
 	workspaceSlug: string | undefined,
 	fetchLinks: () => Promise<void>,
 	fetchAttachments: () => Promise<void>,
@@ -207,7 +234,11 @@ function useIssueCore(
 
 	const fetchIssue = useCallback(async () => {
 		try {
-			const data = await apiFetch<IssueData>(`/api/issues/${issueId}`, { workspaceSlug });
+			// loadIssue, not apiFetch: on the ?id=<uuid> form the inline script prefetched
+			// under that same key, and this is the call that would otherwise duplicate it.
+			// Claiming is single-use, so the refresh-after-mutation callers still go to the
+			// network — which is the whole point of them.
+			const data = await loadIssue(issueId, workspaceSlug);
 			setIssue(data);
 		} catch (e) {
 			setError(String(e));
@@ -215,52 +246,86 @@ function useIssueCore(
 	}, [issueId, workspaceSlug]);
 
 	const fetchComments = useCallback(async () => {
+		if (!readKey) return;
 		try {
-			const data = await apiFetch<Comment[]>(`/api/issues/${issueId}/comments`, { workspaceSlug });
+			const data = await apiFetch<Comment[]>(`/api/issues/${readKey}/comments`, { workspaceSlug });
 			setComments(Array.isArray(data) ? data : []);
 		} catch {
 			// non-fatal
 		}
-	}, [issueId, workspaceSlug]);
+	}, [readKey, workspaceSlug]);
 
+	// PROJ-438: comments and links accept the same ref the URL carries, so they go out
+	// on the identifier we already have rather than waiting a full round trip for the
+	// UUID. `readKey` never changes once set, so this doesn't re-fire when it lands.
+	useEffect(() => {
+		if (!readKey) return;
+		fetchComments();
+		fetchLinks();
+	}, [fetchComments, fetchLinks, readKey]);
+
+	// Nothing here depends on which issue this is — no reason to sequence it behind
+	// the resolve.
+	useEffect(() => {
+		(async () => {
+			try {
+				const data = await apiFetch<TaskStatus[]>("/api/task-statuses", { workspaceSlug });
+				if (Array.isArray(data)) setStatuses(data);
+			} catch {
+				// non-fatal
+			}
+		})();
+		(async () => {
+			try {
+				const data = await apiFetch<{ user: { id: string } }>("/auth/me", { workspaceSlug });
+				setCurrentUserId(data.user.id);
+			} catch {
+				// non-fatal — edit/delete buttons simply won't show
+			}
+		})();
+		(async () => {
+			if (!workspaceSlug) return;
+			try {
+				const data = await apiFetch<{ members: Member[] }>(`/api/workspaces/${workspaceSlug}`, {
+					workspaceSlug,
+				});
+				if (Array.isArray(data?.members)) setMembers(data.members);
+			} catch {
+				// non-fatal — assignee field falls back to display-only
+			}
+		})();
+	}, [workspaceSlug]);
+
+	// PROJ-438: when the resolve seeded us, its response *is* the issue — the same 31
+	// keys /api/issues/{uuid} would return. Fetching it again was a second copy of a
+	// payload already in hand, 100ms behind the first. `fetchIssue` itself stays: the
+	// mutation handlers call it directly to refresh after a write.
 	useEffect(() => {
 		if (!issueId) return;
+		if (seedIssue?.id === issueId) {
+			setLoading(false);
+			return;
+		}
 		setLoading(true);
 		setError(null);
-		Promise.all([
-			fetchIssue(),
-			fetchComments(),
-			fetchLinks(),
-			fetchAttachments(),
-			(async () => {
-				try {
-					const data = await apiFetch<TaskStatus[]>("/api/task-statuses", { workspaceSlug });
-					if (Array.isArray(data)) setStatuses(data);
-				} catch {
-					// non-fatal
-				}
-			})(),
-			(async () => {
-				try {
-					const data = await apiFetch<{ user: { id: string } }>("/auth/me", { workspaceSlug });
-					setCurrentUserId(data.user.id);
-				} catch {
-					// non-fatal — edit/delete buttons simply won't show
-				}
-			})(),
-			(async () => {
-				if (!workspaceSlug) return;
-				try {
-					const data = await apiFetch<{ members: Member[] }>(`/api/workspaces/${workspaceSlug}`, {
-						workspaceSlug,
-					});
-					if (Array.isArray(data?.members)) setMembers(data.members);
-				} catch {
-					// non-fatal — assignee field falls back to display-only
-				}
-			})(),
-		]).finally(() => setLoading(false));
-	}, [fetchIssue, fetchComments, fetchLinks, fetchAttachments, workspaceSlug]);
+		fetchIssue().finally(() => setLoading(false));
+	}, [fetchIssue, issueId, seedIssue]);
+
+	// Attachments render below the body, children and relations — well under the fold —
+	// but were the slowest call in the mount fan-out at 249ms. Off the critical path
+	// entirely: scheduled once the browser has nothing better to do.
+	useEffect(() => {
+		if (!issueId) return;
+		const idle = (
+			window as unknown as { requestIdleCallback?: (cb: () => void, o?: object) => number }
+		).requestIdleCallback;
+		if (idle) {
+			idle(() => fetchAttachments(), { timeout: 2000 });
+			return;
+		}
+		const t = setTimeout(fetchAttachments, 0);
+		return () => clearTimeout(t);
+	}, [fetchAttachments, issueId]);
 
 	return {
 		issue,
@@ -532,7 +597,7 @@ export default function IssueDetail({
 	projectSlug,
 	workspaceSlug,
 }: Props) {
-	const { issueId, resolveError, resolvedIssue, resolving } = useResolvedIssueId(
+	const { issueId, readKey, resolveError, resolvedIssue, resolving } = useResolvedIssueId(
 		issueIdProp,
 		issueNumber,
 		projectSlug,
@@ -540,7 +605,7 @@ export default function IssueDetail({
 	);
 	const backHref = useBackHref();
 
-	const { links, fetchingLinks, fetchLinks } = useIssueLinks(issueId, workspaceSlug);
+	const { links, fetchingLinks, fetchLinks } = useIssueLinks(readKey, workspaceSlug);
 	const { attachments, fetchAttachments } = useIssueAttachments(issueId, workspaceSlug);
 
 	const {
@@ -554,7 +619,7 @@ export default function IssueDetail({
 		currentUserId,
 		fetchIssue,
 		fetchComments,
-	} = useIssueCore(issueId, workspaceSlug, fetchLinks, fetchAttachments, resolvedIssue);
+	} = useIssueCore(issueId, readKey, workspaceSlug, fetchLinks, fetchAttachments, resolvedIssue);
 
 	const { parentEpic, childIssues } = useEpicRelations(issue, workspaceSlug);
 

--- a/apps/web/src/islands/IssueDetail.tsx
+++ b/apps/web/src/islands/IssueDetail.tsx
@@ -316,12 +316,13 @@ function useIssueCore(
 	// entirely: scheduled once the browser has nothing better to do.
 	useEffect(() => {
 		if (!issueId) return;
-		const idle = (
-			window as unknown as { requestIdleCallback?: (cb: () => void, o?: object) => number }
-		).requestIdleCallback;
-		if (idle) {
-			idle(() => fetchAttachments(), { timeout: 2000 });
-			return;
+		const w = window as unknown as {
+			requestIdleCallback?: (cb: () => void, o?: object) => number;
+			cancelIdleCallback?: (h: number) => void;
+		};
+		if (w.requestIdleCallback) {
+			const handle = w.requestIdleCallback(() => fetchAttachments(), { timeout: 2000 });
+			return () => w.cancelIdleCallback?.(handle);
 		}
 		const t = setTimeout(fetchAttachments, 0);
 		return () => clearTimeout(t);

--- a/apps/web/src/pages/issues/view.astro
+++ b/apps/web/src/pages/issues/view.astro
@@ -11,17 +11,36 @@ const workspaceSlug = import.meta.env.PUBLIC_WORKSPACE_SLUG as string | undefine
        This runs during HTML parse instead and hands the in-flight response to
        IssueDetail (utils/issue-prefetch.ts). Deliberately dumb: no retry, no 401
        handling, no error surfacing. Anything other than a 2xx and the island falls
-       through to its normal apiFetch path, which owns all of that (PROJ-430). -->
-  <script is:inline define:vars={{ workspaceSlug }}>
+       through to its normal apiFetch path, which owns all of that (PROJ-430).
+
+       data-astro-rerun is load-bearing. ClientRouter keys inline scripts by their text
+       and refuses to run one it has run before, so without it this fires on the first
+       navigation to an issue page and never again — and clicking through from the issue
+       list is the common case, not a full page load. -->
+  <script is:inline data-astro-rerun define:vars={{ workspaceSlug }}>
     (function () {
       try {
+        // An unclaimed handoff would otherwise outlive the page that made it: the router
+        // swaps the body, not the window. Registered once per tab; deleting is idempotent
+        // and runs before the incoming page's scripts, so it can't eat a fresh handoff.
+        if (!window.__projektorIssuePrefetchBound) {
+          window.__projektorIssuePrefetchBound = true;
+          document.addEventListener('astro:before-swap', function () {
+            delete window.__projektorIssuePrefetch;
+          });
+        }
+
+        // Same precedence the island uses (?id= before the pretty path). They have to
+        // agree: a URL that satisfies both would otherwise be prefetched under one key
+        // and claimed under the other, leaving a handoff nobody ever takes.
         var pretty = location.pathname.match(/^\/projects\/([^/]+)\/issues\/(\d+)\//);
-        var key = pretty
-          ? pretty[1] + '-' + pretty[2]
-          : new URLSearchParams(location.search).get('id');
+        var key =
+          new URLSearchParams(location.search).get('id') ||
+          (pretty ? pretty[1] + '-' + pretty[2] : null);
         if (!key) return;
         window.__projektorIssuePrefetch = {
           key: key,
+          t: Date.now(),
           response: fetch('/api/issues/' + encodeURIComponent(key), {
             credentials: 'include',
             headers: workspaceSlug ? { 'X-Workspace-Slug': workspaceSlug } : {},

--- a/apps/web/src/pages/issues/view.astro
+++ b/apps/web/src/pages/issues/view.astro
@@ -6,6 +6,34 @@ import IssueDetail from '../../islands/IssueDetail';
 const workspaceSlug = import.meta.env.PUBLIC_WORKSPACE_SLUG as string | undefined;
 ---
 <Base title="Issue — Projektor">
+  <!-- PROJ-438: the island can't ask for the issue until its bundle has downloaded and
+       hydrated — measured at ~445ms on a mobile profile, with nothing else in flight.
+       This runs during HTML parse instead and hands the in-flight response to
+       IssueDetail (utils/issue-prefetch.ts). Deliberately dumb: no retry, no 401
+       handling, no error surfacing. Anything other than a 2xx and the island falls
+       through to its normal apiFetch path, which owns all of that (PROJ-430). -->
+  <script is:inline define:vars={{ workspaceSlug }}>
+    (function () {
+      try {
+        var pretty = location.pathname.match(/^\/projects\/([^/]+)\/issues\/(\d+)\//);
+        var key = pretty
+          ? pretty[1] + '-' + pretty[2]
+          : new URLSearchParams(location.search).get('id');
+        if (!key) return;
+        window.__projektorIssuePrefetch = {
+          key: key,
+          response: fetch('/api/issues/' + encodeURIComponent(key), {
+            credentials: 'include',
+            headers: workspaceSlug ? { 'X-Workspace-Slug': workspaceSlug } : {},
+          }).catch(function () {
+            return null;
+          }),
+        };
+      } catch (e) {
+        // Never let a prefetch failure stop the page from loading normally.
+      }
+    })();
+  </script>
   <div class="page-container">
     <IssueDetail client:load workspaceSlug={workspaceSlug} />
   </div>

--- a/apps/web/src/utils/api-client.test.ts
+++ b/apps/web/src/utils/api-client.test.ts
@@ -144,6 +144,38 @@ describe("apiFetch — re-auth loop guard (PROJ-430)", () => {
 		restoreLocation();
 	});
 
+	// A page issues several requests at once. The first 401 triggers the reload; the rest
+	// are the same expiry, not a second failed attempt, so they must stay silent until the
+	// navigation happens. Otherwise whichever one lands second paints "your session has
+	// expired" over the page for the instant before it goes away — and which request that
+	// is depends on effect ordering, so it moves whenever the page's fetches are
+	// rearranged (PROJ-438 moved it onto the issue page).
+	it("stays silent for concurrent 401s while the first one's reload is in flight", async () => {
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401 }));
+
+		const first = apiFetch("/auth/me");
+		await new Promise((r) => setTimeout(r, 0));
+		expect(reload).toHaveBeenCalledTimes(1);
+
+		let settled = false;
+		const second = apiFetch("/api/issues/i1").then(
+			() => {
+				settled = true;
+			},
+			() => {
+				settled = true;
+			}
+		);
+		await new Promise((r) => setTimeout(r, 0));
+
+		expect(settled).toBe(false);
+		expect(reload).toHaveBeenCalledTimes(1);
+		void first;
+		void second;
+
+		restoreLocation();
+	});
+
 	it("re-arms after a successful response, so a later expiry can re-auth again", async () => {
 		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401 }));
 		apiFetch("/api/issues/i1");

--- a/apps/web/src/utils/api-client.ts
+++ b/apps/web/src/utils/api-client.ts
@@ -109,6 +109,13 @@ export async function apiFetch<T = unknown>(
 			if (opts.on401 === "throw") {
 				throw new Error(`API ${method} ${path} failed: 401`);
 			}
+			// A reload this page load has already been triggered by an earlier 401 — this
+			// is the same expiry, not a second failed attempt. Without this, whichever
+			// request happens to 401 second surfaces "your session has expired" on screen
+			// for the instant before the reload navigates away. Which request that is comes
+			// down to effect ordering, so it moves whenever the page's fetches are
+			// rearranged (it moved onto the issue page in PROJ-438).
+			if (reauthReloadInFlight) return new Promise<T>(() => {});
 			if (reauthAttemptedAt !== null) throw new SessionExpiredError();
 			markReauthAttempt();
 			reauthReloadInFlight = true;

--- a/apps/web/src/utils/issue-prefetch.ts
+++ b/apps/web/src/utils/issue-prefetch.ts
@@ -1,0 +1,37 @@
+/**
+ * Handoff between the inline `<script>` in issues/view.astro and the IssueDetail island.
+ *
+ * PROJ-438: nothing reached the API until ~445 ms on a mobile profile, because the first
+ * request was issued by an effect that can't run until the island's module graph has
+ * downloaded, parsed and hydrated. The inline script has none of that in front of it, so
+ * it starts the request during HTML parse and parks the promise here.
+ */
+
+const HANDOFF = "__projektorIssuePrefetch";
+
+export interface IssuePrefetchHandoff {
+	/** Ref ("PROJ-42") or UUID the request was issued for. */
+	key: string;
+	/** Resolves to null if the request itself failed — never rejects. */
+	response: Promise<Response | null>;
+}
+
+/**
+ * Claim the prefetched response for `key`, or null if there isn't one.
+ *
+ * Single-use: a claimed handoff is removed, so a client-side navigation to another issue
+ * can't be served the previous one's payload. Rejects (rather than returning null) if the
+ * prefetch failed or returned a non-2xx — the caller falls back to `apiFetch`, which owns
+ * the 401/re-auth handling this deliberately does not replicate.
+ */
+export function claimPrefetchedIssue<T>(key: string): Promise<T> | null {
+	const w = window as unknown as Record<string, IssuePrefetchHandoff | undefined>;
+	const handoff = w[HANDOFF];
+	if (!handoff || handoff.key !== key) return null;
+	delete w[HANDOFF];
+
+	return handoff.response.then((res) => {
+		if (!res?.ok) throw new Error("issue prefetch missed");
+		return res.json() as Promise<T>;
+	});
+}

--- a/apps/web/src/utils/issue-prefetch.ts
+++ b/apps/web/src/utils/issue-prefetch.ts
@@ -12,12 +12,27 @@ const HANDOFF = "__projektorIssuePrefetch";
 export interface IssuePrefetchHandoff {
 	/** Ref ("PROJ-42") or UUID the request was issued for. */
 	key: string;
+	/** When the request was issued, for the freshness bound below. */
+	t: number;
 	/** Resolves to null if the request itself failed — never rejects. */
 	response: Promise<Response | null>;
 }
 
 /**
- * Claim the prefetched response for `key`, or null if there isn't one.
+ * A handoff only ever has to bridge HTML parse to island hydration — a few hundred
+ * milliseconds, ~2.4s on a throttled mobile profile. Past this it is treated as absent.
+ *
+ * It needs a bound because an unclaimed handoff survives for the life of the tab:
+ * ClientRouter replaces the body, not the window. Navigate to an issue, leave before the
+ * island's chunk hydrates, come back much later, and without this the page would render
+ * that stale payload — and, since a seeded issue skips the refetch, never correct it. The
+ * listener in issues/view.astro clears the handoff on swap too; this is the backstop for
+ * when that hasn't run.
+ */
+const MAX_HANDOFF_AGE_MS = 15_000;
+
+/**
+ * Claim the prefetched response for `key`, or null if there isn't a fresh one.
  *
  * Single-use: a claimed handoff is removed, so a client-side navigation to another issue
  * can't be served the previous one's payload. Rejects (rather than returning null) if the
@@ -29,6 +44,7 @@ export function claimPrefetchedIssue<T>(key: string): Promise<T> | null {
 	const handoff = w[HANDOFF];
 	if (!handoff || handoff.key !== key) return null;
 	delete w[HANDOFF];
+	if (!(Date.now() - handoff.t < MAX_HANDOFF_AGE_MS)) return null;
 
 	return handoff.response.then((res) => {
 		if (!res?.ok) throw new Error("issue prefetch missed");


### PR DESCRIPTION
Closes PROJ-438.

Measured on the deployed instance at v0.4.9: nothing reached the API until 445 ms, the ref→uuid resolve returned at 549 ms, and only then did the four dependent calls go out. Of ~700 ms to content, ~550 ms was spent before the useful requests started — and one of them was a second copy of a payload already in hand.

## Numbers

Same session, same harness (`apps/web/scripts/perf/measure-load.mjs`, Pixel 5 / Lighthouse mobile throttling), one build apart — parent `a9ccc07` vs this branch:

| | before | after |
|---|---|---|
| mobile time-to-content | 3053 ms | **2405 ms** |
| mobile first API request | 1235 ms | **512 ms** |
| mobile LCP | 2532 ms | 2336 ms |
| mobile long-task time | 1653 ms | 1073 ms |
| desktop time-to-content | 699 ms | **506 ms** |
| API requests per load | 8 | 7 |

The baseline waterfall shows `/api/issues/{uuid}` at 110 ms — the duplicate — and it is absent from the after run.

Two caveats, stated plainly. The harness proxies `/api` to the **deployed** Worker, which does not yet have the ref-accepting sub-resources, so in the "after" run `/comments` returns empty and `/links` 400s. Neither is on the paint path and both still cost one request in each run, so the content timings compare fairly — but they are not what the page will do once this is deployed. And these are local-harness numbers against a real API; the honest end-to-end figure comes from a post-deploy run, same as PROJ-432.

## What changed

**1. No more duplicate issue fetch.** The resolve response already *is* the issue, and PROJ-431 already used it as seed state — but `setIssueId` changed `fetchIssue`'s identity, which was in the deps of the mount fan-out, so it refetched anyway. The core-issue effect now skips when the seed is for that id. `fetchIssue` itself stays; the mutation handlers call it directly to refresh after a write.

**2. The issue is requested during HTML parse, not after hydration.** An inline script in `issues/view.astro` starts the request and parks the promise for the island. Deliberately dumb — no retry, no 401 handling, no error surfacing. Anything other than a 2xx and the island falls through to `apiFetch`, which owns all of that.

**3. Comments and links accept a ref.** They only took a UUID, so the browser — which arrives holding a ref — had to wait a full round trip before it could name the issue. `resolveIssueIdParam` resolves inside the caller's workspace only. Writes stay UUID-only; they are never on a first-paint path.

**4. Attachments are off the critical path.** Slowest call in the fan-out at 249 ms, rendering below body, children and relations. Now scheduled on idle.

## Review

Two Opus reviews, one adversarial on the authorization surface and one on the frontend. Both found real things.

**The API surface held up** — no way to read another workspace's comments or links, no bypass of PROJ-311 project grants, no 404/403 leak, no injection. But it found a test passing for the wrong reason: with distinct project keys, the cross-workspace test stays green even with the resolver's workspace filter deleted, because the downstream service re-filters and 404s anyway. Both workspaces now use the *same* key and issue number and the assertion is on the payload. Verified by deleting the filter: 3 tests fail, and pass again with it restored.

**The frontend review found the one path to genuinely wrong data on screen.** ClientRouter keys inline scripts by their text and won't run one twice — so the prefetch fired on the first navigation to an issue page and never again, which is backwards, since clicking through from the issue list is the common case. Worse, an unclaimed handoff outlives the page that made it (the router swaps the body, not the window): leave an issue page before its island hydrates, come back much later, and the stale payload gets claimed — and since a seeded issue skips the refetch, nothing would ever correct it. Handoffs are now stamped and ignored past 15 s, cleared on `astro:before-swap`, and keyed with the same precedence the island uses. A handoff with no timestamp fails closed.

It also caught a regression this change caused elsewhere: moving the issue fetch behind the prefetch await put it second in the 401 race, and the loser of that race throws `SessionExpiredError` — so an expired session painted "your session has expired" over the issue page for the instant before the reload. `apiFetch` now stays silent for concurrent 401s while a reload is already in flight.

## Verification

- `apps/api`: 842/842 green. `apps/web`: 451/451 green. `tsc --noEmit` and `astro check` clean, biome clean.
- Mutation-tested the workspace filter, as above.
- New coverage: ref acceptance and cross-workspace refusal on both sub-resources, writes still refusing a ref, the readKey fetches not double-firing, attachments not in flight at first paint, prefetch claim / non-ok fallback / wrong-key / stale-handoff, and the concurrent-401 silence. The inline script can't be executed by jsdom, so its contract (rerun attribute, timestamp, swap cleanup, key precedence) is pinned against the source.
- Built output checked: `data-astro-rerun` and the swap cleanup are present in `dist/issues/view/index.html`.

## Filed, not fixed here

**PROJ-440** — issue refs don't parse for project keys containing a digit. `ISSUE_REF_PATTERN` is `[A-Z]+` while project keys validate as `[A-Z0-9]+`, so a project keyed `WEB2` has a canonical URL that resolves nowhere. Pre-existing and latent (every project in the dogfood is `PROJ`), but this change propagates the same too-narrow pattern to two more endpoints. Also covers the unbounded `parseInt` still in `fetchIssueByRef` — I bounded the copy added here to `\d{1,9}`, since 400 digits is `Infinity`, which D1 rejects as a type error and turns a 404 into a 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VyJbysfF5u7ocuJArkY2ZS
