### PR TITLE
PROJ-452/454/456/72: MCP 2026-07-28 compliance + tech-debt decision

### DIFF
--- a/apps/api/src/routes/mcp.ts
+++ b/apps/api/src/routes/mcp.ts
@@ -32,6 +32,20 @@ import { pluginRegistry } from "../plugins/registry";
 // release tarballs carry a real version string.
 const SERVER_VERSION = typeof __PROJEKTOR_VERSION__ === "string" ? __PROJEKTOR_VERSION__ : "dev";
 
+// PROJ-454: tools/list cache hint (2026-07-28 spec's cacheable-list-responses
+// addition, SEP-2549). The plugin registry has no change hook to invalidate
+// on, so this is a conservative TTL rather than an exact bound.
+const TOOLS_LIST_TTL_MS = 60_000;
+
+// "private" (HTTP Cache-Control semantics, not a projektor-specific value):
+// only the requesting client may cache this response, not a shared
+// intermediary. Correct today because tools/list is NOT filtered by token
+// scope or role (only tools/call is, below) — every caller in a workspace
+// sees the same list. If list filtering is ever added, this must become
+// per-identity, not just per-workspace, or a shared cache would leak one
+// caller's tool set to another.
+const TOOLS_LIST_CACHE_SCOPE = "private";
+
 // Surfaced to every MCP client at `initialize` (the MCP spec's optional
 // `instructions` field). Clients like Claude Code inject this into the model's
 // context. Deliberately a one-paragraph pointer, not a restatement of the rules —
@@ -49,6 +63,17 @@ const router = new Hono<HonoEnv>();
 
 // MCP endpoint: POST /mcp/{workspaceId}
 // Implements JSON-RPC 2.0 over HTTP (MCP Streamable HTTP transport)
+//
+// This is a "legacy-era" server per the 2026-07-28 spec's versioning model:
+// it still uses the initialize handshake rather than per-request `_meta`
+// (io.modelcontextprotocol/protocolVersion etc.) and has no server/discover
+// endpoint. That's fine — it was already stateless in practice (no session
+// store, no Mcp-Session-Id, no requirement that `initialize` precede other
+// calls; every request carries everything it needs from the URL/auth
+// headers) and legacy-to-legacy is a fully supported combination. Adopting
+// the "modern" per-request-metadata era is real protocol surface, not a
+// bump — tracked separately, not attempted here. See PROJ-452 and
+// docs/superpowers/specs/2026-07-29-mcp-2026-07-28-update-plan.md.
 router.post("/:workspaceId", async (c) => {
 	const workspace = c.get("workspace") as { id: string };
 	const user = c.get("user") as { id: string };
@@ -77,9 +102,13 @@ router.post("/:workspaceId", async (c) => {
 
 	switch (body.method) {
 		case "initialize":
+			// "2025-11-25" is the latest *legacy* (initialize-handshake) protocol
+			// version, not "2026-07-28" — that string denotes the modern per-request
+			// `_meta` era, which has no `initialize` method at all. Claiming it here
+			// while still running the legacy handshake would be spec-incoherent.
 			return c.json(
 				jsonRpcResult(body.id, {
-					protocolVersion: "2024-11-05",
+					protocolVersion: "2025-11-25",
 					capabilities: { tools: {} },
 					serverInfo: { name: "projektor", version: SERVER_VERSION },
 					instructions: SERVER_INSTRUCTIONS,
@@ -95,6 +124,11 @@ router.post("/:workspaceId", async (c) => {
 						description: t.description,
 						inputSchema: t.inputSchema,
 					})),
+					// PROJ-454: the tool list is workspace-scoped (core tools + the
+					// plugin registry's tools for this workspace) and changes rarely,
+					// so a short client-side cache is safe.
+					ttlMs: TOOLS_LIST_TTL_MS,
+					cacheScope: TOOLS_LIST_CACHE_SCOPE,
 				})
 			);
 		}

--- a/apps/api/src/schemas/common.ts
+++ b/apps/api/src/schemas/common.ts
@@ -21,6 +21,17 @@ export const IdSchema = z.string().min(1, "id is required");
 // crypto.randomUUID() (dashed UUID), while seeded defaults use 32-char hex
 // hashes (e.g. "ea3df70345804c3d26ebf139816cae8f"). Accept both so the seeded
 // Epic type / default statuses can actually be assigned to issues. See PROJ-69.
+//
+// PROJ-72 decision: keep the dual format (this schema) rather than migrating
+// seeded rows to real UUIDs. Normalizing would require rewriting seeded IDs
+// and every FK referencing them (issues.type_id/status_id) for a cosmetic
+// win; codifying the convention is cheap and the audited call sites
+// (issues.ts typeId/statusId) already use it correctly. Any *single-id*
+// field that can hold a task-type or task-status ID must use
+// TaxonomyIdSchema, never `.uuid()` directly. Deliberate exceptions:
+// comma-separated filter params (issues.ts statusIds/excludeTypeIds) stay
+// plain z.string() since they're split and passed straight to inArray() /
+// notInArray(), not validated as a single id shape.
 export const TaxonomyIdSchema = z.union([
 	z.string().uuid(),
 	z.string().regex(/^[0-9a-f]{32}$/i, "Invalid id"),

--- a/apps/api/src/test/mcp.test.ts
+++ b/apps/api/src/test/mcp.test.ts
@@ -15,17 +15,26 @@ import {
 type JsonRpcResult<T = unknown> = { jsonrpc: "2.0"; id: unknown; result: T };
 type JsonRpcError = { jsonrpc: "2.0"; id: unknown; error: { code: number; message: string } };
 
+async function mcpFetch(
+	workspaceId: string,
+	method: string,
+	params: unknown,
+	headers: Record<string, string>
+): Promise<Response> {
+	return SELF.fetch(`http://localhost/mcp/${workspaceId}`, {
+		method: "POST",
+		headers,
+		body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+	});
+}
+
 async function mcpCall<T>(
 	workspaceId: string,
 	method: string,
 	params: unknown,
 	headers: Record<string, string>
 ): Promise<JsonRpcResult<T> | JsonRpcError> {
-	const res = await SELF.fetch(`http://localhost/mcp/${workspaceId}`, {
-		method: "POST",
-		headers,
-		body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
-	});
+	const res = await mcpFetch(workspaceId, method, params, headers);
 	return res.json();
 }
 
@@ -56,13 +65,49 @@ describe("MCP endpoint", () => {
 			serverInfo: { name: string; version: string };
 			instructions: string;
 		}>;
-		expect(res.result.protocolVersion).toBe("2024-11-05");
+		// "2025-11-25" is the latest *legacy* protocol version (initialize handshake).
+		// "2026-07-28" denotes the modern per-request `_meta` era, which has no
+		// initialize method — claiming it here while still running the legacy
+		// handshake would misrepresent what this server actually implements.
+		expect(res.result.protocolVersion).toBe("2025-11-25");
 		expect(res.result.serverInfo.name).toBe("projektor");
 		// __PROJEKTOR_VERSION__ is only injected by the release build (scripts/build-release.sh);
 		// tests run without that define, so the fallback applies.
 		expect(res.result.serverInfo.version).toBe("dev");
 		// Instructions point at the canonical workflow spec rather than restating rules (PROJ-251).
 		expect(res.result.instructions).toContain("get_workflow");
+	});
+
+	it("initialize response carries no session identifier (PROJ-452)", async () => {
+		const res = await mcpFetch(workspaceId, "initialize", {}, headers);
+		expect(res.headers.get("Mcp-Session-Id")).toBeNull();
+		const body = (await res.json()) as JsonRpcResult<Record<string, unknown>>;
+		expect(body.result).not.toHaveProperty("sessionId");
+	});
+
+	it("calls tools/list directly with no prior initialize and no session header (PROJ-452)", async () => {
+		// The 2026-07-28 spec drops the initialize/initialized handshake and
+		// Mcp-Session-Id requirement; this asserts projektor never depended on
+		// either in the first place — a fresh request with no session state
+		// attached succeeds identically to one preceded by `initialize`.
+		const res = (await mcpCall<{ tools: Array<{ name: string }> }>(
+			workspaceId,
+			"tools/list",
+			{},
+			headers
+		)) as JsonRpcResult<{ tools: Array<{ name: string }> }>;
+		expect(res.result.tools.length).toBeGreaterThan(0);
+	});
+
+	it("tools/list includes cache hints (PROJ-454)", async () => {
+		const res = (await mcpCall<{ ttlMs: number; cacheScope: string }>(
+			workspaceId,
+			"tools/list",
+			{},
+			headers
+		)) as JsonRpcResult<{ ttlMs: number; cacheScope: string }>;
+		expect(res.result.ttlMs).toBeGreaterThan(0);
+		expect(res.result.cacheScope).toBe("private");
 	});
 
 	it("tools/list returns core tools", async () => {

--- a/apps/docs/src/content/docs/agents/mcp-connection.md
+++ b/apps/docs/src/content/docs/agents/mcp-connection.md
@@ -223,12 +223,37 @@ boundary.
 {
   "jsonrpc": "2.0", "id": 1,
   "result": {
-    "protocolVersion": "2024-11-05",
+    "protocolVersion": "2025-11-25",
     "capabilities": { "tools": {} },
-    "serverInfo": { "name": "projektor", "version": "<the deployed release's version, e.g. from its git tag>" }
+    "serverInfo": { "name": "projektor", "version": "<the deployed release's version, e.g. from its git tag>" },
+    "instructions": "<one-paragraph pointer to get_workflow>"
   }
 }
 ```
+
+`protocolVersion` is `"2025-11-25"` — the latest protocol revision that still uses this
+`initialize` handshake. The 2026-07-28 spec introduced a "modern" era with no `initialize`
+method at all (version + identity travel per-request in `_meta` instead); projektor hasn't
+adopted that yet, so it doesn't claim the `"2026-07-28"` version string here.
+
+### tools/list
+
+`tools/list` results also carry cache hints per the 2026-07-28 spec (SEP-2549):
+
+```json
+{
+  "jsonrpc": "2.0", "id": 2,
+  "result": {
+    "tools": [ /* ... */ ],
+    "ttlMs": 60000,
+    "cacheScope": "private"
+  }
+}
+```
+
+`cacheScope` follows HTTP `Cache-Control` semantics (`"private"` here, since the list
+isn't currently filtered per-caller, but isn't safe for a shared/intermediary cache to
+serve across different callers either).
 
 ### tools/call
 

--- a/docs/superpowers/specs/2026-07-29-mcp-2026-07-28-update-plan.md
+++ b/docs/superpowers/specs/2026-07-29-mcp-2026-07-28-update-plan.md
@@ -1,0 +1,169 @@
+# MCP 2026-07-28 spec update: projektor compliance plan + new feature ideas
+
+## Context
+
+The Model Context Protocol released spec version `2026-07-28` — described by maintainers as
+the most significant update since remote MCP launched. Source: [MCP blog, 2026-07-28
+release](https://blog.modelcontextprotocol.io/posts/2026-07-28/) and the
+[TypeScript SDK repo](https://github.com/modelcontextprotocol/typescript-sdk) (now on v2,
+tracking this spec version).
+
+projektor's MCP surface (`apps/api/src/routes/mcp.ts`) is a **hand-rolled JSON-RPC 2.0
+implementation**, not built on the official SDK — it runs on Cloudflare Workers via Hono.
+It currently reports `protocolVersion: "2024-11-05"` and implements only
+`initialize` / `tools/list` / `tools/call` over a single `POST /mcp/:workspaceId` route. No
+session IDs, no SSE transport, no roots/sampling/logging, no OAuth authorization-server role
+(projektor is a resource server that validates externally-issued tokens — Cloudflare Access /
+agent API tokens — via `jwtClaimsValid` in `apps/api/src/middleware/auth.ts`).
+
+That minimalism turns out to matter: several of the new spec's biggest changes are things
+projektor already does by construction, and several deprecations don't apply because the
+feature was never implemented. The gap is real but narrower than "implement a new spec from
+scratch."
+
+> **Correction (post-implementation, verified against the actual spec text, not just the
+> announcement blog post):** the initial version of this doc treated "stateless" and
+> "`protocolVersion: 2026-07-28`" as the same thing. They aren't. The spec defines two
+> distinct eras: **legacy** (versions ≤ `2025-11-25`, uses the `initialize` handshake) and
+> **modern** (`2026-07-28`+, no `initialize` at all — version/identity/capabilities travel
+> per-request in `_meta`). projektor's `initialize`-based server is legacy-era and was
+> already stateless *within* that era; it does not implement the modern era. Phase 1 below
+> was corrected to report `protocolVersion: "2025-11-25"` (latest legacy version) rather
+> than falsely claiming modern-era support. Adopting the modern era is tracked separately as
+> PROJ-474, since it's substantial new protocol surface (`_meta` parsing, `server/discover`,
+> `MCP-Protocol-Version` header, new error codes), not a version bump.
+
+## What changed in 2026-07-28 (summary)
+
+| Change | Applies to projektor? |
+|---|---|
+| Stateless architecture (no `initialize` handshake / `Mcp-Session-Id` requirement) | **Already true.** No session storage exists today. Work is mostly *documentation + a regression test*, not a rewrite. |
+| Multi Round-Trip Requests (MRTR) — `resultType: "input_required"` mid-call | **Net-new.** No equivalent today; biggest capability gap and biggest opportunity (see feature ideas). |
+| Header-based routing (`Mcp-Method`, `Mcp-Name`) | Optional. Only matters if a gateway/proxy sits in front of the Worker. Low priority unless that's planned. |
+| Cacheable list responses (`ttlMs`, `cacheScope`) | **Net-new, cheap.** `tools/list` is workspace-scoped and changes rarely (plugin registry + static core tools) — a good caching candidate. |
+| OAuth: mandatory issuer validation (RFC 9207), `application_type`, DCR→CIMD | **Partially done.** `iss` is already validated. projektor doesn't run its own authorization server or DCR flow, so CIMD deprecation is N/A. Worth a targeted audit, not a rewrite. |
+| Tasks extension (`io.modelcontextprotocol/tasks`) | **Net-new.** No long-running-task modeling exists; overlaps meaningfully with existing `agents`/`workflow`/`flow-metrics` tools (see feature ideas). |
+| Roots / Sampling / Logging deprecated | **N/A.** Never implemented. |
+| Legacy HTTP+SSE transport deprecated | **N/A.** Only Streamable-HTTP-style POST exists. |
+
+## Phased implementation plan
+
+**Phase 1 — Protocol version bump (must-do, low risk)** — done, PROJ-452
+- Bump `protocolVersion` in the `initialize` response (`apps/api/src/routes/mcp.ts`) from
+  `"2024-11-05"` to `"2025-11-25"` (the latest **legacy** version — see the correction note
+  above; not `"2026-07-28"`, which denotes the modern `_meta`-per-request era this server
+  doesn't implement).
+- Update the matching assertion in `apps/api/src/test/mcp.test.ts`.
+- Add a short doc comment (or a line in the MCP-facing docs) recording that projektor is
+  already stateless by construction — saves a future reader from re-deriving that.
+- Add a regression test asserting the endpoint works with no `Mcp-Session-Id` header and no
+  prior `initialize` call in the same connection (protects the "already stateless" property
+  from regressing if session state is ever added for another reason).
+
+**Phase 2 — Cacheable list responses (net-new, cheap)** — done, PROJ-454
+- Add `ttlMs` + `cacheScope` to the `tools/list` result. `cacheScope: "workspace"` is the
+  natural fit since `getAllTools(workspaceId)` is already workspace-scoped; pick a `ttlMs`
+  short enough to tolerate plugin registry changes (e.g. 60s) or invalidate via the plugin
+  registry's own change hook if one exists.
+- No client-side work needed — this is a server-side hint clients may or may not honor.
+
+**Phase 3 — OAuth/issuer audit (targeted, not a rewrite)** — done, PROJ-456
+- Audited. The only external-issuer JWT path is Cloudflare Access
+  (`tryCfAccessAuth` → `validateCfAccessJwt`); it checks `iss` in both the pre-screen
+  (`auth.ts:283`) and the full `jwtClaimsValid` check (`auth.ts:230`), binding to the
+  workspace's own configured issuer — satisfies RFC 9207 mix-up-attack guidance as-is.
+  Bearer API tokens are opaque/self-issued (no `iss`); dev bypass and public-viewer paths
+  involve no external token. No code change needed.
+- `application_type`/DCR→CIMD: confirmed N/A — projektor never runs its own OAuth
+  authorization server or DCR flow.
+
+**Phase 4 — Multi Round-Trip Requests (net-new, highest leverage)**
+- Design a `resultType: "input_required"` contract for `tools/call` responses and a resume
+  path that re-invokes the same tool with prior context + supplied answer.
+- Pick 1-2 pilot tools to convert first — the workflow human-review gate on `update_issue`
+  transitions is the natural pilot (see Feature 1 below) since the gate concept already
+  exists in the workflow spec.
+- This is the one phase that's genuinely new protocol surface, not a bump — treat it as its
+  own design/plan cycle once this phase is reached, not something to detail inline here.
+
+**Phase 5 — Tasks extension (net-new, second-highest leverage)**
+- Model long-running work (builds, deploys, fleet batches, sprint-completion side effects) as
+  `io.modelcontextprotocol/tasks` objects with `tasks/get` / `tasks/update`.
+- Overlaps with existing `agents.ts` (heartbeat/registration) and `flow-metrics.ts` — the
+  design question is whether Tasks *replaces* parts of that or sits alongside it. Needs its
+  own design pass before implementation (see Feature 3 below).
+
+**Phase 6 — `subscriptions/listen` consolidation (optional, depends on Phase 5)**
+- Only worth doing once Tasks (Phase 5) exists, since the richest events to stream are task
+  progress + issue/claim/lease changes. Natural foundation for Features 5 and 6 below.
+
+Phases 1-3 are safe to schedule immediately. Phases 4-6 are feature work, not compliance
+work, and should go through their own brainstorm → spec → plan cycle when prioritized — they
+are listed here so the phasing shows how the compliance work and the new feature ideas below
+connect to the same two protocol primitives (MRTR, Tasks).
+
+## New feature ideas (MRTR / Tasks / subscriptions-driven)
+
+Generated via a dedicated brainstorm pass, evaluated against projektor's actual user base —
+fleets of autonomous coding agents plus supervising humans — not generic MCP demo ideas.
+
+1. **Gated Transitions (MRTR review gates)** — `update_issue` transitions crossing a
+   human-review gate return `input_required`; the human sees a diff summary and
+   approves/rejects/annotates, and the *same call* resumes with the verdict. Replaces
+   today's out-of-band "waiting for review" status with a synchronous checkpoint in the
+   agent's own execution. Strongest near-term pilot for Phase 4.
+
+2. **Contested-Claim Arbitration** — when `claim_files`/`claim_issue` collides with an
+   existing claim, go `input_required` instead of failing outright, routed to the holding
+   agent or human to negotiate yield/share/hold. Turns the file-claim mutex into a
+   negotiation protocol.
+
+3. **Runs: long-running work as first-class objects** — a `run` object (build, deploy, test
+   suite, fleet batch) tracked via the Tasks extension, auto-linked to the issue/sprint it
+   serves. Gives flow metrics a real "wall-clock work" dimension. Strongest near-term pilot
+   for Phase 5.
+
+4. **Fleet Conductor** (ambitious) — projektor orchestrates a fleet run as a tree of tasks:
+   a supervisor posts a batch plan, projektor mints child tasks per worker, tracks heartbeats
+   against task progress, and uses MRTR to escalate to the human only at plan-level decision
+   points. projektor already holds the issue graph, claims, and agent registry needed to be
+   the conductor.
+
+5. **Live Ops Board** (`subscriptions/listen`) — one consolidated change stream (issue
+   transitions, claim grabs/releases, heartbeats, run progress, wiki edits) replacing
+   poll-based dashboards, with server-side filters ("this sprint", "this agent"). Cuts fleet
+   coordination latency and D1 read load versus timer-based re-listing.
+
+6. **Tripwires** — declarative watch rules ("if anyone claims files overlapping mine", "if my
+   blocker closes", "if a P1 lands in my heatmap area") delivered over
+   `subscriptions/listen`, with an optional MRTR confirmation hop before an automated
+   reaction fires. Expresses events only projektor's schema can — claims, leases, links,
+   heatmap.
+
+7. **Definition-of-Ready Intake Interview** — `create_issue` on an under-specified ticket
+   returns `input_required` with the workflow's DoR gaps as structured questions, interviewed
+   against the *creating* agent (which has the context live). Targets the specific
+   fleet-killing failure mode of vague tickets fanning out to workers who each rediscover the
+   ambiguity.
+
+8. **Edge-Cellular Workspaces** (speculative) — statelessness + `cacheScope: "workspace"` TTL
+   hints let one Worker deployment front many isolated per-workspace D1 shards, routed by
+   auth/`Mcp-Name` headers at the edge; enables cheap ephemeral scratch workspaces per fleet
+   run, archived to R2 on completion.
+
+**Bonus — Attention Ledger**: since MRTR makes every human touchpoint an explicit,
+timestamped resume event, projektor could meter human attention per issue/agent/gate —
+directly serving the existing metrics philosophy of measuring collaboration shape rather than
+agent-vs-human output (see memory: `projektor-no-agent-vs-human`).
+
+**Recommended order if pursued**: Features 1 + 3 first (they exercise MRTR and Tasks against
+schema that already exists — issue-leases, file-claims, workflow gates, agents). Features 4
+and 8 are the boldest bets and should wait until 1/3 prove the primitives out.
+
+## Out of scope for this doc
+
+- Actual code changes — this is a plan, not a PR.
+- Full MRTR/Tasks protocol design — each needs its own brainstorm → spec → plan cycle,
+  flagged above at Phases 4 and 5.
+- Header-based routing (Phase omitted from the table above as "optional") — revisit only if
+  a gateway/proxy is ever placed in front of the Worker.


### PR DESCRIPTION
## Summary
- PROJ-452: `initialize` reports `protocolVersion: "2025-11-25"` (latest legacy/handshake version), with a regression test proving no session header or prior `initialize` call is required. Corrected mid-review from an initial `"2026-07-28"` bump, which turned out to misrepresent the server as supporting the modern per-request-`_meta` era it doesn't implement — see PROJ-452 comments and the plan doc's correction note for the full story.
- PROJ-454: `tools/list` carries `ttlMs`/`cacheScope` cache hints (SEP-2549), `cacheScope: "private"`.
- PROJ-456: audited OAuth/issuer validation against RFC 9207 — already compliant, no code change, conclusion documented.
- PROJ-72: documented the decision to keep the dual UUID/hex-hash taxonomy ID format rather than migrate seeded rows.
- Filed PROJ-474 (adopt the "modern" 2026-07-28 protocol era — real new protocol surface, design-first) and closed PROJ-475 (docs nit, fixed inline).
- Closed the PROJ-65 tech-debt epic (last remaining child was PROJ-72).

## Test plan
- [x] `pnpm --filter api test` — 879 tests passed
- [x] `pnpm biome check` on changed files — clean
- [x] pre-push hooks (lint + api tests + web tests) — all green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RrEwJgYkMyzmFtjg87dbUP