### PR TITLE
PROJ-440: fix issue refs for project keys containing digits

### DIFF
--- a/apps/api/src/routes/issues.ts
+++ b/apps/api/src/routes/issues.ts
@@ -6,6 +6,7 @@ import {
 	createIssue,
 	deleteIssue,
 	getIssue,
+	ISSUE_REF_PATTERN,
 	listIssues,
 	searchIssues,
 	updateIssue,
@@ -94,7 +95,7 @@ router.get("/:id", async (c) => {
 	const ctx = ctxFromHono(c);
 	const param = c.req.param("id");
 	// Accept KEY-NUMBER refs (e.g. PROJ-42) as well as UUIDs
-	const input = /^[A-Z]+-\d+$/.test(param) ? { ref: param } : { id: param };
+	const input = ISSUE_REF_PATTERN.test(param) ? { ref: param } : { id: param };
 	try {
 		return c.json(await getIssue(ctx, input));
 	} catch (e) {

--- a/apps/api/src/schemas/projects.ts
+++ b/apps/api/src/schemas/projects.ts
@@ -6,7 +6,9 @@ export const CreateProjectSchema = z.object({
 		.string()
 		.min(1)
 		.max(10)
-		.regex(/^[A-Z0-9]+$/i)
+		// PROJ-440: no leading digit, so KEY-NUMBER issue refs (ISSUE_REF_PATTERN in
+		// services/issues.ts) stay unambiguous.
+		.regex(/^[A-Z][A-Z0-9]*$/i)
 		.transform((s) => s.toUpperCase()),
 	description: z.string().max(500).optional(),
 	// PROJ-253: per-project agent WIP cap. null/omitted = workspace default.

--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -433,7 +433,7 @@ async function fetchIssueById(orm: ReturnType<typeof drizzle>, ctx: ServiceCtx, 
 // Digits are bounded: parseInt("9".repeat(400)) is Infinity, which drizzle would happily
 // bind and D1 would reject as a type error — a 500 where a 404 belongs. Anything longer
 // than this isn't a ref, so it falls through to being treated as an id and 404s.
-export const ISSUE_REF_PATTERN = /^([A-Z]+)-(\d{1,9})$/;
+export const ISSUE_REF_PATTERN = /^([A-Z][A-Z0-9]*)-(\d{1,9})$/;
 
 /**
  * Accept either identifier in an `:issueId` path segment.
@@ -472,7 +472,7 @@ export async function resolveIssueIdParam(ctx: ServiceCtx, param: string): Promi
 }
 
 async function fetchIssueByRef(orm: ReturnType<typeof drizzle>, ctx: ServiceCtx, ref: string) {
-	const m = ref.match(/^([A-Z]+)-(\d+)$/);
+	const m = ref.match(ISSUE_REF_PATTERN);
 	if (!m)
 		throw new ValidationError({
 			formErrors: ["ref must be in format KEY-NUMBER"],

--- a/apps/api/src/test/issues.test.ts
+++ b/apps/api/src/test/issues.test.ts
@@ -433,6 +433,43 @@ describe("Issues API", () => {
 		expect(issue.project_key).toBe("PROJ");
 	});
 
+	it("GET /api/issues/KEY-NUMBER resolves for a project key containing digits (PROJ-440)", async () => {
+		const digitProject = await seedProject(workspaceId, "WEB2");
+		const createRes = await SELF.fetch("http://localhost/api/issues", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ projectId: digitProject.id, title: "Digit-key ref issue" }),
+		});
+		expect(createRes.status).toBe(201);
+		const created = (await createRes.json()) as { id: string; number: number };
+
+		const getRes = await SELF.fetch(`http://localhost/api/issues/WEB2-${created.number}`, {
+			headers: authHeaders(token, slug),
+		});
+		expect(getRes.status).toBe(200);
+		const issue = (await getRes.json()) as { title: string; project_key: string };
+		expect(issue.title).toBe("Digit-key ref issue");
+		expect(issue.project_key).toBe("WEB2");
+
+		const commentsRes = await SELF.fetch(
+			`http://localhost/api/issues/WEB2-${created.number}/comments`,
+			{ headers: authHeaders(token, slug) }
+		);
+		expect(commentsRes.status).toBe(200);
+
+		const linksRes = await SELF.fetch(`http://localhost/api/issues/WEB2-${created.number}/links`, {
+			headers: authHeaders(token, slug),
+		});
+		expect(linksRes.status).toBe(200);
+	});
+
+	it("GET /api/issues/:ref with an absurdly long number is a 404, not a 500 (PROJ-440)", async () => {
+		const res = await SELF.fetch(`http://localhost/api/issues/PROJ-${"9".repeat(400)}`, {
+			headers: authHeaders(token, slug),
+		});
+		expect(res.status).toBe(404);
+	});
+
 	it("GET /api/issues/:id includes project_key (PROJ-226 tab title regression)", async () => {
 		const created = await seedIssue(workspaceId, projectId, userId, { title: "By id" });
 

--- a/apps/api/src/test/projects.test.ts
+++ b/apps/api/src/test/projects.test.ts
@@ -124,6 +124,24 @@ describe("Projects REST", () => {
 		expect(res.status).toBe(400);
 	});
 
+	it("POST /api/projects returns 400 for a key starting with a digit (PROJ-440)", async () => {
+		const res = await SELF.fetch("http://localhost/api/projects", {
+			method: "POST",
+			headers: ownerHeaders,
+			body: JSON.stringify({ name: "Leading digit", key: "2FA" }),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it("POST /api/projects accepts a key containing digits after the first character (PROJ-440)", async () => {
+		const res = await SELF.fetch("http://localhost/api/projects", {
+			method: "POST",
+			headers: ownerHeaders,
+			body: JSON.stringify({ name: "Digit key", key: "WEB2" }),
+		});
+		expect(res.status).toBe(201);
+	});
+
 	it("POST /api/projects returns 400 for name too long", async () => {
 		const res = await SELF.fetch("http://localhost/api/projects", {
 			method: "POST",

--- a/apps/web/src/lib/issue-ref.test.ts
+++ b/apps/web/src/lib/issue-ref.test.ts
@@ -117,4 +117,12 @@ describe("isValidIssueRef", () => {
 	it("returns false for input with no hyphen", () => {
 		expect(isValidIssueRef("PROJ42")).toBe(false);
 	});
+
+	it("returns true for a key containing digits (PROJ-440)", () => {
+		expect(isValidIssueRef("WEB2-15")).toBe(true);
+	});
+
+	it("returns false for a key starting with a digit", () => {
+		expect(isValidIssueRef("2FA-1")).toBe(false);
+	});
 });

--- a/apps/web/src/lib/issue-ref.ts
+++ b/apps/web/src/lib/issue-ref.ts
@@ -7,5 +7,5 @@ export function normalizeIssueRef(ref: string): string {
 }
 
 export function isValidIssueRef(ref: string): boolean {
-	return /^[A-Z]+-\d+$/.test(ref);
+	return /^[A-Z][A-Z0-9]*-\d+$/.test(ref);
 }


### PR DESCRIPTION
## Summary
- Project keys allow digits (`CreateProjectSchema.key` matches `[A-Z0-9]+`), but every ref parser used `/^[A-Z]+-\d+$/`, so a project keyed `WEB2` produced a pretty URL (`/projects/WEB2/issues/15/...`) whose ref `WEB2-15` was unresolvable — 400 on the issue GET, 404 on comments/links.
- Route (`routes/issues.ts`), sub-resource resolver (`resolveIssueIdParam`), and frontend (`isValidIssueRef`) now share/match the same bounded pattern (`ISSUE_REF_PATTERN` in `services/issues.ts`), instead of three separate copies.
- `fetchIssueByRef` now uses the same bounded pattern too, so an absurdly long number (`PROJ-999...`) falls through to an id lookup and 404s, instead of an unbounded `parseInt` producing `Infinity` that D1 rejected as a 500.
- Project key creation now forbids a leading digit, keeping the `KEY-NUMBER` grammar unambiguous without a lookahead (per the ticket's own recommended resolution).

## Test plan
- [x] New API test: digit-key project's issue, comments, and links all resolve from the ref
- [x] New API test: absurdly long ref number is a 404
- [x] New API tests: project creation rejects a leading-digit key, accepts digits elsewhere
- [x] New web tests: `isValidIssueRef` accepts digit keys, rejects leading-digit keys
- [x] Full API suite (51 files / 869 tests) and web suite (44 files / 466 tests) green
- [x] `tsc --noEmit` clean on `apps/api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6PrZyYWhxC1LxKehovwcH