### PR TITLE
PROJ-437: reject workspace delete when URL slug doesn't match resolved workspace

### DIFF
--- a/apps/api/src/mcp/workspaces.ts
+++ b/apps/api/src/mcp/workspaces.ts
@@ -70,7 +70,7 @@ export const workspacesTools: MCPTool[] = [
 				.get();
 			if (!ws) throw new NotFoundError("Workspace not found");
 
-			return deleteWorkspace({ ...ctx, workspaceId: ws.id }, "projektor");
+			return deleteWorkspace({ ...ctx, workspaceId: ws.id }, workspaceSlug, "projektor");
 		},
 	},
 	{

--- a/apps/api/src/routes/workspaces.ts
+++ b/apps/api/src/routes/workspaces.ts
@@ -95,7 +95,9 @@ router.delete("/:slug/tokens/:tokenId", async (c) => {
 router.delete("/:slug", async (c) => {
 	const ctx = ctxFromHono(c);
 	try {
-		return c.json(await deleteWorkspace(ctx, c.env.DEFAULT_WORKSPACE_SLUG ?? "projektor"));
+		return c.json(
+			await deleteWorkspace(ctx, c.req.param("slug"), c.env.DEFAULT_WORKSPACE_SLUG ?? "projektor")
+		);
 	} catch (e) {
 		return serviceErrToResponse(c, e);
 	}

--- a/apps/api/src/services/workspaces.ts
+++ b/apps/api/src/services/workspaces.ts
@@ -238,6 +238,7 @@ export async function revokeToken(ctx: ServiceCtx, tokenId: string) {
 
 export async function deleteWorkspace(
 	ctx: ServiceCtx,
+	pathSlug: string,
 	defaultWorkspaceSlug: string
 ): Promise<{ ok: true }> {
 	if (ctx.role !== "owner") {
@@ -252,6 +253,13 @@ export async function deleteWorkspace(
 		.get();
 
 	if (!ws) throw new NotFoundError("Workspace not found");
+
+	// PROJ-437: ctx.workspaceId is resolved from the X-Workspace-Slug header (or Host
+	// subdomain), not the URL's :slug — without this check a caller whose header names
+	// workspace A but whose URL names workspace B would silently delete A instead of B.
+	if (ws.slug !== pathSlug) {
+		throw new NotFoundError("Workspace not found");
+	}
 
 	if (ws.slug === defaultWorkspaceSlug) {
 		throw new ValidationError({

--- a/apps/api/src/test/workspaces.test.ts
+++ b/apps/api/src/test/workspaces.test.ts
@@ -351,6 +351,23 @@ describe("DELETE /api/workspaces/:slug (PROJ-96)", () => {
 		});
 		expect(res.status).toBe(409);
 	});
+
+	it("URL slug mismatched with X-Workspace-Slug header → 404, neither workspace is deleted (PROJ-437)", async () => {
+		// ctx.workspaceId (and thus the actual delete target) is resolved from the header,
+		// not the URL. Naming a *different* workspace in the URL must not silently delete
+		// the header's workspace, nor the URL's.
+		const other = await seedWorkspace(`del-437-${crypto.randomUUID().slice(0, 8)}`);
+		const res = await SELF.fetch(`http://localhost/api/workspaces/${other.slug}`, {
+			method: "DELETE",
+			headers: ownerHeaders, // X-Workspace-Slug: slug (the fixture workspace, not `other`)
+		});
+		expect(res.status).toBe(404);
+
+		const stillThere = await SELF.fetch(`http://localhost/api/workspaces/${slug}`, {
+			headers: ownerHeaders,
+		});
+		expect(stillThere.status).toBe(200);
+	});
 });
 
 describe("GET /api/workspaces/:slug (currentUserRole)", () => {


### PR DESCRIPTION
## Summary
- `DELETE /api/workspaces/:slug` ignored its own `:slug` path param entirely — the route handler passed `c.env.DEFAULT_WORKSPACE_SLUG` (used only for the default-workspace guard), and `deleteWorkspace` always operated on `ctx.workspaceId`, which is resolved purely from the `X-Workspace-Slug` header (or `Host` subdomain) by `workspaceMiddleware`.
- Net effect: a request whose URL names workspace A but whose header names workspace B deletes B, silently. The URL was cosmetic.
- Fix: `deleteWorkspace` now takes the URL's slug and rejects (404) if it doesn't match the header-resolved workspace's actual slug, instead of trusting the header alone.
- The MCP `delete_workspace` tool was already correct (it resolves by its own `workspaceSlug` argument, not session context) — updated its call site for the new signature only.

## Test plan
- [x] New regression test: mismatched URL slug vs `X-Workspace-Slug` header → 404, workspace not deleted (`workspaces.test.ts`)
- [x] Full `workspaces.test.ts` suite passes (22/22)
- [x] `tsc --noEmit` clean
- [x] Pre-push suite (lint + full api/web test suites) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6PrZyYWhxC1LxKehovwcH