### PR TITLE
PROJ-425: gate attachment writes on viewer role

### DIFF
--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -86,14 +86,19 @@ router.post("/", async (c) => {
 	// live in the service (PROJ-234).
 	await c.env.R2.put(r2Key, await file.arrayBuffer(), { httpMetadata: { contentType } });
 
-	const { id } = await filesService.recordUpload(ctx, {
-		entityType,
-		entityId,
-		filename: file.name,
-		contentType,
-		size: file.size,
-		r2Key,
-	});
+	let id: string;
+	try {
+		({ id } = await filesService.recordUpload(ctx, {
+			entityType,
+			entityId,
+			filename: file.name,
+			contentType,
+			size: file.size,
+			r2Key,
+		}));
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
 
 	return c.json({ id, filename: file.name, contentType, size: file.size }, 201);
 });

--- a/apps/api/src/services/files.ts
+++ b/apps/api/src/services/files.ts
@@ -8,6 +8,7 @@ import {
 } from "../schemas/files";
 import { visibleProjectSqlFragment } from "./access";
 import {
+	ForbiddenError,
 	NotFoundError,
 	PayloadTooLargeError,
 	UnsupportedMediaTypeError,
@@ -15,6 +16,15 @@ import {
 } from "./errors";
 import type { ServiceCtx } from "./types";
 import * as wikiService from "./wiki";
+
+// PROJ-425: attachments never checked ctx.role at all — a viewer could create/delete
+// them. Mirrors comments.ts's flat viewer guard rather than wiki.ts's per-project
+// requireWikiWrite: attachment entityIds aren't required to reference an existing
+// issue/wiki page row (they're free-floating metadata keyed by entity_type/entity_id),
+// so resolving a project to check per-project role isn't possible in general.
+function requireAttachmentWrite(ctx: ServiceCtx): void {
+	if (ctx.role === "viewer") throw new ForbiddenError("Insufficient permissions");
+}
 
 export interface AttachmentDto {
 	id: string;
@@ -122,6 +132,8 @@ export async function createLinkAttachment(
 	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
 	const data = parsed.data;
 
+	requireAttachmentWrite(ctx);
+
 	if (data.kind === "wiki_ref") {
 		// PROJ-311: getWikiPage enforces project-grant visibility, not just existence —
 		// a page in a project the caller can't see 404s the same as a nonexistent one.
@@ -197,6 +209,8 @@ export async function recordUpload(ctx: ServiceCtx, input: unknown): Promise<{ i
 	const parsed = RecordFileUploadSchema.safeParse(input);
 	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
 	const { entityType, entityId, filename, contentType, size, r2Key } = parsed.data;
+
+	requireAttachmentWrite(ctx);
 
 	const id = crypto.randomUUID();
 	const now = Math.floor(Date.now() / 1000);
@@ -276,6 +290,8 @@ export async function deleteAttachment(
 ): Promise<{ r2Key: string }> {
 	const parsed = DeleteAttachmentSchema.safeParse(input);
 	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
+
+	requireAttachmentWrite(ctx);
 
 	const row = await ctx.db
 		.prepare("SELECT r2_key FROM attachments WHERE id = ? AND workspace_id = ?")

--- a/apps/api/src/test/files.test.ts
+++ b/apps/api/src/test/files.test.ts
@@ -1,6 +1,14 @@
 import { env, SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
-import { authHeaders, seedFixture, seedMember, seedProject, seedToken, seedUser } from "./helpers";
+import {
+	authHeaders,
+	seedFixture,
+	seedMember,
+	seedProject,
+	seedToken,
+	seedUser,
+	seedWorkspaceRoles,
+} from "./helpers";
 
 const ENTITY_ID = crypto.randomUUID();
 
@@ -590,6 +598,60 @@ describe("Files API", () => {
 			expect(list.find((l) => l.kind === "wiki_ref")).toBeUndefined();
 		});
 	});
+
+	describe("PROJ-425: viewer role is denied write access", () => {
+		it("POST /api/files rejects a viewer upload → 403", async () => {
+			const { workspace, viewer } = await seedWorkspaceRoles();
+			const form = new FormData();
+			form.append("file", new File(["data"], "f.txt", { type: "text/plain" }));
+			form.append("entityType", "issue");
+			form.append("entityId", crypto.randomUUID());
+			const res = await SELF.fetch("http://localhost/api/files", {
+				method: "POST",
+				headers: { Authorization: `Bearer ${viewer.token}`, "X-Workspace-Slug": workspace.slug },
+				body: form,
+			});
+			expect(res.status).toBe(403);
+		});
+
+		it("POST /api/files/links rejects a viewer → 403", async () => {
+			const { workspace, viewer } = await seedWorkspaceRoles();
+			const res = await SELF.fetch("http://localhost/api/files/links", {
+				method: "POST",
+				headers: {
+					...authHeaders(viewer.token, workspace.slug),
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					kind: "url",
+					entityType: "issue",
+					entityId: crypto.randomUUID(),
+					url: "https://example.com",
+				}),
+			});
+			expect(res.status).toBe(403);
+		});
+
+		it("DELETE /api/files/:id rejects a viewer → 403", async () => {
+			const { workspace, owner, viewer } = await seedWorkspaceRoles();
+			const form = new FormData();
+			form.append("file", new File(["data"], "f.txt", { type: "text/plain" }));
+			form.append("entityType", "issue");
+			form.append("entityId", crypto.randomUUID());
+			const uploadRes = await SELF.fetch("http://localhost/api/files", {
+				method: "POST",
+				headers: { Authorization: `Bearer ${owner.token}`, "X-Workspace-Slug": workspace.slug },
+				body: form,
+			});
+			const { id } = (await uploadRes.json()) as { id: string };
+
+			const delRes = await SELF.fetch(`http://localhost/api/files/${id}`, {
+				method: "DELETE",
+				headers: authHeaders(viewer.token, workspace.slug),
+			});
+			expect(delRes.status).toBe(403);
+		});
+	});
 });
 
 // PROJ-234: attachments previously had no MCP surface at all. list/get/create-link/delete
@@ -719,5 +781,47 @@ describe("Files MCP tools", () => {
 			authHeaders(other.token, other.workspace.slug)
 		);
 		expect(result).toEqual([]);
+	});
+
+	it("create_link_attachment via MCP rejects a viewer session → JSON-RPC error", async () => {
+		const { workspace, viewer } = await seedWorkspaceRoles();
+		const res = (await mcpCall(
+			workspace.id,
+			"tools/call",
+			{
+				name: "create_link_attachment",
+				arguments: {
+					kind: "url",
+					entityType: "issue",
+					entityId: crypto.randomUUID(),
+					url: "https://example.com",
+				},
+			},
+			authHeaders(viewer.token, workspace.slug)
+		)) as JsonRpcError;
+		expect(res.error).toBeDefined();
+	});
+
+	it("delete_attachment via MCP rejects a viewer session → JSON-RPC error", async () => {
+		const { workspace, owner, viewer } = await seedWorkspaceRoles();
+		const created = await mcpToolResult<{ id: string }>(
+			workspace.id,
+			"create_link_attachment",
+			{
+				kind: "url",
+				entityType: "issue",
+				entityId: crypto.randomUUID(),
+				url: "https://example.com",
+			},
+			authHeaders(owner.token, workspace.slug)
+		);
+
+		const res = (await mcpCall(
+			workspace.id,
+			"tools/call",
+			{ name: "delete_attachment", arguments: { id: created.id } },
+			authHeaders(viewer.token, workspace.slug)
+		)) as JsonRpcError;
+		expect(res.error).toBeDefined();
 	});
 });


### PR DESCRIPTION
## Summary
- `createLinkAttachment`, `recordUpload`, and `deleteAttachment` in `services/files.ts` never checked `ctx.role` — a viewer could create/delete attachments, now reachable via the `create_link_attachment`/`delete_attachment` MCP tools from PROJ-234.
- Adds a `requireAttachmentWrite` guard (flat viewer check, mirroring `comments.ts` rather than `wiki.ts`'s per-project resolution — attachment `entityId`s aren't guaranteed to reference an existing issue/wiki page row, so a project can't always be resolved).
- Fixes the upload route (`POST /api/files`) which called `recordUpload` outside any try/catch, so the new guard would have surfaced as a raw 500 instead of 403.

## Test plan
- [x] `vitest run src/test/files.test.ts` — 35/35 passing, including new viewer-role rejection tests for REST upload/link-create/delete and MCP `create_link_attachment`/`delete_attachment`
- [x] Full API suite: 874/874 passing
- [x] `biome check` clean on changed files
- [x] `tsc --noEmit` clean

Closes PROJ-425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6PrZyYWhxC1LxKehovwcH