### PR TITLE
docs: accuracy pass, Economist style, restore design-principles article

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Implementation details:
 - **Runtime:** Hono on Cloudflare Workers
 - **Data:** D1 (SQLite) for relational data, KV for caching (Access certs, user-by-email), R2 for file attachments
 - **Schema:** Drizzle is the schema and primary query layer; raw `DB.prepare` remains in the auth/workspace middleware hot path, the dev bootstrap, and a handful of service queries (FTS, counters) where hand-written SQL is clearer.
-- **Monorepo:** pnpm workspaces + turbo. `apps/api` (the Worker), `apps/web` (Astro + Preact static site, served in production via CF Workers Static Assets - see below), `packages/*` (db, types, plugin-sdk), `plugins/*`
+- **Monorepo:** pnpm workspaces + turbo. `apps/api` (the Worker), `apps/web` (Astro + Preact static site, served in production via CF Workers Static Assets - see below), `apps/docs` (the Astro docs site linked throughout this file), `packages/*` (db, types, plugin-sdk), `plugins/*`
 - **Deploy:** projektor publishes a self-contained **release artifact** on each `v*` tag; a config-only deploy repo (e.g. `projektor-workspace`) downloads it and ships it with `wrangler` - no submodule, no source checkout downstream. The Worker (`apps/api`) and the built frontend (`apps/web/dist`) ship together: `wrangler.toml` declares an `[assets]` binding with `run_worker_first = ["/api/*", "/mcp/*"]`, so `/api/*` and `/mcp/*` always hit the Hono Worker while every other path serves the static Astro output (per-route HTML, asset-first). The release build compiles `apps/web` and bundles the Worker into a single `worker.js`.
 
 ## Planning and design docs live in the wiki, not the repo
@@ -103,9 +103,11 @@ Bounded arrays (enums like priority) are fine to bind directly. When in doubt, c
 bumped by `release-prepare.yml`, tagged by `release-tag.yml`, and read by
 `release.yml`/`scripts/build-release.sh` to produce the release artifact (embedded
 as `VERSION` in the tarball and injected into the MCP `serverInfo.version` via
-esbuild `--define`). Every other package's `package.json` `version` field is a fixed
-`0.0.0-workspace` placeholder - those packages are workspace-internal and not
-independently released, so their version field is unused and intentionally never bumped.
+esbuild `--define`). Every other `apps/*`/`packages/*` package's `package.json`
+`version` field is a fixed `0.0.0-workspace` placeholder - those packages are
+workspace-internal and not independently released, so their version field is unused
+and intentionally never bumped. `plugins/*` packages carry their own unused
+placeholder versions (e.g. `0.0.0`, `0.0.1`), not `0.0.0-workspace`.
 
 ## File layout per domain
 
@@ -130,7 +132,7 @@ When adding/changing a domain (issues, projects, wiki, comments, …):
 - **IDs** are `crypto.randomUUID()`.
 - **Issue numbers** use `COALESCE(MAX(number),0)+1` per project - known race under concurrency (tracked as a follow-up).
 - **Auth** (`middleware/auth.ts`): Cloudflare Access JWT (browser) OR `Authorization: Bearer <token>` (agents) OR a dev bypass (`DEV_USER_EMAIL`, non-prod only). API tokens are workspace-scoped - don't widen that.
-- **Login provisioning** (`services/provisioning.ts`): runs on every CF Access / dev-bypass login (not the token path). Cloudflare Access is the gate; config decides what a user gets inside - `ADMIN_EMAILS` → `owner` (first admin login also creates the `DEFAULT_WORKSPACE_SLUG` workspace), everyone else → `AUTO_JOIN_ROLE` (default `viewer`; `none` = invite-only). Idempotent; safe to run per request.
+- **Login provisioning** (`services/provisioning.ts`): runs on every CF Access / dev-bypass login (not the token path). Cloudflare Access is the gate; config decides what a user gets inside - `ADMIN_EMAILS` → `owner` (first admin login also creates the `DEFAULT_WORKSPACE_SLUG` workspace), everyone else → `AUTO_JOIN_ROLE` (default `none` = invite-only; set it, e.g. `viewer`, to auto-join). Idempotent; safe to run per request.
 - **Roles** (`owner`/`admin`/`member`/`viewer`) are enforced in services via `ctx.role`. Mutations generally block `viewer`; destructive ops may require `owner`.
 - **Group-based project access (PROJ-311)** is the authorization model for project-scoped data. Access is **default-deny**: owner/admin see everything, but everyone else sees a project only if one of their **groups** holds a `(project, role)` grant. The effective in-project role is the strongest grant across the user's groups and *replaces* their workspace role inside that project (so a workspace `viewer` with a `member` grant can write there). Enforce it through `services/access.ts`: `visibleProjectPredicate` (an indexed `EXISTS` subquery — filter every project-scoped **list** query with it), `effectiveProjectRole`/`requireProjectAccess` (resolve a single resource; `null` → 404 to hide existence), and `canWriteProject`. Membership is read per-request, so grant/revoke takes effect on the next request with no session state. The `groups` domain (service/routes/mcp) is owner/admin-only CRUD over groups, members, and grants.
 - **The plugin system is not wired at runtime yet** (`pluginRegistry` is empty; `enabled_plugins` is unread). Treat `plugins/*` as not-yet-functional until that lands.
@@ -185,16 +187,16 @@ curl -H "X-Bootstrap-Secret: localdev" http://127.0.0.1:8787/bootstrap
 Then open **http://localhost:4321** - with `DEV_USER_EMAIL` set, the dev auth bypass logs you in
 as that user (a member of the seeded `projektor` workspace), and the islands load real data.
 
-**Before opening a PR:** `pnpm lint`, `pnpm turbo type-check`, `pnpm --filter @projektor/api test`, `pnpm --filter @projektor/web test`, and `pnpm --filter @projektor/web build` must all be green. CI runs exactly these.
+**Before opening a PR:** `pnpm lint`, `pnpm turbo type-check`, `pnpm --filter @projektor/db test`, `pnpm --filter @projektor/api test:coverage`, `pnpm --filter @projektor/web test:coverage`, `pnpm --filter @projektor/web build`, and `pnpm --filter @projektor/docs build` must all be green, and `pnpm gen:docs` must produce no diff. CI runs exactly these (`.github/workflows/ci.yml`).
 
 ## Git hooks (lefthook)
 
 `pnpm install` runs `prepare`, which calls `lefthook install` and wires two hooks:
 
 - **pre-commit** - `pnpm turbo type-check` (fast; leverages turbo's cache, near-instant on unchanged packages), `pnpm biome check --changed --no-errors-on-unmatched` (lint, changed files only), and the island API convention check.
-- **pre-push** - `pnpm --filter @projektor/api test` and `pnpm --filter @projektor/web test` (too slow for every commit but catches the failures that most often break CI).
+- **pre-push** - `pnpm biome check .` (full-repo lint), `pnpm --filter @projektor/api test`, and `pnpm --filter @projektor/web test` (too slow for every commit but catches the failures that most often break CI).
 
-These mirror CI (`.github/workflows/ci.yml`), which additionally runs `pnpm lint` (full repo) and `pnpm --filter @projektor/web build` as PR gates. New contributors get the hooks automatically after `pnpm install`.
+CI (`.github/workflows/ci.yml`) runs a superset of these: the generated-docs freshness check, `pnpm lint`, `pnpm turbo type-check`, `pnpm --filter @projektor/db test`, coverage-enforced test runs for `@projektor/api` and `@projektor/web`, and both the web and docs builds. New contributors get the hooks automatically after `pnpm install`.
 
 **Bypass for WIP commits/pushes:** pass `--no-verify` (or `-n`) to git:
 
@@ -287,11 +289,14 @@ it up. See the [deploy guide](https://tajd.github.io/projektor/guides/deploying/
 
 **CI commands** (must all pass before opening a PR):
 ```bash
+pnpm gen:docs   # must produce no diff
 pnpm lint
 pnpm turbo type-check
-pnpm --filter @projektor/api test
-pnpm --filter @projektor/web test
+pnpm --filter @projektor/db test
+pnpm --filter @projektor/api test:coverage
+pnpm --filter @projektor/web test:coverage
 pnpm --filter @projektor/web build
+pnpm --filter @projektor/docs build
 ```
 
 **Merge ordering rule:** if two agents both touch the same frontend file (e.g.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,7 @@ curl -H "X-Bootstrap-Secret: localdev" http://127.0.0.1:8787/bootstrap
 Then open **http://localhost:4321** - with `DEV_USER_EMAIL` set, the dev auth bypass logs you in
 as that user (a member of the seeded `projektor` workspace), and the islands load real data.
 
-**Before opening a PR:** `pnpm lint`, `pnpm turbo type-check`, `pnpm --filter @projektor/db test`, `pnpm --filter @projektor/api test:coverage`, `pnpm --filter @projektor/web test:coverage`, `pnpm --filter @projektor/web build`, and `pnpm --filter @projektor/docs build` must all be green, and `pnpm gen:docs` must produce no diff. CI runs exactly these (`.github/workflows/ci.yml`).
+**Before opening a PR:** `pnpm lint`, `pnpm turbo type-check`, `pnpm --filter @projektor/db test`, `pnpm --filter @projektor/api test:coverage`, `pnpm --filter @projektor/web test:coverage`, `pnpm --filter @projektor/web build`, and `pnpm --filter @projektor/docs build` must all be green, and `pnpm gen:docs` must produce no diff. CI runs these plus `node scripts/check-island-api.mjs` (`.github/workflows/ci.yml`).
 
 ## Git hooks (lefthook)
 
@@ -196,7 +196,7 @@ as that user (a member of the seeded `projektor` workspace), and the islands loa
 - **pre-commit** - `pnpm turbo type-check` (fast; leverages turbo's cache, near-instant on unchanged packages), `pnpm biome check --changed --no-errors-on-unmatched` (lint, changed files only), and the island API convention check.
 - **pre-push** - `pnpm biome check .` (full-repo lint), `pnpm --filter @projektor/api test`, and `pnpm --filter @projektor/web test` (too slow for every commit but catches the failures that most often break CI).
 
-CI (`.github/workflows/ci.yml`) runs a superset of these: the generated-docs freshness check, `pnpm lint`, `pnpm turbo type-check`, `pnpm --filter @projektor/db test`, coverage-enforced test runs for `@projektor/api` and `@projektor/web`, and both the web and docs builds. New contributors get the hooks automatically after `pnpm install`.
+CI (`.github/workflows/ci.yml`) runs a superset of these: the generated-docs freshness check, `pnpm lint`, `pnpm turbo type-check`, `pnpm --filter @projektor/db test`, coverage-enforced test runs for `@projektor/api` and `@projektor/web`, both the web and docs builds, and `node scripts/check-island-api.mjs`. New contributors get the hooks automatically after `pnpm install`.
 
 **Bypass for WIP commits/pushes:** pass `--no-verify` (or `-n`) to git:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ conventions: file layout, the service-layer contract (REST and MCP must stay at
 parity), and how to work in parallel without conflicts. Read it before changing
 anything.
 
-Both checks must be green:
+Both checks must be green (CI runs a fuller set - see [AGENTS.md](./AGENTS.md)):
 
 ```bash
 pnpm --filter @projektor/api test   # vitest against an in-process Worker + Miniflare D1

--- a/README.md
+++ b/README.md
@@ -146,14 +146,16 @@ pnpm --filter @projektor/api test   # vitest against an in-process Worker + Mini
 pnpm turbo type-check               # tsc --noEmit across the monorepo
 ```
 
-Both must be green before opening a PR - they mirror CI exactly (`.github/workflows/ci.yml`).
+Both must be green before opening a PR. CI (`.github/workflows/ci.yml`) runs these plus more -
+coverage-enforced test runs, the `@projektor/db` and `@projektor/docs` suites, the web build, and
+a generated-docs freshness check. See [AGENTS.md](./AGENTS.md) for the full list.
 
 ### Git hooks (lefthook)
 
 `pnpm install` wires two hooks automatically:
 
 - **pre-commit** - `pnpm turbo type-check` (fast; turbo-cached)
-- **pre-push** - `pnpm --filter @projektor/api test` (~8 s vitest suite)
+- **pre-push** - `pnpm biome check .`, `pnpm --filter @projektor/api test`, and `pnpm --filter @projektor/web test`
 
 Bypass for WIP commits: `git commit --no-verify -m "wip: …"`
 
@@ -179,7 +181,7 @@ Frontend: **Astro + Preact**, served as static assets via Workers Static Assets;
 
 ## Roadmap / Contributing
 
-Feature requests and bugs are tracked in the live projektor dogfood instance - projektor is built with itself.
+The live projektor dogfood instance tracks feature requests and bugs - projektor is built with itself.
 
 [AGENTS.md](./AGENTS.md) is the contributor guide: conventions, file layout, the service-layer contract, and how to work in parallel without conflicts. Read it before opening a PR.
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ a generated-docs freshness check. See [AGENTS.md](./AGENTS.md) for the full list
 
 `pnpm install` wires two hooks automatically:
 
-- **pre-commit** - `pnpm turbo type-check` (fast; turbo-cached)
+- **pre-commit** - `pnpm turbo type-check` (fast; turbo-cached), `pnpm biome check --changed` (lint, changed files only), and the island API convention check
 - **pre-push** - `pnpm biome check .`, `pnpm --filter @projektor/api test`, and `pnpm --filter @projektor/web test`
 
 Bypass for WIP commits: `git commit --no-verify -m "wip: …"`

--- a/apps/docs/src/content/docs/agents/agent-workflows.md
+++ b/apps/docs/src/content/docs/agents/agent-workflows.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 Projektor is **MCP-native**: AI agents are a first-class client, not an afterthought.
 Everything a browser user can do, an agent can do over a JSON-RPC MCP endpoint. This
-page gives an overview of the layers agents use to do that work.
+page describes the layers agents use to do it.
 
 Agentic development breaks down into three concerns. Projektor integrates across all of them.
 

--- a/apps/docs/src/content/docs/agents/mcp-connection.md
+++ b/apps/docs/src/content/docs/agents/mcp-connection.md
@@ -43,7 +43,7 @@ curl -s http://127.0.0.1:8787/bootstrap \
   | jq -r .mcpAddCommand | sh
 ```
 
-The bootstrap endpoint is disabled when `ENVIRONMENT=production`. It is idempotent, so it's safe to call more than once.
+The bootstrap endpoint is enabled only when `ENVIRONMENT=development` - any other value, including an unset one, disables it. It is idempotent, so it's safe to call more than once.
 
 ---
 
@@ -76,7 +76,7 @@ curl -s -X POST "https://<your-worker>.workers.dev/auth/tokens" \
 # Response: { "token": "pk_..." }
 ```
 
-`scopes` must be `["read"]`, `["write"]`, or `["read", "write"]`. `expiresAt` is optional (unix seconds).
+`scopes` is a list of `"read"`, `"write"`, or `"*"` (full access) - e.g. `["read"]`, `["read", "write"]`, or `["*"]`. `expiresAt` is optional (unix seconds).
 
 ---
 
@@ -225,7 +225,7 @@ boundary.
   "result": {
     "protocolVersion": "2024-11-05",
     "capabilities": { "tools": {} },
-    "serverInfo": { "name": "projektor", "version": "0.1.0" }
+    "serverInfo": { "name": "projektor", "version": "<release version, e.g. 0.4.13>" }
   }
 }
 ```

--- a/apps/docs/src/content/docs/agents/mcp-connection.md
+++ b/apps/docs/src/content/docs/agents/mcp-connection.md
@@ -225,7 +225,7 @@ boundary.
   "result": {
     "protocolVersion": "2024-11-05",
     "capabilities": { "tools": {} },
-    "serverInfo": { "name": "projektor", "version": "<release version, e.g. 0.4.13>" }
+    "serverInfo": { "name": "projektor", "version": "<the deployed release's version, e.g. from its git tag>" }
   }
 }
 ```

--- a/apps/docs/src/content/docs/contributing/conventions.md
+++ b/apps/docs/src/content/docs/contributing/conventions.md
@@ -26,7 +26,7 @@ Implementation details:
 - **Runtime:** Hono on Cloudflare Workers
 - **Data:** D1 (SQLite) for relational data, KV for caching (Access certs, user-by-email), R2 for file attachments
 - **Schema:** Drizzle is the schema and primary query layer; raw `DB.prepare` remains in the auth/workspace middleware hot path, the dev bootstrap, and a handful of service queries (FTS, counters) where hand-written SQL is clearer.
-- **Monorepo:** pnpm workspaces + turbo. `apps/api` (the Worker), `apps/web` (Astro + Preact static site, served in production via CF Workers Static Assets - see below), `packages/*` (db, types, plugin-sdk), `plugins/*`
+- **Monorepo:** pnpm workspaces + turbo. `apps/api` (the Worker), `apps/web` (Astro + Preact static site, served in production via CF Workers Static Assets - see below), `apps/docs` (the Astro docs site linked throughout this file), `packages/*` (db, types, plugin-sdk), `plugins/*`
 - **Deploy:** projektor publishes a self-contained **release artifact** on each `v*` tag; a config-only deploy repo (e.g. `projektor-workspace`) downloads it and ships it with `wrangler` - no submodule, no source checkout downstream. The Worker (`apps/api`) and the built frontend (`apps/web/dist`) ship together: `wrangler.toml` declares an `[assets]` binding with `run_worker_first = ["/api/*", "/mcp/*"]`, so `/api/*` and `/mcp/*` always hit the Hono Worker while every other path serves the static Astro output (per-route HTML, asset-first). The release build compiles `apps/web` and bundles the Worker into a single `worker.js`.
 
 ## Planning and design docs live in the wiki, not the repo
@@ -109,9 +109,11 @@ Bounded arrays (enums like priority) are fine to bind directly. When in doubt, c
 bumped by `release-prepare.yml`, tagged by `release-tag.yml`, and read by
 `release.yml`/`scripts/build-release.sh` to produce the release artifact (embedded
 as `VERSION` in the tarball and injected into the MCP `serverInfo.version` via
-esbuild `--define`). Every other package's `package.json` `version` field is a fixed
-`0.0.0-workspace` placeholder - those packages are workspace-internal and not
-independently released, so their version field is unused and intentionally never bumped.
+esbuild `--define`). Every other `apps/*`/`packages/*` package's `package.json`
+`version` field is a fixed `0.0.0-workspace` placeholder - those packages are
+workspace-internal and not independently released, so their version field is unused
+and intentionally never bumped. `plugins/*` packages carry their own unused
+placeholder versions (e.g. `0.0.0`, `0.0.1`), not `0.0.0-workspace`.
 
 ## File layout per domain
 
@@ -136,7 +138,7 @@ When adding/changing a domain (issues, projects, wiki, comments, …):
 - **IDs** are `crypto.randomUUID()`.
 - **Issue numbers** use `COALESCE(MAX(number),0)+1` per project - known race under concurrency (tracked as a follow-up).
 - **Auth** (`middleware/auth.ts`): Cloudflare Access JWT (browser) OR `Authorization: Bearer <token>` (agents) OR a dev bypass (`DEV_USER_EMAIL`, non-prod only). API tokens are workspace-scoped - don't widen that.
-- **Login provisioning** (`services/provisioning.ts`): runs on every CF Access / dev-bypass login (not the token path). Cloudflare Access is the gate; config decides what a user gets inside - `ADMIN_EMAILS` → `owner` (first admin login also creates the `DEFAULT_WORKSPACE_SLUG` workspace), everyone else → `AUTO_JOIN_ROLE` (default `viewer`; `none` = invite-only). Idempotent; safe to run per request.
+- **Login provisioning** (`services/provisioning.ts`): runs on every CF Access / dev-bypass login (not the token path). Cloudflare Access is the gate; config decides what a user gets inside - `ADMIN_EMAILS` → `owner` (first admin login also creates the `DEFAULT_WORKSPACE_SLUG` workspace), everyone else → `AUTO_JOIN_ROLE` (default `none` = invite-only; set it, e.g. `viewer`, to auto-join). Idempotent; safe to run per request.
 - **Roles** (`owner`/`admin`/`member`/`viewer`) are enforced in services via `ctx.role`. Mutations generally block `viewer`; destructive ops may require `owner`.
 - **Group-based project access (PROJ-311)** is the authorization model for project-scoped data. Access is **default-deny**: owner/admin see everything, but everyone else sees a project only if one of their **groups** holds a `(project, role)` grant. The effective in-project role is the strongest grant across the user's groups and *replaces* their workspace role inside that project (so a workspace `viewer` with a `member` grant can write there). Enforce it through `services/access.ts`: `visibleProjectPredicate` (an indexed `EXISTS` subquery — filter every project-scoped **list** query with it), `effectiveProjectRole`/`requireProjectAccess` (resolve a single resource; `null` → 404 to hide existence), and `canWriteProject`. Membership is read per-request, so grant/revoke takes effect on the next request with no session state. The `groups` domain (service/routes/mcp) is owner/admin-only CRUD over groups, members, and grants.
 - **The plugin system is not wired at runtime yet** (`pluginRegistry` is empty; `enabled_plugins` is unread). Treat `plugins/*` as not-yet-functional until that lands.
@@ -191,16 +193,16 @@ curl -H "X-Bootstrap-Secret: localdev" http://127.0.0.1:8787/bootstrap
 Then open **http://localhost:4321** - with `DEV_USER_EMAIL` set, the dev auth bypass logs you in
 as that user (a member of the seeded `projektor` workspace), and the islands load real data.
 
-**Before opening a PR:** `pnpm lint`, `pnpm turbo type-check`, `pnpm --filter @projektor/api test`, `pnpm --filter @projektor/web test`, and `pnpm --filter @projektor/web build` must all be green. CI runs exactly these.
+**Before opening a PR:** `pnpm lint`, `pnpm turbo type-check`, `pnpm --filter @projektor/db test`, `pnpm --filter @projektor/api test:coverage`, `pnpm --filter @projektor/web test:coverage`, `pnpm --filter @projektor/web build`, and `pnpm --filter @projektor/docs build` must all be green, and `pnpm gen:docs` must produce no diff. CI runs exactly these (`.github/workflows/ci.yml`).
 
 ## Git hooks (lefthook)
 
 `pnpm install` runs `prepare`, which calls `lefthook install` and wires two hooks:
 
 - **pre-commit** - `pnpm turbo type-check` (fast; leverages turbo's cache, near-instant on unchanged packages), `pnpm biome check --changed --no-errors-on-unmatched` (lint, changed files only), and the island API convention check.
-- **pre-push** - `pnpm --filter @projektor/api test` and `pnpm --filter @projektor/web test` (too slow for every commit but catches the failures that most often break CI).
+- **pre-push** - `pnpm biome check .` (full-repo lint), `pnpm --filter @projektor/api test`, and `pnpm --filter @projektor/web test` (too slow for every commit but catches the failures that most often break CI).
 
-These mirror CI (`.github/workflows/ci.yml`), which additionally runs `pnpm lint` (full repo) and `pnpm --filter @projektor/web build` as PR gates. New contributors get the hooks automatically after `pnpm install`.
+CI (`.github/workflows/ci.yml`) runs a superset of these: the generated-docs freshness check, `pnpm lint`, `pnpm turbo type-check`, `pnpm --filter @projektor/db test`, coverage-enforced test runs for `@projektor/api` and `@projektor/web`, and both the web and docs builds. New contributors get the hooks automatically after `pnpm install`.
 
 **Bypass for WIP commits/pushes:** pass `--no-verify` (or `-n`) to git:
 
@@ -293,11 +295,14 @@ it up. See the [deploy guide](https://tajd.github.io/projektor/guides/deploying/
 
 **CI commands** (must all pass before opening a PR):
 ```bash
+pnpm gen:docs   # must produce no diff
 pnpm lint
 pnpm turbo type-check
-pnpm --filter @projektor/api test
-pnpm --filter @projektor/web test
+pnpm --filter @projektor/db test
+pnpm --filter @projektor/api test:coverage
+pnpm --filter @projektor/web test:coverage
 pnpm --filter @projektor/web build
+pnpm --filter @projektor/docs build
 ```
 
 **Merge ordering rule:** if two agents both touch the same frontend file (e.g.

--- a/apps/docs/src/content/docs/contributing/conventions.md
+++ b/apps/docs/src/content/docs/contributing/conventions.md
@@ -193,7 +193,7 @@ curl -H "X-Bootstrap-Secret: localdev" http://127.0.0.1:8787/bootstrap
 Then open **http://localhost:4321** - with `DEV_USER_EMAIL` set, the dev auth bypass logs you in
 as that user (a member of the seeded `projektor` workspace), and the islands load real data.
 
-**Before opening a PR:** `pnpm lint`, `pnpm turbo type-check`, `pnpm --filter @projektor/db test`, `pnpm --filter @projektor/api test:coverage`, `pnpm --filter @projektor/web test:coverage`, `pnpm --filter @projektor/web build`, and `pnpm --filter @projektor/docs build` must all be green, and `pnpm gen:docs` must produce no diff. CI runs exactly these (`.github/workflows/ci.yml`).
+**Before opening a PR:** `pnpm lint`, `pnpm turbo type-check`, `pnpm --filter @projektor/db test`, `pnpm --filter @projektor/api test:coverage`, `pnpm --filter @projektor/web test:coverage`, `pnpm --filter @projektor/web build`, and `pnpm --filter @projektor/docs build` must all be green, and `pnpm gen:docs` must produce no diff. CI runs these plus `node scripts/check-island-api.mjs` (`.github/workflows/ci.yml`).
 
 ## Git hooks (lefthook)
 
@@ -202,7 +202,7 @@ as that user (a member of the seeded `projektor` workspace), and the islands loa
 - **pre-commit** - `pnpm turbo type-check` (fast; leverages turbo's cache, near-instant on unchanged packages), `pnpm biome check --changed --no-errors-on-unmatched` (lint, changed files only), and the island API convention check.
 - **pre-push** - `pnpm biome check .` (full-repo lint), `pnpm --filter @projektor/api test`, and `pnpm --filter @projektor/web test` (too slow for every commit but catches the failures that most often break CI).
 
-CI (`.github/workflows/ci.yml`) runs a superset of these: the generated-docs freshness check, `pnpm lint`, `pnpm turbo type-check`, `pnpm --filter @projektor/db test`, coverage-enforced test runs for `@projektor/api` and `@projektor/web`, and both the web and docs builds. New contributors get the hooks automatically after `pnpm install`.
+CI (`.github/workflows/ci.yml`) runs a superset of these: the generated-docs freshness check, `pnpm lint`, `pnpm turbo type-check`, `pnpm --filter @projektor/db test`, coverage-enforced test runs for `@projektor/api` and `@projektor/web`, both the web and docs builds, and `node scripts/check-island-api.mjs`. New contributors get the hooks automatically after `pnpm install`.
 
 **Bypass for WIP commits/pushes:** pass `--no-verify` (or `-n`) to git:
 

--- a/apps/docs/src/content/docs/contributing/island-api-plugin.md
+++ b/apps/docs/src/content/docs/contributing/island-api-plugin.md
@@ -12,7 +12,7 @@ how it replaced an older grep script (CD-69).
 
 ## Why a cofferdam plugin instead of a grep script
 
-The convention used to be enforced by a shell script that grepped island source files
+A shell script used to enforce the convention, grepping island source files
 for `buildHeaders` and `fetch(`. That worked, but it had no AST awareness — it couldn't
 tell a real `fetch()` call from a string that happened to contain the word, and it
 couldn't be extended to catch `window.fetch()`-style bypasses without ad-hoc regex
@@ -70,7 +70,7 @@ for (const ln of file.lines()) {
 }
 ```
 
-Deliberately, this loop does **not** skip lines flagged by `LineView.isComment` or
+This loop deliberately does **not** skip lines flagged by `LineView.isComment` or
 `isStringLiteral` — the original grep script scanned raw text unconditionally, and
 preserving that means the plugin doesn't silently lose coverage relative to what it
 replaced (the fixture's third case exists specifically to guard against a future "skip

--- a/apps/docs/src/content/docs/guides/deploying.md
+++ b/apps/docs/src/content/docs/guides/deploying.md
@@ -5,8 +5,8 @@ sidebar:
   order: 2
 ---
 Projektor ships as a **self-contained release artifact** and deploys from **config
-only**. There is no source checkout, no submodule or any build step on the machine that
-deploys. This page covers the model, how to stand up your own
+only**. There is no source checkout, no submodule, and no build step on the deploy
+machine. This page covers the model, how to stand up your own
 instance, how releases are cut, and how to keep an instance updated automatically.
 
 > Looking for the 5-minute version? See [Self-hosting](/projektor/guides/self-hosting/).
@@ -95,7 +95,7 @@ echo "v0.3.7" > projektor.version          # pin whichever tag you picked
 ```
 
 Fill in the `REPLACE_` values: D1 `database_id`, KV `id`, your Cloudflare Access
-team domain + audience, and `ADMIN_EMAILS`. The artifact-owned paths
+team domain and audience, and `ADMIN_EMAILS`. The artifact-owned paths
 (`main = ./vendor/worker.js`, `[assets].directory = ./vendor/web`,
 `migrations_dir = ./vendor/migrations`) and `compatibility_flags = ["nodejs_compat"]`
 are already set - leave them.
@@ -215,7 +215,7 @@ How it's wired:
    `projektor.version` (a `[skip ci]` commit), and deploys.
 
 The result: `git push --tags` in `projektor` → your instance is running the new
-version, no manual step. To deploy by hand instead, just bump `projektor.version`,
+version, no manual step. To deploy by hand instead, bump `projektor.version`,
 commit, and push.
 
 ## Operating notes

--- a/apps/docs/src/content/docs/guides/live-demo.md
+++ b/apps/docs/src/content/docs/guides/live-demo.md
@@ -4,15 +4,15 @@ description: "See Projektor running before you deploy your own instance."
 sidebar:
   order: 1
 ---
-Want to see Projektor running before you deploy your own? Check out the
+Want to see Projektor running before you deploy your own? Visit the
 [live demo](https://projektor-demo.tajdickson.workers.dev) - a fresh, unseeded instance
-standing up the wiki + issue tracker on a single Cloudflare Worker.
+standing up the wiki and issue tracker on a single Cloudflare Worker.
 
 No login is configured on the demo, so the app shell loads and then the
 project/issue views get stuck on "Loading projects..." - that's expected, not broken.
 The API requires Cloudflare Access, which the demo leaves unconfigured, so
 `/api/projects` returns 401 and the UI never gets past the loading state. It's the same
-Worker code you'd deploy yourself, just kept empty and login-less on purpose. To use
+Worker code you'd deploy yourself, kept empty and login-less on purpose. To use
 Projektor, deploy your own instance.
 
 When you're ready to stand up your own instance, the

--- a/apps/docs/src/content/docs/guides/self-hosting.md
+++ b/apps/docs/src/content/docs/guides/self-hosting.md
@@ -9,7 +9,7 @@ Projektor deploys to **your own Cloudflare account** from a small **config-only 
 downloads a pre-built release artifact - no source checkout and no build step. Pick the
 path that suits you; they're ordered easiest first.
 
-Want to see it running before you deploy your own? Check out the
+Want to see it running before you deploy your own? Visit the
 [live demo](https://projektor-demo.tajdickson.workers.dev).
 
 ## One click
@@ -39,7 +39,7 @@ The Worker is live, but **Cloudflare Access** must front it before anyone can lo
 `ADMIN_EMAILS` becomes owner - and mint a token for agents. Full handoff:
 [CONFIGURE.md](https://github.com/TAJD/projektor-deploy-example/blob/main/CONFIGURE.md).
 
-**Updating later:** bump `projektor.version` and re-deploy (or just push, if you wired CI).
+**Updating later:** bump `projektor.version` and re-deploy (or push, if you wired CI).
 
 ## Manual or CI deploys
 

--- a/apps/docs/src/content/docs/philosophy/design-principles.md
+++ b/apps/docs/src/content/docs/philosophy/design-principles.md
@@ -4,7 +4,7 @@ description: "The research behind Projektor's workflow design: flow literature, 
 sidebar:
   order: 2
 ---
-Projektor's tagline is "AI native design and tried and tested principles". This
+Projektor combines AI-native design with tried-and-tested principles. This
 page presents the evidence: the two bodies of research the design draws on, and
 the principles that fall out where they agree.
 
@@ -89,8 +89,9 @@ and its rules cannot diverge.
 
 The WIP research is blunt: nobody can tell you your optimal limit. So the
 tracker stamps transition timestamps and exposes lead time, cycle time, and
-WIP-over-time — and defaults (like the agent concurrency cap) derive from your
-measured baseline, not folklore.
+WIP-over-time — the measurements a team needs before tuning defaults like the
+agent concurrency cap (currently a flat default of 3) against its own baseline,
+not folklore.
 
 ### 6. Humans gate the exits
 

--- a/apps/docs/src/content/docs/philosophy/design-principles.md
+++ b/apps/docs/src/content/docs/philosophy/design-principles.md
@@ -1,0 +1,112 @@
+---
+title: "Design principles"
+description: "The research behind Projektor's workflow design: flow literature, agent engineering, and the six principles where they converge."
+sidebar:
+  order: 2
+---
+Projektor's tagline is "AI native design and tried and tested principles". This
+page presents the evidence: the two bodies of research the design draws on, and
+the principles that fall out where they agree.
+
+Two literatures matter. One is decades old and studies how *humans* move work
+through a tracker. The other is a few years old and studies how *agents* fail.
+Strikingly, they often reach the same conclusion from opposite directions.
+
+## What the flow literature says
+
+The strongest empirical work on project management is lean/flow research, not
+tool-vendor guidance:
+
+- **Small batches win.** The [Accelerate/DORA research](https://openpracticelibrary.com/blog/accelerate-metrics-software-delivery-performance-measurement/)
+  (Forsgren, Humble, Kim) links small batch sizes, short lead times, and
+  frequent integration to organizational performance — the most rigorous
+  evidence in the field.
+- **There is no magic WIP number.** An [empirical study of WIP in kanban teams](https://dl.acm.org/doi/10.1145/3239235.3239238)
+  found lower work-in-progress correlates with shorter lead time, but no
+  published evidence supports a universal optimal limit. The honest advice:
+  [measure your own flow first, then set limits](https://www.atlassian.com/agile/kanban/wip-limits).
+- **Pull beats push.** Practitioner consensus on top of the research: explicit
+  workflow states with entry/exit criteria, a single prioritized backlog, and
+  workers pulling the next item instead of having it pushed onto them.
+
+## What the agent-engineering literature says
+
+- **Boundaries, not vibes.** Anthropic's engineering posts —
+  [Building effective agents](https://resources.anthropic.com/building-effective-ai-agents),
+  [the multi-agent research system](https://www.anthropic.com/engineering/multi-agent-research-system),
+  [context engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) —
+  converge on giving each agent explicit objectives, output formats, and task
+  boundaries. Their early orchestrators spawned fifty subagents for simple
+  queries; the fix was structural, not exhortative.
+- **The ticket is the dispatch unit.** The emerging
+  [trackers-as-agent-infrastructure argument](https://www.mindstudio.ai/blog/issue-trackers-ai-agent-infrastructure-jira-linear):
+  API-first trackers win because the ticket carries the spec, the audit trail,
+  and the coordination state.
+- **Checkpoints are architecture.** Governance work
+  ([InfoWorld](https://www.infoworld.com/article/4154570/best-practices-for-building-agentic-systems.html),
+  [enterprise patterns](https://virtido.com/blog/agentic-workflows-patterns-best-practices-enterprise))
+  puts human-in-the-loop gates at defined workflow stages and enforces policy
+  at the point of action — not in the operator's memory.
+
+## The six principles
+
+Where the two literatures agree, Projektor treats the conclusion as a design
+constraint.
+
+### 1. Tickets are self-contained specs
+
+Humans tolerate tribal context; agents don't. DORA's small-batch finding and
+Anthropic's task-boundary finding are the same requirement seen from two
+directions: work items must be small, unambiguous, and independently
+verifiable. A ticket ready for an agent states its acceptance criteria, names
+its files and scope, and includes a verification command.
+
+### 2. WIP limits are enforced by the tool
+
+For humans, WIP discipline is culture. For agents it must be mechanism,
+because agents make WIP inflation free — spawning ten workers costs one
+prompt. The fifty-subagent failure mode is what unenforced WIP looks like at
+agent speed. Concurrency caps belong in the tracker's claim path, not in the
+operator's restraint.
+
+### 3. The tracker is the coordination substrate
+
+Agent sessions, file claims, issue leases, heartbeats, channel messages:
+coordination state lives in the same durable store as the work itself, not in
+ad-hoc side channels. The issue graph is the shared memory; status changes are
+the events. (This is the thesis of
+[Where Projektor fits](/projektor/philosophy/where-projektor-fits/).)
+
+### 4. One canonical workflow spec, looked up — not copied
+
+Workflow rules drift the moment they exist in two places. The rules get
+exactly one home — this documentation site — and every consumer (the MCP
+server's instructions, contributor docs, skills, spawn prompts) points at it
+rather than restating it. The server *serves* the spec so the deployed version
+and its rules cannot diverge.
+
+### 5. Measure flow before tuning it
+
+The WIP research is blunt: nobody can tell you your optimal limit. So the
+tracker stamps transition timestamps and exposes lead time, cycle time, and
+WIP-over-time — and defaults (like the agent concurrency cap) derive from your
+measured baseline, not folklore.
+
+### 6. Humans gate the exits
+
+Agents may pull work autonomously; they do not declare their own work done.
+Agent-completed issues land in review with a structured completion report —
+what changed, verification output, PR link — and only a human moves them to
+done. The checkpoint is enforced in the state machine, not requested in the
+prompt.
+
+## What this deliberately isn't
+
+Projektor defers the fashionable automations — triage bots, grooming bots,
+status-rollup agents — until the measurement and gating above exist. The
+literature suggests them as low-risk starting points; the same literature says
+you can't evaluate them without flow metrics. Measure first.
+
+For how these principles play out in practice — the multi-agent loop,
+coordination primitives, and the tool catalog — see
+[Agentic workflows](/projektor/agents/agent-workflows/).

--- a/apps/docs/src/content/docs/philosophy/where-projektor-fits.md
+++ b/apps/docs/src/content/docs/philosophy/where-projektor-fits.md
@@ -6,31 +6,31 @@ sidebar:
 ---
 Tools for agentic development split into three concerns: running the agents,
 coordinating them, and tracking the work. The mistake is to treat each concern
-as its own product. They are not products - they are concerns, and the real
+as its own product. They are not products — they are concerns, and the real
 product boundary is the API. With MCP as the shared interface, one tool can cut
 a vertical slice through several concerns and stay coherent, because the
 interface stays coherent. That is what Projektor is: not one layer, but a slice
 across several.
 
-This page is the *why*. For the *how* - the multi-agent loop these concerns
-combine into - see [Agentic workflows](/projektor/agents/agent-workflows/).
+This page is the *why*. For the *how* — the multi-agent loop these concerns
+combine into — see [Agentic workflows](/projektor/agents/agent-workflows/).
 
 ## The three concerns
 
-1. **Implementation - the runtime.** Spawning agents, worktrees, job objects.
+1. **Implementation — the runtime.** Spawning agents, worktrees, job objects.
    Choosing which model runs (Opus plans, Sonnet builds, Haiku looks up). Tuning
    prompts and context to keep tokens cheap. And the verification steps that move
    work forward: running the tests, doing the human review.
-2. **Coordination - communication.** A message bus, agent presence, context
+2. **Coordination — communication.** A message bus, agent presence, context
    fetching, shared skills. For a fleet, most of this collapses into project
    management: the issue graph **is** the shared memory, and status changes
    **are** the events.
-3. **Project management - the source of truth.** The durable state: the issue,
+3. **Project management — the source of truth.** The durable state: the issue,
    epic, and sprint graph; machine-readable priorities; and the state-machine
    nodes that record what verification decided.
 
 Projektor is a single MCP surface spanning coordination and project management.
-Through file claims it also reaches into the runtime - deciding who may write
+Through file claims it also reaches into the runtime — deciding who may write
 which file. It owns the **nodes** of the work state machine; the implementation
 layer owns the **transitions**. Projektor never runs a test or judges a diff. It
 records the outcome.
@@ -78,7 +78,7 @@ Projektor sits between two kinds of tool that already exist:
 - **Jira / Notion** are mature and scalable, but human-first: agent access is
   bolted on, the API is not the primary surface, and you cannot cheaply
   self-host a slice of them.
-- **beads** is genuinely agent-native, but it is a git-file tracker - issues
+- **beads** is genuinely agent-native, but it is a git-file tracker — issues
   stored as JSONL in the repo. That gives offline resilience and issues that
   version alongside the code, but it is structurally per-repo and bound to git
   merges.
@@ -102,7 +102,7 @@ not a rewrite.
 These are deliberate bets, not oversights:
 
 1. **A central coordinator on the write path.** A deployed tracker puts
-   Projektor's availability on every worker's critical path - the price of
+   Projektor's availability on every worker's critical path — the price of
    cross-project claims and presence that beads, being offline and git-backed,
    never pays. The bet: fleet-scale coordination is worth more than git's offline
    resilience and the issue-versioned-with-code property.
@@ -115,7 +115,7 @@ These are deliberate bets, not oversights:
 
 ## Where to go next
 
-- **The operational loop:** [Agentic workflows](/projektor/agents/agent-workflows/) - how the
+- **The operational loop:** [Agentic workflows](/projektor/agents/agent-workflows/) — how the
   three concerns combine into a real multi-agent dev cycle.
 - **The system underneath:** [Architecture](/projektor/architecture/system-design/).
 - **Connect an agent:** [Connect an AI agent](/projektor/agents/mcp-connection/).


### PR DESCRIPTION
## Summary
- Audited every doc (AGENTS.md, README.md, CONTRIBUTING.md, and the apps/docs Starlight site) against the current codebase and fixed drift: wrong `AUTO_JOIN_ROLE` default, incomplete CI/pre-push command lists, missing `apps/docs` in the monorepo layout, wrong `plugins/*` versioning claim, wrong MCP bootstrap gating direction, missing `"*"` token scope, stale `serverInfo.version` example.
- Recovered `apps/docs/src/content/docs/philosophy/design-principles.md` from the never-merged `docs/design-principles-article` branch (2026-07-04) and verified every technical claim it makes against the actual MCP/workflow code.
- Applied the Economist style guide to touched prose (active voice, cut filler/weasel words) — code, commands, paths, frontmatter untouched.
- Regenerated `conventions.md` from the corrected `AGENTS.md` so the two stay in sync (it's a generated mirror).

## Test plan
- [x] `pnpm gen:docs` — no diff (generated docs stay fresh)
- [x] `pnpm biome check .` — clean
- [x] `pnpm --filter @projektor/docs build` — 16 pages, all internal links valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARqSwME8YJWaLecL2KFh9k