### PR TITLE
PROJ-486: FTS5 wiki search with ranking, snippets, filters

### DIFF
--- a/apps/api/src/mcp/wiki.ts
+++ b/apps/api/src/mcp/wiki.ts
@@ -20,14 +20,30 @@ export const wikiTools: MCPTool[] = [
 	},
 	{
 		name: "search_wiki",
-		description: "Search wiki pages by keyword in title or content",
+		description:
+			"Full-text search over wiki pages (FTS5, BM25-ranked, title weighted above body). " +
+			"Returns match-anchored snippets highlighted with ** markers. type/tags/status are " +
+			"accepted for forward compatibility with the frontmatter (R6) and freshness (R7) " +
+			"work but are not yet implemented and are ignored if passed.",
 		inputSchema: {
 			type: "object",
 			required: ["query"],
 			properties: {
 				query: { type: "string" },
 				limit: { type: "number", default: 10 },
+				offset: { type: "number", default: 0 },
 				projectId: { type: "string", description: "Restrict search to this project ID" },
+				updatedSince: {
+					type: "number",
+					description: "Unix seconds — only return pages updated at or after this time",
+				},
+				type: { type: "string", description: "Not yet supported (R6, PROJ-488); ignored" },
+				tags: {
+					type: "array",
+					items: { type: "string" },
+					description: "Not yet supported (R6, PROJ-488); ignored",
+				},
+				status: { type: "string", description: "Not yet supported (R7, PROJ-489); ignored" },
 			},
 		},
 		async handler(input, ctx) {

--- a/apps/api/src/routes/wiki.ts
+++ b/apps/api/src/routes/wiki.ts
@@ -31,8 +31,13 @@ router.get("/search", async (c) => {
 	const ctx = ctxFromHono(c);
 	const q = c.req.query("q") ?? "";
 	const projectId = c.req.query("projectId");
+	const limit = c.req.query("limit");
+	const offset = c.req.query("offset");
+	const updatedSince = c.req.query("updatedSince");
 	try {
-		return c.json(await wikiService.searchWiki(ctx, { query: q, projectId }));
+		return c.json(
+			await wikiService.searchWiki(ctx, { query: q, projectId, limit, offset, updatedSince })
+		);
 	} catch (e) {
 		return serviceErrToResponse(c, e);
 	}

--- a/apps/api/src/schemas/wiki.ts
+++ b/apps/api/src/schemas/wiki.ts
@@ -49,8 +49,21 @@ export const ListPagesInputSchema = z.object({
 
 export const SearchWikiInputSchema = z.object({
 	query: z.string(),
-	limit: z.number().int().min(1).max(50).optional().default(10),
+	limit: z.coerce.number().int().min(1).max(50).optional().default(10),
+	offset: z.coerce.number().int().min(0).optional().default(0),
 	projectId: z.string().uuid().optional(),
+	// Unix seconds — only pages updated at/after this time are returned.
+	updatedSince: z.coerce.number().int().nonnegative().optional(),
+	// PROJ-486: `type`/`tags`/`status` are frontmatter/verification concepts that belong
+	// to R6 (PROJ-488, frontmatter metadata) and R7 (PROJ-489, freshness model) — neither
+	// has landed, so wiki_pages has no type/tags/status/freshness columns yet. Accepted
+	// here so the API shape is forward-compatible and R6/R7 won't need to change this
+	// schema later; services/wiki.ts#searchWiki no-ops them today rather than rejecting
+	// the request, since blocking search on an unimplemented filter would be more
+	// surprising than silently ignoring it.
+	type: z.string().optional(),
+	tags: z.array(z.string()).optional(),
+	status: z.string().optional(),
 });
 
 export const DeleteWikiPageOptionsSchema = z.object({

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -266,40 +266,77 @@ export async function listWikiPages(ctx: ServiceCtx, input: unknown) {
 	return rows.map((r) => ({ ...r, url: wikiPagePath(r.slug, r.project_id) }));
 }
 
+// PROJ-486: FTS5 MATCH treats bare input as query syntax (AND/OR/NOT, column filters,
+// prefix "*", etc). Wrap each whitespace-separated token in double quotes so raw user
+// text is always treated as a literal phrase search, mirroring services/issues.ts's
+// sanitizeFtsQuery for issues_fts.
+function sanitizeWikiFtsQuery(q: string): string {
+	return q
+		.trim()
+		.split(/\s+/)
+		.filter((t) => Boolean(t) && /\w/.test(t))
+		.map((t) => `"${t.replace(/"/g, '""')}"`)
+		.join(" ");
+}
+
+// PROJ-486: title is weighted well above content and tags so a title match ranks
+// above a match buried deep in body content — bm25() weight args are positional,
+// one per wiki_fts column (page_id, workspace_id, title, content, tags); the first
+// two are UNINDEXED so their weight is irrelevant, left at 0 for clarity.
+const WIKI_FTS_BM25_WEIGHTS = "0, 0, 10.0, 1.0, 5.0";
+
 export async function searchWiki(ctx: ServiceCtx, input: unknown) {
 	const parsed = SearchWikiInputSchema.safeParse(input);
 	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
-	const { query, limit, projectId } = parsed.data;
-	if (!query) return [];
+	const { query, limit, offset, projectId, updatedSince } = parsed.data;
+	// PROJ-486: `type`/`tags`/`status` are accepted by the schema for forward
+	// compatibility with R6/R7 but intentionally unused here — see schemas/wiki.ts.
+
+	const ftsQuery = sanitizeWikiFtsQuery(query);
+	if (!ftsQuery) return [];
+
 	if (projectId) {
 		// PROJ-311: searching a specific project the user can't see returns nothing.
 		if (!isWorkspaceAdmin(ctx.role) && (await effectiveProjectRole(ctx, projectId)) === null) {
 			return [];
 		}
-		const { results } = await ctx.db
-			.prepare(
-				`SELECT id, slug, title, project_id, substr(content, 1, 250) as excerpt
-         FROM wiki_pages
-         WHERE workspace_id = ? AND project_id = ? AND (title LIKE ? OR content LIKE ?)
-         ORDER BY updated_at DESC LIMIT ?`
-			)
-			.bind(ctx.workspaceId, projectId, `%${query}%`, `%${query}%`, limit)
-			.all();
-		return results;
 	}
-	// PROJ-311: across the workspace, exclude project-scoped pages the user isn't granted.
-	const visible = visibleProjectSqlFragment(ctx, "project_id");
-	const visClause = visible ? ` AND (project_id IS NULL OR ${visible.sql})` : "";
+
+	let q = `SELECT p.id, p.slug, p.title, p.project_id,
+              snippet(wiki_fts, -1, '**', '**', '…', 24) as excerpt,
+              bm25(wiki_fts, ${WIKI_FTS_BM25_WEIGHTS}) as rank
+            FROM wiki_fts
+            JOIN wiki_pages p ON p.id = wiki_fts.page_id
+            WHERE wiki_fts MATCH ? AND wiki_fts.workspace_id = ?`;
+	const params: unknown[] = [ftsQuery, ctx.workspaceId];
+
+	if (projectId) {
+		q += " AND p.project_id = ?";
+		params.push(projectId);
+	} else {
+		// PROJ-311: across the workspace, exclude project-scoped pages the user isn't granted.
+		const visible = visibleProjectSqlFragment(ctx, "p.project_id");
+		if (visible) {
+			q += ` AND (p.project_id IS NULL OR ${visible.sql})`;
+			params.push(...visible.params);
+		}
+	}
+
+	if (updatedSince !== undefined) {
+		q += " AND p.updated_at >= ?";
+		params.push(updatedSince);
+	}
+
+	q += ` ORDER BY bm25(wiki_fts, ${WIKI_FTS_BM25_WEIGHTS}) LIMIT ? OFFSET ?`;
+	params.push(limit, offset);
+
 	const { results } = await ctx.db
-		.prepare(
-			`SELECT id, slug, title, project_id, substr(content, 1, 250) as excerpt
-       FROM wiki_pages
-       WHERE workspace_id = ? AND (title LIKE ? OR content LIKE ?)${visClause}
-       ORDER BY updated_at DESC LIMIT ?`
-		)
-		.bind(ctx.workspaceId, `%${query}%`, `%${query}%`, ...(visible ? visible.params : []), limit)
+		.prepare(q)
+		.bind(...params)
 		.all();
-	return results;
+	// PROJ-489 (R7, not landed): no freshness model exists yet, so freshness is
+	// omitted-as-null rather than fabricated.
+	return (results as Array<Record<string, unknown>>).map((r) => ({ ...r, freshness: null }));
 }
 
 const wikiPageDetailColumns = {
@@ -404,6 +441,13 @@ export async function createWikiPage(ctx: ServiceCtx, input: unknown) {
 		}
 		throw e;
 	}
+	// PROJ-486: tags is left empty until R6 (PROJ-488) populates it from frontmatter.
+	await ctx.db
+		.prepare(
+			"INSERT INTO wiki_fts (page_id, workspace_id, title, content, tags) VALUES (?, ?, ?, ?, ?)"
+		)
+		.bind(id, ctx.workspaceId, title, content ?? "", "")
+		.run();
 	await recordActivity(ctx, { entityType: "wiki_page", entityId: id, action: "created" });
 	return { id, slug, projectId: projectId ?? null, url: wikiPagePath(slug, projectId ?? null) };
 }
@@ -585,6 +629,50 @@ function buildUnifiedDiff(baseContent: string, currentContent: string): string {
 	return `--- base\n+++ current\n${hunks.join("\n")}`;
 }
 
+// PROJ-486: mirrors issues.ts's reindexIssueFts — delete-then-reinsert the wiki_fts
+// mirror row after a title/content edit. Re-reads the page rather than trusting the
+// caller's partial `data` so a title-only or content-only update still reindexes the
+// unchanged field's current value, not a stale/empty one.
+async function reindexWikiFts(
+	ctx: ServiceCtx,
+	orm: ReturnType<typeof drizzle<typeof schema>>,
+	id: string,
+	data: { title?: string; content?: string }
+): Promise<void> {
+	if (data.title === undefined && data.content === undefined) return;
+
+	const current = await orm
+		.select({ title: schema.wikiPages.title, content: schema.wikiPages.content })
+		.from(schema.wikiPages)
+		.where(and(eq(schema.wikiPages.id, id), eq(schema.wikiPages.workspaceId, ctx.workspaceId)))
+		.get();
+	if (!current) return;
+
+	await ctx.db
+		.prepare("DELETE FROM wiki_fts WHERE page_id = ? AND workspace_id = ?")
+		.bind(id, ctx.workspaceId)
+		.run();
+	await ctx.db
+		.prepare(
+			"INSERT INTO wiki_fts (page_id, workspace_id, title, content, tags) VALUES (?, ?, ?, ?, ?)"
+		)
+		.bind(id, ctx.workspaceId, current.title, current.content, "")
+		.run();
+}
+
+// PROJ-486: chunked so a cascade delete of a large subtree stays under D1's 100-bound
+// parameter cap (services/sql.ts#inChunks).
+async function deleteWikiFtsEntries(ctx: ServiceCtx, pageIds: string[]): Promise<void> {
+	await inChunks(pageIds, async (chunk) => {
+		const placeholders = chunk.map(() => "?").join(",");
+		await ctx.db
+			.prepare(`DELETE FROM wiki_fts WHERE page_id IN (${placeholders}) AND workspace_id = ?`)
+			.bind(...chunk, ctx.workspaceId)
+			.run();
+		return [];
+	});
+}
+
 export async function updateWikiPage(ctx: ServiceCtx, idOrSlug: string, input: unknown) {
 	const parsed = UpdatePageSchema.safeParse(input);
 	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
@@ -657,6 +745,8 @@ export async function updateWikiPage(ctx: ServiceCtx, idOrSlug: string, input: u
 		}
 		throw e;
 	}
+
+	await reindexWikiFts(ctx, orm, page.id, { title, content });
 
 	if (isRename) {
 		// Upsert: the old slug may already carry a stale redirect from an earlier rename
@@ -793,6 +883,7 @@ export async function deleteWikiPage(ctx: ServiceCtx, slug: string, options?: un
 			await orm.delete(schema.wikiPages).where(inArray(schema.wikiPages.id, chunk));
 			return [];
 		});
+		await deleteWikiFtsEntries(ctx, allIds);
 		await recordActivity(ctx, {
 			entityType: "wiki_page",
 			entityId: page.id,
@@ -812,6 +903,7 @@ export async function deleteWikiPage(ctx: ServiceCtx, slug: string, options?: un
 
 	await deleteWikiPageAttachments(ctx, orm, [page.id]);
 	await orm.delete(schema.wikiPages).where(eq(schema.wikiPages.id, page.id));
+	await deleteWikiFtsEntries(ctx, [page.id]);
 	await recordActivity(ctx, { entityType: "wiki_page", entityId: page.id, action: "deleted" });
 	return { ok: true, deletedCount: 1 };
 }

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -327,7 +327,10 @@ export async function searchWiki(ctx: ServiceCtx, input: unknown) {
 		params.push(updatedSince);
 	}
 
-	q += ` ORDER BY bm25(wiki_fts, ${WIKI_FTS_BM25_WEIGHTS}) LIMIT ? OFFSET ?`;
+	// PROJ-486: bm25() alone ties on equal-rank rows, which makes LIMIT/OFFSET
+	// paging non-deterministic (duplicate/skip results across pages) — break
+	// ties by page id for a stable order.
+	q += ` ORDER BY bm25(wiki_fts, ${WIKI_FTS_BM25_WEIGHTS}), p.id LIMIT ? OFFSET ?`;
 	params.push(limit, offset);
 
 	const { results } = await ctx.db

--- a/apps/api/src/test/migrations.ts
+++ b/apps/api/src/test/migrations.ts
@@ -43,6 +43,7 @@ import m0039 from "../../../../packages/db/migrations/0039_wip_cap_denials.sql?r
 import m0040 from "../../../../packages/db/migrations/0040_provisioning_removals.sql?raw";
 import m0041 from "../../../../packages/db/migrations/0041_wiki_slug_unique.sql?raw";
 import m0042 from "../../../../packages/db/migrations/0042_wiki_revision_title_summary.sql?raw";
+import m0043 from "../../../../packages/db/migrations/0043_wiki_fts.sql?raw";
 
 export const MIGRATIONS = [
 	m0000,
@@ -88,4 +89,5 @@ export const MIGRATIONS = [
 	m0040,
 	m0041,
 	m0042,
+	m0043,
 ];

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -392,6 +392,46 @@ describe("Wiki API", () => {
 		expect(page2Results.map((r) => r.id)).not.toContain(page1Results[1].id);
 	});
 
+	it("GET /api/wiki/search paginates deterministically when results tie in rank", async () => {
+		// All three pages below match equally (same term, same content shape), so bm25()
+		// alone ties -- pagination must fall back to a stable tiebreaker (page id) rather
+		// than duplicating or dropping rows across pages. Distinct titles avoid PROJ-483
+		// slug-collision 409s; the rate_limit reset avoids tripping the 5-req/window cap
+		// (RATE_LIMIT_API_MAX) across the create + fetch calls below.
+		for (let i = 0; i < 3; i++) {
+			const createRes = await SELF.fetch("http://localhost/api/wiki", {
+				method: "POST",
+				headers: authHeaders(token, slug),
+				body: JSON.stringify({
+					title: `Tie Rank Page ${i}`,
+					content: "tie-rank-search-term",
+				}),
+			});
+			expect(createRes.status).toBe(201);
+		}
+		await env.DB.prepare("DELETE FROM rate_limit").run();
+
+		const fetchAll = () =>
+			SELF.fetch("http://localhost/api/wiki/search?q=tie-rank-search-term&limit=2", {
+				headers: authHeaders(token, slug),
+			}).then((r) => r.json() as Promise<Array<{ id: string }>>);
+
+		const first = await fetchAll();
+		await env.DB.prepare("DELETE FROM rate_limit").run();
+		const second = await fetchAll();
+		expect(first.map((r) => r.id)).toEqual(second.map((r) => r.id));
+
+		await env.DB.prepare("DELETE FROM rate_limit").run();
+		const page2 = await SELF.fetch(
+			"http://localhost/api/wiki/search?q=tie-rank-search-term&limit=2&offset=2",
+			{ headers: authHeaders(token, slug) }
+		);
+		const page2Results = (await page2.json()) as Array<{ id: string }>;
+		const allIds = [...first.map((r) => r.id), ...page2Results.map((r) => r.id)];
+		expect(new Set(allIds).size).toBe(allIds.length);
+		expect(allIds).toHaveLength(3);
+	});
+
 	it("GET /api/wiki/search updatedSince filters out pages updated before the cutoff", async () => {
 		const createRes = await SELF.fetch("http://localhost/api/wiki", {
 			method: "POST",

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -204,6 +204,39 @@ describe("Wiki API", () => {
 		expect(results[0].title).toBe("Deployment Guide");
 	});
 
+	// PROJ-486: freshness (R7, PROJ-489) hasn't landed — the field is present but null,
+	// never fabricated.
+	it("GET /api/wiki/search returns freshness: null (R7 not yet implemented)", async () => {
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Freshness Placeholder Page", content: "wrangler" }),
+		});
+		const res = await SELF.fetch("http://localhost/api/wiki/search?q=wrangler", {
+			headers: authHeaders(token, slug),
+		});
+		const results = (await res.json()) as Array<{ freshness: unknown }>;
+		expect(results.length).toBeGreaterThan(0);
+		for (const r of results) expect(r.freshness).toBeNull();
+	});
+
+	// PROJ-486: type/tags/status are accepted for R6/R7 forward compatibility but not
+	// yet implemented — passing them must not error or change results.
+	it("GET /api/wiki/search ignores unsupported type/status filters instead of erroring", async () => {
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Noop Filter Page", content: "wrangler" }),
+		});
+		const res = await SELF.fetch(
+			"http://localhost/api/wiki/search?q=wrangler&type=guide&status=fresh",
+			{ headers: authHeaders(token, slug) }
+		);
+		expect(res.status).toBe(200);
+		const results = (await res.json()) as Array<{ title: string }>;
+		expect(results.map((r) => r.title)).toContain("Noop Filter Page");
+	});
+
 	it("accepts a custom slug", async () => {
 		const res = await SELF.fetch("http://localhost/api/wiki", {
 			method: "POST",
@@ -278,19 +311,221 @@ describe("Wiki API", () => {
 		expect(await res.json()).toEqual([]);
 	});
 
-	it("GET /api/wiki/search excerpt is at most 250 chars", async () => {
-		const longContent = "x".repeat(1000);
+	// PROJ-486: replaces the old "first 250 chars" excerpt with an FTS5 snippet()
+	// that is anchored to the actual match and highlighted with ** markers.
+	it("GET /api/wiki/search snippet is match-anchored and highlighted", async () => {
+		const filler = "lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod ".repeat(
+			20
+		);
 		await SELF.fetch("http://localhost/api/wiki", {
 			method: "POST",
 			headers: authHeaders(token, slug),
-			body: JSON.stringify({ title: "Long Page", content: longContent }),
+			body: JSON.stringify({
+				title: "Deep Match Page",
+				content: `${filler} needle-term ${filler}`,
+			}),
 		});
-		const res = await SELF.fetch("http://localhost/api/wiki/search?q=Long+Page", {
+		const res = await SELF.fetch("http://localhost/api/wiki/search?q=needle-term", {
 			headers: authHeaders(token, slug),
 		});
 		const results = (await res.json()) as Array<{ excerpt: string }>;
 		expect(results).toHaveLength(1);
-		expect(results[0].excerpt.length).toBeLessThanOrEqual(250);
+		// The match is buried deep in a long page; a static first-250-chars excerpt
+		// would never contain it, but a match-anchored snippet does.
+		expect(results[0].excerpt).toContain("needle");
+		expect(results[0].excerpt).toContain("**");
+	});
+
+	// PROJ-486: BM25 ranking with a title-weight boost — a query matching only the
+	// title of one page should rank it above a page where the term only appears deep
+	// in a long body.
+	it("GET /api/wiki/search ranks a title match above a buried body match", async () => {
+		const filler = "lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod ".repeat(
+			20
+		);
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({
+				title: "Unrelated Page",
+				content: `${filler} zylophone ${filler}`,
+			}),
+		});
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Zylophone Guide", content: "short body, no repeat term" }),
+		});
+
+		const res = await SELF.fetch("http://localhost/api/wiki/search?q=zylophone", {
+			headers: authHeaders(token, slug),
+		});
+		const results = (await res.json()) as Array<{ title: string }>;
+		expect(results).toHaveLength(2);
+		expect(results[0].title).toBe("Zylophone Guide");
+	});
+
+	it("GET /api/wiki/search supports limit/offset pagination", async () => {
+		for (let i = 0; i < 3; i++) {
+			await SELF.fetch("http://localhost/api/wiki", {
+				method: "POST",
+				headers: authHeaders(token, slug),
+				body: JSON.stringify({ title: `Paginated Page ${i}`, content: "shared-search-term" }),
+			});
+		}
+		const page1 = await SELF.fetch(
+			"http://localhost/api/wiki/search?q=shared-search-term&limit=2",
+			{
+				headers: authHeaders(token, slug),
+			}
+		);
+		const page1Results = (await page1.json()) as Array<{ id: string }>;
+		expect(page1Results).toHaveLength(2);
+
+		const page2 = await SELF.fetch(
+			"http://localhost/api/wiki/search?q=shared-search-term&limit=2&offset=2",
+			{ headers: authHeaders(token, slug) }
+		);
+		const page2Results = (await page2.json()) as Array<{ id: string }>;
+		expect(page2Results).toHaveLength(1);
+		expect(page2Results.map((r) => r.id)).not.toContain(page1Results[0].id);
+		expect(page2Results.map((r) => r.id)).not.toContain(page1Results[1].id);
+	});
+
+	it("GET /api/wiki/search updatedSince filters out pages updated before the cutoff", async () => {
+		const createRes = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Stale Match Page", content: "freshness-cutoff-term" }),
+		});
+		const created = (await createRes.json()) as { id: string };
+		const pageRow = await env.DB.prepare("SELECT updated_at FROM wiki_pages WHERE id = ?")
+			.bind(created.id)
+			.first<{ updated_at: number }>();
+		const cutoff = (pageRow?.updated_at ?? 0) + 1000;
+
+		const res = await SELF.fetch(
+			`http://localhost/api/wiki/search?q=freshness-cutoff-term&updatedSince=${cutoff}`,
+			{ headers: authHeaders(token, slug) }
+		);
+		expect(await res.json()).toEqual([]);
+
+		const resAll = await SELF.fetch("http://localhost/api/wiki/search?q=freshness-cutoff-term", {
+			headers: authHeaders(token, slug),
+		});
+		const allResults = (await resAll.json()) as Array<{ id: string }>;
+		expect(allResults).toHaveLength(1);
+	});
+
+	it("GET /api/wiki/search never returns another workspace's pages", async () => {
+		const other = await seedFixture();
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(other.token, other.workspace.slug),
+			body: JSON.stringify({ title: "Other Workspace Page", content: "cross-tenant-term" }),
+		});
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "This Workspace Page", content: "cross-tenant-term" }),
+		});
+
+		const res = await SELF.fetch("http://localhost/api/wiki/search?q=cross-tenant-term", {
+			headers: authHeaders(token, slug),
+		});
+		const results = (await res.json()) as Array<{ title: string }>;
+		expect(results).toHaveLength(1);
+		expect(results[0].title).toBe("This Workspace Page");
+	});
+
+	// PROJ-486: the wiki_fts mirror table must track create/update/delete of wiki_pages.
+	describe("wiki_fts index stays in sync", () => {
+		it("a newly created page is searchable immediately", async () => {
+			await SELF.fetch("http://localhost/api/wiki", {
+				method: "POST",
+				headers: authHeaders(token, slug),
+				body: JSON.stringify({ title: "Sync Create Page", content: "sync-create-term" }),
+			});
+			const res = await SELF.fetch("http://localhost/api/wiki/search?q=sync-create-term", {
+				headers: authHeaders(token, slug),
+			});
+			expect(await res.json()).toHaveLength(1);
+		});
+
+		it("an updated page's new content becomes searchable and old content stops matching", async () => {
+			const createRes = await SELF.fetch("http://localhost/api/wiki", {
+				method: "POST",
+				headers: authHeaders(token, slug),
+				body: JSON.stringify({ title: "Sync Update Page", content: "before-update-term" }),
+			});
+			const created = (await createRes.json()) as { slug: string };
+
+			await SELF.fetch(`http://localhost/api/wiki/${created.slug}`, {
+				method: "PUT",
+				headers: authHeaders(token, slug),
+				body: JSON.stringify({ content: "after-update-term" }),
+			});
+
+			const oldRes = await SELF.fetch("http://localhost/api/wiki/search?q=before-update-term", {
+				headers: authHeaders(token, slug),
+			});
+			expect(await oldRes.json()).toEqual([]);
+
+			const newRes = await SELF.fetch("http://localhost/api/wiki/search?q=after-update-term", {
+				headers: authHeaders(token, slug),
+			});
+			expect(await newRes.json()).toHaveLength(1);
+		});
+
+		it("a deleted page is no longer searchable", async () => {
+			// Deleting a workspace-level page requires admin/owner (services/wiki.ts).
+			const owner = await seedFixture({ role: "owner" });
+			const createRes = await SELF.fetch("http://localhost/api/wiki", {
+				method: "POST",
+				headers: authHeaders(owner.token, owner.workspace.slug),
+				body: JSON.stringify({ title: "Sync Delete Page", content: "sync-delete-term" }),
+			});
+			const created = (await createRes.json()) as { slug: string };
+
+			await SELF.fetch(`http://localhost/api/wiki/${created.slug}`, {
+				method: "DELETE",
+				headers: authHeaders(owner.token, owner.workspace.slug),
+			});
+
+			const res = await SELF.fetch("http://localhost/api/wiki/search?q=sync-delete-term", {
+				headers: authHeaders(owner.token, owner.workspace.slug),
+			});
+			expect(await res.json()).toEqual([]);
+		});
+
+		it("a cascade-deleted subtree's pages are no longer searchable", async () => {
+			const owner = await seedFixture({ role: "owner" });
+			const parentRes = await SELF.fetch("http://localhost/api/wiki", {
+				method: "POST",
+				headers: authHeaders(owner.token, owner.workspace.slug),
+				body: JSON.stringify({ title: "Sync Cascade Parent", content: "root" }),
+			});
+			const parent = (await parentRes.json()) as { id: string; slug: string };
+			await SELF.fetch("http://localhost/api/wiki", {
+				method: "POST",
+				headers: authHeaders(owner.token, owner.workspace.slug),
+				body: JSON.stringify({
+					title: "Sync Cascade Child",
+					content: "sync-cascade-term",
+					parentId: parent.id,
+				}),
+			});
+
+			await SELF.fetch(`http://localhost/api/wiki/${parent.slug}?cascade=true`, {
+				method: "DELETE",
+				headers: authHeaders(owner.token, owner.workspace.slug),
+			});
+
+			const res = await SELF.fetch("http://localhost/api/wiki/search?q=sync-cascade-term", {
+				headers: authHeaders(owner.token, owner.workspace.slug),
+			});
+			expect(await res.json()).toEqual([]);
+		});
 	});
 
 	it("PUT /api/wiki/:slug title-only update does not create a revision", async () => {

--- a/apps/docs/src/content/docs/agents/tool-catalog.md
+++ b/apps/docs/src/content/docs/agents/tool-catalog.md
@@ -133,7 +133,7 @@ running server.
 | Tool | Description |
 |------|-------------|
 | `list_wiki_pages` | List wiki pages in the workspace, optionally filtered by parent or project |
-| `search_wiki` | Search wiki pages by keyword in title or content |
+| `search_wiki` | Full-text search over wiki pages (FTS5, BM25-ranked, title weighted above body). Returns match-anchored snippets highlighted with ** markers. type/tags/status are accepted for forward compatibility with the frontmatter (R6) and freshness (R7) work but are not yet implemented and are ignored if passed. |
 | `get_wiki_page` | Get a wiki page by slug, including full content |
 | `create_wiki_page` | Create a new wiki page |
 | `update_wiki_page` | Update a wiki page by id or slug (saves a revision when content changes). Pass baseRevisionId (the current revision id from list_wiki_revisions/get_wiki_revision, or null if the page has never been revised) for conflict-safe writes: if the page advanced since baseRevisionId, the write is rejected with a structured conflict (currentRevisionId + a unified diff) instead of silently overwriting. Omitting baseRevisionId is DEPRECATED — it keeps today's last-write-wins behavior during the transition and will be rejected in a future version. |

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -149,6 +149,22 @@ function TreeNodeItem({
 	);
 }
 
+// PROJ-486: search excerpts come back with `**match**` markers from the
+// backend's FTS5 snippet() highlighting — split and render as <mark> instead
+// of showing the literal asterisks.
+function renderHighlightedExcerpt(excerpt: string) {
+	const parts = excerpt.split(/(\*\*[^*]*\*\*)/g).filter((part) => part !== "");
+	return parts.map((part, i) =>
+		part.startsWith("**") && part.endsWith("**") ? (
+			<mark key={i} class="bg-accent/30 text-inherit rounded-sm">
+				{part.slice(2, -2)}
+			</mark>
+		) : (
+			<span key={i}>{part}</span>
+		)
+	);
+}
+
 const SEARCH_RESULT_BUTTON_CLASS = [
 	"block w-full text-left py-[0.375rem] px-2 rounded border-none cursor-pointer text-sm",
 	"bg-transparent text-text-base hover:bg-border focus-visible:outline-2",
@@ -173,7 +189,9 @@ function SearchResultsList({
 					<button type="button" class={SEARCH_RESULT_BUTTON_CLASS} onClick={() => onSelect(r.slug)}>
 						<span class="font-medium">{r.title}</span>
 						{r.excerpt && (
-							<span class="block text-[0.75rem] text-text-muted truncate">{r.excerpt}</span>
+							<span class="block text-[0.75rem] text-text-muted truncate">
+								{renderHighlightedExcerpt(r.excerpt)}
+							</span>
 						)}
 					</button>
 				</li>

--- a/packages/db/migrations/0043_wiki_fts.sql
+++ b/packages/db/migrations/0043_wiki_fts.sql
@@ -1,0 +1,16 @@
+-- 0043: FTS5 full-text search index for wiki title + content + tags (PROJ-486)
+--
+-- tags is populated by future R6 work (PROJ-488, frontmatter metadata) — wiki_pages
+-- has no tags column yet, so every row is indexed with an empty tags string for now.
+
+CREATE VIRTUAL TABLE IF NOT EXISTS wiki_fts USING fts5(
+  page_id UNINDEXED,
+  workspace_id UNINDEXED,
+  title,
+  content,
+  tags
+);
+
+-- Backfill existing wiki pages
+INSERT INTO wiki_fts (page_id, workspace_id, title, content, tags)
+SELECT id, workspace_id, title, content, '' FROM wiki_pages;

--- a/packages/db/src/test/helpers.ts
+++ b/packages/db/src/test/helpers.ts
@@ -32,7 +32,7 @@ export function migratedDb(): DatabaseSync {
 			// node:sqlite's bundled build doesn't consistently ship the fts5 module
 			// across Node patch versions; production D1/Cloudflare sqlite does.
 			// Skip fts5-dependent statements here rather than gate tests on it.
-			if (/\bfts5\b/i.test(stmt) || /\bissues_fts\b/i.test(stmt)) continue;
+			if (/\bfts5\b/i.test(stmt) || /\b(issues|wiki)_fts\b/i.test(stmt)) continue;
 			db.exec(stmt);
 		}
 	}


### PR DESCRIPTION
## Summary
- Adds `wiki_fts` FTS5 virtual table (`title`, `content`, `tags`), mirroring `issues_fts` (`packages/db/migrations/0007_issue_fts.sql`), in `packages/db/migrations/0043_wiki_fts.sql`.
- Kept in sync via explicit service-layer writes (same pattern as `issues.ts`, not triggers): insert on `createWikiPage`, delete+reinsert on `updateWikiPage` (when title/content changes), delete on `deleteWikiPage` (single and cascade, chunked via `inChunks`).
- `searchWiki` (`apps/api/src/services/wiki.ts`) replaces the `LIKE '%q%'` implementation with FTS5 `MATCH` + `bm25()` ranking (title weighted 10x above content, tags 5x) and `snippet(wiki_fts, -1, '**', '**', '…', 24)` for match-anchored, highlighted excerpts (auto-selects whichever column actually matched, so a title-only match still gets a sensible snippet).
- New filters: `updatedSince` (unix seconds, `wiki_pages.updated_at`) and pagination (`limit`/`offset`). `projectId` scoping and workspace visibility (`visibleProjectSqlFragment`) preserved from the old implementation.
- `type`/`tags`/`status` accepted in `schemas/wiki.ts`'s `SearchWikiInputSchema` for forward API-shape compatibility with R6 (PROJ-488, frontmatter metadata) and R7 (PROJ-489, freshness model) — neither has landed, so these are no-op'd today rather than rejected (commented with the rationale). Results include `freshness: null` rather than a fabricated value.
- `routes/wiki.ts` and `mcp/wiki.ts` stay thin wrappers; `mcp/wiki.ts`'s `search_wiki` tool description/schema updated to document the new params.
- `wiki_fts` is not represented in the Drizzle schema, matching `issues_fts`'s precedent (raw SQL only).
- `packages/db/src/test/helpers.ts` and the existing fts5-skip regex extended to also skip `wiki_fts` statements when running migrations against `node:sqlite` in tests (mirrors the existing `issues_fts` skip — node's bundled sqlite build doesn't consistently ship fts5).
- README's "full-text search" claim for the wiki (line 31) is now accurate — no change needed there since it already read that way.

## Test plan
- [x] `apps/api/src/test/wiki.test.ts`: ranking (title match ranks above a buried body match), snippet highlighting/anchoring, pagination (limit/offset), `updatedSince` filter, cross-workspace scoping, freshness:null, type/status no-op, and `wiki_fts` index sync across create/update/delete (including cascade delete)
- [x] `pnpm gen:docs` — no diff
- [x] `pnpm lint` (`biome check .`)
- [x] `pnpm turbo type-check`
- [x] `pnpm --filter @projektor/db test`
- [x] `pnpm --filter @projektor/api test:coverage` (908 tests passed, coverage thresholds met)
- [x] `pnpm --filter @projektor/web test:coverage`
- [x] `pnpm --filter @projektor/web build`
- [x] `pnpm --filter @projektor/docs build`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_011hWCkPPh9HXWofqi5Gg7qu