### PR TITLE
perf(harness): compress proxied API responses like production does

### DIFF
--- a/apps/web/scripts/perf/measure-load.mjs
+++ b/apps/web/scripts/perf/measure-load.mjs
@@ -34,8 +34,18 @@ const server = createServer(async (req, res) => {
       });
       const buf = Buffer.from(await upstream.arrayBuffer());
       apiTimings.push({ path: url.pathname + url.search, ms: performance.now() - t0, status: upstream.status, bytes: buf.length });
-      res.writeHead(upstream.status, { 'content-type': upstream.headers.get('content-type') ?? 'application/json' });
-      res.end(buf);
+      // Cloudflare serves API JSON compressed too; without matching that, the mobile
+      // profile charges ~4x the API bytes production actually sends over the wire.
+      const ctype = upstream.headers.get('content-type') ?? 'application/json';
+      const acc = String(req.headers['accept-encoding'] ?? '');
+      const compressible = /json|text/.test(ctype) && buf.length > 0;
+      const enc = compressible && acc.includes('br') ? 'br' : compressible && acc.includes('gzip') ? 'gzip' : null;
+      const out = enc === 'br' ? brotliCompressSync(buf) : enc === 'gzip' ? gzipSync(buf, { level: 9 }) : buf;
+      res.writeHead(upstream.status, {
+        'content-type': ctype,
+        ...(enc ? { 'content-encoding': enc } : {}),
+      });
+      res.end(out);
     } catch (e) {
       res.writeHead(502).end(JSON.stringify({ error: String(e) }));
     }


### PR DESCRIPTION
The measure-load proxy brotli/gzips static assets but re-served API JSON **uncompressed**, while Cloudflare compresses `application/json` in production. The Lighthouse-mobile profile (1.6 Mbps down) therefore charged ~4× the API bytes production actually ships — `/api/issues?limit=30` is 106 KB raw vs ~25 KB compressed.

Effect measured back-to-back on `/issues` (post-#143 build, mobile Slow 4G / 4× CPU, median of 3): LCP 3916 ms → 2628 ms, last-API-done 4124 ms → 2785 ms. That ~1.3 s was measurement artifact, not app behaviour.

Numbers from before this fix remain internally comparable (both sides of any same-session pair carried the same inflation), but absolute mobile figures overstated API transfer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JqjYsNSNRWbdNCrXdR11FA