### PR TITLE
perf(web): stop the issues page refetching the list 4x on every load

### DIFF
--- a/apps/web/src/islands/IssueList.test.tsx
+++ b/apps/web/src/islands/IssueList.test.tsx
@@ -827,3 +827,22 @@ describe("date-range filter (server-side, PROJ-212)", () => {
 		await waitFor(() => expect(lastIssuesUrl(mock2)).toMatch(/completedAfter=\d+/));
 	});
 });
+
+describe("mount fetch count (perf regression)", () => {
+	it("fetches the main list once and the epic dropdown once on a plain load", async () => {
+		const mockFetch = setupEpicFetch();
+		render(<IssueList />);
+		await waitForLoaded();
+
+		// Let the lookup arrivals (projects/task-types) and URL sync settle —
+		// each used to refire the main list fetch via effect-dep identity churn.
+		await screen.findByRole("combobox", { name: "Filter by epic" });
+		await new Promise((r) => setTimeout(r, 50));
+
+		const urls = (mockFetch.mock.calls as [string][]).map((c) => String(c[0]));
+		const listCalls = urls.filter((u) => u.includes("/api/issues?") && !u.includes("typeId="));
+		const epicDropdownCalls = urls.filter((u) => u.includes("typeId=type-epic"));
+		expect(listCalls).toHaveLength(1);
+		expect(epicDropdownCalls).toHaveLength(1);
+	});
+});

--- a/apps/web/src/islands/issue-list/useIssueFetching.ts
+++ b/apps/web/src/islands/issue-list/useIssueFetching.ts
@@ -42,24 +42,13 @@ export function useIssueFetching(
 	const [total, setTotal] = useState(0);
 
 	// Build the filter query params shared by the initial fetch and "Load more"
-	// (everything except limit/cursor, which the callers set).
-	const buildFilterParams = useCallback(
-		() => buildFilterQueryParams(filters, projects, taskTypes),
-		[
-			filters.filterStatuses,
-			filters.filterPriorities,
-			filters.filterProject,
-			filters.filterType,
-			filters.filterEpicId,
-			filters.filterSprintId,
-			filters.hideEpics,
-			filters.filterDateField,
-			filters.filterDateFrom,
-			filters.filterDateTo,
-			projects,
-			taskTypes,
-		]
-	);
+	// (everything except limit/cursor, which the callers set). Keyed on the
+	// *serialized* params, not input identities: the filter arrays and lookup
+	// lists get fresh identities on mount/arrival without changing the resulting
+	// query, and each identity change used to refire the issues fetch — 4
+	// byte-identical GETs per page load.
+	const filterQs = buildFilterQueryParams(filters, projects, taskTypes).toString();
+	const buildFilterParams = useCallback(() => new URLSearchParams(filterQs), [filterQs]);
 
 	// List view paginates 30 at a time (PROJ-201). Board/backlog operate on the
 	// whole working set, so they request a larger page.

--- a/apps/web/src/islands/issue-list/useIssueLookups.ts
+++ b/apps/web/src/islands/issue-list/useIssueLookups.ts
@@ -133,9 +133,14 @@ export function useIssueLookups(
 	}, [workspaceSlug]);
 
 	// Fetch epics for the epic filter dropdown, independent of the paginated list
-	// (PROJ-211). Scoped to the active project filter when set.
+	// (PROJ-211). Scoped to the active project filter when set. Keyed on the
+	// derived ids, not the lookup-array identities — a fresh projects/taskTypes
+	// array that resolves to the same ids must not refire this fetch.
+	const epicTypeId = taskTypes.find((t) => t.key === "epic")?.id;
+	const epicProjectId = filterProject
+		? projects.find((p) => p.key === filterProject)?.id
+		: undefined;
 	useEffect(() => {
-		const epicTypeId = taskTypes.find((t) => t.key === "epic")?.id;
 		if (!epicTypeId) {
 			setEpics([]);
 			return;
@@ -143,10 +148,7 @@ export function useIssueLookups(
 		(async () => {
 			try {
 				const qs = new URLSearchParams({ typeId: epicTypeId, limit: "100" });
-				const projectId = filterProject
-					? projects.find((p) => p.key === filterProject)?.id
-					: undefined;
-				if (projectId) qs.set("project", projectId);
+				if (epicProjectId) qs.set("project", epicProjectId);
 				const data = await apiFetch<{ items: Issue[] }>(`/api/issues?${qs.toString()}`, {
 					workspaceSlug,
 				});
@@ -155,7 +157,7 @@ export function useIssueLookups(
 				// non-fatal — epic dropdown just won't populate
 			}
 		})();
-	}, [workspaceSlug, taskTypes, filterProject, projects]);
+	}, [workspaceSlug, epicTypeId, epicProjectId]);
 
 	return {
 		statuses,


### PR DESCRIPTION
## What

The issues page fired `GET /api/issues?limit=30` (106 KB) **4 times** and the epic-dropdown lookup (`typeId=…&limit=100`, 154 KB) **2 times** on every plain page load. Cause: the fetch effects were keyed on filter-array / lookup-array *identities* — the mount URL-sync writes fresh empty arrays, then the `projects` and `task-types` lookups arrive, and each identity change refired a byte-identical request.

Fix: key the main list fetch on the **serialized query string** (`useIssueFetching.ts`) and the epic-dropdown fetch on the **derived type/project ids** (`useIssueLookups.ts`). Identity churn that doesn't change the request no longer refires it; churn that does change it (e.g. task-types arriving while `hideEpics` is set) still does.

## Numbers (PROJ-431 harness, deployed Worker, before/after minutes apart in the same session)

| metric | before | after |
|---|---|---|
| API requests per load | 12 | 8 |
| `/api/issues?limit=30` per load | 4 | 1 |
| epic-dropdown fetch per load | 2 | 1 |
| LCP desktop (unthrottled) | 1444 ms | 628 ms |
| LCP mobile (Slow 4G, 4× CPU) | 6816 ms | 3916 ms |
| last API response done (mobile) | 6588 ms | 4124 ms |

## Tests

New regression test asserts exactly one list fetch and one dropdown fetch per plain mount — verified it **fails** against the pre-fix code. Full web suite (452), api suite, type-check, biome all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JqjYsNSNRWbdNCrXdR11FA