### PR TITLE
chore(web): bump version to 0.4.10 for release

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@projektor/web",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "private": true,
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
Manual release cut — release-prepare.yml is currently blocked by an invalid/expired WORKSPACE_PAT secret (checkout auth fails). Bumping version by hand to get PROJ-449 (needsAudit boolean-coercion fix) deployed. Merging this triggers release-tag.yml (tag) → release.yml (build + GitHub Release).