### PR TITLE
PROJ-436: make member removal durable via tombstone

### DIFF
--- a/apps/api/src/services/provisioning.ts
+++ b/apps/api/src/services/provisioning.ts
@@ -4,6 +4,27 @@ import { and, eq } from "drizzle-orm";
 import { ConflictError } from "./errors";
 import { createWorkspace } from "./workspaces";
 
+// PROJ-436: an owner's explicit removeMember call is durable — provisioning must not
+// re-add a tombstoned (workspace, user) pair, even though ADMIN_EMAILS / AUTO_JOIN_ROLE /
+// WORKSPACE_DOMAIN_MAP would otherwise say they belong. inviteMember clears the tombstone.
+async function isRemovalTombstoned(
+	orm: ReturnType<typeof drizzle>,
+	workspaceId: string,
+	userId: string
+): Promise<boolean> {
+	const row = await orm
+		.select({ workspaceId: schema.provisioningRemovals.workspaceId })
+		.from(schema.provisioningRemovals)
+		.where(
+			and(
+				eq(schema.provisioningRemovals.workspaceId, workspaceId),
+				eq(schema.provisioningRemovals.userId, userId)
+			)
+		)
+		.get();
+	return !!row;
+}
+
 const VALID_ROLES = ["owner", "admin", "member", "viewer"] as const;
 type Role = (typeof VALID_ROLES)[number];
 
@@ -91,6 +112,9 @@ async function grantOwner(
 	workspaceId: string,
 	userId: string
 ): Promise<void> {
+	// PROJ-436: an owner who was explicitly removed from this workspace stays removed,
+	// even though they're still an admin instance-wide.
+	if (await isRemovalTombstoned(orm, workspaceId, userId)) return;
 	await orm
 		.insert(schema.workspaceMembers)
 		.values({ workspaceId, userId, role: "owner", joinedAt: Math.floor(Date.now() / 1000) })
@@ -228,11 +252,10 @@ export async function forgetProvisionedForTests(env: Env, userId: string): Promi
  * createWorkspace. Changing AUTO_JOIN_ROLE or WORKSPACE_DOMAIN_MAP likewise takes up to
  * that long to affect an already-marked user — the KV marker outlives a redeploy.
  *
- * Note this is what re-adds a membership that removeMember deleted (see
- * services/workspaces.ts): for anyone in ADMIN_EMAILS, or on an instance with AUTO_JOIN_ROLE
- * or a domain mapping, removal has always been undone by the next provisioning run. It used
- * to be undone on the user's very next request, so it visibly never worked; now it holds
- * until the marker expires and then reverts.
+ * PROJ-436: removeMember (services/workspaces.ts) tombstones the removal in
+ * provisioning_removals, and grantOwner / the domain-map and auto-join paths above all check
+ * it before re-adding — so a config match (ADMIN_EMAILS, AUTO_JOIN_ROLE, WORKSPACE_DOMAIN_MAP)
+ * no longer undoes an explicit removal. inviteMember clears the tombstone.
  */
 export async function ensureUserProvisioned(
 	env: Env,
@@ -268,6 +291,8 @@ async function runProvisioning(env: Env, user: { id: string; email: string }): P
 			.where(eq(schema.workspaces.slug, mapped.slug))
 			.get();
 		if (!ws) return false; // mapped workspace doesn't exist yet — nothing to join
+		// PROJ-436: a removed user's domain mapping no longer re-adds them to this workspace.
+		if (await isRemovalTombstoned(orm, ws.id, user.id)) return true;
 		await orm
 			.insert(schema.workspaceMembers)
 			.values({
@@ -291,6 +316,8 @@ async function runProvisioning(env: Env, user: { id: string; email: string }): P
 		.get();
 	if (!ws) return false; // wait for an admin to bootstrap the default workspace
 
+	// PROJ-436: a removed user isn't auto-rejoined to the default workspace.
+	if (await isRemovalTombstoned(orm, ws.id, user.id)) return true;
 	await orm
 		.insert(schema.workspaceMembers)
 		.values({

--- a/apps/api/src/services/workspaces.ts
+++ b/apps/api/src/services/workspaces.ts
@@ -135,6 +135,16 @@ export async function inviteMember(ctx: ServiceCtx, input: unknown) {
 	await orm
 		.insert(schema.workspaceMembers)
 		.values({ workspaceId: ctx.workspaceId, userId: user.id, role: newRole, joinedAt: now });
+	// PROJ-436: re-inviting a previously-removed user clears their removal tombstone, so
+	// provisioning can re-add them again if config (ADMIN_EMAILS etc) says it should.
+	await orm
+		.delete(schema.provisioningRemovals)
+		.where(
+			and(
+				eq(schema.provisioningRemovals.workspaceId, ctx.workspaceId),
+				eq(schema.provisioningRemovals.userId, user.id)
+			)
+		);
 	return { ok: true };
 }
 
@@ -155,6 +165,20 @@ export async function removeMember(ctx: ServiceCtx, targetUserId: string) {
 				eq(schema.workspaceMembers.userId, targetUserId)
 			)
 		);
+	// PROJ-436: tombstone the removal so ensureUserProvisioned (ADMIN_EMAILS / AUTO_JOIN_ROLE /
+	// WORKSPACE_DOMAIN_MAP) doesn't silently re-add this user once their provisioning cache
+	// expires. Cleared by inviteMember above.
+	await orm
+		.insert(schema.provisioningRemovals)
+		.values({
+			workspaceId: ctx.workspaceId,
+			userId: targetUserId,
+			removedAt: Math.floor(Date.now() / 1000),
+		})
+		.onConflictDoUpdate({
+			target: [schema.provisioningRemovals.workspaceId, schema.provisioningRemovals.userId],
+			set: { removedAt: Math.floor(Date.now() / 1000) },
+		});
 	return { ok: true };
 }
 

--- a/apps/api/src/test/migrations.ts
+++ b/apps/api/src/test/migrations.ts
@@ -40,6 +40,7 @@ import m0036 from "../../../../packages/db/migrations/0036_feedback.sql?raw";
 import m0037 from "../../../../packages/db/migrations/0037_issue_author_kind.sql?raw";
 import m0038 from "../../../../packages/db/migrations/0038_attachment_kinds.sql?raw";
 import m0039 from "../../../../packages/db/migrations/0039_wip_cap_denials.sql?raw";
+import m0040 from "../../../../packages/db/migrations/0040_provisioning_removals.sql?raw";
 
 export const MIGRATIONS = [
 	m0000,
@@ -82,4 +83,5 @@ export const MIGRATIONS = [
 	m0037,
 	m0038,
 	m0039,
+	m0040,
 ];

--- a/apps/api/src/test/provisioning.test.ts
+++ b/apps/api/src/test/provisioning.test.ts
@@ -30,6 +30,15 @@ async function memberRole(workspaceId: string, userId: string) {
 	return row?.role ?? null;
 }
 
+// Simulates a prior removeMember call without going through the HTTP route.
+async function tombstoneRemoval(workspaceId: string, userId: string) {
+	await env.DB.prepare(
+		"INSERT INTO provisioning_removals (workspace_id, user_id, removed_at) VALUES (?, ?, ?)"
+	)
+		.bind(workspaceId, userId, Math.floor(Date.now() / 1000))
+		.run();
+}
+
 // cofferdam-ignore: Readability.MaxFunctionLength: full integration test suite in one describe block, normal test style
 describe("login provisioning", () => {
 	it("first admin login creates the default workspace and makes them owner", async () => {
@@ -218,6 +227,66 @@ describe("login provisioning", () => {
 			.first<{ id: string }>();
 		expect(ws).not.toBeNull();
 		expect(await memberRole(ws!.id, user.id)).toBe("owner");
+	});
+});
+
+// PROJ-436: removeMember tombstones the removal (provisioning_removals); provisioning must
+// respect it across all three re-add paths, without affecting workspaces the user wasn't
+// removed from.
+describe("PROJ-436: removal tombstone", () => {
+	it("a tombstoned admin is not re-owned of that workspace, but still owns others", async () => {
+		const removedFrom = await seedWorkspace("prov-436-admin-removed");
+		const stillOwns = await seedWorkspace("prov-436-admin-other");
+		const admin = await seedUser("removed-admin@example.com");
+		await tombstoneRemoval(removedFrom.id, admin.id);
+
+		await ensureUserProvisioned(
+			envWith({
+				ADMIN_EMAILS: "removed-admin@example.com",
+				DEFAULT_WORKSPACE_SLUG: "prov-436-admin-default-unused",
+				AUTO_JOIN_ROLE: "viewer",
+			}),
+			admin
+		);
+
+		expect(await memberRole(removedFrom.id, admin.id)).toBeNull();
+		expect(await memberRole(stillOwns.id, admin.id)).toBe("owner");
+	});
+
+	it("a tombstoned user is not auto-rejoined to the default workspace", async () => {
+		const slug = "prov-436-autojoin-removed";
+		const ws = await seedWorkspace(slug);
+		const user = await seedUser("removed-viewer@example.com");
+		await tombstoneRemoval(ws.id, user.id);
+
+		await ensureUserProvisioned(
+			envWith({
+				ADMIN_EMAILS: "boss@example.com",
+				DEFAULT_WORKSPACE_SLUG: slug,
+				AUTO_JOIN_ROLE: "viewer",
+			}),
+			user
+		);
+
+		expect(await memberRole(ws.id, user.id)).toBeNull();
+	});
+
+	it("a tombstoned user is not re-mapped into their domain's workspace", async () => {
+		const mappedWs = await seedWorkspace("prov-436-domain-removed");
+		const user = await seedUser("removed-colleague@example.com");
+		await tombstoneRemoval(mappedWs.id, user.id);
+
+		await ensureUserProvisioned(
+			envWith({
+				ADMIN_EMAILS: "boss@example.com",
+				DEFAULT_WORKSPACE_SLUG: "prov-436-domain-default-unused",
+				AUTO_JOIN_ROLE: "viewer",
+				WORKSPACE_DOMAIN_MAP: '{"example.com":{"slug":"prov-436-domain-removed","role":"member"}}',
+			}),
+			user
+		);
+
+		expect(await memberRole(mappedWs.id, user.id)).toBeNull();
 	});
 });
 

--- a/apps/api/src/test/workspaces.test.ts
+++ b/apps/api/src/test/workspaces.test.ts
@@ -1,4 +1,4 @@
-import { SELF } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
 	authHeaders,
@@ -6,6 +6,7 @@ import {
 	seedMember,
 	seedProject,
 	seedToken,
+	seedUser,
 	seedWorkspace,
 } from "./helpers";
 
@@ -367,6 +368,41 @@ describe("DELETE /api/workspaces/:slug (PROJ-96)", () => {
 			headers: ownerHeaders,
 		});
 		expect(stillThere.status).toBe(200);
+	});
+});
+
+describe("Member removal tombstone (PROJ-436)", () => {
+	async function tombstoneRow(workspaceId: string, userId: string) {
+		return env.DB.prepare(
+			"SELECT removed_at FROM provisioning_removals WHERE workspace_id = ? AND user_id = ?"
+		)
+			.bind(workspaceId, userId)
+			.first<{ removed_at: number }>();
+	}
+
+	it("removing a member records a tombstone; re-inviting them clears it", async () => {
+		const fixture = await seedFixture({ role: "owner" });
+		const memberUser = await seedUser(`m-436-${crypto.randomUUID().slice(0, 8)}@example.com`);
+		await seedMember(fixture.workspace.id, memberUser.id, "member");
+		const ownerHeaders = authHeaders(fixture.token, fixture.workspace.slug);
+
+		const delRes = await SELF.fetch(
+			`http://localhost/api/workspaces/${fixture.workspace.slug}/members/${memberUser.id}`,
+			{ method: "DELETE", headers: ownerHeaders }
+		);
+		expect(delRes.status).toBe(200);
+		expect(await tombstoneRow(fixture.workspace.id, memberUser.id)).not.toBeNull();
+
+		const inviteRes = await SELF.fetch(
+			`http://localhost/api/workspaces/${fixture.workspace.slug}/members`,
+			{
+				method: "POST",
+				headers: ownerHeaders,
+				body: JSON.stringify({ email: memberUser.email, role: "member" }),
+			}
+		);
+		expect(inviteRes.status).toBe(201);
+		expect(await tombstoneRow(fixture.workspace.id, memberUser.id)).toBeNull();
 	});
 });
 

--- a/packages/db/migrations/0040_provisioning_removals.sql
+++ b/packages/db/migrations/0040_provisioning_removals.sql
@@ -1,0 +1,12 @@
+-- PROJ-436: removeMember only deleted the workspace_members row, but provisioning
+-- (ensureUserProvisioned in services/provisioning.ts) re-derives membership from config on
+-- every unprovisioned run — ADMIN_EMAILS, AUTO_JOIN_ROLE, WORKSPACE_DOMAIN_MAP — so a removed
+-- user who matches any of those was silently re-added once their provisioning cache expired.
+-- This tombstones an explicit removal so provisioning can skip re-adding that (workspace,
+-- user) pair; re-inviting the user to the same workspace clears it (see inviteMember).
+CREATE TABLE provisioning_removals (
+	workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+	user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+	removed_at INTEGER NOT NULL,
+	PRIMARY KEY (workspace_id, user_id)
+);

--- a/packages/db/src/schema/core.ts
+++ b/packages/db/src/schema/core.ts
@@ -34,6 +34,25 @@ export const workspaceMembers = sqliteTable(
 	})
 );
 
+// PROJ-436: a durable record that an owner explicitly removed this user from this
+// workspace, so provisioning (ADMIN_EMAILS / AUTO_JOIN_ROLE / WORKSPACE_DOMAIN_MAP) skips
+// re-adding them here. Cleared by re-inviting the user to the same workspace.
+export const provisioningRemovals = sqliteTable(
+	"provisioning_removals",
+	{
+		workspaceId: text("workspace_id")
+			.notNull()
+			.references(() => workspaces.id, { onDelete: "cascade" }),
+		userId: text("user_id")
+			.notNull()
+			.references(() => users.id, { onDelete: "cascade" }),
+		removedAt: integer("removed_at").notNull(),
+	},
+	(t) => ({
+		pk: primaryKey({ columns: [t.workspaceId, t.userId] }),
+	})
+);
+
 export const apiTokens = sqliteTable("api_tokens", {
 	id: text("id").primaryKey(),
 	// NULL = user-scoped token (valid across all workspaces the user is a member of)


### PR DESCRIPTION
## Summary
- Auto-provisioning (`ADMIN_EMAILS`, `WORKSPACE_DOMAIN_MAP`, `AUTO_JOIN_ROLE`) silently re-added removed members the next time they authenticated, since it only checks current membership state, not removal history.
- Adds a `provisioning_removals` tombstone table; `removeMember` upserts a tombstone row, and each auto-membership grant path in `ensureUserProvisioned` checks it before inserting.
- `inviteMember` clears any existing tombstone so an explicit re-invite still works as expected.

## Test plan
- [x] `provisioning.test.ts` + `workspaces.test.ts` — new tombstone-specific tests pass
- [x] Full API suite: 51 files / 865 tests pass
- [x] `tsc --noEmit` clean on `apps/api` and `packages/db`
- [x] Pre-push lint/test/test-web all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6PrZyYWhxC1LxKehovwcH