### PR TITLE
PROJ-426: clean up R2 objects when a wiki page is deleted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ dist/
 dev-server.log
 .cofferdam/cache/
 coverage/
+
+# local agent tooling state (spawn-claude worktrees, scratch plans/research) — a nested
+# biome.json under here otherwise trips `biome check .`'s nested-root-config detection
+.claude/

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -398,6 +398,44 @@ async function collectDescendantIds(
 	return descendants;
 }
 
+// PROJ-426: file attachments uploaded directly to a wiki page (entityType="wiki_page",
+// entityId=pageId) aren't covered by the FK cascade on linkedWikiPageId — that column is
+// only set for wiki_ref pointer attachments elsewhere that link to this page. Delete the
+// R2 objects before dropping the rows, mirroring mcp/files.ts's delete_attachment handler.
+async function deleteWikiPageAttachments(
+	ctx: ServiceCtx,
+	orm: ReturnType<typeof drizzle<typeof schema>>,
+	pageIds: string[]
+): Promise<void> {
+	const fileAttachments = await orm
+		.select({ r2Key: schema.attachments.r2Key })
+		.from(schema.attachments)
+		.where(
+			and(
+				eq(schema.attachments.entityType, "wiki_page"),
+				inArray(schema.attachments.entityId, pageIds),
+				eq(schema.attachments.kind, "file")
+			)
+		);
+	for (const { r2Key } of fileAttachments) {
+		if (r2Key) await ctx.r2.delete(r2Key);
+	}
+
+	await orm
+		.delete(schema.attachments)
+		.where(
+			and(
+				eq(schema.attachments.entityType, "wiki_page"),
+				inArray(schema.attachments.entityId, pageIds)
+			)
+		);
+
+	// PROJ-407: mirror the migration's ON DELETE CASCADE at the app level too, since
+	// D1 does not guarantee FK enforcement is on for every connection. wiki_ref pointer
+	// rows have no R2 object (r2Key is "").
+	await orm.delete(schema.attachments).where(inArray(schema.attachments.linkedWikiPageId, pageIds));
+}
+
 export async function deleteWikiPage(ctx: ServiceCtx, slug: string, options?: unknown) {
 	const idCheck = IdSchema.safeParse(slug);
 	if (!idCheck.success)
@@ -432,9 +470,7 @@ export async function deleteWikiPage(ctx: ServiceCtx, slug: string, options?: un
 		const descendantIds = await collectDescendantIds(ctx.db, page.id, ctx.workspaceId);
 		const allIds = [page.id, ...descendantIds];
 		await inChunks(allIds, async (chunk) => {
-			await orm
-				.delete(schema.attachments)
-				.where(inArray(schema.attachments.linkedWikiPageId, chunk));
+			await deleteWikiPageAttachments(ctx, orm, chunk);
 			return [];
 		});
 		await inChunks(allIds, async (chunk) => {
@@ -458,9 +494,7 @@ export async function deleteWikiPage(ctx: ServiceCtx, slug: string, options?: un
 		.set({ parentId: page.parentId })
 		.where(eq(schema.wikiPages.parentId, page.id));
 
-	// PROJ-407: mirror the migration's ON DELETE CASCADE at the app level too, since
-	// D1 does not guarantee FK enforcement is on for every connection.
-	await orm.delete(schema.attachments).where(eq(schema.attachments.linkedWikiPageId, page.id));
+	await deleteWikiPageAttachments(ctx, orm, [page.id]);
 	await orm.delete(schema.wikiPages).where(eq(schema.wikiPages.id, page.id));
 	await recordActivity(ctx, { entityType: "wiki_page", entityId: page.id, action: "deleted" });
 	return { ok: true, deletedCount: 1 };

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -542,6 +542,87 @@ describe("Wiki API", () => {
 		}
 	});
 
+	async function uploadFileToPage(token: string, slug: string, pageId: string) {
+		const form = new FormData();
+		form.append("file", new File(["attachment content"], "doc.txt", { type: "text/plain" }));
+		form.append("entityType", "wiki_page");
+		form.append("entityId", pageId);
+		const res = await SELF.fetch("http://localhost/api/files", {
+			method: "POST",
+			headers: { Authorization: `Bearer ${token}`, "X-Workspace-Slug": slug },
+			body: form,
+		});
+		const { id } = (await res.json()) as { id: string };
+		const row = await env.DB.prepare("SELECT r2_key FROM attachments WHERE id = ?")
+			.bind(id)
+			.first<{ r2_key: string }>();
+		return { attachmentId: id, r2Key: row!.r2_key };
+	}
+
+	it("DELETE /api/wiki/:slug (default) removes the R2 object for a file attached to the page (PROJ-426)", async () => {
+		const owner = await seedFixture({ role: "owner" });
+		const ownerHeaders = authHeaders(owner.token, owner.workspace.slug);
+
+		const pageRes = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: ownerHeaders,
+			body: JSON.stringify({ title: "Page With File", content: "" }),
+		});
+		const page = (await pageRes.json()) as { id: string; slug: string };
+
+		const { attachmentId, r2Key } = await uploadFileToPage(
+			owner.token,
+			owner.workspace.slug,
+			page.id
+		);
+		expect(await env.R2.get(r2Key)).not.toBeNull();
+
+		const delRes = await SELF.fetch(`http://localhost/api/wiki/${page.slug}`, {
+			method: "DELETE",
+			headers: ownerHeaders,
+		});
+		expect(delRes.status).toBe(200);
+
+		expect(await env.R2.get(r2Key)).toBeNull();
+		const row = await env.DB.prepare("SELECT id FROM attachments WHERE id = ?")
+			.bind(attachmentId)
+			.first();
+		expect(row).toBeNull();
+	});
+
+	it("DELETE /api/wiki/:slug?cascade=true removes R2 objects for files attached across the subtree (PROJ-426)", async () => {
+		const owner = await seedFixture({ role: "owner" });
+		const ownerHeaders = authHeaders(owner.token, owner.workspace.slug);
+
+		const parentRes = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: ownerHeaders,
+			body: JSON.stringify({ title: "Cascade Parent With File", content: "" }),
+		});
+		const parent = (await parentRes.json()) as { id: string; slug: string };
+
+		const childRes = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: ownerHeaders,
+			body: JSON.stringify({ title: "Cascade Child With File", content: "", parentId: parent.id }),
+		});
+		const child = (await childRes.json()) as { id: string; slug: string };
+
+		const parentFile = await uploadFileToPage(owner.token, owner.workspace.slug, parent.id);
+		const childFile = await uploadFileToPage(owner.token, owner.workspace.slug, child.id);
+		expect(await env.R2.get(parentFile.r2Key)).not.toBeNull();
+		expect(await env.R2.get(childFile.r2Key)).not.toBeNull();
+
+		const delRes = await SELF.fetch(`http://localhost/api/wiki/${parent.slug}?cascade=true`, {
+			method: "DELETE",
+			headers: ownerHeaders,
+		});
+		expect(delRes.status).toBe(200);
+
+		expect(await env.R2.get(parentFile.r2Key)).toBeNull();
+		expect(await env.R2.get(childFile.r2Key)).toBeNull();
+	});
+
 	it("DELETE /api/wiki/:slug returns 403 for viewer role", async () => {
 		await SELF.fetch("http://localhost/api/wiki", {
 			method: "POST",

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,7 +10,7 @@ pre-commit:
 pre-push:
   commands:
     lint:
-      run: pnpm biome check .
+      run: pnpm biome check apps packages
     test:
       run: pnpm --filter @projektor/api test
     test-web:


### PR DESCRIPTION
## Summary
- `deleteWikiPage` deleted attachment rows matched by `linkedWikiPageId`, which is only set for `wiki_ref` pointer attachments (no R2 object) — files uploaded directly onto a page (`entityType: "wiki_page"`, `entityId: pageId`, as the wiki editor's drag-drop uploader does) were never cleaned up, so both the row and its R2 blob outlived the page.
- The `cascade=true` path (PROJ-238) could leak many R2 objects in a single subtree delete.
- Added `deleteWikiPageAttachments`, which selects and deletes R2 objects for `kind="file"` attachments (by `entityType`/`entityId`, chunked for the cascade path) before dropping the rows, then still drops `linkedWikiPageId` pointer rows as before.
- Unrelated but blocking: the pre-push `lint` hook ran `pnpm biome check .`, which walks the whole repo tree and trips biome's nested-root-config detection on a spawn-claude worktree checked out under `.claude/worktrees/`. Scoped it to the same dirs `biome.json` already lints (`apps`, `packages`) and gitignored `.claude/` (local agent tooling state, not project source).

## Test plan
- [x] New regression tests: single-page delete removes the R2 object + row for a directly-attached file; cascade delete removes R2 objects across the whole subtree
- [x] Full API suite: 876/876 passing
- [x] `tsc --noEmit` and `biome check` clean

Closes PROJ-426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6PrZyYWhxC1LxKehovwcH