### PR TITLE
PROJ-450: hydrate the glossary toggletip lazily

### DIFF
--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -720,7 +720,7 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
                 )}
                 <span class="link-label">{item.label}</span>
               </a>
-              {item.glossaryId && <GlossaryHelp client:load id={item.glossaryId} />}
+              {item.glossaryId && <GlossaryHelp client:idle id={item.glossaryId} />}
             </span>
           ))}
         </nav>


### PR DESCRIPTION
## Summary
- `GlossaryHelp` is a click-to-open jargon toggletip present on every page (via `Base.astro`'s nav), with pure local state and no data fetching — never needed at first paint.
- Switched its Astro hydration directive from `client:load` to `client:idle`, so it hydrates once the main thread is free instead of blocking on it at load.
- Spun off a mobile-hydration-cost investigation (PROJ-431's perf sweep flagged 400-1100ms of long-task time per page, never profiled). Every other island is either a page's primary interactive surface or (for `AccountMenu`/`OfflineBanner`) has a reason to stay eager — this was the one clean, low-risk candidate.

## Test plan
- [x] Full web suite green (44 files / 466 tests) — no test asserts on Astro's `client:*` hydration timing
- [x] `pnpm build` succeeds, SW precache budget check passes
- [x] Manual check: served `dist/` locally, clicked the toggletip on `/settings/tokens` — opens correctly with the expected content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6PrZyYWhxC1LxKehovwcH