### PR TITLE
PROJ-449: fix needsAudit=false being silently inverted

### DIFF
--- a/apps/api/src/schemas/common.ts
+++ b/apps/api/src/schemas/common.ts
@@ -25,3 +25,13 @@ export const TaxonomyIdSchema = z.union([
 	z.string().uuid(),
 	z.string().regex(/^[0-9a-f]{32}$/i, "Invalid id"),
 ]);
+
+// Query-string booleans arrive as strings; MCP sends real JSON booleans. z.coerce.boolean()
+// makes the string "false" truthy (any non-empty string coerces to true), silently inverting
+// params like needsAudit=false. Parse the string forms explicitly instead. "" (bare ?flag with
+// no value) maps to false, matching Boolean("") under the old z.coerce.boolean() behavior.
+export const BooleanQueryParam = z.union([
+	z.boolean(),
+	z.enum(["true", "1"]).transform(() => true),
+	z.enum(["false", "0", ""]).transform(() => false),
+]);

--- a/apps/api/src/schemas/issues.ts
+++ b/apps/api/src/schemas/issues.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { PriorityEnum, StatusEnum, TaxonomyIdSchema } from "./common";
+import { BooleanQueryParam, PriorityEnum, StatusEnum, TaxonomyIdSchema } from "./common";
 import { CustomFieldFilterSchema } from "./custom-fields";
 
 export const CreateIssueSchema = z.object({
@@ -55,7 +55,7 @@ export const ListIssuesSchema = z.object({
 	// the schema (rather than folded silently into z.string()) so both surfaces document it.
 	assignee: z.union([z.literal("me"), z.string()]).optional(),
 	parentId: z.string().uuid().optional(),
-	noParent: z.coerce.boolean().optional(),
+	noParent: BooleanQueryParam.optional(),
 	typeId: TaxonomyIdSchema.optional(),
 	excludeTypeIds: z.string().optional(),
 	sprintId: z.string().uuid().optional(),
@@ -67,14 +67,14 @@ export const ListIssuesSchema = z.object({
 	updatedBefore: z.coerce.number().optional(),
 	// PROJ-375: surface agent-initiated done-closures whose evidence wasn't
 	// externally checkable, for periodic human audit.
-	needsAudit: z.coerce.boolean().optional(),
+	needsAudit: BooleanQueryParam.optional(),
 	// PROJ-441: compute child rollups for the returned page in one grouped query
 	// (see computeChildRollupsForParents in services/issues.ts) instead of the
 	// frontend fanning out a getIssue call per row.
-	includeRollups: z.coerce.boolean().optional(),
+	includeRollups: BooleanQueryParam.optional(),
 	// PROJ-442: list items omit `body` by default (it's rarely needed and can be
 	// large); set this to restore it.
-	includeBody: z.coerce.boolean().optional(),
+	includeBody: BooleanQueryParam.optional(),
 	cursor: z.coerce.number().optional(),
 	limit: z.coerce.number().min(1).max(100).default(30),
 });

--- a/apps/api/src/test/review-gating.test.ts
+++ b/apps/api/src/test/review-gating.test.ts
@@ -239,6 +239,38 @@ describe("Review gating (PROJ-254/287/289/292/293/375)", () => {
 		expect(ids).not.toContain(clean.id);
 	});
 
+	it("list_issues({ needsAudit: false }) surfaces unflagged closures only (PROJ-449)", async () => {
+		const flagged = await seedIssue(workspaceId, projectId, userId, { title: "Flagged" });
+		const clean = await seedIssue(workspaceId, projectId, userId, { title: "Clean" });
+		const { agentSessionId: flaggedAgent } = await seedAgentLease(workspaceId, flagged.id);
+		const { agentSessionId: cleanAgent } = await seedAgentLease(workspaceId, clean.id);
+
+		await patch(flagged.id, {
+			status: "done",
+			agentSessionId: flaggedAgent,
+			completionReport: report,
+		});
+		await patch(clean.id, {
+			status: "done",
+			agentSessionId: cleanAgent,
+			completionReport: {
+				summary: "Did the thing",
+				verification: "https://github.com/TAJD/projektor/pull/93",
+			},
+		});
+
+		// z.coerce.boolean() would coerce the string "false" to true, silently
+		// inverting this filter. Guards against regressing to that.
+		const res = await SELF.fetch(
+			`http://localhost/api/issues?projectId=${projectId}&needsAudit=false`,
+			{ headers: authHeaders(token, slug) }
+		);
+		const { items } = (await res.json()) as { items: Array<{ id: string }> };
+		const ids = items.map((i) => i.id);
+		expect(ids).toContain(clean.id);
+		expect(ids).not.toContain(flagged.id);
+	});
+
 	// --- Report stamped only on a real transition (PROJ-293) ---
 
 	it("does not stamp/post a completionReport on a title-only update", async () => {


### PR DESCRIPTION
## Summary
- `z.coerce.boolean()` on `ListIssuesSchema` treated any non-empty query-string value — including the literal `"false"` — as `true`.
- Investigated blast radius: `noParent`/`includeRollups`/`includeBody` are presence-only in practice (no caller ever sends `false`), so those were theoretical. `needsAudit` is genuinely tri-state and the MCP `list_issues` tool docs advertise the `false` case, so `?needsAudit=false` over REST silently returned flagged issues instead of unflagged ones.
- Added a `BooleanQueryParam` helper (`schemas/common.ts`) that parses explicit `true`/`1`/`false`/`0`/`""` string forms (and passes through real JSON booleans for MCP) instead of coercing, and swapped it into all four boolean fields on `ListIssuesSchema`.

## Test plan
- [x] New regression test: `list_issues({ needsAudit: false })` surfaces unflagged closures only (`review-gating.test.ts`)
- [x] Full API + web test suites pass locally (860 + 464 tests)
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6PrZyYWhxC1LxKehovwcH