### PR TITLE
chore(deps): upgrade @cofferdam/cofferdam to 0.3.13 (CD-153)

### DIFF
--- a/.cofferdam/baseline.json
+++ b/.cofferdam/baseline.json
@@ -1,4 +1,2980 @@
 {
   "version": 3,
-  "findings": []
+  "findings": [
+    {
+      "file": "apps/api/scripts/gen-mcp-catalog.ts",
+      "check_id": "Refactor.PreferArrayMethodOverLoop",
+      "rule_signature": "b5250d912bcc0a0ce804454144b524cd8389cd15564146c7bb5d4524963c33d1"
+    },
+    {
+      "file": "apps/api/src/auth/scopes.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "8316f978fb3925c8bac47c1c7dd8d584535057ee5585787261da47fcc289b21b"
+    },
+    {
+      "file": "apps/api/src/examples/feedback-widget-submit.ts",
+      "check_id": "Design.DuplicateExportName",
+      "rule_signature": "3ca2490bc53217dc4b91b495908ece520a46fd94c8fe1ad22c3303e721ee7bd1"
+    },
+    {
+      "file": "apps/api/src/examples/feedback-widget-submit.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "3ca2490bc53217dc4b91b495908ece520a46fd94c8fe1ad22c3303e721ee7bd1"
+    },
+    {
+      "file": "apps/api/src/http/error-adapter.ts",
+      "check_id": "Design.ImportFanOutOutlier",
+      "rule_signature": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "file": "apps/api/src/http/error-adapter.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "3106e88562297943b5fd7ae55091daea86cc1334e63bea24e4f45539b6a095be"
+    },
+    {
+      "file": "apps/api/src/index.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "551454d58d7fdd26d9156d4e937d99307e8de85496a9dd6a6a406c0115f54284"
+    },
+    {
+      "file": "apps/api/src/lib/urls.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "40dd3ea685e65ce4bb6814766c23d880a70eea566f12bac6e4a9c17bea124bbb"
+    },
+    {
+      "file": "apps/api/src/mcp/agent-messages.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "56d88da63c96751fb5bdbfdc18aae437f30a451412472b977a3af6dbc3c5dd19"
+    },
+    {
+      "file": "apps/api/src/mcp/agents.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "3a092810bc7139305ab212e290d57e462961155e090516a96444b7c39bb7fec3"
+    },
+    {
+      "file": "apps/api/src/mcp/catalog.ts",
+      "check_id": "Design.ImportFanOutOutlier",
+      "rule_signature": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "file": "apps/api/src/mcp/catalog.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "a4450d5da2f8b10d2c911d908cb3b531b04c17480bc9e59de99cca856d71f83c"
+    },
+    {
+      "file": "apps/api/src/mcp/code-heatmap.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "2cb574028a3ddc866a48a27b9518c48dc470be9c75cce5affdc0480432718e40"
+    },
+    {
+      "file": "apps/api/src/mcp/comments.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "9f5b917ab62a37847ddbd777c09f2d8da5fcd295287acbd7e6ee4f1a4f563d16"
+    },
+    {
+      "file": "apps/api/src/mcp/custom-fields.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "32d322c957d71a0d420148464c4689b11b6df6209fbed2bbbdfafeb6e59dc829"
+    },
+    {
+      "file": "apps/api/src/mcp/error-adapter.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "be85a9c330ffc6538aa732551dcf484204cbd5323962e8c65fbe3e7a7d4dbab7"
+    },
+    {
+      "file": "apps/api/src/mcp/feedback.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "b4f3fc5726c9cefd659c470ad7844386767f67a0209d41c7d37b373f3d493ea8"
+    },
+    {
+      "file": "apps/api/src/mcp/file-claims.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "0dc2d06d21012b1bb2352e007efec52be136cadd8f6c1cf3801dbd7917f20237"
+    },
+    {
+      "file": "apps/api/src/mcp/files.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "8054450ecf29d2eb1c8a6c7ca88209f148a11bc2105e9631c3a8d311a7e4fc12"
+    },
+    {
+      "file": "apps/api/src/mcp/flow-metrics.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "377cb23288d201b2db301ced3cf60b33a0230e222adce7a1ff1845a5aa69fd26"
+    },
+    {
+      "file": "apps/api/src/mcp/groups.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "faaf4e02d33a4576b2937251707f03be307974cb044f9a620f0590405977966a"
+    },
+    {
+      "file": "apps/api/src/mcp/groups.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "ef96d02c05dd1ef2b2e0c0ab0394ccb78466c84d56f387de3a903a9de8837d04"
+    },
+    {
+      "file": "apps/api/src/mcp/issue-leases.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "5bedab6e4ddfdc39d9e62e00249c2199bf4fd825ae50d4cdbee2d359914f30cc"
+    },
+    {
+      "file": "apps/api/src/mcp/issue-links.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "14a1a55c5fe9db7d7d9083ab27703b925a7d2da582293c38e3ade19c55f393d8"
+    },
+    {
+      "file": "apps/api/src/mcp/issues.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "76868a9fd86afe827d7c3fd069cda4acc80cb8e53d1d378bae68b6a0a0728ed5"
+    },
+    {
+      "file": "apps/api/src/mcp/issues.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "f6cdc834840983f22c9c44bb4559bddccb27e4661de9ba3a010b595bdcf7f530"
+    },
+    {
+      "file": "apps/api/src/mcp/project-activity.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "e09c0211c764410b71566d00628e48774c863d0c15ea34d79efa4bbd01d0b7f4"
+    },
+    {
+      "file": "apps/api/src/mcp/projects.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "996c7d3828b360edb5403564851cf918ea8945eaa569b281105f049ecca4b8b2"
+    },
+    {
+      "file": "apps/api/src/mcp/sprints.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "d8c00cf451dc7e8e8b6486f28ae79ef2db4794760a0be7bd25ebf2366ec7ef4d"
+    },
+    {
+      "file": "apps/api/src/mcp/task-statuses.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "20ca2558d4f6af4b80fc4266fa826a5c3e04408ab67db850bf0cb128f379f7b8"
+    },
+    {
+      "file": "apps/api/src/mcp/task-types.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "19f99a4995f0e1bc73b1a8f0f1295927e8e0331b76ef978c6db8dc89827a313e"
+    },
+    {
+      "file": "apps/api/src/mcp/wiki.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "59c50380e29e000a7c15ea711dd143341301478487ace186160378d518ca0ab0"
+    },
+    {
+      "file": "apps/api/src/mcp/workflow.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "802affcc7378dfe0d05dad985a8e6cef93e8b4c1ce04b757fd4429a62c2b298f"
+    },
+    {
+      "file": "apps/api/src/mcp/workspaces.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "a8674339392b91f330387f8d45919128b9335e4ff8cab954909efcefff44ebcf"
+    },
+    {
+      "file": "apps/api/src/middleware/auth.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "10e62e8c718d1c570a8b9ef79b31e7ab37e0a84eee71b522461d8a102f8fc8e3"
+    },
+    {
+      "file": "apps/api/src/middleware/auth.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "4889c940ee4ddd528bcba19b484b57efa1d11c429396c861eb3df3f5781ad32a"
+    },
+    {
+      "file": "apps/api/src/middleware/auth.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "78d591cdab6ad81df8bf4f466ed694127a0e47ac9d4c18bd407f39a95f71c0a5"
+    },
+    {
+      "file": "apps/api/src/middleware/auth.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "d2f4468c1bbf9230683056334b6bef581bdfe1d32a53a12c684edd987729b827"
+    },
+    {
+      "file": "apps/api/src/middleware/auth.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "d2f4468c1bbf9230683056334b6bef581bdfe1d32a53a12c684edd987729b827"
+    },
+    {
+      "file": "apps/api/src/middleware/auth.ts",
+      "check_id": "Refactor.CognitiveComplexity",
+      "rule_signature": "0f311fbba51513a2f6ead5ec1ab1c0f3a8e81c47cd5b72c78cecf3bddc1d8c2f"
+    },
+    {
+      "file": "apps/api/src/middleware/auth.ts",
+      "check_id": "Refactor.CyclomaticComplexity",
+      "rule_signature": "0f311fbba51513a2f6ead5ec1ab1c0f3a8e81c47cd5b72c78cecf3bddc1d8c2f"
+    },
+    {
+      "file": "apps/api/src/middleware/etag.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "81b91ab174bc08070f58c0d68bd043597a50781fbe802d72ec090a06d61a501e"
+    },
+    {
+      "file": "apps/api/src/middleware/etag.ts",
+      "check_id": "Refactor.MutatedParameter",
+      "rule_signature": "63b32e57177b8a0daea0ef22c87522ba1c40a3d266f6ef5780c826eaaf8f0bd4"
+    },
+    {
+      "file": "apps/api/src/middleware/rate-limit.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "7b5e6bf4e45bf5fcbd2b165a8c1dfc9e2e60bc82f0b15e4b05b442240cc4a803"
+    },
+    {
+      "file": "apps/api/src/middleware/workspace.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "833ceee4f74f6a3bce25a4e10fa1c2c7fdb1fb2b8c552edf35cc3a632f464b8a"
+    },
+    {
+      "file": "apps/api/src/middleware/workspace.ts",
+      "check_id": "Refactor.CyclomaticComplexity",
+      "rule_signature": "f0ef1b9d130c013f941bc55387a94c1ddbf6bfe98c4a2f1fef66dce5ec106f29"
+    },
+    {
+      "file": "apps/api/src/plugins/registry.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "43a0fcb7dd80dc3304d3ebde1be4743589e0c96e733c6cd168cd58947a5d71f5"
+    },
+    {
+      "file": "apps/api/src/routes/agent-messages.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "3ac3cd5d21e20efdbcdc7d4ebf3f646fb1869c0a1d6ec4aff93cfcd655e8be5f"
+    },
+    {
+      "file": "apps/api/src/routes/agents.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "4946ffeca4f8f7dc933efaa206b9c51cd201de742a829390b2b0cc52f51768ff"
+    },
+    {
+      "file": "apps/api/src/routes/auth.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "4a34abd29f1c775938b60dd492398ad34e3b79679239fbf9f1b4b05368bce5c5"
+    },
+    {
+      "file": "apps/api/src/routes/code-heatmap.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "47de24a9d856b13776c0666ed660b04c6179eaa65e0538c2731faff3fff444d9"
+    },
+    {
+      "file": "apps/api/src/routes/comments.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "2d22fee7ddd9161121aecbef252991983957d40081ef1cd85b757e77d3c57539"
+    },
+    {
+      "file": "apps/api/src/routes/custom-fields.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "372fc2c44cc20b90c12a4139e2acb73d21e491df4e131bbb2bf3f45336cb8320"
+    },
+    {
+      "file": "apps/api/src/routes/feedback-sources.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "84aedbdce151a534269b6e8bff56112668681dfaee95dcbc97659b621e6911f2"
+    },
+    {
+      "file": "apps/api/src/routes/feedback.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "6a0a28f9d94fbdd0f27ddfc26697bb085f2734a875579af1b0e365c955b5fd65"
+    },
+    {
+      "file": "apps/api/src/routes/feedback.ts",
+      "check_id": "Refactor.CognitiveComplexity",
+      "rule_signature": "93e391851a60a7eb0bd6e6a291b89512918aeb120e7ef4922609660d3c40e17e"
+    },
+    {
+      "file": "apps/api/src/routes/feedback.ts",
+      "check_id": "Refactor.CyclomaticComplexity",
+      "rule_signature": "93e391851a60a7eb0bd6e6a291b89512918aeb120e7ef4922609660d3c40e17e"
+    },
+    {
+      "file": "apps/api/src/routes/file-claims.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "8136891e79f99d6a521a3582bb657d0479ba8de0e49c93766c803cee0472289c"
+    },
+    {
+      "file": "apps/api/src/routes/files.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "cf26c375b5ff47b056361576094c5187ebb6c58f2d01f36bf07ff7d66f8b940e"
+    },
+    {
+      "file": "apps/api/src/routes/files.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "171148fca1e768e54298da4c868aef937fb8ad35a1f8b00919533ae8985a5ab5"
+    },
+    {
+      "file": "apps/api/src/routes/files.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "b843c5048ca25d35ee5790c35a45d8e9e87fd9c47bafc3742be2b03abfa2e4e2"
+    },
+    {
+      "file": "apps/api/src/routes/flow-metrics.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "2b9e4c0e6130a59e6c8d973e6c99dccd1cf823ad038d4c691aa528987959acb3"
+    },
+    {
+      "file": "apps/api/src/routes/groups.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "3f7e80b5e5186a8e2033624dab5f271893caefccded64c8234ac8f7b8d389ef4"
+    },
+    {
+      "file": "apps/api/src/routes/issue-links.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "13d42c9be00bdf1e6392fa5c54e7bac02cfd425124b575f8eec535bec4a595f6"
+    },
+    {
+      "file": "apps/api/src/routes/issues.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "d6bc7c74cc94ccce1d09d4dd9dc0cbe5f8df4eb008a8a0f103521c46b9516a2e"
+    },
+    {
+      "file": "apps/api/src/routes/mcp.ts",
+      "check_id": "Consistency.ErrorHandlingIdiom",
+      "rule_signature": "b79f9fea697b89ca51d5fa9c20f86d9a8fcaa5c5963bf351960e82164b7e173e"
+    },
+    {
+      "file": "apps/api/src/routes/mcp.ts",
+      "check_id": "Design.ImportFanOutOutlier",
+      "rule_signature": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "file": "apps/api/src/routes/mcp.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "5dd80c371f4166522531ffdd61bbac5c5e2d1a495975b362d7fd854b23435929"
+    },
+    {
+      "file": "apps/api/src/routes/project-activity.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "db773ef663172b0457ae1193b3b642e2d12a0f347559cb62f15e6f4995d05b07"
+    },
+    {
+      "file": "apps/api/src/routes/projects.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "a9c1db57281e8ce0871358b8e966c6e41e7629113256e327d364216b3344324b"
+    },
+    {
+      "file": "apps/api/src/routes/share.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "ee5e94f337d2807d3da23baf657d41ba09d6f6cd437c55a773d3755557e3ea49"
+    },
+    {
+      "file": "apps/api/src/routes/sprints.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "e8742761ec3c159dc98ec6f99e6e8a97fd412ca241fd667c6b4fc4cf208dbfae"
+    },
+    {
+      "file": "apps/api/src/routes/task-statuses.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "0e6fbeb78f37e77f15625aecbc05496a93fdfe36335c439b01bff7ba358c826b"
+    },
+    {
+      "file": "apps/api/src/routes/task-types.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "fe34c449385102877eb0644e00367d5368ddd5c48c2cd1c9af8c619d3946984d"
+    },
+    {
+      "file": "apps/api/src/routes/wiki.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "601ec8189d22d3222237e7efed9b543769d2f199ff33b4d2614f9bc33b5d4871"
+    },
+    {
+      "file": "apps/api/src/routes/workflow.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "2c0d56d9edf62144c11563bf2ff9af49bf8e46b408b63db2bfc84e11baf5bee8"
+    },
+    {
+      "file": "apps/api/src/routes/workspaces.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "b3e4c2fe3606db9489b68c86c10d0f186c6c7ba80f1be833f787b75bb63f0883"
+    },
+    {
+      "file": "apps/api/src/schemas/agent-messages.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "cd4766d1346d00100b8b76b33b1c75170510e7ad19b2a18888e53bc145728176"
+    },
+    {
+      "file": "apps/api/src/schemas/agents.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "74da0e82e423e3e0b20224e0c762edea9860131a0d9517ae41519dc9c3b22bb6"
+    },
+    {
+      "file": "apps/api/src/schemas/code-heatmap.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "f7faefe8cb097fe63fd32328feb1226e3ce70cf2faa44468fc014aebb40a2cb6"
+    },
+    {
+      "file": "apps/api/src/schemas/comments.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "0ba5419ab63fd48f3df344de8e2addf7d9e19098fdc6083b35bdc0dfc095e99c"
+    },
+    {
+      "file": "apps/api/src/schemas/common.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "352b0758df85ed28fa5f28f8c9f88540051978664a149797e0a1773453ef3bdf"
+    },
+    {
+      "file": "apps/api/src/schemas/custom-fields.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "80957ad7775b053b3011bd7483b984a24f2825637ba83bcf3b3f96359901f4bb"
+    },
+    {
+      "file": "apps/api/src/schemas/feedback.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "d586458cb75105862a0bd9019fcd322be15caf08849b5c051767de55e8429251"
+    },
+    {
+      "file": "apps/api/src/schemas/file-claims.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "0b2ed1237e9d46b75e606338ce7c3ba13db44febb4ebe813655e0e36ccc2246d"
+    },
+    {
+      "file": "apps/api/src/schemas/files.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "3bfee4bffab26f4d9c363e14bade1bea7b37041406b5c98c5b61f5972fa4df09"
+    },
+    {
+      "file": "apps/api/src/schemas/files.ts",
+      "check_id": "Design.OrphanExport",
+      "rule_signature": "3bfee4bffab26f4d9c363e14bade1bea7b37041406b5c98c5b61f5972fa4df09"
+    },
+    {
+      "file": "apps/api/src/schemas/flow-metrics.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "17c0e71e8af4ae55f2101701b8c07d79d3502583140c2f58458dc0ffc47f2ca4"
+    },
+    {
+      "file": "apps/api/src/schemas/groups.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "c3fb177f397037e86d40b175f847be8696c71fc7bdcbb346f4b5e7cecc978c2d"
+    },
+    {
+      "file": "apps/api/src/schemas/groups.ts",
+      "check_id": "Design.OrphanExport",
+      "rule_signature": "c3fb177f397037e86d40b175f847be8696c71fc7bdcbb346f4b5e7cecc978c2d"
+    },
+    {
+      "file": "apps/api/src/schemas/issue-leases.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "6106239c29c061df2f4f5eb5d0ade21fc5c8b834cb51aa05f6db09a6f29bc76b"
+    },
+    {
+      "file": "apps/api/src/schemas/issues.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "92615023d3d24b83046f5ea0e1424d33edad17a985cdc65fe435c7358649985a"
+    },
+    {
+      "file": "apps/api/src/schemas/projects.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "2718e97dc2eea27a3a671cfb0aad4257a87d3bb8ce34dc7601cfc0895a04f49f"
+    },
+    {
+      "file": "apps/api/src/schemas/sprints.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "28b1f4d2e6f831c1841121615e08bb916b21a29699d9fd162bc9f6fa9547e430"
+    },
+    {
+      "file": "apps/api/src/schemas/task-statuses.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "7bacbfdab46984e1526b40b135594b33e8b5442b4ce3b38b8f4f651be90035a8"
+    },
+    {
+      "file": "apps/api/src/schemas/task-types.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "8dfd447dcfbcf81fe4821f1c5b6d78f1fed9b8719e9c9375231f1b8bd79b30be"
+    },
+    {
+      "file": "apps/api/src/schemas/user-tokens.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "7e53bd15f07a7d24ae51d48e7908bea52510c159ccb862d050c03c9f1b5afd6d"
+    },
+    {
+      "file": "apps/api/src/schemas/wiki.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "565cc42a1dca058d408374ae7b98aa7644d5e2ba7716cfaf206f04a327b1c9cb"
+    },
+    {
+      "file": "apps/api/src/schemas/workspaces.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "41c31a27dca1f9086b654c40c5a6d684533c22189f014dc719486ccade58c092"
+    },
+    {
+      "file": "apps/api/src/services/access.ts",
+      "check_id": "Design.ImportFanOutOutlier",
+      "rule_signature": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "file": "apps/api/src/services/access.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "8e3b1c6490b1f02273357ab960ecc0057267bcce937b5b6f12a43119152e4a09"
+    },
+    {
+      "file": "apps/api/src/services/access.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "6322ea33a18858114dd4970a364f932bacdc119d91669d5237d1c76c784fb9b0"
+    },
+    {
+      "file": "apps/api/src/services/activity.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "acebe3cf5e562df53d0db69a7332835811e64315a6b0fe94a476891efe0fa9d0"
+    },
+    {
+      "file": "apps/api/src/services/activity.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "ab5464a66e3e5c2e5181f1f161d6dee133c48d9d54bc16b6b8e1523f645e3269"
+    },
+    {
+      "file": "apps/api/src/services/agent-messages.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "3c8ea7b5c4ad50c91dd6df71c1672340a0111889830eda121b2ef7473ae9283c"
+    },
+    {
+      "file": "apps/api/src/services/agents.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "32c2b57f6ff14f740aeb809eeacd25b77d91e1b5229b457b035beea035b23e7f"
+    },
+    {
+      "file": "apps/api/src/services/cache.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "2998b3232d29e8dc5a78d97a32ce83f556f3ed31b057077503df05641dd79158"
+    },
+    {
+      "file": "apps/api/src/services/code-heatmap.ts",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "0fc8b45ae3dc1091e380a89ee8c31ee6d02b2cdba246dd69065fc7228612dac1"
+    },
+    {
+      "file": "apps/api/src/services/code-heatmap.ts",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "99f1ed202f1924b2d2cac46161d55ce5db3a363fdf10e66ad51214e22db2b2fb"
+    },
+    {
+      "file": "apps/api/src/services/code-heatmap.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "6095e41a23a62410d4f6aa9e2a4f22987dd325059970a78a17444950ed724629"
+    },
+    {
+      "file": "apps/api/src/services/code-heatmap.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "181797d2d5ee704732a6a08425e47d4b0bfdfa8a3bf6b915bcac39fb59a7c6f5"
+    },
+    {
+      "file": "apps/api/src/services/code-heatmap.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "b7120d8086a9561c644197fcd7709e7ca5f5fde61e514fbde6b2f30c1aa56122"
+    },
+    {
+      "file": "apps/api/src/services/code-heatmap.ts",
+      "check_id": "Refactor.DuplicateBlock",
+      "rule_signature": "15d015906a7705970e4146dc3f7afd1a6aba16afd3fce95685e767e4e561fd39"
+    },
+    {
+      "file": "apps/api/src/services/code-heatmap.ts",
+      "check_id": "Refactor.DuplicateBlock",
+      "rule_signature": "5925853000bb6ef1e86289c90600a41791d4c7d00fedc5d28d32ad555669f476"
+    },
+    {
+      "file": "apps/api/src/services/comments.ts",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "3fe3fbe5c3fe591fbfb548e1eb817bc2bfc9f4cb48d707f98d880a39817e80a0"
+    },
+    {
+      "file": "apps/api/src/services/comments.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "d5609579fadfb4886bc642adf7b49cc54cd60c8b15732b235df7bdf305fd08a7"
+    },
+    {
+      "file": "apps/api/src/services/custom-fields.ts",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "12a1f2e97fb37968a5305f656032b1807fced3df6dcc215f383a5c1ae2e3db92"
+    },
+    {
+      "file": "apps/api/src/services/custom-fields.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "c2e1c263f8bec7d2c64f00cc86a0e21590af2a270aa91d24e51f4c9532b62173"
+    },
+    {
+      "file": "apps/api/src/services/custom-fields.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "c635b241f2f03407bb2d5e68edb4f93917265c0152920965378723175797c565"
+    },
+    {
+      "file": "apps/api/src/services/definition-of-ready.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "a30c3d7d9934b60238c4b876830c41430a6ccbf93e3a729f89b25c99ca898f08"
+    },
+    {
+      "file": "apps/api/src/services/errors.ts",
+      "check_id": "Design.ImportFanOutOutlier",
+      "rule_signature": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "file": "apps/api/src/services/evidence-classification.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "2833b5a8559bab98981be280710384f6c5bab689e4d7c9cc9073729dbc3aed4d"
+    },
+    {
+      "file": "apps/api/src/services/feedback-sources.ts",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "2de0a30ef587ffcb18230ce8cc9416cc81b305c98bf84f7fc16ab9865f3ec1cf"
+    },
+    {
+      "file": "apps/api/src/services/feedback-sources.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "beb950fd0866506eeba544f0efad1d3c97ee38d2095d8317fd4eb317064b7c13"
+    },
+    {
+      "file": "apps/api/src/services/feedback-sources.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "7b78e2ac968534b2adde1d2539238b106565c9c1df0b23a58fd7b4f7e9371f3a"
+    },
+    {
+      "file": "apps/api/src/services/feedback.ts",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "542dd5e73ab0097684ed1dafe56a2698fcda81306968f65512ae7588609ed41e"
+    },
+    {
+      "file": "apps/api/src/services/feedback.ts",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "94f98d300c91e14febcd43fe496f3550c29970398bbfb1e565fab9a0b895beae"
+    },
+    {
+      "file": "apps/api/src/services/feedback.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "1013f9e15a7227efd57f312f35c8ac4d2d25e2b9d4c30e844a10880e91c37e6e"
+    },
+    {
+      "file": "apps/api/src/services/feedback.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "4c1ffd7daa63025de58124cc2bb0b7a5563d25083a50507efecb5bfff2d290fc"
+    },
+    {
+      "file": "apps/api/src/services/feedback.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "62da6eee5905fcc6ebfc7715d3a4db6f2a9fbaed92583abbceb92d5577049f2e"
+    },
+    {
+      "file": "apps/api/src/services/feedback.ts",
+      "check_id": "Refactor.CyclomaticComplexity",
+      "rule_signature": "df564f3fb6c0d2915a82e22ec8b82241df1ce04eecf916b0f1f4f749c6d63fd5"
+    },
+    {
+      "file": "apps/api/src/services/feedback.ts",
+      "check_id": "Refactor.DuplicateBlock",
+      "rule_signature": "d42b58d8df2ea85caf5f0c4529d1019af106f65d286713b6333f7d2564a746b5"
+    },
+    {
+      "file": "apps/api/src/services/file-claims.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "95aaf5a6d7c0b0a96b089f537524b574a4921c7d1b783bb92befd5432ac25eec"
+    },
+    {
+      "file": "apps/api/src/services/file-claims.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "041990a10e569c8542a2aa7ab9f8cda16f3d50c16a6aa516122f8b7a7853cb56"
+    },
+    {
+      "file": "apps/api/src/services/file-claims.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "687f17019415485fadd80e1f9d32cd0ee91f93e28ea3f2643b8df07926f4c67d"
+    },
+    {
+      "file": "apps/api/src/services/file-claims.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "ec0fb1da06497bd848c9229df2130d0a61bdbbfd34dddad7be1183366be5c43a"
+    },
+    {
+      "file": "apps/api/src/services/file-claims.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "afa4fa9f7f8c606ce5f888d9744d2588aac19f6540983085ea69d1c4fd4be2b1"
+    },
+    {
+      "file": "apps/api/src/services/files.ts",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "e7ea178a8b6449dee8f25863ff70e37d457e622611756eb4f1c435e6e512f24e"
+    },
+    {
+      "file": "apps/api/src/services/files.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "a00a61628a1cf2b957b5a51972a1627b3405bbc1827605c36c9eae75a96ab288"
+    },
+    {
+      "file": "apps/api/src/services/files.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "3ebe26b6a268f16ce4466792a6e165e46e4d18870c9a3ddb5266d460c3f251b3"
+    },
+    {
+      "file": "apps/api/src/services/files.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "b172b225de24e9a38b6b395802dd7c9d69a748f9b7c172366442e31794396415"
+    },
+    {
+      "file": "apps/api/src/services/flow-metrics.ts",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "72a23e549d099bbd49b9266bb96afba35da89e5a93a91b056a61c9326c16266f"
+    },
+    {
+      "file": "apps/api/src/services/flow-metrics.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "9cd0d721183dce40c6720861db963a4d58d4014dbeae6726983c4540e03b3bcf"
+    },
+    {
+      "file": "apps/api/src/services/flow-metrics.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "09b58fa317194af30768504d5e2b101fd2910db43d79c02e3423b882b59d770a"
+    },
+    {
+      "file": "apps/api/src/services/flow-metrics.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "09b58fa317194af30768504d5e2b101fd2910db43d79c02e3423b882b59d770a"
+    },
+    {
+      "file": "apps/api/src/services/flow-metrics.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "09b58fa317194af30768504d5e2b101fd2910db43d79c02e3423b882b59d770a"
+    },
+    {
+      "file": "apps/api/src/services/flow-metrics.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "09b58fa317194af30768504d5e2b101fd2910db43d79c02e3423b882b59d770a"
+    },
+    {
+      "file": "apps/api/src/services/flow-metrics.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "09b58fa317194af30768504d5e2b101fd2910db43d79c02e3423b882b59d770a"
+    },
+    {
+      "file": "apps/api/src/services/flow-metrics.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "09b58fa317194af30768504d5e2b101fd2910db43d79c02e3423b882b59d770a"
+    },
+    {
+      "file": "apps/api/src/services/flow-metrics.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "09b58fa317194af30768504d5e2b101fd2910db43d79c02e3423b882b59d770a"
+    },
+    {
+      "file": "apps/api/src/services/flow-metrics.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "09b58fa317194af30768504d5e2b101fd2910db43d79c02e3423b882b59d770a"
+    },
+    {
+      "file": "apps/api/src/services/flow-metrics.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "09b58fa317194af30768504d5e2b101fd2910db43d79c02e3423b882b59d770a"
+    },
+    {
+      "file": "apps/api/src/services/flow-metrics.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "09b58fa317194af30768504d5e2b101fd2910db43d79c02e3423b882b59d770a"
+    },
+    {
+      "file": "apps/api/src/services/flow-metrics.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "09b58fa317194af30768504d5e2b101fd2910db43d79c02e3423b882b59d770a"
+    },
+    {
+      "file": "apps/api/src/services/flow-metrics.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "1674ebd009f9e561cfa1f1ca26f12124cefb55c762a47d825929cb72c2cead92"
+    },
+    {
+      "file": "apps/api/src/services/flow-metrics.ts",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "30e9488df859aded65fdfe20151e5e4c794824b0220756f036c9250bb45bc597"
+    },
+    {
+      "file": "apps/api/src/services/flow-metrics.ts",
+      "check_id": "Refactor.CognitiveComplexity",
+      "rule_signature": "0acfba53c96247d3411d9ca0cf61f4271bf91d18d86d7ced249b530787371a3e"
+    },
+    {
+      "file": "apps/api/src/services/flow-metrics.ts",
+      "check_id": "Refactor.CyclomaticComplexity",
+      "rule_signature": "0acfba53c96247d3411d9ca0cf61f4271bf91d18d86d7ced249b530787371a3e"
+    },
+    {
+      "file": "apps/api/src/services/groups.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "995da9898af51d84e7e5c860f06fb5d3054ad087b6bb405c671ec66d09e3ef17"
+    },
+    {
+      "file": "apps/api/src/services/groups.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "6859e1633d0c53dad47726cd8f73e03b43a7d16259b0fba1bb162e91f7f93a1b"
+    },
+    {
+      "file": "apps/api/src/services/groups.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "9b710407ee925765177d5823b9ecf20eaf17b03a249107e6d88f9a8b914f48d7"
+    },
+    {
+      "file": "apps/api/src/services/groups.ts",
+      "check_id": "Refactor.DuplicateBlock",
+      "rule_signature": "49ac4ce3320f853f6c527e39354f68f8e4c61eb30401d570327f23d97064ee4e"
+    },
+    {
+      "file": "apps/api/src/services/issue-leases.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "f6f6d8dd888bf433a471ed4a403df74296e220ebe93ddeff4d85513a7709e429"
+    },
+    {
+      "file": "apps/api/src/services/issue-leases.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "1511d382af7d1188d43258cc8be233a520f9c0aa6b333b4d2095834bdd5e7894"
+    },
+    {
+      "file": "apps/api/src/services/issue-links.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "7a3345feccb3bd8466c036d2547b49b8c5f9a3f46c34ab1e36b7b94ed7ae998a"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Design.ImportFanOutOutlier",
+      "rule_signature": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Design.MaxParameters",
+      "rule_signature": "0b74b45877b1bc9eed832f71bb36df04c207ff845777bb0344807c010a0ff382"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "35436c65e1f9554f6df1de819183aa2b447dafd0a68b1f915053ef6009b668b6"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "1bd81ac8c1315d5a6e85059a32db2baa7fcf9dafd7f00f3f482e69a7cce2a828"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "1e7d5e94245ce254b618f5f8233de12f1223dc3e697781bd1a6997000def9bb1"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "570b89f79428c8b9cd216ba3c2bc96351418f4518e28132ba2d426eb5987de7e"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "5870a8b12731e893a193c5cce267fd4e06911adf16a9f4b93a94dd50bbd00f50"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "ed8da26b3cea5afe868d591210aeef3c49d50fa568b2cb4a9463a62cd9ea1408"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Refactor.CyclomaticComplexity",
+      "rule_signature": "1bcbe9a3b9df6b2c133ec52ccb295e26833b50879f94aa9ac0346d2d9f289987"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Refactor.MutatedParameter",
+      "rule_signature": "1c24dda99c652c04212d1531a4ba778dbf96ed7fbde3964cb214a3e8d7c21bde"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Refactor.MutatedParameter",
+      "rule_signature": "229a9e257778db1a96eec35a9b19bceb17ea3732514bf4edc676518dbefd58f7"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Refactor.MutatedParameter",
+      "rule_signature": "2ac0d1e5e5682ea895470c854e561812b2fb5d8b536cca1d3963397cdb9ab1b4"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Refactor.MutatedParameter",
+      "rule_signature": "413e8573d3f31dafbfc185b7eb69e58f9486034c1da11b67f660be0a6201639a"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Refactor.MutatedParameter",
+      "rule_signature": "41815c2ecfa423caebff332bdc14adb696dc1c2a0fd1bf3037fc9a5213b5f6f3"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Refactor.MutatedParameter",
+      "rule_signature": "47049d392723cd9da627fa5ffe36279db25a80094897599a332cf2d76caad43a"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Refactor.MutatedParameter",
+      "rule_signature": "4ca08a38d6439583b08ec0bb3f3a06f6733e844359b34485b3b83f5d4ef57ba9"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Refactor.MutatedParameter",
+      "rule_signature": "5fd13a76db8ac6cd0fe33104019e17de3da2ef9b80afdb9fac8ad8a6ee153016"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Refactor.MutatedParameter",
+      "rule_signature": "7ffffb735826b9f4d7567805d15ed8f46fade2f09e6fa1a13bdb904bc871566a"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Refactor.MutatedParameter",
+      "rule_signature": "8836a64747893987b86b461dfdf00cf02a7334d421917553cbde027341c1bb72"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Refactor.MutatedParameter",
+      "rule_signature": "bd04267beb1244dcf67d048a7f86ac60efa0a1491a3f1d966307c98987e2f2c9"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Refactor.MutatedParameter",
+      "rule_signature": "c1f0f77a6169fbe6a7c6007bd4d7546191fd768453f89f59a4f3261f8ef5af3b"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Refactor.MutatedParameter",
+      "rule_signature": "ceb415a93a42112209edb192f948fc12fa5e10e72c7271663ac82bed21fc2fe3"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Refactor.MutatedParameter",
+      "rule_signature": "d0c40a98d0eca022f3ef927e703b5f3eca8703932aa76d12f0ef17f3b6646392"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Refactor.MutatedParameter",
+      "rule_signature": "d8d8b90f36ad934ab3e9040586b3a4529cbbc5f7ebd4255a4dd175089a7bd573"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Refactor.MutatedParameter",
+      "rule_signature": "ebc833d697654d20d927d3d97ef6f6b203b5630a30962f46cdd6f2f9292c71e3"
+    },
+    {
+      "file": "apps/api/src/services/issues.ts",
+      "check_id": "Refactor.MutatedParameter",
+      "rule_signature": "ebf2c32452f1d0543238a9d1e83228bee9689f55f690696ae4bbfe47b77920ea"
+    },
+    {
+      "file": "apps/api/src/services/project-activity.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "09f4c17149e40807549a6816a483ac242d02a591d09e83fa59ac6312267d7f54"
+    },
+    {
+      "file": "apps/api/src/services/projects.ts",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "42d5e308759a6fecc4d49aa0d10f503d7a6179f13f21e5903ae14db11048f69f"
+    },
+    {
+      "file": "apps/api/src/services/projects.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "a54a15e9699f095b88b8d3a0bc74a4835b5845d6b111537b0d225a2ea85f4daa"
+    },
+    {
+      "file": "apps/api/src/services/provisioning.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "ad1f1c0f67192b75fbab58c2d64c3dd73cb83c9105c50c97246a024c3263fb2f"
+    },
+    {
+      "file": "apps/api/src/services/provisioning.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "17279a8fba0649b35fb70939158c1933abf57a9164569156c475f137057af9d2"
+    },
+    {
+      "file": "apps/api/src/services/provisioning.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "20e47045c4b5e38cfcfe807b4a59b41fb25274fe97f65c9f2aa993ac765d449e"
+    },
+    {
+      "file": "apps/api/src/services/share.ts",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "3b3ca0ccda35b8e713add42f3cf8278b33a6e53958790af4c93f1cd10b48734c"
+    },
+    {
+      "file": "apps/api/src/services/share.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "76325b045c3b03f253e3d094e8577a5f8880a31fed8bab907a0f14aa9e0df540"
+    },
+    {
+      "file": "apps/api/src/services/sprints.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "b405802cf46943f62fac9ffad766745fdc57d03c2cb0fa7fd5f3fb70db47fef2"
+    },
+    {
+      "file": "apps/api/src/services/sql.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "c8c7a9822d64bddef38c3ab33fbfe350604fc87702c114a1c2279fa15d3720dd"
+    },
+    {
+      "file": "apps/api/src/services/sql.ts",
+      "check_id": "Refactor.PreferArrayMethodOverLoop",
+      "rule_signature": "81afdc07d6208a0983d12b00a6ddeef26797b8a000e9d7ba3c1fadf22909825b"
+    },
+    {
+      "file": "apps/api/src/services/task-statuses.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "07dcab2a98ef19834bafe7161451a47132951901ef4e97e228148a35ee2ef3c1"
+    },
+    {
+      "file": "apps/api/src/services/task-types.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "a673f4fe78a2973f42165ee7f566139f7411f3b9bfdc3fadffb71568c4479334"
+    },
+    {
+      "file": "apps/api/src/services/types.ts",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "cb20d9ffb9e22e0bfe4a3476df69746d9e36b888b8ef6cee265ddd5ac872acb7"
+    },
+    {
+      "file": "apps/api/src/services/types.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "8b1ca4a18c807244c6bca306eac96d44cd32be8f2c7773cea1670f4bb434eeec"
+    },
+    {
+      "file": "apps/api/src/services/user-tokens.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "71359509eaa17f7e54f462e54be5e883af9c0002edcadf148c964a38029cc7f4"
+    },
+    {
+      "file": "apps/api/src/services/wiki.ts",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "be38d7b6a45f66442c4faaabe7e5de20f362f7c64d27686b8920c13e614bbfe8"
+    },
+    {
+      "file": "apps/api/src/services/wiki.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "815c0faf2126239db60445e6fc65d3caadd7f5322424db1433bdae46b0be46c3"
+    },
+    {
+      "file": "apps/api/src/services/wiki.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "60d2722c678e51caeeef31550abdf85bd60fd946324d98e69de2d58c5279152f"
+    },
+    {
+      "file": "apps/api/src/services/wiki.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "8d77188efaf76b7c3bc9aa7845d1740677c03047341ef9c62513470ca766da97"
+    },
+    {
+      "file": "apps/api/src/services/wiki.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "940d380abed130714c330cad4eafc0dc1903d8c1ad36496ecefd373ddd6a35f8"
+    },
+    {
+      "file": "apps/api/src/services/wiki.ts",
+      "check_id": "Refactor.CyclomaticComplexity",
+      "rule_signature": "75d715468c442ef6b06931e4631b9fade72a47df61dc7c64b66a24d005110268"
+    },
+    {
+      "file": "apps/api/src/services/workflow-content.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "c5b929e87a0451a9a9d09d43d1ead472f35776b5d72fe434ae0a6ef33b473f97"
+    },
+    {
+      "file": "apps/api/src/services/workflow.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "55c63276968d2dcb7b02cc201599b67f90e4060d3180c2cd2b994775a0536209"
+    },
+    {
+      "file": "apps/api/src/services/workspaces.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "1b45301a406551688339fb521719cf39aca85d4f6dc36f9a0a8ada5a61b0990e"
+    },
+    {
+      "file": "apps/api/src/services/workspaces.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "254651d8844c1ecbef94000d0ee04acc07fdbfbf08261ec58d99f9cf7d0a4299"
+    },
+    {
+      "file": "apps/api/src/services/workspaces.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "8111062e496a1d67011e9ded80c12a1f74bd1b475c20192a351d591e51294fd9"
+    },
+    {
+      "file": "apps/api/src/test/activity.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "05f47b4c9d8aef11fadc43b34f5fcadfbf5ec2d0a415cd5b6646087613dffa57"
+    },
+    {
+      "file": "apps/api/src/test/activity.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "0ce7fadccf63964418cf2f20a9cc0e82da7a9a43501d24430f01e72f96e30747"
+    },
+    {
+      "file": "apps/api/src/test/activity.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/activity.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "e9de8627336a79c8b55a244b27f5db01a2ca673d026892dc9a34285f2bc8d83c"
+    },
+    {
+      "file": "apps/api/src/test/agent-messages.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "05f47b4c9d8aef11fadc43b34f5fcadfbf5ec2d0a415cd5b6646087613dffa57"
+    },
+    {
+      "file": "apps/api/src/test/agent-messages.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "0ce7fadccf63964418cf2f20a9cc0e82da7a9a43501d24430f01e72f96e30747"
+    },
+    {
+      "file": "apps/api/src/test/agent-messages.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/agent-messages.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "2cb35bda2c34a413dbcfccfb2ec42a130ca7a62027d2d76eccccacfde5f67eef"
+    },
+    {
+      "file": "apps/api/src/test/agent-messages.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/agent-messages.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "e9de8627336a79c8b55a244b27f5db01a2ca673d026892dc9a34285f2bc8d83c"
+    },
+    {
+      "file": "apps/api/src/test/agents.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "05f47b4c9d8aef11fadc43b34f5fcadfbf5ec2d0a415cd5b6646087613dffa57"
+    },
+    {
+      "file": "apps/api/src/test/agents.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "0ce7fadccf63964418cf2f20a9cc0e82da7a9a43501d24430f01e72f96e30747"
+    },
+    {
+      "file": "apps/api/src/test/agents.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/agents.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/agents.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "e9de8627336a79c8b55a244b27f5db01a2ca673d026892dc9a34285f2bc8d83c"
+    },
+    {
+      "file": "apps/api/src/test/auth.test.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "3f8987320693a179cdc3acfd783cb2a01823f550cc5eb7e29010248b28d783f3"
+    },
+    {
+      "file": "apps/api/src/test/authorization.test.ts",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "913a0267a559996dcdcfad0248b62ff913ae04251a38bb474dbcb76d7b10965b"
+    },
+    {
+      "file": "apps/api/src/test/authorization.test.ts",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "bd49cd8b473cd980ecc6cc135b5984c3c56be14683b8de54a9b09f7968271570"
+    },
+    {
+      "file": "apps/api/src/test/cache.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "05f47b4c9d8aef11fadc43b34f5fcadfbf5ec2d0a415cd5b6646087613dffa57"
+    },
+    {
+      "file": "apps/api/src/test/cache.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "0ce7fadccf63964418cf2f20a9cc0e82da7a9a43501d24430f01e72f96e30747"
+    },
+    {
+      "file": "apps/api/src/test/cache.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/cache.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/cache.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "e9de8627336a79c8b55a244b27f5db01a2ca673d026892dc9a34285f2bc8d83c"
+    },
+    {
+      "file": "apps/api/src/test/code-heatmap.test.ts",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "179d2e901fae3f2848bcbbb74e738ab79f155c50cd93322dd9cd0c628274a2b5"
+    },
+    {
+      "file": "apps/api/src/test/code-heatmap.test.ts",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "b1f7303dc5ce75f2b496883b68d900f81d5a8eebca4b980142bade02f0ee77c5"
+    },
+    {
+      "file": "apps/api/src/test/code-heatmap.test.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "42e40d175f2315e46fc0e63068a7b3ab5e91ef1120367a41e5c2cfb98208c303"
+    },
+    {
+      "file": "apps/api/src/test/code-heatmap.test.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "58bc0da972a5a74a7dbbfc2925734a63b8a900c601833195b9255cfc3f7470cc"
+    },
+    {
+      "file": "apps/api/src/test/code-heatmap.test.ts",
+      "check_id": "Refactor.DuplicateBlock",
+      "rule_signature": "5b17c43d1466d5e1d4146f9f210532610a6ca9f2dde4f040e072cb0db824a5c7"
+    },
+    {
+      "file": "apps/api/src/test/code-heatmap.test.ts",
+      "check_id": "Refactor.DuplicateBlock",
+      "rule_signature": "d48c83142f60d94457bb296ae57c5a2af0958c6803c679242ba2e3c653ab08f2"
+    },
+    {
+      "file": "apps/api/src/test/code-heatmap.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "05f47b4c9d8aef11fadc43b34f5fcadfbf5ec2d0a415cd5b6646087613dffa57"
+    },
+    {
+      "file": "apps/api/src/test/code-heatmap.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "0ce7fadccf63964418cf2f20a9cc0e82da7a9a43501d24430f01e72f96e30747"
+    },
+    {
+      "file": "apps/api/src/test/code-heatmap.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/code-heatmap.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/code-heatmap.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "e9de8627336a79c8b55a244b27f5db01a2ca673d026892dc9a34285f2bc8d83c"
+    },
+    {
+      "file": "apps/api/src/test/comments.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "05f47b4c9d8aef11fadc43b34f5fcadfbf5ec2d0a415cd5b6646087613dffa57"
+    },
+    {
+      "file": "apps/api/src/test/comments.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "0ce7fadccf63964418cf2f20a9cc0e82da7a9a43501d24430f01e72f96e30747"
+    },
+    {
+      "file": "apps/api/src/test/comments.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/coordination-access.test.ts",
+      "check_id": "Consistency.UnusedSuppression",
+      "rule_signature": "aa36c06653fb073757abc09d3951f988e146ab3454acb881146121c9724238ef"
+    },
+    {
+      "file": "apps/api/src/test/custom-fields.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/custom-fields.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/custom-fields.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/custom-fields.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/custom-fields.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/custom-fields.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/etag.test.ts",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "b1f7303dc5ce75f2b496883b68d900f81d5a8eebca4b980142bade02f0ee77c5"
+    },
+    {
+      "file": "apps/api/src/test/feedback-bulk.test.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "47be153ba495e2d3bf52bb3ae62c18372c6f8bc64291e000dc739f00d9244e0a"
+    },
+    {
+      "file": "apps/api/src/test/feedback-bulk.test.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "8af66cdd122b0897725e41f5ded08535b21db655e0aefe7583f6ccaf1b12e79c"
+    },
+    {
+      "file": "apps/api/src/test/feedback-bulk.test.ts",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "b1f7303dc5ce75f2b496883b68d900f81d5a8eebca4b980142bade02f0ee77c5"
+    },
+    {
+      "file": "apps/api/src/test/feedback-bulk.test.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "3ceeb2161298fdb03d05e19ddd48176d3d96854845f1cdcbbe9dfe6247d04e97"
+    },
+    {
+      "file": "apps/api/src/test/feedback-summary.test.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "8af66cdd122b0897725e41f5ded08535b21db655e0aefe7583f6ccaf1b12e79c"
+    },
+    {
+      "file": "apps/api/src/test/feedback-summary.test.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "b3f6424a61b2a7190d684f47f180231eeb782f412546557bf72411733344cd6a"
+    },
+    {
+      "file": "apps/api/src/test/feedback-summary.test.ts",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "b1f7303dc5ce75f2b496883b68d900f81d5a8eebca4b980142bade02f0ee77c5"
+    },
+    {
+      "file": "apps/api/src/test/feedback.test.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "340e34387a6ec900ec47a4fdbd38b5d09e5e7904fc2ec62db2662b9843d9fcbb"
+    },
+    {
+      "file": "apps/api/src/test/feedback.test.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "8af66cdd122b0897725e41f5ded08535b21db655e0aefe7583f6ccaf1b12e79c"
+    },
+    {
+      "file": "apps/api/src/test/feedback.test.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "8af66cdd122b0897725e41f5ded08535b21db655e0aefe7583f6ccaf1b12e79c"
+    },
+    {
+      "file": "apps/api/src/test/feedback.test.ts",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "b1f7303dc5ce75f2b496883b68d900f81d5a8eebca4b980142bade02f0ee77c5"
+    },
+    {
+      "file": "apps/api/src/test/feedback.test.ts",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "b1f7303dc5ce75f2b496883b68d900f81d5a8eebca4b980142bade02f0ee77c5"
+    },
+    {
+      "file": "apps/api/src/test/feedback.test.ts",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "b1f7303dc5ce75f2b496883b68d900f81d5a8eebca4b980142bade02f0ee77c5"
+    },
+    {
+      "file": "apps/api/src/test/feedback.test.ts",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "b1f7303dc5ce75f2b496883b68d900f81d5a8eebca4b980142bade02f0ee77c5"
+    },
+    {
+      "file": "apps/api/src/test/file-claims.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "05f47b4c9d8aef11fadc43b34f5fcadfbf5ec2d0a415cd5b6646087613dffa57"
+    },
+    {
+      "file": "apps/api/src/test/file-claims.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "0ce7fadccf63964418cf2f20a9cc0e82da7a9a43501d24430f01e72f96e30747"
+    },
+    {
+      "file": "apps/api/src/test/file-claims.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/file-claims.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "2cb35bda2c34a413dbcfccfb2ec42a130ca7a62027d2d76eccccacfde5f67eef"
+    },
+    {
+      "file": "apps/api/src/test/file-claims.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/file-claims.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "e9de8627336a79c8b55a244b27f5db01a2ca673d026892dc9a34285f2bc8d83c"
+    },
+    {
+      "file": "apps/api/src/test/files.test.ts",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "b1f7303dc5ce75f2b496883b68d900f81d5a8eebca4b980142bade02f0ee77c5"
+    },
+    {
+      "file": "apps/api/src/test/files.test.ts",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "b1f7303dc5ce75f2b496883b68d900f81d5a8eebca4b980142bade02f0ee77c5"
+    },
+    {
+      "file": "apps/api/src/test/flow-metrics.test.ts",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "5191c3aedc256fcb38cf420647f2d301517a7727c85dbea81d8ebe47db1c2385"
+    },
+    {
+      "file": "apps/api/src/test/flow-metrics.test.ts",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "b1f7303dc5ce75f2b496883b68d900f81d5a8eebca4b980142bade02f0ee77c5"
+    },
+    {
+      "file": "apps/api/src/test/flow-metrics.test.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "0635a092b410f5830bd30aa44cf99cebee41142021a648a2fb5f3e2cbd59c775"
+    },
+    {
+      "file": "apps/api/src/test/flow-metrics.test.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "8ff616cbb6ccc88a9b27c8f143b756e26e73805ae6ff2c2fa35a01611ec3711a"
+    },
+    {
+      "file": "apps/api/src/test/flow-metrics.test.ts",
+      "check_id": "Refactor.DuplicateBlock",
+      "rule_signature": "8f2ad708790f04d2f2ef66030e11d4966c534a28308cbd131c946a203c0ef9b4"
+    },
+    {
+      "file": "apps/api/src/test/flow-metrics.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "05f47b4c9d8aef11fadc43b34f5fcadfbf5ec2d0a415cd5b6646087613dffa57"
+    },
+    {
+      "file": "apps/api/src/test/flow-metrics.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "05f47b4c9d8aef11fadc43b34f5fcadfbf5ec2d0a415cd5b6646087613dffa57"
+    },
+    {
+      "file": "apps/api/src/test/flow-metrics.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "0ce7fadccf63964418cf2f20a9cc0e82da7a9a43501d24430f01e72f96e30747"
+    },
+    {
+      "file": "apps/api/src/test/flow-metrics.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "0ce7fadccf63964418cf2f20a9cc0e82da7a9a43501d24430f01e72f96e30747"
+    },
+    {
+      "file": "apps/api/src/test/flow-metrics.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/flow-metrics.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/flow-metrics.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/flow-metrics.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/flow-metrics.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "e9de8627336a79c8b55a244b27f5db01a2ca673d026892dc9a34285f2bc8d83c"
+    },
+    {
+      "file": "apps/api/src/test/flow-metrics.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "e9de8627336a79c8b55a244b27f5db01a2ca673d026892dc9a34285f2bc8d83c"
+    },
+    {
+      "file": "apps/api/src/test/groups.test.ts",
+      "check_id": "Consistency.UnusedSuppression",
+      "rule_signature": "7c0d83a744ab578b09260c832bf9e1c6a140269435b751270b40011267adcf25"
+    },
+    {
+      "file": "apps/api/src/test/helpers.ts",
+      "check_id": "Design.ImportFanOutOutlier",
+      "rule_signature": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "file": "apps/api/src/test/helpers.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "bd5e3b48bcdbe70b42039202a57c677e93fa31c8b9ef327cac30f8835d1da646"
+    },
+    {
+      "file": "apps/api/src/test/helpers.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "20b85001cf729d46de9d2ddc8953f77696343968aceaf16f9d4b331d06fdee01"
+    },
+    {
+      "file": "apps/api/src/test/helpers.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "20b85001cf729d46de9d2ddc8953f77696343968aceaf16f9d4b331d06fdee01"
+    },
+    {
+      "file": "apps/api/src/test/helpers.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "2cd489e4bd721bdd423366abce4d993eb932ee106f5e2421ebbc72547c6cbe3f"
+    },
+    {
+      "file": "apps/api/src/test/helpers.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "349e9be6fc09303f244c726e3906544b93b3e00f06f869159e9042752c8c50f7"
+    },
+    {
+      "file": "apps/api/src/test/helpers.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "49f31d624ab817ba7d64db88222a6515ee8ee51f0176199dd046dabcbb71a636"
+    },
+    {
+      "file": "apps/api/src/test/helpers.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "64d45dc06286263d346598fd786b4ec5dad318d57fbf62a997e02770fe1a0f66"
+    },
+    {
+      "file": "apps/api/src/test/helpers.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "7eaae5d728d1c435ef9bbe8846dcc4bd6346f4b9810a2321947993d7e157776a"
+    },
+    {
+      "file": "apps/api/src/test/helpers.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "aee69ab97ad0231dbda2a12ec56a80b658a40719b9fb38e483d09caa4daf3289"
+    },
+    {
+      "file": "apps/api/src/test/helpers.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "b20b0988aee030e2ebc1ea5886f1f1719b2f6ce412f9cf8f9d2479de5f60892b"
+    },
+    {
+      "file": "apps/api/src/test/helpers.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "c9a4ef9d43a9d2da73a30c72c87e803eef3cf5e73274bb3b14ab96fabdbfd9e4"
+    },
+    {
+      "file": "apps/api/src/test/helpers.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "fe86a84adcf1c11650ac6868b7bdaa26dc001d005bc4b04dd6ab9c3c5f15ae5a"
+    },
+    {
+      "file": "apps/api/src/test/issue-leases.test.ts",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "b1f7303dc5ce75f2b496883b68d900f81d5a8eebca4b980142bade02f0ee77c5"
+    },
+    {
+      "file": "apps/api/src/test/issue-leases.test.ts",
+      "check_id": "Refactor.DuplicateBlock",
+      "rule_signature": "17c9576f39928ac4113ed5e0f1b2e9561749673e4fa7e50f8013fb5a7aa50476"
+    },
+    {
+      "file": "apps/api/src/test/issue-leases.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "05f47b4c9d8aef11fadc43b34f5fcadfbf5ec2d0a415cd5b6646087613dffa57"
+    },
+    {
+      "file": "apps/api/src/test/issue-leases.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "05f47b4c9d8aef11fadc43b34f5fcadfbf5ec2d0a415cd5b6646087613dffa57"
+    },
+    {
+      "file": "apps/api/src/test/issue-leases.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "05f47b4c9d8aef11fadc43b34f5fcadfbf5ec2d0a415cd5b6646087613dffa57"
+    },
+    {
+      "file": "apps/api/src/test/issue-leases.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "0ce7fadccf63964418cf2f20a9cc0e82da7a9a43501d24430f01e72f96e30747"
+    },
+    {
+      "file": "apps/api/src/test/issue-leases.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "0ce7fadccf63964418cf2f20a9cc0e82da7a9a43501d24430f01e72f96e30747"
+    },
+    {
+      "file": "apps/api/src/test/issue-leases.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "0ce7fadccf63964418cf2f20a9cc0e82da7a9a43501d24430f01e72f96e30747"
+    },
+    {
+      "file": "apps/api/src/test/issue-leases.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/issue-leases.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/issue-leases.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/issue-leases.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/issue-leases.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/issue-leases.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/issue-leases.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "e9de8627336a79c8b55a244b27f5db01a2ca673d026892dc9a34285f2bc8d83c"
+    },
+    {
+      "file": "apps/api/src/test/issue-leases.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "e9de8627336a79c8b55a244b27f5db01a2ca673d026892dc9a34285f2bc8d83c"
+    },
+    {
+      "file": "apps/api/src/test/issue-leases.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "e9de8627336a79c8b55a244b27f5db01a2ca673d026892dc9a34285f2bc8d83c"
+    },
+    {
+      "file": "apps/api/src/test/issues.test.ts",
+      "check_id": "Consistency.UnusedSuppression",
+      "rule_signature": "7c0d83a744ab578b09260c832bf9e1c6a140269435b751270b40011267adcf25"
+    },
+    {
+      "file": "apps/api/src/test/issues.test.ts",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "b1f7303dc5ce75f2b496883b68d900f81d5a8eebca4b980142bade02f0ee77c5"
+    },
+    {
+      "file": "apps/api/src/test/issues.test.ts",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "b1f7303dc5ce75f2b496883b68d900f81d5a8eebca4b980142bade02f0ee77c5"
+    },
+    {
+      "file": "apps/api/src/test/issues.test.ts",
+      "check_id": "Refactor.DuplicateBlock",
+      "rule_signature": "e80c8566c190e5eb2ba3328f815f3c79b3832258ebc517e27240135119114c02"
+    },
+    {
+      "file": "apps/api/src/test/issues.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/issues.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/issues.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/migrations.ts",
+      "check_id": "Design.ImportFanOutOutlier",
+      "rule_signature": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "file": "apps/api/src/test/migrations.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "3cc85807f9d6f56ed1ef29908f7794130c62134db90b2c028bb9355bd33a37f5"
+    },
+    {
+      "file": "apps/api/src/test/project-activity.test.ts",
+      "check_id": "Consistency.UnusedSuppression",
+      "rule_signature": "7c0d83a744ab578b09260c832bf9e1c6a140269435b751270b40011267adcf25"
+    },
+    {
+      "file": "apps/api/src/test/project-activity.test.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "7c6dff039cb27193c9c6575c4917678822aa22e107206db1b524cce690df1940"
+    },
+    {
+      "file": "apps/api/src/test/project-activity.test.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "d2db33711c2c700314f9df2c1e5be6fa1fd86182fdf8b89542b501844db6e7d0"
+    },
+    {
+      "file": "apps/api/src/test/project-activity.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "05f47b4c9d8aef11fadc43b34f5fcadfbf5ec2d0a415cd5b6646087613dffa57"
+    },
+    {
+      "file": "apps/api/src/test/project-activity.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "05f47b4c9d8aef11fadc43b34f5fcadfbf5ec2d0a415cd5b6646087613dffa57"
+    },
+    {
+      "file": "apps/api/src/test/project-activity.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "0ce7fadccf63964418cf2f20a9cc0e82da7a9a43501d24430f01e72f96e30747"
+    },
+    {
+      "file": "apps/api/src/test/project-activity.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "0ce7fadccf63964418cf2f20a9cc0e82da7a9a43501d24430f01e72f96e30747"
+    },
+    {
+      "file": "apps/api/src/test/project-activity.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/project-activity.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/project-activity.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/project-activity.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/project-activity.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "e9de8627336a79c8b55a244b27f5db01a2ca673d026892dc9a34285f2bc8d83c"
+    },
+    {
+      "file": "apps/api/src/test/project-activity.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "e9de8627336a79c8b55a244b27f5db01a2ca673d026892dc9a34285f2bc8d83c"
+    },
+    {
+      "file": "apps/api/src/test/review-gating.test.ts",
+      "check_id": "Refactor.DuplicateBlock",
+      "rule_signature": "07c6084e3df9d99f356118b8f846e73af1a4e36a541b5021812da213727ed1a4"
+    },
+    {
+      "file": "apps/api/src/test/review-gating.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "05f47b4c9d8aef11fadc43b34f5fcadfbf5ec2d0a415cd5b6646087613dffa57"
+    },
+    {
+      "file": "apps/api/src/test/review-gating.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "0ce7fadccf63964418cf2f20a9cc0e82da7a9a43501d24430f01e72f96e30747"
+    },
+    {
+      "file": "apps/api/src/test/review-gating.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/review-gating.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/review-gating.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "e9de8627336a79c8b55a244b27f5db01a2ca673d026892dc9a34285f2bc8d83c"
+    },
+    {
+      "file": "apps/api/src/test/scopes.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "0ce7fadccf63964418cf2f20a9cc0e82da7a9a43501d24430f01e72f96e30747"
+    },
+    {
+      "file": "apps/api/src/test/scopes.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "0ce7fadccf63964418cf2f20a9cc0e82da7a9a43501d24430f01e72f96e30747"
+    },
+    {
+      "file": "apps/api/src/test/scopes.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/scopes.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/share.test.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "bfb379b1fed6a664364a913245b9ea6f76d0329d4872008ef8be1cb1857300bf"
+    },
+    {
+      "file": "apps/api/src/test/share.test.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "c505e723a046bab59e064236a2affc48889bbe974521d170ea12338c91269c92"
+    },
+    {
+      "file": "apps/api/src/test/share.test.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "d3a68dee26154e879f9a744654cec167a90b6bb681b6de6c069aabf349952fa2"
+    },
+    {
+      "file": "apps/api/src/test/share.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "05f47b4c9d8aef11fadc43b34f5fcadfbf5ec2d0a415cd5b6646087613dffa57"
+    },
+    {
+      "file": "apps/api/src/test/share.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "0ce7fadccf63964418cf2f20a9cc0e82da7a9a43501d24430f01e72f96e30747"
+    },
+    {
+      "file": "apps/api/src/test/share.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/share.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "2cb35bda2c34a413dbcfccfb2ec42a130ca7a62027d2d76eccccacfde5f67eef"
+    },
+    {
+      "file": "apps/api/src/test/share.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "e9de8627336a79c8b55a244b27f5db01a2ca673d026892dc9a34285f2bc8d83c"
+    },
+    {
+      "file": "apps/api/src/test/sprints.test.ts",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "b1f7303dc5ce75f2b496883b68d900f81d5a8eebca4b980142bade02f0ee77c5"
+    },
+    {
+      "file": "apps/api/src/test/sprints.test.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "cbb7cbf6e22b5b276816e0bfaed016c84d8343419e6d4b50bd3a0b558cf6f723"
+    },
+    {
+      "file": "apps/api/src/test/sprints.test.ts",
+      "check_id": "Refactor.DuplicateBlock",
+      "rule_signature": "b881b14dbd846c8fe68f2fcebacd32832667aadfd28b0bf6d8d1c500fbdbf620"
+    },
+    {
+      "file": "apps/api/src/test/sprints.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "05f47b4c9d8aef11fadc43b34f5fcadfbf5ec2d0a415cd5b6646087613dffa57"
+    },
+    {
+      "file": "apps/api/src/test/sprints.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "0ce7fadccf63964418cf2f20a9cc0e82da7a9a43501d24430f01e72f96e30747"
+    },
+    {
+      "file": "apps/api/src/test/sprints.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/sprints.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/sprints.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "e9de8627336a79c8b55a244b27f5db01a2ca673d026892dc9a34285f2bc8d83c"
+    },
+    {
+      "file": "apps/api/src/test/task-statuses.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/task-statuses.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/task-statuses.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/task-statuses.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/task-types.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/task-types.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "121cac71eb171184e3f395104c6beb19a87d4548707c5e4694f3efc5f114f82a"
+    },
+    {
+      "file": "apps/api/src/test/task-types.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/task-types.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "8be4c146d2f16c84d6e03fc4cee4915bf54f1283d3bcb8e27db8c3382ef0228f"
+    },
+    {
+      "file": "apps/api/src/test/task-types.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "e9de8627336a79c8b55a244b27f5db01a2ca673d026892dc9a34285f2bc8d83c"
+    },
+    {
+      "file": "apps/api/src/test/task-types.test.ts",
+      "check_id": "Refactor.PreferConstOverLet",
+      "rule_signature": "e9de8627336a79c8b55a244b27f5db01a2ca673d026892dc9a34285f2bc8d83c"
+    },
+    {
+      "file": "apps/api/src/test/wiki.test.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "bcaf036452faa4a2a56d012e3d5f2b251f68768858705610ec2d6f8174cb06d3"
+    },
+    {
+      "file": "apps/api/vitest.config.mts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "e22d75b2935e7bd2683d47ef1e699750966886f9990db4ae0d470320e6ff9593"
+    },
+    {
+      "file": "apps/docs/src/content.config.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "00699f600cf5a0ff57479ad90a83a32a0f993732fce1b33adc551556c35d066c"
+    },
+    {
+      "file": "apps/web/e2e/global-setup.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "2e740567371936ea43e2dcdcfbd44d01b76715a5a3dbe399a17ab4f23aa4ff31"
+    },
+    {
+      "file": "apps/web/e2e/global-setup.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "805ed632ed05e02197faf17b3e2399b1d5992c7dda6975650ca5c2557dc0e608"
+    },
+    {
+      "file": "apps/web/e2e/global-teardown.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "fedfb32b073778755487009b43afaae309deaaddfaecf86d6fd87aa078c4d56d"
+    },
+    {
+      "file": "apps/web/e2e/issue-attachments.spec.ts",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "b1f7303dc5ce75f2b496883b68d900f81d5a8eebca4b980142bade02f0ee77c5"
+    },
+    {
+      "file": "apps/web/src/islands/AccessPending.tsx",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "23d7f9546bcd7c1846e5fdda8403b63202c7121b809593aa43c4221dc2569890"
+    },
+    {
+      "file": "apps/web/src/islands/AccountMenu.tsx",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "f5eaf989f47d570eba03a95f213f5c005ae1ff9020d1eab0703e76733c00abcc"
+    },
+    {
+      "file": "apps/web/src/islands/AccountMenu.tsx",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "d59cb6dbd25076295fae4e7a906eb04fa9e3547f24a03bfa820a80e1b7839e78"
+    },
+    {
+      "file": "apps/web/src/islands/EpicList.test.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "f62dddd9187fcdb70becafdf5bacc0e1f04fb29b8128f4c8385efd7fe1aef423"
+    },
+    {
+      "file": "apps/web/src/islands/EpicList.test.tsx",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "b1f7303dc5ce75f2b496883b68d900f81d5a8eebca4b980142bade02f0ee77c5"
+    },
+    {
+      "file": "apps/web/src/islands/EpicList.tsx",
+      "check_id": "Consistency.ErrorHandlingIdiom",
+      "rule_signature": "125c0c16dba0c64ef115c7d2a9b54450deebddc3621ee2705697c8f41f94527a"
+    },
+    {
+      "file": "apps/web/src/islands/EpicList.tsx",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "95ea735e25f9a9ea62bad82a9fdd3481929ee4db4d942972b385be9a084dbe42"
+    },
+    {
+      "file": "apps/web/src/islands/EpicList.tsx",
+      "check_id": "Design.MaxParameters",
+      "rule_signature": "93a6707966b816a9ee734a022ee77f77e85903a6f9751a642a8d430fbf02e495"
+    },
+    {
+      "file": "apps/web/src/islands/EpicList.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "3b1ed94a65c6d85e2f86b35f9dc10ceae76de4b4c5d9b05e063f168e1040c6f7"
+    },
+    {
+      "file": "apps/web/src/islands/EpicList.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "3b1ed94a65c6d85e2f86b35f9dc10ceae76de4b4c5d9b05e063f168e1040c6f7"
+    },
+    {
+      "file": "apps/web/src/islands/EpicList.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "3b1ed94a65c6d85e2f86b35f9dc10ceae76de4b4c5d9b05e063f168e1040c6f7"
+    },
+    {
+      "file": "apps/web/src/islands/EpicList.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "6846f57581e530ecb3f540f3b3f8f00ce264c2ea9b36fd7f2ab96c9470faeec4"
+    },
+    {
+      "file": "apps/web/src/islands/EpicList.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "794cc118aa627d3478de7ea288dc41975f1671b904743bc5528fe4997b0a6e0b"
+    },
+    {
+      "file": "apps/web/src/islands/EpicList.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "8b5bda33baba376e3031019e322eefba54d3f5fe51a0e352f6842b97b6f5bc2c"
+    },
+    {
+      "file": "apps/web/src/islands/EpicList.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "8b5bda33baba376e3031019e322eefba54d3f5fe51a0e352f6842b97b6f5bc2c"
+    },
+    {
+      "file": "apps/web/src/islands/FeedbackList.test.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "34cbc3e897650e715f9c818528b66ad94036946ff5bfaaef15eb722838026f8e"
+    },
+    {
+      "file": "apps/web/src/islands/FeedbackList.tsx",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "cb7141a20db92af80e6710d50c3d325a7106ff0468182b172d7f8848a13ca6c7"
+    },
+    {
+      "file": "apps/web/src/islands/FeedbackList.tsx",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "2f7ae76e92825d44239c627cc82418c942773fe38256c13757bcd7693216c1c8"
+    },
+    {
+      "file": "apps/web/src/islands/FeedbackSourceDetail.tsx",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "3a8d77e354bf105233bb3210ed8ac4be1e39974a6be6e16fcab1e6ae67c7b447"
+    },
+    {
+      "file": "apps/web/src/islands/FeedbackSourceDetail.tsx",
+      "check_id": "Refactor.DuplicateBlock",
+      "rule_signature": "01c8e59e8037d51731e3ee2bc5b273f0cc5fff37187b34bddc7c716050f84d1d"
+    },
+    {
+      "file": "apps/web/src/islands/FeedbackSourceGrid.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "ba06f1534eaeb78ef90683ddfda140fc25061ef341558f717b26044c48d6b654"
+    },
+    {
+      "file": "apps/web/src/islands/FeedbackSourceSettings.tsx",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "2162cff01d43d7973964499c106ab2d68bdd04956252e3f864283e448bd1428c"
+    },
+    {
+      "file": "apps/web/src/islands/GroupManager.test.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "d92a8c9f22913c684d79c0967b75b36fa5746239c00a5cc52a735bcad55b2327"
+    },
+    {
+      "file": "apps/web/src/islands/GroupManager.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "091587eabb1e49a25878b68404d6cee7486c6cdc65fe9c1e697296f6e9bff3ed"
+    },
+    {
+      "file": "apps/web/src/islands/GroupManager.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "69e6960919a8f472c5beb3e29fa9f8c17773f3e93417cafe061e1d5d1df70dab"
+    },
+    {
+      "file": "apps/web/src/islands/GroupManager.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "879b87c705aad9f379964cbb8a3b9af43e99a8da48450d6ef1a6fc67134f37f7"
+    },
+    {
+      "file": "apps/web/src/islands/GroupManager.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "c8f99691b0c678760dbb714e978de119dc5a95eeb159e46bb5aeee0a2489ef64"
+    },
+    {
+      "file": "apps/web/src/islands/GroupManager.tsx",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "f0a04320b78f52c8af4f6f07be9048e3146518b509a212353f47c834b1ea2d80"
+    },
+    {
+      "file": "apps/web/src/islands/GroupManager.tsx",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "4b27eb458a2488337dccbfe399c5da274c983654d9adf8eb134507de3ce158f4"
+    },
+    {
+      "file": "apps/web/src/islands/GroupManager.tsx",
+      "check_id": "Refactor.CognitiveComplexity",
+      "rule_signature": "dde0eeedf66828389b78b775756802f49cf89d3275f340637940752ca6a0f863"
+    },
+    {
+      "file": "apps/web/src/islands/GroupManager.tsx",
+      "check_id": "Refactor.CyclomaticComplexity",
+      "rule_signature": "dde0eeedf66828389b78b775756802f49cf89d3275f340637940752ca6a0f863"
+    },
+    {
+      "file": "apps/web/src/islands/GroupManager.tsx",
+      "check_id": "Refactor.LongAndComplex",
+      "rule_signature": "b6aac031f755f4102f1a0713f587c03d6fcb9557854f0c0bd76edf4f3c053788"
+    },
+    {
+      "file": "apps/web/src/islands/IssueDetail.test.tsx",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "008bf29878463ef36d372ccab2a9b42f5b4019d38bb856c0006ddbe39c82a918"
+    },
+    {
+      "file": "apps/web/src/islands/IssueDetail.test.tsx",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "b1f7303dc5ce75f2b496883b68d900f81d5a8eebca4b980142bade02f0ee77c5"
+    },
+    {
+      "file": "apps/web/src/islands/IssueDetail.tsx",
+      "check_id": "Consistency.ErrorHandlingIdiom",
+      "rule_signature": "6ac88aa3d10c3dd3ffeaf7a8c0d292db641a62fa0a14cf0dbeaf7c38e2f16df4"
+    },
+    {
+      "file": "apps/web/src/islands/IssueDetail.tsx",
+      "check_id": "Design.MaxParameters",
+      "rule_signature": "9a2f26f8cf909556b5a9d0f4e7fb5411ac823bbbc5560349eede19f5060a9a02"
+    },
+    {
+      "file": "apps/web/src/islands/IssueDetail.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "a8ad09061f0041053bdabd3e2f8916cfa723ca8f78e4503094065f7d696c9701"
+    },
+    {
+      "file": "apps/web/src/islands/IssueDetail.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "e3cb2fd7426b73967d2e23323779405248771301994b683f84de8c9a467064b1"
+    },
+    {
+      "file": "apps/web/src/islands/IssueDetailParts.tsx",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "80384035c97412b20e9b648a7327673c91c49ab59c88a3e1adbdb52069cd40c9"
+    },
+    {
+      "file": "apps/web/src/islands/IssueDetailParts.tsx",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "6ddede21125c0478bd87704abd1ff704ba8851059eac3295029f0b31c2d52876"
+    },
+    {
+      "file": "apps/web/src/islands/IssueDetailParts.tsx",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "fa37ff77761ddf735825b8afdb06d2033ae569300258ab207c2d269e8bbd4e9a"
+    },
+    {
+      "file": "apps/web/src/islands/IssueDetailParts.tsx",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "4450110d4ad7d3b07be68ed50169df320bb98b745300ef93403fb0e8094180aa"
+    },
+    {
+      "file": "apps/web/src/islands/IssueDetailParts.tsx",
+      "check_id": "Refactor.CyclomaticComplexity",
+      "rule_signature": "69a2119d0c7a0b29b1680362e8c44b6e2a7e33794c49d228bb647e31c6175b68"
+    },
+    {
+      "file": "apps/web/src/islands/IssueList-helpers.ts",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "3efc9257bcdc70e3f98f3ee3223459c2edb2db46c3d9aa38e820180661aed2f1"
+    },
+    {
+      "file": "apps/web/src/islands/IssueList-helpers.ts",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "415d25f32232e031505c58ea4dc231979acad54e9eea0ae13963c8a2696896b7"
+    },
+    {
+      "file": "apps/web/src/islands/IssueList-helpers.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "a1e0b15612cdd955dca0ec07472e6fd889e1953c6535f64557ff6f801854d678"
+    },
+    {
+      "file": "apps/web/src/islands/IssueList-helpers.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "2156075a090c52aae98c62a190ddd927f50906286055f0f14dc3131c153b1ad2"
+    },
+    {
+      "file": "apps/web/src/islands/IssueList-helpers.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "3d208c58b538834e33ba0a36e8476f8542b98d31ac2107ffff5a1c976be51ebf"
+    },
+    {
+      "file": "apps/web/src/islands/IssueList-helpers.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "43705bbf9bcaaa875ad9d766f532c8da77ca7952a6f37a30e271564314b21331"
+    },
+    {
+      "file": "apps/web/src/islands/IssueList-helpers.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "fbc7c3504f20310aac76f81973a1961b482af65ea8e9e54496b204425a9c494b"
+    },
+    {
+      "file": "apps/web/src/islands/IssueList.test.tsx",
+      "check_id": "Refactor.DuplicateBlock",
+      "rule_signature": "cd8c6b7e95b095cc4f89a0f874950e3fdc9977c219af5b019c5c6d74ad12998d"
+    },
+    {
+      "file": "apps/web/src/islands/LazyMarkdownEditor.tsx",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "cb7141a20db92af80e6710d50c3d325a7106ff0468182b172d7f8848a13ca6c7"
+    },
+    {
+      "file": "apps/web/src/islands/MarkdownEditor.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "292896a73f66bfd407ba8e28984808080ef75142e7565c1eefad93cd91ef7816"
+    },
+    {
+      "file": "apps/web/src/islands/MarkdownEditor.tsx",
+      "check_id": "Refactor.PreferArrayMethodOverLoop",
+      "rule_signature": "d5a9405f4b56d70dba0aa0e44373b94b28d57cc2577960d06f2b949701e93526"
+    },
+    {
+      "file": "apps/web/src/islands/MetricHelp.tsx",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "0228b5cbfeca65d96e74798041192b7a1290090f42c3e1c8811acbe55d9d8e31"
+    },
+    {
+      "file": "apps/web/src/islands/MetricsDashboard.test.tsx",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "b1f7303dc5ce75f2b496883b68d900f81d5a8eebca4b980142bade02f0ee77c5"
+    },
+    {
+      "file": "apps/web/src/islands/MetricsDashboard.test.tsx",
+      "check_id": "Refactor.DuplicateBlock",
+      "rule_signature": "7f0bcae4d35ddaad4f9f950aeb6b0d2e2c654a802ce5b3cfd9e6d01dc3bf64b7"
+    },
+    {
+      "file": "apps/web/src/islands/MetricsDashboard.tsx",
+      "check_id": "Consistency.ErrorHandlingIdiom",
+      "rule_signature": "0a6ca40d3f7ed3dc4a716f98e43c16e9ac8a9de61fa1567a700171db20a9f719"
+    },
+    {
+      "file": "apps/web/src/islands/MetricsDashboard.tsx",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "04b8ee375276955ed7c065e277de4f4b6b1082c17203d35c6dd69da4ed561917"
+    },
+    {
+      "file": "apps/web/src/islands/MetricsDashboard.tsx",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "742a2db6bb8e77749b77733eb96f9fd3538160ba7433f6ce8afc630e5baaf9d9"
+    },
+    {
+      "file": "apps/web/src/islands/MetricsDashboard.tsx",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "d3d3a58b340becd9438819f3517fd89901422cf86534a3c23fadd6451726f873"
+    },
+    {
+      "file": "apps/web/src/islands/MetricsDashboard.tsx",
+      "check_id": "Refactor.DuplicateBlock",
+      "rule_signature": "e827aba210d2c46cbf7257c4692683bc289b3b59c752c388a1145a4412cb5184"
+    },
+    {
+      "file": "apps/web/src/islands/MetricsDashboard.tsx",
+      "check_id": "Refactor.PreferArrayMethodOverLoop",
+      "rule_signature": "f1da14b050653791a4127dc419dcf0b49435bcb9a0a2c7c052548b397de27be3"
+    },
+    {
+      "file": "apps/web/src/islands/MetricsDashboard.tsx",
+      "check_id": "Refactor.PreferArrayMethodOverLoop",
+      "rule_signature": "f1da14b050653791a4127dc419dcf0b49435bcb9a0a2c7c052548b397de27be3"
+    },
+    {
+      "file": "apps/web/src/islands/MetricsDashboard.tsx",
+      "check_id": "Refactor.PreferArrayMethodOverLoop",
+      "rule_signature": "f1da14b050653791a4127dc419dcf0b49435bcb9a0a2c7c052548b397de27be3"
+    },
+    {
+      "file": "apps/web/src/islands/MyIssues.test.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "a003a0c027670bb6f35c85e46c041014a846fa853fac94052b8f2bc234803d1e"
+    },
+    {
+      "file": "apps/web/src/islands/MyIssues.tsx",
+      "check_id": "Consistency.UnusedSuppression",
+      "rule_signature": "d3368ca2e06e4045f47a501bde7781376a0d6cb4cc2e718791278a95acba9ae6"
+    },
+    {
+      "file": "apps/web/src/islands/MyIssues.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "029e94492cc6a10dfbb56b907871d8db840dfe475cdd5ce83462f9407c357df5"
+    },
+    {
+      "file": "apps/web/src/islands/NewSourceModal.tsx",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "4ab3a4d65201add806966479ae52235e6c5244152e4aba117efd21312b8aede6"
+    },
+    {
+      "file": "apps/web/src/islands/ProjectFlowCharts.tsx",
+      "check_id": "Consistency.ErrorHandlingIdiom",
+      "rule_signature": "b741b8b47c2470d5500ba4608355e06015f871759f7d416f131d453d751f9a01"
+    },
+    {
+      "file": "apps/web/src/islands/ProjectFlowCharts.tsx",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "145de633dd917feade367cd114e37d4d72009c63dd92887895428697d1e2e731"
+    },
+    {
+      "file": "apps/web/src/islands/ProjectLanding.test.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "27a025c9dd399cf99f08c2963741b69c6343e2b687f30592e0d2fdf6c93584be"
+    },
+    {
+      "file": "apps/web/src/islands/ProjectLanding.test.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "6b1e7960a792e9820ed7a109a622678443ae49fe9473fb533d6b1ae8bf6d28fb"
+    },
+    {
+      "file": "apps/web/src/islands/ProjectLanding.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "9f157df2e1a163f4b15617b25c0d746d5f03f196063b4daabb79880d90bb2b0c"
+    },
+    {
+      "file": "apps/web/src/islands/Select.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "b7eae722686b4474585b33bfbae5244ab8e2f5402051a4d6df1f0c07af8e89d6"
+    },
+    {
+      "file": "apps/web/src/islands/ShareView.tsx",
+      "check_id": "Consistency.UnusedSuppression",
+      "rule_signature": "ded5204fef1c93f71c37bc76b9f8220890128f8a97d4ec46cf71ddb278fad156"
+    },
+    {
+      "file": "apps/web/src/islands/SprintManager.test.tsx",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "fd04788626e5f87b3b22b2b855bddaae2f1ee43956232d2fa57c5afa7d3f09b9"
+    },
+    {
+      "file": "apps/web/src/islands/SprintManager.test.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "e6f34dffa47a2b19d130a1ea78534638ce0b904ed4990a1053a88fa69c3b0436"
+    },
+    {
+      "file": "apps/web/src/islands/SprintManager.tsx",
+      "check_id": "Consistency.ErrorHandlingIdiom",
+      "rule_signature": "07ed66ecca4c791d0672df845fa2172cfd6464643808dd9fa28139d645615c78"
+    },
+    {
+      "file": "apps/web/src/islands/SprintManager.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "e825f7a49cc0e5ca1bda6efbca64a7fed51951b61814bd9da5745fa4008a43ba"
+    },
+    {
+      "file": "apps/web/src/islands/SprintManager.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "f53576b1534a5f1f633f665cbcb8a81057bb3c700174ed39104852582c8f7006"
+    },
+    {
+      "file": "apps/web/src/islands/SprintManager.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "f53576b1534a5f1f633f665cbcb8a81057bb3c700174ed39104852582c8f7006"
+    },
+    {
+      "file": "apps/web/src/islands/SprintManager.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "f53576b1534a5f1f633f665cbcb8a81057bb3c700174ed39104852582c8f7006"
+    },
+    {
+      "file": "apps/web/src/islands/SprintManager.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "f53576b1534a5f1f633f665cbcb8a81057bb3c700174ed39104852582c8f7006"
+    },
+    {
+      "file": "apps/web/src/islands/TokenManager.test.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "6beef88d5e9e4ed624722689ecd11be3166e7f7b9792423386669a44ebf540a8"
+    },
+    {
+      "file": "apps/web/src/islands/WikiPage.test.tsx",
+      "check_id": "Design.DuplicateTypeShape",
+      "rule_signature": "1efb37654e7ae59fa2d74a9ef00385fc5098629f4ba592950211acd5a94994d3"
+    },
+    {
+      "file": "apps/web/src/islands/WikiPage.tsx",
+      "check_id": "Consistency.ErrorHandlingIdiom",
+      "rule_signature": "1fa21beed7e49dcda9acb0a3842cca98a1a20549c37a4286e3013b95f52b39ac"
+    },
+    {
+      "file": "apps/web/src/islands/WikiPage.tsx",
+      "check_id": "Consistency.ErrorHandlingIdiom",
+      "rule_signature": "516f5accfa88a004fa68294a29c35c219bf3599844830ee2efb2e11a0b575cd4"
+    },
+    {
+      "file": "apps/web/src/islands/WikiPage.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "4e93b2276f5c92f8bb8f729da6c17d9bada4244d46947a4b6f660314de26d6c3"
+    },
+    {
+      "file": "apps/web/src/islands/WikiPage.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "605fb324ac981f4175f0770bc4f808bc6f86936eb2c976eba3b4dd75d48ec956"
+    },
+    {
+      "file": "apps/web/src/islands/WikiPage.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "87a1dacde495d7fbf9914425a98bb1cdd59a2510e1f34d95513c7f3a6ae46415"
+    },
+    {
+      "file": "apps/web/src/islands/WikiPage.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "90cd944f2790421f7b57343de1b7ba383dcea965275a7538a0b35a8e296c1637"
+    },
+    {
+      "file": "apps/web/src/islands/WikiPage.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "918a4a85b0e8ed1b990b9ef4404ee434cfb7295bfa4794e8e992dfb2a02560ed"
+    },
+    {
+      "file": "apps/web/src/islands/WikiPage.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "b511a0d673f8687e488cffb27486108bc9708cbe39a45b4d128e0d236abc2ff2"
+    },
+    {
+      "file": "apps/web/src/islands/WikiPage.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "cb5a1db9b91c400ab37f187753c10fcad4717f05ae49115032997d8738064624"
+    },
+    {
+      "file": "apps/web/src/islands/WikiPage.tsx",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "846c1b115634c5387e02043051f3537a7ff983acce3a1702e48e8a6b8a5cbfa7"
+    },
+    {
+      "file": "apps/web/src/islands/WikiPage.tsx",
+      "check_id": "Refactor.MutatedParameter",
+      "rule_signature": "8949438afc60eb4d8e8000159a4a71a6643bbf87925c66a6c69060395d99d4a2"
+    },
+    {
+      "file": "apps/web/src/islands/board-utils.ts",
+      "check_id": "Design.ImportFanOutOutlier",
+      "rule_signature": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "file": "apps/web/src/islands/board-utils.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "6846f57581e530ecb3f540f3b3f8f00ce264c2ea9b36fd7f2ab96c9470faeec4"
+    },
+    {
+      "file": "apps/web/src/islands/board-utils.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "794cc118aa627d3478de7ea288dc41975f1671b904743bc5528fe4997b0a6e0b"
+    },
+    {
+      "file": "apps/web/src/islands/board-utils.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "c8515302129d3cb2831dd9ea6d97d6f381835ccd1ef8cb306fe406cd95c44c55"
+    },
+    {
+      "file": "apps/web/src/islands/board-utils.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "e825f7a49cc0e5ca1bda6efbca64a7fed51951b61814bd9da5745fa4008a43ba"
+    },
+    {
+      "file": "apps/web/src/islands/board-utils.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "e825f7a49cc0e5ca1bda6efbca64a7fed51951b61814bd9da5745fa4008a43ba"
+    },
+    {
+      "file": "apps/web/src/islands/board-utils.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "e825f7a49cc0e5ca1bda6efbca64a7fed51951b61814bd9da5745fa4008a43ba"
+    },
+    {
+      "file": "apps/web/src/islands/board-utils.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "e825f7a49cc0e5ca1bda6efbca64a7fed51951b61814bd9da5745fa4008a43ba"
+    },
+    {
+      "file": "apps/web/src/islands/charts/CodeHeatmap.tsx",
+      "check_id": "Consistency.ErrorHandlingIdiom",
+      "rule_signature": "387430287dc092d1e34930b1db4e1c56018a906fccedb49d211c57d8b9ca9586"
+    },
+    {
+      "file": "apps/web/src/islands/charts/CodeHeatmap.tsx",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "7ddc67f59bd63e16e60efdef1dbd900b4391a53d151c7adbba8f61e592c93208"
+    },
+    {
+      "file": "apps/web/src/islands/charts/CodeHeatmap.tsx",
+      "check_id": "Refactor.CyclomaticComplexity",
+      "rule_signature": "745fee4345b72682096d8d505a44d52cb54a71e0aa7ec6967754dfe1c1517046"
+    },
+    {
+      "file": "apps/web/src/islands/charts/UplotChart.tsx",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "946e1177e0ea707ff08e0e54b4616da96646c04fbe16800e45aef46777a7e4b5"
+    },
+    {
+      "file": "apps/web/src/islands/charts/UplotChart.tsx",
+      "check_id": "Refactor.PreferNullishCoalescing",
+      "rule_signature": "fe04d574598448cfcb32697343779ea8cf8df7f6a32ebe1ceb3ff59f0cf1ca50"
+    },
+    {
+      "file": "apps/web/src/islands/glossary-definitions.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "215395385d854a4d5f0312deed02adb56dead3db66ff263344265edb9606ebf8"
+    },
+    {
+      "file": "apps/web/src/islands/issue-detail-helpers.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "7b3fd480d020b4a93e5e7a6326bbb2b94c0a168a09b242ea690c1960fe9a5995"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/BacklogView.tsx",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "71ac2245330dd1ea8137685c4d4a4e69566564cd05fb8398b6d9c7cd5de7b6a6"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/BacklogView.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "e825f7a49cc0e5ca1bda6efbca64a7fed51951b61814bd9da5745fa4008a43ba"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/BoardView.test.tsx",
+      "check_id": "Refactor.DuplicateBlock",
+      "rule_signature": "6f1f99eb8fa64a1d00f4472c4bd478376028375e9f3a564bbf8d565ff7c205bb"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/CreateIssueModal.tsx",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "df89fa4db7415b63552f027ac27db180a06699404ad0642ff4bb72472e7527ca"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/FiltersPopover.tsx",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "7a9ab99e4b4893c2a4064ae8bf1e69c8ae4abb8575d4b422c29fe237b00ee8db"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/HeaderRow.tsx",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "8b0e15724e64aa36b520cf02c05dacfd181b6a38eee2cf868ff2978e159adf91"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/HeaderRow.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "84e983d65367c6cde13c0cd5a8c80504f8358e2e9ce1f8d778fbfd7312e50c97"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/IssueListLayout.tsx",
+      "check_id": "Design.ImportFanOutOutlier",
+      "rule_signature": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/IssueListLayout.tsx",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "9cf57a49298dd1199bf3a8f84319633292440f0400c9f00e2f89663a6e93f28e"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/ListSection.tsx",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "1b482a990e9561fd2edeec5b571716c2d9aef09f32293b862b0d5bd1f9b72ee1"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/MainContent.tsx",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "5a08bf746d9874830409c19bdf7840f1b2d68f7af9af48cb8b4e6fe28a269f05"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/SavedViewsControl.tsx",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "2e6ef66564f8be420bdbf61e2f7dd841617b41ddc5e7c58c4076d0e0b8e3aa00"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/SearchBox.tsx",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "a9653f35bc2725e4106c3fa71002c049011e8209529274147008392b78cb232c"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/SearchBox.tsx",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "c49bb172f9aeeba887e512e7f783804f40f76b9cb24d1cc83195979969f53120"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/SprintBannerSection.tsx",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "6dc5535f1d68939cb964e19644c0f3343a2f2bd5666ca0b5f58617e4f835ab4f"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/Toolbar.tsx",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "184993429b8146d6b6a85007b2c67500b98167543c6114f40039dab5c9638fdd"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/derive.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "ffdd42fe337f583065c67cacc294df2734155df8687b5c7bfb557370110f74a8"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/derive.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "3b1ed94a65c6d85e2f86b35f9dc10ceae76de4b4c5d9b05e063f168e1040c6f7"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/derive.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "c8515302129d3cb2831dd9ea6d97d6f381835ccd1ef8cb306fe406cd95c44c55"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/derive.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "e825f7a49cc0e5ca1bda6efbca64a7fed51951b61814bd9da5745fa4008a43ba"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/derive.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "e825f7a49cc0e5ca1bda6efbca64a7fed51951b61814bd9da5745fa4008a43ba"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/derive.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "e825f7a49cc0e5ca1bda6efbca64a7fed51951b61814bd9da5745fa4008a43ba"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/issue-render-helpers.tsx",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "8b85ee4280f6e70957b033010995e5019119fc948783182613cb4f22125d2f89"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/useFilterUrlSync.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "dfc010ff12725a8e0b831e8977411eeb77e73bf62db4660a59d1e1de78924cc6"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/useIssueFetching.ts",
+      "check_id": "Consistency.ErrorHandlingIdiom",
+      "rule_signature": "3eebff6f77828bba8f624b2a07188ac8b7c2ade0be9d55f35f5eb2c3208cb32a"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/useIssueFetching.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "53b13c90c1d5a0f3a1d24ffa2c974840f98154d4a5561898930175e3f9d87e3f"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/useIssueFilters.ts",
+      "check_id": "Consistency.UnusedSuppression",
+      "rule_signature": "ea19087c6a19074a3166b6c5e0cb3824466a607e5804bc5503de42863344b71b"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/useIssueFilters.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "837bb620bf5d6229371dd9a5823d4f6d17af9248b3a1de7004b687adfb5a4088"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/useIssueListData.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "9c2774318b21d6f8c87fe2a2c71a3667bdb9832c59fa5b89cdd1c90673b1ad36"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/useIssueLookups.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "598f2ffaf0695d38951e02db0c28152307de0d16bd1acd7350342a13c1515809"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/useIssueMutations.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "328dd0d5f6e3642fb315b51184eb0807fb1cf8aa504a6d5e5509ffa0c4ac630d"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/useIssueMutations.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "c8515302129d3cb2831dd9ea6d97d6f381835ccd1ef8cb306fe406cd95c44c55"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/useIssueSearch.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "f07dd53dea5b5cc055d194a638f50bfdeb566f430007225df623d616d52a5460"
+    },
+    {
+      "file": "apps/web/src/islands/issue-list/useSavedViews.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "6b6506bdab63068e619d5d13616246780a4a61760c2a8f2c3a99e973a2a44b16"
+    },
+    {
+      "file": "apps/web/src/islands/metric-definitions.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "55c016cb0294e827824dc45301bcefc287bd7bca7dbea42a1b7594014558cf46"
+    },
+    {
+      "file": "apps/web/src/islands/metric-definitions.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "1b59c41968f3de4f992e019f99c1bc5bb41dda85adc50ef059190028226f643d"
+    },
+    {
+      "file": "apps/web/src/islands/metric-definitions.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "34de5b10d518100f8bfc6ffbe0d7a9cca2cfb6c17d8bb513ad3df210560ccf2a"
+    },
+    {
+      "file": "apps/web/src/islands/metric-definitions.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "d7c4787fbaa068cb310a671cdd5a44e9e135511351f783ea8dc94f120bbd5b2a"
+    },
+    {
+      "file": "apps/web/src/islands/metric-definitions.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "df445579c999d7dec7b77d49569a1d5185ac9be1b88ad2aaa0b6fdbe1313a22b"
+    },
+    {
+      "file": "apps/web/src/islands/metrics/flow-charts.tsx",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "3485e0f2779b607b487daed5e4afbc387a54b9b68b43451159166a51e26bc22a"
+    },
+    {
+      "file": "apps/web/src/islands/metrics/flow-charts.tsx",
+      "check_id": "Design.OrphanExport",
+      "rule_signature": "a05054aedd37cd24e93e32242ca84fcee7baa3d2aae4a905842f9b5d2481c885"
+    },
+    {
+      "file": "apps/web/src/islands/metrics/flow-charts.tsx",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "09540ec1ffaf91049878cbdcf95a49a82f8a85a1e01f7a1814440fcb5dac1fb7"
+    },
+    {
+      "file": "apps/web/src/islands/metrics/flow-charts.tsx",
+      "check_id": "Refactor.PreferArrayMethodOverLoop",
+      "rule_signature": "f1da14b050653791a4127dc419dcf0b49435bcb9a0a2c7c052548b397de27be3"
+    },
+    {
+      "file": "apps/web/src/islands/saved-views.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "0b7a76e437089120fb4e2c5054205f03ae878dd729f2ae4b5950ed7c79c59496"
+    },
+    {
+      "file": "apps/web/src/islands/saved-views.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "afe1e9cea33edd69dfd81ccc2ae20222b013d10f5f2b589dd0e5f2b923af3737"
+    },
+    {
+      "file": "apps/web/src/islands/saved-views.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "afe1e9cea33edd69dfd81ccc2ae20222b013d10f5f2b589dd0e5f2b923af3737"
+    },
+    {
+      "file": "apps/web/src/islands/saved-views.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "e33d072b7db555c65b664fcda22c1c7aa5797d2c997afbf2f8a1c6a73aeea299"
+    },
+    {
+      "file": "apps/web/src/layouts/Base.astro",
+      "check_id": "Design.ImportFanOutOutlier",
+      "rule_signature": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "file": "apps/web/src/test/viewport.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "7a2ee0c99b4024b8e87eee66cb0a18918cf27c4af109f468aca5835fa5e6ee03"
+    },
+    {
+      "file": "apps/web/src/test/viewport.ts",
+      "check_id": "Design.OrphanExport",
+      "rule_signature": "c583243fd751a2a91e47c2cc7fdb283bb24f2005822d4a5f635f7ae0561429bf"
+    },
+    {
+      "file": "apps/web/src/utils/access-gate.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "69fffc6b4a101d11736e7de6eb549cd2847429e13f62c1ce09dd5bd1ddbe5ef0"
+    },
+    {
+      "file": "apps/web/src/utils/api-client.ts",
+      "check_id": "Design.ImportFanOutOutlier",
+      "rule_signature": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "file": "apps/web/src/utils/api-client.ts",
+      "check_id": "Design.ReadonlyArrayParam",
+      "rule_signature": "e1271ad5bf1b4f57afb36e6e624ec68f5c5655494e6b573b49f6f4d845800ba9"
+    },
+    {
+      "file": "apps/web/src/utils/api-client.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "f7faa95c3cbd016bd59bcdfe6e60cf5f73d4e2e871b81b8b1692dc8cbc7d386b"
+    },
+    {
+      "file": "apps/web/src/utils/api-client.ts",
+      "check_id": "Refactor.CognitiveComplexity",
+      "rule_signature": "513ab77f15376cd3a223aa2beb875f0db710e0d1dc5e2737e6d6f0c814fca387"
+    },
+    {
+      "file": "apps/web/src/utils/api-client.ts",
+      "check_id": "Refactor.CyclomaticComplexity",
+      "rule_signature": "3963e47a66a771337fd64285a30d535fed73a9a5cb92e95ceef96caa253b6900"
+    },
+    {
+      "file": "apps/web/src/utils/api-client.ts",
+      "check_id": "Refactor.CyclomaticComplexity",
+      "rule_signature": "513ab77f15376cd3a223aa2beb875f0db710e0d1dc5e2737e6d6f0c814fca387"
+    },
+    {
+      "file": "apps/web/src/utils/issue-prefetch.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "b4bd05c05af37de140884769bc3de55bd44bdfb48c3137f7d1b45f813e181a2c"
+    },
+    {
+      "file": "apps/web/src/utils/issue-url.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "a4d02c327a05b406b6daec5074229a46ff22ebb565f19e33355e60c37f7e069e"
+    },
+    {
+      "file": "apps/web/src/utils/issue-utils.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "d37288205aa2ed588d96a6b40929631bd40e30379c7e45bd5983a73df724437c"
+    },
+    {
+      "file": "apps/web/src/utils/use-fetch.ts",
+      "check_id": "Consistency.ErrorHandlingIdiom",
+      "rule_signature": "8c66b7c24e73d9b9da6933ee0829f9f8fb4e219be158d7256b20713f447b4f9c"
+    },
+    {
+      "file": "apps/web/src/utils/use-fetch.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "652929e48e76c542e9d4d89bd379d8ec4544dc3b0b7f2c24753e1e2591586244"
+    },
+    {
+      "file": "packages/db/drizzle.config.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "42c180d5df25d4067ca7189bd35f5ffc03d5c119c80e214a5fc5f39ee48ac0ea"
+    },
+    {
+      "file": "packages/db/src/schema/agent-messages.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "e59499fe245740d5b250aa8f2905116668bfc6f1d0b8af3639990fb353c898fb"
+    },
+    {
+      "file": "packages/db/src/schema/agents.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "d37a34f6fc55edb1e170d3fa9358b9b7a0a853c855f88d9d227fa79efac26de1"
+    },
+    {
+      "file": "packages/db/src/schema/attachments.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "3930e671c9e40dee2a33442c6f1055e8e8b75958ee19da8bd470754fd44beec2"
+    },
+    {
+      "file": "packages/db/src/schema/core.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "6e8d79980fba5ccc49472622f6af250f4c52d0271c3df8b665860a9b535313ae"
+    },
+    {
+      "file": "packages/db/src/schema/custom-fields.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "240bc65694f2c4d085c534b3374d692e459cb7142ca728e628b8445d09bb2870"
+    },
+    {
+      "file": "packages/db/src/schema/file-claims.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "87b24240583b48426cbfca9ebf1579e1bfccffd82ff3c1c1da40f13aab780e4b"
+    },
+    {
+      "file": "packages/db/src/schema/groups.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "806102f583890a4cd03a321bd4a081e13c41427a7353b73dc34f0ecb2cd4273f"
+    },
+    {
+      "file": "packages/db/src/schema/issue-leases.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "45c403ab188abc5ff29323d758464162c7320258535c43d940a692826b0c4de5"
+    },
+    {
+      "file": "packages/db/src/schema/issues.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "2577c0f557b2e4b591e9587374c6330c9c64de8017d5a848a682a135251a6f6f"
+    },
+    {
+      "file": "packages/db/src/schema/sprints.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "9c4a535033d89a730e574b5caa269991d9bade574a676505b96fce4a452f5ed4"
+    },
+    {
+      "file": "packages/db/src/schema/wiki.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "557d1c2bd69997a48095721767a41abbdea431efc0aed26ef4953056415e5803"
+    },
+    {
+      "file": "packages/db/src/test/helpers.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "ae154bf7b9da0b4596e049d0feb87ae72b13cbf0fc498459845770036a7fa002"
+    },
+    {
+      "file": "packages/db/src/test/migrations.test.ts",
+      "check_id": "Readability.MaxFunctionLength",
+      "rule_signature": "b1f7303dc5ce75f2b496883b68d900f81d5a8eebca4b980142bade02f0ee77c5"
+    },
+    {
+      "file": "packages/plugin-sdk/src/index.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "65da9e0c53c32aadbef5d9efa5d4a4ec578c5fe7439231df0e6feef6de85d461"
+    },
+    {
+      "file": "plugins/github/src/index.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "56a2d3ea32c9056357f9a884cf72ba97ee5777aa46de79163d5812a1e003755d"
+    },
+    {
+      "file": "plugins/island-api",
+      "check_id": "Warning.PluginLoadFailed",
+      "rule_signature": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "file": "plugins/island-api/fixtures/apps/web/src/islands/fixture.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "0c04bdf9b5bfa6ec6873ca0cce14321896ae478d974686f6338bec5f139cbe55"
+    },
+    {
+      "file": "plugins/island-api/fixtures/apps/web/src/islands/fixture.ts",
+      "check_id": "Design.OrphanExport",
+      "rule_signature": "0c04bdf9b5bfa6ec6873ca0cce14321896ae478d974686f6338bec5f139cbe55"
+    },
+    {
+      "file": "plugins/island-api/fixtures/apps/web/src/islands/fixture.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "3dd46d5f444ea7d654c0afd72bbce0a9dbab20bb60a5e0bc222e21a0789208f5"
+    },
+    {
+      "file": "plugins/island-api/fixtures/apps/web/src/islands/fixture.ts",
+      "check_id": "Refactor.UnusedVariable",
+      "rule_signature": "28e5ebabd9d8f6e237df63da2b503785093f0229241bc7021198f63c43b93269"
+    },
+    {
+      "file": "plugins/island-api/src/index.ts",
+      "check_id": "Design.MissingTestFile",
+      "rule_signature": "07e668120f2f045bcc2bb13357b6016be9b81ce001e445239b26a1299ab04d80"
+    },
+    {
+      "file": "plugins/island-api/src/index.ts",
+      "check_id": "Design.OrphanExport",
+      "rule_signature": "07e668120f2f045bcc2bb13357b6016be9b81ce001e445239b26a1299ab04d80"
+    },
+    {
+      "file": "scripts/gen-conventions-page.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "6111ac29546b47ad18ac14617a2e60d18dcb03dba17f42c22411e0e4b54a1749"
+    },
+    {
+      "file": "scripts/gen-feedback-example-page.ts",
+      "check_id": "Readability.MaxLineLength",
+      "rule_signature": "90af7b58eaab5667e85eb67a513697a8186463e2052538591abce14bd05f06bf"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -18,15 +18,20 @@
     "@biomejs/biome": "^2.5.1",
     "@biomejs/cli-win32-x64": "2.5.1",
     "@cloudflare/workers-types": "^4.20250620.0",
-    "@cofferdam/cofferdam": "^0.3.12",
+    "@cofferdam/cofferdam": "^0.3.13",
     "lefthook": "^1.11.0",
-    "turbo": "^2.3.0",
     "tsx": "^4.19.0",
+    "turbo": "^2.3.0",
     "typescript": "^5.5.0"
   },
   "packageManager": "pnpm@10.18.0",
   "pnpm": {
-    "onlyBuiltDependencies": ["esbuild", "workerd", "sharp", "@cofferdam/cofferdam"]
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "workerd",
+      "sharp",
+      "@cofferdam/cofferdam"
+    ]
   },
   "engines": {
     "node": ">=22.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^4.20250620.0
         version: 4.20260621.1
       '@cofferdam/cofferdam':
-        specifier: ^0.3.12
-        version: 0.3.12
+        specifier: ^0.3.13
+        version: 0.3.13
       lefthook:
         specifier: ^1.11.0
         version: 1.13.6
@@ -71,7 +71,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.10)(happy-dom@15.11.7)(jsdom@25.0.1)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.10)(happy-dom@15.11.7)(jsdom@25.0.1)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       wrangler:
         specifier: ^4.105.0
         version: 4.105.0(@cloudflare/workers-types@4.20260621.1)
@@ -80,13 +80,13 @@ importers:
     dependencies:
       '@astrojs/starlight':
         specifier: ^0.41.3
-        version: 0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3)
+        version: 0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3)
       astro:
         specifier: ^7.0.6
-        version: 7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
       astro-mermaid:
         specifier: ^2.1.0
-        version: 2.1.0(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(mermaid@11.16.0)
+        version: 2.1.0(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))(mermaid@11.16.0)
       mermaid:
         specifier: ^11.16.0
         version: 11.16.0
@@ -96,13 +96,13 @@ importers:
     devDependencies:
       starlight-links-validator:
         specifier: ^0.25.2
-        version: 0.25.2(@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 0.25.2(@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/web:
     dependencies:
       '@astrojs/preact':
         specifier: ^4.0.0
-        version: 4.1.3(@babel/core@7.29.7)(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(preact@10.29.2)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 4.1.3(@babel/core@7.29.7)(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(preact@10.29.2)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
       '@codemirror/commands':
         specifier: ^6.10.4
         version: 6.10.4
@@ -120,7 +120,7 @@ importers:
         version: link:../../packages/types
       astro:
         specifier: ^5.0.0
-        version: 5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+        version: 5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
       dompurify:
         specifier: ^3.2.0
         version: 3.4.11
@@ -145,7 +145,7 @@ importers:
         version: 0.9.9(prettier@3.8.4)(typescript@5.9.3)
       '@astrojs/tailwind':
         specifier: ^6.0.2
-        version: 6.0.2(astro@5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.9.0))
+        version: 6.0.2(astro@5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.9.0))
       '@playwright/test':
         specifier: ^1.52.0
         version: 1.61.0
@@ -160,10 +160,10 @@ importers:
         version: 3.2.0
       '@vite-pwa/astro':
         specifier: ^0.5.1
-        version: 0.5.1(astro@5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(vite-plugin-pwa@0.21.2(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1))
+        version: 0.5.1(astro@5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(vite-plugin-pwa@0.21.2(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1))
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.7(vitest@3.2.6(@types/debug@4.1.13)(@types/node@26.0.0)(happy-dom@15.11.7)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 3.2.7(vitest@3.2.6(@types/debug@4.1.13)(@types/node@26.0.0)(happy-dom@15.11.7)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       jsdom:
         specifier: ^25.0.0
         version: 25.0.1
@@ -175,10 +175,10 @@ importers:
         version: 5.9.3
       vite-plugin-pwa:
         specifier: 0.21.2
-        version: 0.21.2(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
+        version: 0.21.2(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
       vitest:
         specifier: ^3.0.0
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@26.0.0)(happy-dom@15.11.7)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@26.0.0)(happy-dom@15.11.7)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
 
   packages/db:
     dependencies:
@@ -206,7 +206,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@types/node@22.20.1)(happy-dom@15.11.7)(jsdom@25.0.1)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@types/node@22.20.1)(happy-dom@15.11.7)(jsdom@25.0.1)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/plugin-sdk:
     dependencies:
@@ -1148,8 +1148,8 @@ packages:
     resolution: {integrity: sha512-CsgDhJ2w8mIt6sHSnPUNsDFmkwN5DMZ4GRB19hAbeiZzetHIG9RWJsgoWz+0CfONsoTf3inrCprvT2GhzDkK4A==}
     engines: {node: '>=16'}
 
-  '@cofferdam/cofferdam@0.3.12':
-    resolution: {integrity: sha512-owpeuG7aHwUA1WBN5E0Zepyhsg6K7UO7P6WqEyxEWo1FtKPKDtfmULu1GEmIt/f1kYqYTELDipL2BjKH2+nHeg==}
+  '@cofferdam/cofferdam@0.3.13':
+    resolution: {integrity: sha512-3phmKswhcLCY+DhTNic3KeoOqlljXSzKLiRaZHIlce5KA4WiVpurXw3C9tnihdSdk3QyAzlDNxRFwHXfgZaPYg==}
     engines: {node: '>=16', npm: '>=7'}
     cpu: [x64, arm64]
     os: [linux, darwin, win32]
@@ -2558,8 +2558,18 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@rollup/rollup-android-arm-eabi@4.62.3':
+    resolution: {integrity: sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==}
+    cpu: [arm]
+    os: [android]
+
   '@rollup/rollup-android-arm64@4.62.2':
     resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.3':
+    resolution: {integrity: sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==}
     cpu: [arm64]
     os: [android]
 
@@ -2568,8 +2578,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-arm64@4.62.3':
+    resolution: {integrity: sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rollup/rollup-darwin-x64@4.62.2':
     resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.3':
+    resolution: {integrity: sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==}
     cpu: [x64]
     os: [darwin]
 
@@ -2578,8 +2598,18 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@rollup/rollup-freebsd-arm64@4.62.3':
+    resolution: {integrity: sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@rollup/rollup-freebsd-x64@4.62.2':
     resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.3':
+    resolution: {integrity: sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==}
     cpu: [x64]
     os: [freebsd]
 
@@ -2588,8 +2618,18 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.3':
+    resolution: {integrity: sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==}
+    cpu: [arm]
+    os: [linux]
+
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.3':
+    resolution: {integrity: sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==}
     cpu: [arm]
     os: [linux]
 
@@ -2598,8 +2638,18 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rollup/rollup-linux-arm64-gnu@4.62.3':
+    resolution: {integrity: sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.3':
+    resolution: {integrity: sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==}
     cpu: [arm64]
     os: [linux]
 
@@ -2608,8 +2658,18 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@rollup/rollup-linux-loong64-gnu@4.62.3':
+    resolution: {integrity: sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==}
+    cpu: [loong64]
+    os: [linux]
+
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.3':
+    resolution: {integrity: sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==}
     cpu: [loong64]
     os: [linux]
 
@@ -2618,8 +2678,18 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@rollup/rollup-linux-ppc64-gnu@4.62.3':
+    resolution: {integrity: sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==}
+    cpu: [ppc64]
+    os: [linux]
+
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.3':
+    resolution: {integrity: sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==}
     cpu: [ppc64]
     os: [linux]
 
@@ -2628,8 +2698,18 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@rollup/rollup-linux-riscv64-gnu@4.62.3':
+    resolution: {integrity: sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==}
+    cpu: [riscv64]
+    os: [linux]
+
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.3':
+    resolution: {integrity: sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==}
     cpu: [riscv64]
     os: [linux]
 
@@ -2638,8 +2718,18 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@rollup/rollup-linux-s390x-gnu@4.62.3':
+    resolution: {integrity: sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==}
+    cpu: [s390x]
+    os: [linux]
+
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.3':
+    resolution: {integrity: sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==}
     cpu: [x64]
     os: [linux]
 
@@ -2648,8 +2738,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rollup/rollup-linux-x64-musl@4.62.3':
+    resolution: {integrity: sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==}
+    cpu: [x64]
+    os: [linux]
+
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openbsd-x64@4.62.3':
+    resolution: {integrity: sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==}
     cpu: [x64]
     os: [openbsd]
 
@@ -2658,8 +2758,18 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@rollup/rollup-openharmony-arm64@4.62.3':
+    resolution: {integrity: sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@rollup/rollup-win32-arm64-msvc@4.62.2':
     resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.3':
+    resolution: {integrity: sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==}
     cpu: [arm64]
     os: [win32]
 
@@ -2668,13 +2778,28 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rollup/rollup-win32-ia32-msvc@4.62.3':
+    resolution: {integrity: sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rollup/rollup-win32-x64-gnu@4.62.2':
     resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
     cpu: [x64]
     os: [win32]
 
+  '@rollup/rollup-win32-x64-gnu@4.62.3':
+    resolution: {integrity: sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.3':
+    resolution: {integrity: sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==}
     cpu: [x64]
     os: [win32]
 
@@ -3082,6 +3207,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -3267,6 +3397,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  baseline-browser-mapping@2.11.7:
+    resolution: {integrity: sha512-APw5YuIQAg6L9w4sHDI6j26DGFJI6RpYOhnkMPdC9lWbkKvsyPHzDsve1yd73lk21yz7Y09Kci8B2Pp9FonzWA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   bcp-47-match@2.0.3:
     resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
 
@@ -3290,9 +3425,16 @@ packages:
   brace-expansion@2.1.1:
     resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
+
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3300,6 +3442,11 @@ packages:
 
   browserslist@4.28.4:
     resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  browserslist@4.28.7:
+    resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -3332,6 +3479,9 @@ packages:
 
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
+
+  caniuse-lite@1.0.30001806:
+    resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -3911,6 +4061,9 @@ packages:
   electron-to-chromium@1.5.376:
     resolution: {integrity: sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==}
 
+  electron-to-chromium@1.5.398:
+    resolution: {integrity: sha512-AsvhAxopJGh6museTDMIjn6JpDYOfgu4RLlygomt87MUwBUqTfd/1EiPtx10/LZE8xpTvkP2E9Gafq7lkLtodQ==}
+
   emmet@2.4.11:
     resolution: {integrity: sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==}
 
@@ -3971,8 +4124,8 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
-  es-to-primitive@1.3.1:
-    resolution: {integrity: sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g==}
+  es-to-primitive@1.3.4:
+    resolution: {integrity: sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==}
     engines: {node: '>= 0.4'}
 
   es-toolkit@1.49.0:
@@ -4831,9 +4984,6 @@ packages:
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
-  lodash.sortby@4.7.0:
-    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
-
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -4849,6 +4999,10 @@ packages:
 
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
@@ -5088,6 +5242,10 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
@@ -5136,6 +5294,10 @@ packages:
 
   node-releases@2.0.48:
     resolution: {integrity: sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==}
+    engines: {node: '>=18'}
+
+  node-releases@2.0.51:
+    resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
     engines: {node: '>=18'}
 
   normalize-path@3.0.0:
@@ -5188,8 +5350,8 @@ packages:
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
-  own-keys@1.0.1:
-    resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
+  own-keys@1.0.2:
+    resolution: {integrity: sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==}
     engines: {node: '>= 0.4'}
 
   p-limit@6.2.0:
@@ -5586,6 +5748,11 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rollup@4.62.3:
+    resolution: {integrity: sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
@@ -5636,8 +5803,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  serialize-javascript@7.0.6:
-    resolution: {integrity: sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==}
+  serialize-javascript@7.0.7:
+    resolution: {integrity: sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==}
     engines: {node: '>=20.0.0'}
 
   set-function-length@1.2.2:
@@ -5735,10 +5902,9 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
-  source-map@0.8.0-beta.0:
-    resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
-    engines: {node: '>= 8'}
-    deprecated: The work that was done in this beta branch won't be included in future versions
+  source-map@0.8.0:
+    resolution: {integrity: sha512-d8EqvL+k/SOXCreS/SUzg2ciyHqBBLcN/yuRjFsbvVhHTE2pgei7oAhmPM7kWFbkX6OSMQfUq4KbkF3au9lhYQ==}
+    engines: {node: '>= 12'}
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -5878,8 +6044,8 @@ packages:
     resolution: {integrity: sha512-qFAy10MTMwjzjU8U16YS4YoZD+NQLHzLssFMNqgravjbvIPNiqkGFR4yjhJfmY9R5OFU7+yHxc6y+uGHkKwLRA==}
     engines: {node: '>=20'}
 
-  terser@5.48.0:
-    resolution: {integrity: sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==}
+  terser@5.49.0:
+    resolution: {integrity: sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -5945,9 +6111,6 @@ packages:
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
-
-  tr46@1.0.1:
-    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
 
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
@@ -6502,9 +6665,6 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
-  webidl-conversions@4.0.2:
-    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
-
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -6525,9 +6685,6 @@ packages:
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
-
-  whatwg-url@7.1.0:
-    resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -6923,13 +7080,13 @@ snapshots:
       github-slugger: 2.0.0
       satteri: 0.9.4
 
-  '@astrojs/mdx@7.0.2(@astrojs/markdown-satteri@0.3.3)(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@astrojs/mdx@7.0.2(@astrojs/markdown-satteri@0.3.3)(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@astrojs/internal-helpers': 0.10.1
       '@astrojs/markdown-remark': 7.2.1
       '@mdx-js/mdx': 3.1.1
       acorn: 8.17.0
-      astro: 7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      astro: 7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -6945,13 +7102,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/preact@4.1.3(@babel/core@7.29.7)(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(preact@10.29.2)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)':
+  '@astrojs/preact@4.1.3(@babel/core@7.29.7)(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(preact@10.29.2)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)':
     dependencies:
-      '@preact/preset-vite': 2.10.5(@babel/core@7.29.7)(preact@10.29.2)(rollup@4.62.2)(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@preact/preset-vite': 2.10.5(@babel/core@7.29.7)(preact@10.29.2)(rollup@4.62.3)(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       '@preact/signals': 2.9.2(preact@10.29.2)
       preact: 10.29.2
       preact-render-to-string: 6.7.0(preact@10.29.2)
-      vite: 6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/node'
@@ -6982,17 +7139,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.3
 
-  '@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3)':
+  '@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3)':
     dependencies:
       '@astrojs/markdown-satteri': 0.3.3
-      '@astrojs/mdx': 7.0.2(@astrojs/markdown-satteri@0.3.3)(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@astrojs/mdx': 7.0.2(@astrojs/markdown-satteri@0.3.3)(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       '@astrojs/sitemap': 3.7.3
       '@pagefind/default-ui': 1.5.2
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      astro-expressive-code: 0.44.0(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      astro: 7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      astro-expressive-code: 0.44.0(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -7020,9 +7177,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@astrojs/tailwind@6.0.2(astro@5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.9.0))':
+  '@astrojs/tailwind@6.0.2(astro@5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      astro: 5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      astro: 5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
       autoprefixer: 10.5.1(postcss@8.5.16)
       postcss: 8.5.16
       postcss-load-config: 4.0.2(postcss@8.5.16)
@@ -7842,7 +7999,7 @@ snapshots:
       cjs-module-lexer: 1.2.3
       esbuild: 0.28.1
       miniflare: 4.20260625.0
-      vitest: 4.1.9(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.10)(happy-dom@15.11.7)(jsdom@25.0.1)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.10)(happy-dom@15.11.7)(jsdom@25.0.1)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       wrangler: 4.105.0(@cloudflare/workers-types@4.20260621.1)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -7949,7 +8106,7 @@ snapshots:
 
   '@cofferdam/check-sdk@0.3.7': {}
 
-  '@cofferdam/cofferdam@0.3.12': {}
+  '@cofferdam/cofferdam@0.3.13': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -8779,19 +8936,19 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
-  '@preact/preset-vite@2.10.5(@babel/core@7.29.7)(preact@10.29.2)(rollup@4.62.2)(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@preact/preset-vite@2.10.5(@babel/core@7.29.7)(preact@10.29.2)(rollup@4.62.3)(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-react-jsx-development': 7.29.7(@babel/core@7.29.7)
-      '@prefresh/vite': 2.4.12(preact@10.29.2)(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
+      '@prefresh/vite': 2.4.12(preact@10.29.2)(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@rollup/pluginutils': 5.4.0(rollup@4.62.3)
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.29.7)
       debug: 4.4.3
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      vite-prerender-plugin: 0.5.13(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vite: 6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite-prerender-plugin: 0.5.13(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       zimmerframe: 1.1.4
     transitivePeerDependencies:
       - preact
@@ -8813,7 +8970,7 @@ snapshots:
 
   '@prefresh/utils@1.2.1': {}
 
-  '@prefresh/vite@2.4.12(preact@10.29.2)(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@prefresh/vite@2.4.12(preact@10.29.2)(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@prefresh/babel-plugin': 0.5.3
@@ -8821,7 +8978,7 @@ snapshots:
       '@prefresh/utils': 1.2.1
       '@rollup/pluginutils': 4.2.1
       preact: 10.29.2
-      vite: 6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8876,127 +9033,202 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.62.2)':
+  '@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.62.3)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.29.7
-      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
+      '@rollup/pluginutils': 5.4.0(rollup@4.62.3)
     optionalDependencies:
-      rollup: 4.62.2
+      rollup: 4.62.3
     transitivePeerDependencies:
       - supports-color
 
-  '@rollup/plugin-node-resolve@16.0.3(rollup@4.62.2)':
+  '@rollup/plugin-node-resolve@16.0.3(rollup@4.62.3)':
     dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
+      '@rollup/pluginutils': 5.4.0(rollup@4.62.3)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.12
     optionalDependencies:
-      rollup: 4.62.2
+      rollup: 4.62.3
 
-  '@rollup/plugin-replace@6.0.3(rollup@4.62.2)':
+  '@rollup/plugin-replace@6.0.3(rollup@4.62.3)':
     dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
+      '@rollup/pluginutils': 5.4.0(rollup@4.62.3)
       magic-string: 0.30.21
     optionalDependencies:
-      rollup: 4.62.2
+      rollup: 4.62.3
 
-  '@rollup/plugin-terser@1.0.0(rollup@4.62.2)':
+  '@rollup/plugin-terser@1.0.0(rollup@4.62.3)':
     dependencies:
-      serialize-javascript: 7.0.6
+      serialize-javascript: 7.0.7
       smob: 1.6.2
-      terser: 5.48.0
+      terser: 5.49.0
     optionalDependencies:
-      rollup: 4.62.2
+      rollup: 4.62.3
 
   '@rollup/pluginutils@4.2.1':
     dependencies:
       estree-walker: 2.0.2
       picomatch: 2.3.2
 
-  '@rollup/pluginutils@5.4.0(rollup@4.62.2)':
+  '@rollup/pluginutils@5.4.0(rollup@4.62.3)':
     dependencies:
       '@types/estree': 1.0.9
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
-      rollup: 4.62.2
+      rollup: 4.62.3
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.62.3':
     optional: true
 
   '@rollup/rollup-android-arm64@4.62.2':
     optional: true
 
+  '@rollup/rollup-android-arm64@4.62.3':
+    optional: true
+
   '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.3':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.62.2':
     optional: true
 
+  '@rollup/rollup-darwin-x64@4.62.3':
+    optional: true
+
   '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.3':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.62.2':
     optional: true
 
+  '@rollup/rollup-freebsd-x64@4.62.3':
+    optional: true
+
   '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.3':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     optional: true
 
+  '@rollup/rollup-linux-arm-musleabihf@4.62.3':
+    optional: true
+
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.3':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     optional: true
 
+  '@rollup/rollup-linux-arm64-musl@4.62.3':
+    optional: true
+
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.3':
     optional: true
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     optional: true
 
+  '@rollup/rollup-linux-loong64-musl@4.62.3':
+    optional: true
+
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.3':
     optional: true
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     optional: true
 
+  '@rollup/rollup-linux-ppc64-musl@4.62.3':
+    optional: true
+
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.3':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     optional: true
 
+  '@rollup/rollup-linux-riscv64-musl@4.62.3':
+    optional: true
+
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.3':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     optional: true
 
+  '@rollup/rollup-linux-x64-gnu@4.62.3':
+    optional: true
+
   '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.3':
     optional: true
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     optional: true
 
+  '@rollup/rollup-openbsd-x64@4.62.3':
+    optional: true
+
   '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.3':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.62.2':
     optional: true
 
+  '@rollup/rollup-win32-arm64-msvc@4.62.3':
+    optional: true
+
   '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.3':
     optional: true
 
   '@rollup/rollup-win32-x64-gnu@4.62.2':
     optional: true
 
+  '@rollup/rollup-win32-x64-gnu@4.62.3':
+    optional: true
+
   '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.3':
     optional: true
 
   '@shikijs/core@3.23.0':
@@ -9330,10 +9562,10 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vite-pwa/astro@0.5.1(astro@5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(vite-plugin-pwa@0.21.2(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1))':
+  '@vite-pwa/astro@0.5.1(astro@5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(vite-plugin-pwa@0.21.2(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1))':
     dependencies:
-      astro: 5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
-      vite-plugin-pwa: 0.21.2(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
+      astro: 5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      vite-plugin-pwa: 0.21.2(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
 
   '@vitest/coverage-istanbul@4.1.10(vitest@4.1.9)':
     dependencies:
@@ -9347,11 +9579,11 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.3
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.10)(happy-dom@15.11.7)(jsdom@25.0.1)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.10)(happy-dom@15.11.7)(jsdom@25.0.1)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.7(vitest@3.2.6(@types/debug@4.1.13)(@types/node@26.0.0)(happy-dom@15.11.7)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/coverage-v8@3.2.7(vitest@3.2.6(@types/debug@4.1.13)(@types/node@26.0.0)(happy-dom@15.11.7)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -9366,7 +9598,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.6(@types/debug@4.1.13)(@types/node@26.0.0)(happy-dom@15.11.7)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest: 3.2.6(@types/debug@4.1.13)(@types/node@26.0.0)(happy-dom@15.11.7)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9387,29 +9619,29 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@3.2.6(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@3.2.6(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.9(vite@8.1.3(@types/node@22.20.1)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.9(vite@8.1.3(@types/node@22.20.1)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.3(@types/node@22.20.1)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.3(@types/node@22.20.1)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.9(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.9(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.6':
     dependencies:
@@ -9517,6 +9749,8 @@ snapshots:
 
   acorn@8.17.0: {}
 
+  acorn@8.18.0: {}
+
   agent-base@7.1.4: {}
 
   ajv-draft-04@1.0.0(ajv@8.20.0):
@@ -9598,21 +9832,21 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.44.0(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  astro-expressive-code@0.44.0(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
-      astro: 7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      astro: 7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
       rehype-expressive-code: 0.44.0
       url-extras: 0.1.0
 
-  astro-mermaid@2.1.0(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(mermaid@11.16.0):
+  astro-mermaid@2.1.0(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))(mermaid@11.16.0):
     dependencies:
-      astro: 7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      astro: 7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
       import-meta-resolve: 4.2.0
       mdast-util-to-string: 4.0.0
       mermaid: 11.16.0
       unist-util-visit: 5.1.0
 
-  astro@5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0):
+  astro@5.18.2(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/internal-helpers': 0.7.6
@@ -9620,7 +9854,7 @@ snapshots:
       '@astrojs/telemetry': 3.3.0
       '@capsizecss/unpack': 4.0.1
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
+      '@rollup/pluginutils': 5.4.0(rollup@4.62.3)
       acorn: 8.17.0
       aria-query: 5.3.2
       axobject-query: 4.1.0
@@ -9669,8 +9903,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vite: 6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.3
@@ -9714,7 +9948,7 @@ snapshots:
       - uploadthing
       - yaml
 
-  astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
+  astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler-rs': 0.3.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@astrojs/internal-helpers': 0.10.1
@@ -9723,7 +9957,7 @@ snapshots:
       '@capsizecss/unpack': 4.0.1
       '@clack/prompts': 1.7.0
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
+      '@rollup/pluginutils': 5.4.0(rollup@4.62.3)
       am-i-vibing: 0.4.0
       aria-query: 5.3.2
       axobject-query: 4.1.0
@@ -9764,8 +9998,8 @@ snapshots:
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unstorage: 1.17.5
-      vite: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vite: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.3
@@ -9868,6 +10102,8 @@ snapshots:
 
   baseline-browser-mapping@2.10.38: {}
 
+  baseline-browser-mapping@2.11.7: {}
+
   bcp-47-match@2.0.3: {}
 
   bcp-47@2.1.0:
@@ -9897,7 +10133,15 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
+  brace-expansion@2.1.4:
+    dependencies:
+      balanced-match: 1.0.2
+
   brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
+
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -9912,6 +10156,14 @@ snapshots:
       electron-to-chromium: 1.5.376
       node-releases: 2.0.48
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
+
+  browserslist@4.28.7:
+    dependencies:
+      baseline-browser-mapping: 2.11.7
+      caniuse-lite: 1.0.30001806
+      electron-to-chromium: 1.5.398
+      node-releases: 2.0.51
+      update-browserslist-db: 1.2.3(browserslist@4.28.7)
 
   buffer-from@1.1.2: {}
 
@@ -9939,6 +10191,8 @@ snapshots:
   camelcase@8.0.0: {}
 
   caniuse-lite@1.0.30001799: {}
+
+  caniuse-lite@1.0.30001806: {}
 
   ccount@2.0.1: {}
 
@@ -10051,7 +10305,7 @@ snapshots:
 
   core-js-compat@3.49.0:
     dependencies:
-      browserslist: 4.28.4
+      browserslist: 4.28.7
 
   cose-base@1.0.3:
     dependencies:
@@ -10459,6 +10713,8 @@ snapshots:
 
   electron-to-chromium@1.5.376: {}
 
+  electron-to-chromium@1.5.398: {}
+
   emmet@2.4.11:
     dependencies:
       '@emmetio/abbreviation': 2.3.3
@@ -10499,7 +10755,7 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.2
       es-set-tostringtag: 2.1.0
-      es-to-primitive: 1.3.1
+      es-to-primitive: 1.3.4
       function.prototype.name: 1.2.0
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
@@ -10525,7 +10781,7 @@ snapshots:
       object-inspect: 1.13.4
       object-keys: 1.1.1
       object.assign: 4.1.7
-      own-keys: 1.0.1
+      own-keys: 1.0.2
       regexp.prototype.flags: 1.5.4
       safe-array-concat: 1.1.4
       safe-push-apply: 1.0.0
@@ -10573,9 +10829,10 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.4
 
-  es-to-primitive@1.3.1:
+  es-to-primitive@1.3.4:
     dependencies:
       es-abstract-get: 1.0.0
+      es-define-property: 1.0.1
       es-errors: 1.3.0
       is-callable: 1.2.7
       is-date-object: 1.1.0
@@ -10961,7 +11218,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.2.3
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
@@ -11648,8 +11905,6 @@ snapshots:
 
   lodash.debounce@4.0.8: {}
 
-  lodash.sortby@4.7.0: {}
-
   longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
@@ -11662,6 +11917,8 @@ snapshots:
   lru-cache@10.4.3: {}
 
   lru-cache@11.5.1: {}
+
+  lru-cache@11.5.2: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -12213,9 +12470,13 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.6
 
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:
@@ -12253,6 +12514,8 @@ snapshots:
   node-mock-http@1.0.4: {}
 
   node-releases@2.0.48: {}
+
+  node-releases@2.0.51: {}
 
   normalize-path@3.0.0: {}
 
@@ -12302,8 +12565,9 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  own-keys@1.0.1:
+  own-keys@1.0.2:
     dependencies:
+      call-bound: 1.0.4
       get-intrinsic: 1.3.0
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
@@ -12382,7 +12646,7 @@ snapshots:
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.5.1
+      lru-cache: 11.5.2
       minipass: 7.1.3
 
   path-to-regexp@6.3.0: {}
@@ -12802,6 +13066,37 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
+  rollup@4.62.3:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.3
+      '@rollup/rollup-android-arm64': 4.62.3
+      '@rollup/rollup-darwin-arm64': 4.62.3
+      '@rollup/rollup-darwin-x64': 4.62.3
+      '@rollup/rollup-freebsd-arm64': 4.62.3
+      '@rollup/rollup-freebsd-x64': 4.62.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.3
+      '@rollup/rollup-linux-arm64-gnu': 4.62.3
+      '@rollup/rollup-linux-arm64-musl': 4.62.3
+      '@rollup/rollup-linux-loong64-gnu': 4.62.3
+      '@rollup/rollup-linux-loong64-musl': 4.62.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.3
+      '@rollup/rollup-linux-ppc64-musl': 4.62.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.3
+      '@rollup/rollup-linux-riscv64-musl': 4.62.3
+      '@rollup/rollup-linux-s390x-gnu': 4.62.3
+      '@rollup/rollup-linux-x64-gnu': 4.62.3
+      '@rollup/rollup-linux-x64-musl': 4.62.3
+      '@rollup/rollup-openbsd-x64': 4.62.3
+      '@rollup/rollup-openharmony-arm64': 4.62.3
+      '@rollup/rollup-win32-arm64-msvc': 4.62.3
+      '@rollup/rollup-win32-ia32-msvc': 4.62.3
+      '@rollup/rollup-win32-x64-gnu': 4.62.3
+      '@rollup/rollup-win32-x64-msvc': 4.62.3
+      fsevents: 2.3.3
+
   roughjs@4.6.6:
     dependencies:
       hachure-fill: 0.5.2
@@ -12867,7 +13162,7 @@ snapshots:
 
   semver@7.8.5: {}
 
-  serialize-javascript@7.0.6: {}
+  serialize-javascript@7.0.7: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -13040,9 +13335,7 @@ snapshots:
 
   source-map@0.7.6: {}
 
-  source-map@0.8.0-beta.0:
-    dependencies:
-      whatwg-url: 7.1.0
+  source-map@0.8.0: {}
 
   space-separated-tokens@2.0.2: {}
 
@@ -13050,12 +13343,12 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  starlight-links-validator@0.25.2(@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  starlight-links-validator@0.25.2(@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@astrojs/markdown-satteri': 0.3.3
-      '@astrojs/starlight': 0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3)
+      '@astrojs/starlight': 0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3)
       '@types/picomatch': 4.0.3
-      astro: 7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      astro: 7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(jiti@1.21.7)(rollup@4.62.3)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       is-absolute-url: 5.0.0
@@ -13252,10 +13545,10 @@ snapshots:
       ansi-escapes: 7.3.0
       supports-hyperlinks: 4.5.0
 
-  terser@5.48.0:
+  terser@5.49.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.17.0
+      acorn: 8.18.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -13309,10 +13602,6 @@ snapshots:
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
-
-  tr46@1.0.1:
-    dependencies:
-      punycode: 2.3.1
 
   tr46@5.1.1:
     dependencies:
@@ -13517,6 +13806,12 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  update-browserslist-db@1.2.3(browserslist@4.28.7):
+    dependencies:
+      browserslist: 4.28.7
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   uplot@1.6.32: {}
 
   url-extras@0.1.0: {}
@@ -13540,13 +13835,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite-node@3.2.4(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -13561,18 +13856,18 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-pwa@0.21.2(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1):
+  vite-plugin-pwa@0.21.2(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1):
     dependencies:
       debug: 4.4.3
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.17
-      vite: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
       workbox-build: 7.4.1
       workbox-window: 7.4.1
     transitivePeerDependencies:
       - supports-color
 
-  vite-prerender-plugin@0.5.13(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vite-prerender-plugin@0.5.13(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       kolorist: 1.8.0
       magic-string: 0.30.21
@@ -13580,9 +13875,9 @@ snapshots:
       simple-code-frame: 1.3.0
       source-map: 0.7.6
       stack-trace: 1.0.0
-      vite: 6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -13595,11 +13890,11 @@ snapshots:
       fsevents: 2.3.3
       jiti: 1.21.7
       lightningcss: 1.32.0
-      terser: 5.48.0
+      terser: 5.49.0
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vite@8.1.3(@types/node@22.20.1)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@8.1.3(@types/node@22.20.1)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -13611,11 +13906,11 @@ snapshots:
       esbuild: 0.19.12
       fsevents: 2.3.3
       jiti: 1.21.7
-      terser: 5.48.0
+      terser: 5.49.0
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -13627,23 +13922,23 @@ snapshots:
       esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 1.21.7
-      terser: 5.48.0
+      terser: 5.49.0
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitefu@1.1.3(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  vitefu@1.1.3(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  vitest@3.2.6(@types/debug@4.1.13)(@types/node@26.0.0)(happy-dom@15.11.7)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
+  vitest@3.2.6(@types/debug@4.1.13)(@types/node@26.0.0)(happy-dom@15.11.7)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.6(vite@6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.6
       '@vitest/runner': 3.2.6
       '@vitest/snapshot': 3.2.6
@@ -13661,8 +13956,8 @@ snapshots:
       tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 6.4.3(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@26.0.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.13
@@ -13683,10 +13978,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.9(@types/node@22.20.1)(happy-dom@15.11.7)(jsdom@25.0.1)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.9(@types/node@22.20.1)(happy-dom@15.11.7)(jsdom@25.0.1)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.1.3(@types/node@22.20.1)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.9(vite@8.1.3(@types/node@22.20.1)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
@@ -13703,7 +13998,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.3(@types/node@22.20.1)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.3(@types/node@22.20.1)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.20.1
@@ -13712,10 +14007,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.9(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.10)(happy-dom@15.11.7)(jsdom@25.0.1)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.9(@types/node@26.0.0)(@vitest/coverage-istanbul@4.1.10)(happy-dom@15.11.7)(jsdom@25.0.1)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.9(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
@@ -13732,7 +14027,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.0.0
@@ -13856,8 +14151,6 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
-  webidl-conversions@4.0.2: {}
-
   webidl-conversions@7.0.0: {}
 
   whatwg-encoding@3.1.1:
@@ -13873,12 +14166,6 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
-
-  whatwg-url@7.1.0:
-    dependencies:
-      lodash.sortby: 4.7.0
-      tr46: 1.0.1
-      webidl-conversions: 4.0.2
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -13951,10 +14238,10 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/preset-env': 7.29.7(@babel/core@7.29.7)
       '@babel/runtime': 7.29.7
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)(rollup@4.62.2)
-      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.62.2)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.62.2)
-      '@rollup/plugin-terser': 1.0.0(rollup@4.62.2)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)(rollup@4.62.3)
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.62.3)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.62.3)
+      '@rollup/plugin-terser': 1.0.0(rollup@4.62.3)
       '@trickfilm400/rollup-plugin-off-main-thread': 3.0.0-pre1
       ajv: 8.20.0
       common-tags: 1.8.2
@@ -13963,8 +14250,8 @@ snapshots:
       fs-extra: 9.1.0
       glob: 11.1.0
       pretty-bytes: 5.6.0
-      rollup: 4.62.2
-      source-map: 0.8.0-beta.0
+      rollup: 4.62.3
+      source-map: 0.8.0
       stringify-object: 3.3.0
       strip-comments: 2.0.1
       tempy: 0.6.0


### PR DESCRIPTION
## Summary
- Bumps `@cofferdam/cofferdam` from `^0.3.12` (resolved 0.3.12) to `^0.3.13`, which fixes CD-153: baseline matching broke on cache-warmed runs, causing findings that should have matched the baseline to be incorrectly reported as new.
- Regenerates `.cofferdam/baseline.json` against 0.3.13 with a cleared cache.

## Notable finding
The previously committed baseline was `"findings": []` (unchanged since #43, "drive all cofferdam findings to zero"). Regenerating against 0.3.13 surfaced 595 real findings that had accumulated in the codebase since then — mostly `Design.MissingTestFile`, `Design.ReadonlyArrayParam`, and `Refactor.PreferConstOverLet`. These are pre-existing issues, not new problems introduced by this upgrade; `cofferdam check` now reports 0 new / 595 baselined (clean, exit 0). This pattern is consistent with the CD-153 bug: the empty baseline may have been silently masking real findings in CI's cache-warmed runs all along.

## Test plan
- [x] `pnpm list @cofferdam/cofferdam` resolves to 0.3.13
- [x] `pnpm run cofferdam:fix` regenerated the baseline (595 findings)
- [x] `pnpm run cofferdam` reports 0 new / 595 baselined, exit 0
- [x] pre-push hook (lint + full test suite) passed