### PR TITLE
PROJ-485: server-side wiki link graph + backlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ command shown beside it (token + workspace pre-filled). The full walkthrough - A
 setup, first login, token, MCP - is in
 [CONFIGURE.md](https://github.com/TAJD/projektor-deploy-example/blob/main/CONFIGURE.md).
 
-See the **[agent connection guide](https://tajd.github.io/projektor/agents/mcp-connection/)** for the full connection guide, protocol reference, and tool catalog (<!-- gen-mcp-stats:start -->90 tools across 21 domains<!-- gen-mcp-stats:end --> - project data plus agent-coordination primitives).
+See the **[agent connection guide](https://tajd.github.io/projektor/agents/mcp-connection/)** for the full connection guide, protocol reference, and tool catalog (<!-- gen-mcp-stats:start -->93 tools across 21 domains<!-- gen-mcp-stats:end --> - project data plus agent-coordination primitives).
 
 ## Development
 

--- a/apps/api/src/mcp/wiki.ts
+++ b/apps/api/src/mcp/wiki.ts
@@ -203,7 +203,9 @@ export const wikiTools: MCPTool[] = [
 		name: "list_broken_wiki_links",
 		description:
 			"List unresolved wiki links in the workspace — [[Target]]/URL links whose target " +
-			"title or slug didn't match any page at write time. Useful as a maintenance queue.",
+			"title or slug didn't match any page at write time. Useful as a maintenance queue. " +
+			"Note: a broken link does not auto-re-resolve if the missing page is created later — " +
+			"only backfill_wiki_links (or re-saving the linking page) re-resolves it.",
 		inputSchema: {
 			type: "object",
 			properties: {

--- a/apps/api/src/mcp/wiki.ts
+++ b/apps/api/src/mcp/wiki.ts
@@ -182,6 +182,49 @@ export const wikiTools: MCPTool[] = [
 		},
 	},
 	{
+		name: "get_backlinks",
+		description:
+			"List pages that link to the given page via a resolved [[wikilink]] or same-workspace " +
+			"URL (id-backed, so renames never break a backlink). Each result includes a snippet of " +
+			"the citing text when it can still be located in the source page's current content.",
+		inputSchema: {
+			type: "object",
+			required: ["slug"],
+			properties: {
+				slug: { type: "string", description: "Page ID or slug to find backlinks for" },
+			},
+		},
+		async handler(input, ctx) {
+			const { slug } = input as { slug: string };
+			return wikiService.getWikiBacklinks(ctx as ServiceCtx, slug);
+		},
+	},
+	{
+		name: "list_broken_wiki_links",
+		description:
+			"List unresolved wiki links in the workspace — [[Target]]/URL links whose target " +
+			"title or slug didn't match any page at write time. Useful as a maintenance queue.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				projectId: { type: "string", description: "Restrict to links from pages in this project" },
+			},
+		},
+		async handler(input, ctx) {
+			return wikiService.listBrokenWikiLinks(ctx, input);
+		},
+	},
+	{
+		name: "backfill_wiki_links",
+		description:
+			"One-time (idempotent, safe to re-run) recompute of the wiki_links graph for every " +
+			"existing page in the workspace. Owner/admin only.",
+		inputSchema: { type: "object", properties: {} },
+		async handler(_input, ctx) {
+			return wikiService.backfillWikiLinks(ctx as ServiceCtx);
+		},
+	},
+	{
 		name: "list_wiki_revisions",
 		description: "List revision history for a wiki page",
 		inputSchema: {

--- a/apps/api/src/routes/wiki.ts
+++ b/apps/api/src/routes/wiki.ts
@@ -43,6 +43,34 @@ router.get("/search", async (c) => {
 	}
 });
 
+router.get("/broken-links", async (c) => {
+	const ctx = ctxFromHono(c);
+	try {
+		const projectId = c.req.query("projectId");
+		return c.json(await wikiService.listBrokenWikiLinks(ctx, { projectId }));
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
+});
+
+router.post("/backfill-links", async (c) => {
+	const ctx = ctxFromHono(c);
+	try {
+		return c.json(await wikiService.backfillWikiLinks(ctx));
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
+});
+
+router.get("/:slug/backlinks", async (c) => {
+	const ctx = ctxFromHono(c);
+	try {
+		return c.json(await wikiService.getWikiBacklinks(ctx, c.req.param("slug")));
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
+});
+
 router.get("/:slug/revisions/:revisionId", async (c) => {
 	const ctx = ctxFromHono(c);
 	try {

--- a/apps/api/src/schemas/wiki.ts
+++ b/apps/api/src/schemas/wiki.ts
@@ -71,3 +71,8 @@ export const DeleteWikiPageOptionsSchema = z.object({
 	// deleted page's entire subtree is removed too.
 	cascade: z.boolean().optional().default(false),
 });
+
+// PROJ-485: broken-link reporting, optionally scoped to a project.
+export const ListBrokenWikiLinksInputSchema = z.object({
+	projectId: z.string().uuid().optional(),
+});

--- a/apps/api/src/services/wiki-links.ts
+++ b/apps/api/src/services/wiki-links.ts
@@ -1,0 +1,370 @@
+// PROJ-485: server-side wiki link graph. Parses [[Target]] / [[Target|label]] wikilinks
+// and same-workspace wiki URLs out of a page's content on every write, resolves each to
+// a page id (or leaves it unresolved for broken-link reporting), and stores the result in
+// `wiki_links` — id-backed so renames never break a link (target_title is kept purely for
+// display/re-resolution, target_page_id is the source of truth).
+//
+// No dependency on services/wiki.ts (avoids a circular import) — page resolution/
+// visibility for a *specific* page stays in wiki.ts, which calls into this file's
+// `backlinksForResolvedPage` after resolving. listBrokenWikiLinks/backfillWikiLinks
+// don't need a single resolved page so they're self-contained here.
+import { drizzle, schema } from "@projektor/db";
+import { and, eq, inArray, isNull, or, sql } from "drizzle-orm";
+import { wikiPagePath } from "../lib/urls";
+import { ListBrokenWikiLinksInputSchema } from "../schemas/wiki";
+import { effectiveProjectRole, isWorkspaceAdmin, visibleProjectPredicate } from "./access";
+import { ForbiddenError, ValidationError } from "./errors";
+import type { ServiceCtx } from "./types";
+
+type Orm = ReturnType<typeof drizzle<typeof schema>>;
+
+// Mirrors apps/web/src/utils/markdown.ts's resolveWikilinks regex — same link syntax
+// rules, server-side.
+const WIKILINK_RE = /\[\[([^\]|]+?)(?:\|([^\]]+?))?\]\]/g;
+// Markdown link syntax `[label](url)` — used to catch same-workspace wiki URLs
+// (`/wiki/:slug`, `/wiki?slug=...`, or the relative `?slug=...` form markdown.ts emits
+// for already-resolved wikilinks).
+const MD_LINK_RE = /\[[^\]]*\]\(([^)\s]+)\)/g;
+
+type ParsedLinkTarget = { kind: "title"; title: string } | { kind: "slug"; slug: string };
+
+function extractWikiSlugFromUrl(url: string): string | null {
+	// Only relative or same-origin-rooted URLs are treated as same-workspace links —
+	// an absolute cross-origin URL is never a link to a page in this workspace.
+	const pathAndQuery = url.replace(/^https?:\/\/[^/]+/, "");
+	const pathMatch = pathAndQuery.match(/^\/wiki\/([a-z0-9-/]+)/i);
+	if (pathMatch) return decodeURIComponent(pathMatch[1]);
+	const queryMatch = pathAndQuery.match(/[?&]slug=([^&]+)/);
+	if (queryMatch) return decodeURIComponent(queryMatch[1]);
+	return null;
+}
+
+export function parseWikiLinkTargets(content: string): ParsedLinkTarget[] {
+	const targets: ParsedLinkTarget[] = [];
+	for (const m of content.matchAll(WIKILINK_RE)) {
+		const title = m[1].trim();
+		if (title) targets.push({ kind: "title", title });
+	}
+	for (const m of content.matchAll(MD_LINK_RE)) {
+		const slug = extractWikiSlugFromUrl(m[1].trim());
+		if (slug) targets.push({ kind: "slug", slug });
+	}
+	return targets;
+}
+
+async function resolveTitleTarget(
+	orm: Orm,
+	workspaceId: string,
+	title: string
+): Promise<string | null> {
+	const row = await orm
+		.select({ id: schema.wikiPages.id })
+		.from(schema.wikiPages)
+		.where(
+			and(
+				eq(schema.wikiPages.workspaceId, workspaceId),
+				sql`lower(${schema.wikiPages.title}) = lower(${title})`
+			)
+		)
+		.get();
+	return row?.id ?? null;
+}
+
+async function resolveSlugTarget(
+	orm: Orm,
+	workspaceId: string,
+	slug: string
+): Promise<{ id: string; title: string } | null> {
+	const direct = await orm
+		.select({ id: schema.wikiPages.id, title: schema.wikiPages.title })
+		.from(schema.wikiPages)
+		.where(and(eq(schema.wikiPages.workspaceId, workspaceId), eq(schema.wikiPages.slug, slug)))
+		.get();
+	if (direct) return direct;
+	// PROJ-483 redirects: an old slug still resolves to its page.
+	const redirect = await orm
+		.select({ pageId: schema.wikiRedirects.pageId })
+		.from(schema.wikiRedirects)
+		.where(
+			and(eq(schema.wikiRedirects.workspaceId, workspaceId), eq(schema.wikiRedirects.oldSlug, slug))
+		)
+		.get();
+	if (!redirect) return null;
+	const page = await orm
+		.select({ id: schema.wikiPages.id, title: schema.wikiPages.title })
+		.from(schema.wikiPages)
+		.where(
+			and(eq(schema.wikiPages.id, redirect.pageId), eq(schema.wikiPages.workspaceId, workspaceId))
+		)
+		.get();
+	return page ?? null;
+}
+
+type ResolvedLink = { targetPageId: string | null; targetTitle: string };
+
+async function resolveLinkTargets(
+	orm: Orm,
+	workspaceId: string,
+	targets: ParsedLinkTarget[]
+): Promise<ResolvedLink[]> {
+	// Dedupe by resolved page id (or the raw unresolved key) so a page linking to the
+	// same target multiple times only gets one wiki_links row.
+	const resolved = new Map<string, ResolvedLink>();
+	for (const t of targets) {
+		if (t.kind === "title") {
+			const targetPageId = await resolveTitleTarget(orm, workspaceId, t.title);
+			const key = targetPageId ?? `title:${t.title.toLowerCase()}`;
+			if (!resolved.has(key)) resolved.set(key, { targetPageId, targetTitle: t.title });
+		} else {
+			const found = await resolveSlugTarget(orm, workspaceId, t.slug);
+			const key = found?.id ?? `slug:${t.slug.toLowerCase()}`;
+			if (!resolved.has(key)) {
+				resolved.set(key, { targetPageId: found?.id ?? null, targetTitle: found?.title ?? t.slug });
+			}
+		}
+	}
+	return [...resolved.values()];
+}
+
+// D1 caps bound params at 100; each row binds 6 params (id, workspaceId, sourcePageId,
+// targetPageId, targetTitle, createdAt) — 15 rows/insert stays comfortably under that
+// with headroom, unlike services/sql.ts#inChunks (calibrated for single-param-per-item
+// IN-list queries, not multi-column inserts).
+const LINK_INSERT_CHUNK_SIZE = 15;
+
+/**
+ * Recompute a page's outgoing wiki_links rows from its current content: delete-then-
+ * reinsert, mirroring services/wiki.ts's reindexWikiFts. Call after every content write
+ * (create or update) — never partially, since a stale row would misreport backlinks.
+ */
+export async function reindexWikiLinks(
+	ctx: ServiceCtx,
+	orm: Orm,
+	sourcePageId: string,
+	content: string
+): Promise<void> {
+	await ctx.db
+		.prepare("DELETE FROM wiki_links WHERE source_page_id = ? AND workspace_id = ?")
+		.bind(sourcePageId, ctx.workspaceId)
+		.run();
+
+	const targets = parseWikiLinkTargets(content);
+	if (targets.length === 0) return;
+
+	const resolved = await resolveLinkTargets(orm, ctx.workspaceId, targets);
+	const now = Math.floor(Date.now() / 1000);
+	const rows = resolved.map((r) => ({
+		id: crypto.randomUUID(),
+		workspaceId: ctx.workspaceId,
+		sourcePageId,
+		targetPageId: r.targetPageId,
+		targetTitle: r.targetTitle,
+		createdAt: now,
+	}));
+
+	for (let i = 0; i < rows.length; i += LINK_INSERT_CHUNK_SIZE) {
+		await orm.insert(schema.wikiLinks).values(rows.slice(i, i + LINK_INSERT_CHUNK_SIZE));
+	}
+}
+
+/**
+ * One-time backfill: recompute wiki_links for every existing page in the workspace.
+ * D1 migrations are pure SQL and can't run this parsing logic, so it's exposed as an
+ * idempotent (delete-then-reinsert per page, safe to re-run) owner/admin-gated action
+ * instead — see mcp/wiki.ts's backfill_wiki_links tool / routes/wiki.ts's REST
+ * equivalent, and the PR description for why this shape was chosen over a standalone
+ * script.
+ */
+export async function backfillWikiLinks(ctx: ServiceCtx): Promise<{ pagesProcessed: number }> {
+	if (!isWorkspaceAdmin(ctx.role)) throw new ForbiddenError("Insufficient permissions");
+
+	const orm = drizzle(ctx.db, { schema });
+	const pages = await orm
+		.select({ id: schema.wikiPages.id, content: schema.wikiPages.content })
+		.from(schema.wikiPages)
+		.where(eq(schema.wikiPages.workspaceId, ctx.workspaceId));
+
+	for (const page of pages) {
+		await reindexWikiLinks(ctx, orm, page.id, page.content);
+	}
+	return { pagesProcessed: pages.length };
+}
+
+// Called from services/wiki.ts's deleteWikiPage so a deleted page's outgoing link rows
+// don't linger (ON DELETE CASCADE on source_page_id already guarantees this at the DB
+// level for D1 connections that enforce FKs, but PROJ-407 established that isn't
+// guaranteed for every connection — mirrors deleteWikiPageAttachments's rationale).
+export async function deleteWikiLinksForPages(ctx: ServiceCtx, pageIds: string[]): Promise<void> {
+	const CHUNK = 90;
+	for (let i = 0; i < pageIds.length; i += CHUNK) {
+		const chunk = pageIds.slice(i, i + CHUNK);
+		const placeholders = chunk.map(() => "?").join(",");
+		await ctx.db
+			.prepare(
+				`DELETE FROM wiki_links WHERE source_page_id IN (${placeholders}) AND workspace_id = ?`
+			)
+			.bind(...chunk, ctx.workspaceId)
+			.run();
+	}
+}
+
+// PROJ-485: count of distinct pages that link to any page in `pageIds`, for delete
+// warnings ("N pages link here"). Must be read BEFORE the delete runs — target_page_id
+// is ON DELETE SET NULL, so the count would read as 0 afterwards.
+export async function countBacklinkSources(ctx: ServiceCtx, pageIds: string[]): Promise<number> {
+	if (pageIds.length === 0) return 0;
+	const orm = drizzle(ctx.db, { schema });
+	const rows = await orm
+		.select({ sourcePageId: schema.wikiLinks.sourcePageId })
+		.from(schema.wikiLinks)
+		.where(
+			and(
+				eq(schema.wikiLinks.workspaceId, ctx.workspaceId),
+				inArray(schema.wikiLinks.targetPageId, pageIds)
+			)
+		)
+		.groupBy(schema.wikiLinks.sourcePageId);
+	// Exclude self-links (a page linking to itself isn't "another page" linking here).
+	return rows.filter((r) => !pageIds.includes(r.sourcePageId)).length;
+}
+
+// PROJ-485: best-effort citing context for a backlink — the raw text surrounding the
+// first occurrence of the link syntax in the source page's current content. Returns
+// null rather than guessing if the exact text can't be located (e.g. content changed
+// since the link was indexed).
+function extractSnippet(content: string, targetTitle: string): string | null {
+	const marker = `[[${targetTitle.toLowerCase()}`;
+	const idx = content.toLowerCase().indexOf(marker);
+	if (idx === -1) return null;
+	const SNIPPET_RADIUS = 60;
+	const start = Math.max(0, idx - SNIPPET_RADIUS);
+	const end = Math.min(content.length, idx + marker.length + SNIPPET_RADIUS);
+	const text = content.slice(start, end).replace(/\s+/g, " ").trim();
+	return `${start > 0 ? "…" : ""}${text}${end < content.length ? "…" : ""}`;
+}
+
+export interface WikiBacklink {
+	linkId: string;
+	pageId: string;
+	slug: string;
+	title: string;
+	url: string;
+	snippet: string | null;
+}
+
+/**
+ * Pages that link to an already-resolved+visibility-checked page, via target_page_id
+ * (id-backed — a rename of the target never breaks this). Called by
+ * services/wiki.ts#getWikiBacklinks after it resolves idOrSlug and checks the caller
+ * can see the target page itself.
+ */
+export async function backlinksForResolvedPage(
+	ctx: ServiceCtx,
+	page: { id: string }
+): Promise<WikiBacklink[]> {
+	const orm = drizzle(ctx.db, { schema });
+	const rows = await orm
+		.select({
+			linkId: schema.wikiLinks.id,
+			targetTitle: schema.wikiLinks.targetTitle,
+			pageId: schema.wikiPages.id,
+			slug: schema.wikiPages.slug,
+			title: schema.wikiPages.title,
+			content: schema.wikiPages.content,
+			projectId: schema.wikiPages.projectId,
+		})
+		.from(schema.wikiLinks)
+		.innerJoin(schema.wikiPages, eq(schema.wikiPages.id, schema.wikiLinks.sourcePageId))
+		.where(
+			and(
+				eq(schema.wikiLinks.workspaceId, ctx.workspaceId),
+				eq(schema.wikiLinks.targetPageId, page.id)
+			)
+		);
+
+	// PROJ-311: a backlink from a project-scoped page the caller can't see shouldn't
+	// leak that page's existence.
+	const visibleSourceIds = new Set(
+		isWorkspaceAdmin(ctx.role)
+			? rows.map((r) => r.pageId)
+			: await visibleSourcePageIds(
+					ctx,
+					rows.filter((r) => r.projectId !== null)
+				)
+	);
+	const visible = rows.filter((r) => r.projectId === null || visibleSourceIds.has(r.pageId));
+
+	return visible.map((r) => ({
+		linkId: r.linkId,
+		pageId: r.pageId,
+		slug: r.slug,
+		title: r.title,
+		url: wikiPagePath(r.slug, r.projectId),
+		snippet: extractSnippet(r.content, r.targetTitle),
+	}));
+}
+
+// Resolves which of `rows` (all project-scoped) the caller has an effective grant on.
+async function visibleSourcePageIds(
+	ctx: ServiceCtx,
+	rows: Array<{ pageId: string; projectId: string | null }>
+): Promise<string[]> {
+	if (rows.length === 0) return [];
+	const uniqueProjectIds = [
+		...new Set(rows.map((r) => r.projectId).filter((p): p is string => p !== null)),
+	];
+	const grantedProjectIds = new Set<string>();
+	for (const projectId of uniqueProjectIds) {
+		if ((await effectiveProjectRole(ctx, projectId)) !== null) grantedProjectIds.add(projectId);
+	}
+	return rows
+		.filter((r) => r.projectId !== null && grantedProjectIds.has(r.projectId))
+		.map((r) => r.pageId);
+}
+
+export interface BrokenWikiLink {
+	linkId: string;
+	sourcePageId: string;
+	sourceSlug: string;
+	sourceTitle: string;
+	targetTitle: string;
+}
+
+/** All unresolved (target_page_id null) wiki_links in the workspace, optionally scoped to a project. */
+export async function listBrokenWikiLinks(
+	ctx: ServiceCtx,
+	input: unknown
+): Promise<BrokenWikiLink[]> {
+	const parsed = ListBrokenWikiLinksInputSchema.safeParse(input);
+	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
+	const { projectId } = parsed.data;
+
+	const orm = drizzle(ctx.db, { schema });
+	const conditions = [
+		eq(schema.wikiLinks.workspaceId, ctx.workspaceId),
+		isNull(schema.wikiLinks.targetPageId),
+	];
+	if (projectId) conditions.push(eq(schema.wikiPages.projectId, projectId));
+
+	// PROJ-311: same visibility filter as listWikiPages — hide project-scoped source
+	// pages the caller isn't granted, workspace-level pages stay visible to everyone.
+	const visible = visibleProjectPredicate(ctx, schema.wikiPages.projectId);
+	if (visible) {
+		const cond = or(isNull(schema.wikiPages.projectId), visible);
+		if (cond) conditions.push(cond);
+	}
+
+	const rows = await orm
+		.select({
+			linkId: schema.wikiLinks.id,
+			sourcePageId: schema.wikiPages.id,
+			sourceSlug: schema.wikiPages.slug,
+			sourceTitle: schema.wikiPages.title,
+			targetTitle: schema.wikiLinks.targetTitle,
+		})
+		.from(schema.wikiLinks)
+		.innerJoin(schema.wikiPages, eq(schema.wikiPages.id, schema.wikiLinks.sourcePageId))
+		.where(and(...conditions));
+
+	return rows;
+}

--- a/apps/api/src/services/wiki-links.ts
+++ b/apps/api/src/services/wiki-links.ts
@@ -14,6 +14,7 @@ import { wikiPagePath } from "../lib/urls";
 import { ListBrokenWikiLinksInputSchema } from "../schemas/wiki";
 import { effectiveProjectRole, isWorkspaceAdmin, visibleProjectPredicate } from "./access";
 import { ForbiddenError, ValidationError } from "./errors";
+import { inChunks } from "./sql";
 import type { ServiceCtx } from "./types";
 
 type Orm = ReturnType<typeof drizzle<typeof schema>>;
@@ -29,12 +30,16 @@ const MD_LINK_RE = /\[[^\]]*\]\(([^)\s]+)\)/g;
 type ParsedLinkTarget = { kind: "title"; title: string } | { kind: "slug"; slug: string };
 
 function extractWikiSlugFromUrl(url: string): string | null {
-	// Only relative or same-origin-rooted URLs are treated as same-workspace links —
-	// an absolute cross-origin URL is never a link to a page in this workspace.
-	const pathAndQuery = url.replace(/^https?:\/\/[^/]+/, "");
-	const pathMatch = pathAndQuery.match(/^\/wiki\/([a-z0-9-/]+)/i);
+	// Only relative, path-rooted URLs are treated as same-workspace links. An absolute
+	// URL (http://, https://, //host/...) is never resolved here — we have no reliable
+	// request origin at parse time to compare it against, so treating "strip whatever
+	// origin is present" as "same workspace" would wrongly index links to other hosts
+	// as same-workspace links (even a same-origin absolute URL is written as relative
+	// by the app, so this doesn't lose any real link).
+	if (/^(?:[a-z][a-z0-9+.-]*:)?\/\//i.test(url)) return null;
+	const pathMatch = url.match(/^\/wiki\/([a-z0-9-/]+)/i);
 	if (pathMatch) return decodeURIComponent(pathMatch[1]);
-	const queryMatch = pathAndQuery.match(/[?&]slug=([^&]+)/);
+	const queryMatch = url.match(/[?&]slug=([^&]+)/);
 	if (queryMatch) return decodeURIComponent(queryMatch[1]);
 	return null;
 }
@@ -52,22 +57,39 @@ export function parseWikiLinkTargets(content: string): ParsedLinkTarget[] {
 	return targets;
 }
 
-async function resolveTitleTarget(
+// Resolves all title-kind targets in one query (rather than one round trip per link),
+// matched case-insensitively. Page titles aren't unique like slugs are (PROJ-483 only
+// enforces slug uniqueness); when more than one page shares a (lowercased) title, this
+// picks whichever row the query happens to return first — an arbitrary but stable-ish
+// match, not a documented/guaranteed one. Undocumented behavior, not a bug: titles were
+// never meant to be a stable identifier, slugs are.
+async function resolveTitleTargets(
 	orm: Orm,
 	workspaceId: string,
-	title: string
-): Promise<string | null> {
-	const row = await orm
-		.select({ id: schema.wikiPages.id })
-		.from(schema.wikiPages)
-		.where(
-			and(
-				eq(schema.wikiPages.workspaceId, workspaceId),
-				sql`lower(${schema.wikiPages.title}) = lower(${title})`
+	titles: string[]
+): Promise<Map<string, string>> {
+	const byLower = new Map<string, string>();
+	if (titles.length === 0) return byLower;
+	const lowered = [...new Set(titles.map((t) => t.toLowerCase()))];
+	const rows = await inChunks(lowered, (chunk) =>
+		orm
+			.select({ id: schema.wikiPages.id, title: schema.wikiPages.title })
+			.from(schema.wikiPages)
+			.where(
+				and(
+					eq(schema.wikiPages.workspaceId, workspaceId),
+					sql`lower(${schema.wikiPages.title}) IN (${sql.join(
+						chunk.map((t) => sql`${t}`),
+						sql`, `
+					)})`
+				)
 			)
-		)
-		.get();
-	return row?.id ?? null;
+	);
+	for (const row of rows) {
+		const key = row.title.toLowerCase();
+		if (!byLower.has(key)) byLower.set(key, row.id);
+	}
+	return byLower;
 }
 
 async function resolveSlugTarget(
@@ -110,17 +132,31 @@ async function resolveLinkTargets(
 	// Dedupe by resolved page id (or the raw unresolved key) so a page linking to the
 	// same target multiple times only gets one wiki_links row.
 	const resolved = new Map<string, ResolvedLink>();
+
+	// Title-kind targets resolve in one batched query instead of one round trip per
+	// link (a page with N distinct title-links previously made N sequential queries).
+	const titleTargets = targets.filter(
+		(t): t is Extract<ParsedLinkTarget, { kind: "title" }> => t.kind === "title"
+	);
+	const titleMatches = await resolveTitleTargets(
+		orm,
+		workspaceId,
+		titleTargets.map((t) => t.title)
+	);
+	for (const t of titleTargets) {
+		const targetPageId = titleMatches.get(t.title.toLowerCase()) ?? null;
+		const key = targetPageId ?? `title:${t.title.toLowerCase()}`;
+		if (!resolved.has(key)) resolved.set(key, { targetPageId, targetTitle: t.title });
+	}
+
+	// Slug-kind targets (from same-workspace wiki URLs) each need a redirect-fallback
+	// lookup, so they stay sequential rather than batched.
 	for (const t of targets) {
-		if (t.kind === "title") {
-			const targetPageId = await resolveTitleTarget(orm, workspaceId, t.title);
-			const key = targetPageId ?? `title:${t.title.toLowerCase()}`;
-			if (!resolved.has(key)) resolved.set(key, { targetPageId, targetTitle: t.title });
-		} else {
-			const found = await resolveSlugTarget(orm, workspaceId, t.slug);
-			const key = found?.id ?? `slug:${t.slug.toLowerCase()}`;
-			if (!resolved.has(key)) {
-				resolved.set(key, { targetPageId: found?.id ?? null, targetTitle: found?.title ?? t.slug });
-			}
+		if (t.kind !== "slug") continue;
+		const found = await resolveSlugTarget(orm, workspaceId, t.slug);
+		const key = found?.id ?? `slug:${t.slug.toLowerCase()}`;
+		if (!resolved.has(key)) {
+			resolved.set(key, { targetPageId: found?.id ?? null, targetTitle: found?.title ?? t.slug });
 		}
 	}
 	return [...resolved.values()];
@@ -195,9 +231,7 @@ export async function backfillWikiLinks(ctx: ServiceCtx): Promise<{ pagesProcess
 // level for D1 connections that enforce FKs, but PROJ-407 established that isn't
 // guaranteed for every connection — mirrors deleteWikiPageAttachments's rationale).
 export async function deleteWikiLinksForPages(ctx: ServiceCtx, pageIds: string[]): Promise<void> {
-	const CHUNK = 90;
-	for (let i = 0; i < pageIds.length; i += CHUNK) {
-		const chunk = pageIds.slice(i, i + CHUNK);
+	await inChunks(pageIds, async (chunk) => {
 		const placeholders = chunk.map(() => "?").join(",");
 		await ctx.db
 			.prepare(
@@ -205,7 +239,29 @@ export async function deleteWikiLinksForPages(ctx: ServiceCtx, pageIds: string[]
 			)
 			.bind(...chunk, ctx.workspaceId)
 			.run();
-	}
+		return [];
+	});
+}
+
+// Called from services/wiki.ts's deleteWikiPage alongside deleteWikiLinksForPages —
+// the same app-level-mirrors-the-FK rationale (PROJ-407), but for the *incoming* side.
+// ON DELETE SET NULL on target_page_id already guarantees this at the DB level for
+// connections that enforce FKs; this is the defensive fallback for connections that
+// don't, so a deleted page's id never lingers as a dangling target_page_id (which
+// would make the link invisible to list_broken_wiki_links, since that only looks for
+// target_page_id IS NULL). Only nulls target_page_id — target_title is left untouched
+// so the link still shows up as broken with its original display text.
+export async function clearIncomingLinkTargets(ctx: ServiceCtx, pageIds: string[]): Promise<void> {
+	await inChunks(pageIds, async (chunk) => {
+		const placeholders = chunk.map(() => "?").join(",");
+		await ctx.db
+			.prepare(
+				`UPDATE wiki_links SET target_page_id = NULL WHERE target_page_id IN (${placeholders}) AND workspace_id = ?`
+			)
+			.bind(...chunk, ctx.workspaceId)
+			.run();
+		return [];
+	});
 }
 
 // PROJ-485: count of distinct pages that link to any page in `pageIds`, for delete
@@ -214,18 +270,25 @@ export async function deleteWikiLinksForPages(ctx: ServiceCtx, pageIds: string[]
 export async function countBacklinkSources(ctx: ServiceCtx, pageIds: string[]): Promise<number> {
 	if (pageIds.length === 0) return 0;
 	const orm = drizzle(ctx.db, { schema });
-	const rows = await orm
-		.select({ sourcePageId: schema.wikiLinks.sourcePageId })
-		.from(schema.wikiLinks)
-		.where(
-			and(
-				eq(schema.wikiLinks.workspaceId, ctx.workspaceId),
-				inArray(schema.wikiLinks.targetPageId, pageIds)
+	const rows = await inChunks(pageIds, (chunk) =>
+		orm
+			.select({ sourcePageId: schema.wikiLinks.sourcePageId })
+			.from(schema.wikiLinks)
+			.where(
+				and(
+					eq(schema.wikiLinks.workspaceId, ctx.workspaceId),
+					inArray(schema.wikiLinks.targetPageId, chunk)
+				)
 			)
-		)
-		.groupBy(schema.wikiLinks.sourcePageId);
+			.groupBy(schema.wikiLinks.sourcePageId)
+	);
 	// Exclude self-links (a page linking to itself isn't "another page" linking here).
-	return rows.filter((r) => !pageIds.includes(r.sourcePageId)).length;
+	// Dedup across chunks too, since a source page could link to targets that land in
+	// different chunks and otherwise be counted more than once.
+	const distinctSources = new Set(
+		rows.map((r) => r.sourcePageId).filter((id) => !pageIds.includes(id))
+	);
+	return distinctSources.size;
 }
 
 // PROJ-485: best-effort citing context for a backlink — the raw text surrounding the

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -23,6 +23,7 @@ import { inChunks } from "./sql";
 import type { ServiceCtx } from "./types";
 import {
 	backlinksForResolvedPage,
+	clearIncomingLinkTargets,
 	countBacklinkSources,
 	deleteWikiLinksForPages,
 	reindexWikiLinks,
@@ -930,9 +931,10 @@ export async function deleteWikiPage(ctx: ServiceCtx, slug: string, options?: un
 			return [];
 		});
 		await deleteWikiFtsEntries(ctx, allIds);
-		// PROJ-407-style defensive cleanup: mirror the FK's ON DELETE CASCADE at the app
-		// level too, since D1 doesn't guarantee FK enforcement on every connection.
+		// PROJ-407-style defensive cleanup: mirror the FK's ON DELETE CASCADE/SET NULL at
+		// the app level too, since D1 doesn't guarantee FK enforcement on every connection.
 		await deleteWikiLinksForPages(ctx, allIds);
+		await clearIncomingLinkTargets(ctx, allIds);
 		await recordActivity(ctx, {
 			entityType: "wiki_page",
 			entityId: page.id,
@@ -955,6 +957,7 @@ export async function deleteWikiPage(ctx: ServiceCtx, slug: string, options?: un
 	await orm.delete(schema.wikiPages).where(eq(schema.wikiPages.id, page.id));
 	await deleteWikiFtsEntries(ctx, [page.id]);
 	await deleteWikiLinksForPages(ctx, [page.id]);
+	await clearIncomingLinkTargets(ctx, [page.id]);
 	await recordActivity(ctx, { entityType: "wiki_page", entityId: page.id, action: "deleted" });
 	return { ok: true, deletedCount: 1, linkedByCount };
 }

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -21,6 +21,13 @@ import { recordActivity } from "./activity";
 import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from "./errors";
 import { inChunks } from "./sql";
 import type { ServiceCtx } from "./types";
+import {
+	backlinksForResolvedPage,
+	countBacklinkSources,
+	deleteWikiLinksForPages,
+	reindexWikiLinks,
+	type WikiBacklink,
+} from "./wiki-links";
 
 type TreeNode = { id: string; slug: string; title: string; url: string; children: TreeNode[] };
 
@@ -404,6 +411,31 @@ export async function getWikiPage(ctx: ServiceCtx, slugOrId: string) {
 	return { ...page, url: wikiPagePath(page.slug, page.project_id) };
 }
 
+// PROJ-485: "what links here" — pages that link to `slugOrId` via a resolved wiki_links
+// row. Resolves the target the same way getWikiPage does (live slug/id, then redirect
+// fallback) and enforces the same visibility check before exposing anything.
+export async function getWikiBacklinks(ctx: ServiceCtx, slugOrId: string): Promise<WikiBacklink[]> {
+	const orm = drizzle(ctx.db, { schema });
+	const direct = await orm
+		.select({ id: schema.wikiPages.id, project_id: schema.wikiPages.projectId })
+		.from(schema.wikiPages)
+		.where(
+			and(
+				or(eq(schema.wikiPages.id, slugOrId), eq(schema.wikiPages.slug, slugOrId)),
+				eq(schema.wikiPages.workspaceId, ctx.workspaceId)
+			)
+		)
+		.get();
+	const page = direct ?? (await resolveWikiPageByRedirect(orm, ctx.workspaceId, slugOrId));
+	if (!page) throw new NotFoundError("Wiki page not found");
+	await assertWikiPageVisible(ctx, page.project_id);
+	return backlinksForResolvedPage(ctx, { id: page.id });
+}
+
+// PROJ-485: re-exported so routes/wiki.ts and mcp/wiki.ts only need to import from this
+// module, matching every other domain function's entry point.
+export { backfillWikiLinks, listBrokenWikiLinks } from "./wiki-links";
+
 export async function createWikiPage(ctx: ServiceCtx, input: unknown) {
 	const parsed = CreatePageSchema.safeParse(input);
 	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
@@ -451,6 +483,8 @@ export async function createWikiPage(ctx: ServiceCtx, input: unknown) {
 		)
 		.bind(id, ctx.workspaceId, title, content ?? "", "")
 		.run();
+	// PROJ-485: parse [[Target]]/URL links out of the new page's content into wiki_links.
+	await reindexWikiLinks(ctx, orm, id, content ?? "");
 	await recordActivity(ctx, { entityType: "wiki_page", entityId: id, action: "created" });
 	return { id, slug, projectId: projectId ?? null, url: wikiPagePath(slug, projectId ?? null) };
 }
@@ -750,6 +784,11 @@ export async function updateWikiPage(ctx: ServiceCtx, idOrSlug: string, input: u
 	}
 
 	await reindexWikiFts(ctx, orm, page.id, { title, content });
+	// PROJ-485: outgoing links are derived purely from content — a title/slug/parent-only
+	// update leaves them unchanged, so only reindex when content actually changed.
+	if (content !== undefined) {
+		await reindexWikiLinks(ctx, orm, page.id, content);
+	}
 
 	if (isRename) {
 		// Upsert: the old slug may already carry a stale redirect from an earlier rename
@@ -878,6 +917,10 @@ export async function deleteWikiPage(ctx: ServiceCtx, slug: string, options?: un
 	if (cascade) {
 		const descendantIds = await collectDescendantIds(ctx.db, page.id, ctx.workspaceId);
 		const allIds = [page.id, ...descendantIds];
+		// PROJ-485: read before the delete — target_page_id is ON DELETE SET NULL, so the
+		// count would read as 0 once the pages are gone. Non-blocking: surfaced as info on
+		// the response, matching the PRD's "delete warnings" (not a hard block).
+		const linkedByCount = await countBacklinkSources(ctx, allIds);
 		await inChunks(allIds, async (chunk) => {
 			await deleteWikiPageAttachments(ctx, orm, chunk);
 			return [];
@@ -887,13 +930,16 @@ export async function deleteWikiPage(ctx: ServiceCtx, slug: string, options?: un
 			return [];
 		});
 		await deleteWikiFtsEntries(ctx, allIds);
+		// PROJ-407-style defensive cleanup: mirror the FK's ON DELETE CASCADE at the app
+		// level too, since D1 doesn't guarantee FK enforcement on every connection.
+		await deleteWikiLinksForPages(ctx, allIds);
 		await recordActivity(ctx, {
 			entityType: "wiki_page",
 			entityId: page.id,
 			action: "deleted",
 			diff: { cascade: true, deletedCount: allIds.length },
 		});
-		return { ok: true, deletedCount: allIds.length };
+		return { ok: true, deletedCount: allIds.length, linkedByCount };
 	}
 
 	// PROJ-238: no FK constraint on parent_id, so a plain delete would otherwise leave
@@ -904,11 +950,13 @@ export async function deleteWikiPage(ctx: ServiceCtx, slug: string, options?: un
 		.set({ parentId: page.parentId })
 		.where(eq(schema.wikiPages.parentId, page.id));
 
+	const linkedByCount = await countBacklinkSources(ctx, [page.id]);
 	await deleteWikiPageAttachments(ctx, orm, [page.id]);
 	await orm.delete(schema.wikiPages).where(eq(schema.wikiPages.id, page.id));
 	await deleteWikiFtsEntries(ctx, [page.id]);
+	await deleteWikiLinksForPages(ctx, [page.id]);
 	await recordActivity(ctx, { entityType: "wiki_page", entityId: page.id, action: "deleted" });
-	return { ok: true, deletedCount: 1 };
+	return { ok: true, deletedCount: 1, linkedByCount };
 }
 
 export async function getWikiTree(ctx: ServiceCtx, projectId?: string): Promise<TreeNode[]> {

--- a/apps/api/src/test/mcp.test.ts
+++ b/apps/api/src/test/mcp.test.ts
@@ -546,7 +546,11 @@ describe("MCP endpoint", () => {
 			{ name: "delete_wiki_page", arguments: { slug: parent.slug, cascade: true } },
 			ownerHeaders
 		)) as JsonRpcResult<{ content: Array<{ text: string }> }>;
-		expect(JSON.parse(delRes.result.content[0].text)).toEqual({ ok: true, deletedCount: 2 });
+		expect(JSON.parse(delRes.result.content[0].text)).toEqual({
+			ok: true,
+			deletedCount: 2,
+			linkedByCount: 0,
+		});
 
 		const childRes2 = await SELF.fetch(`http://localhost/api/wiki/${child.slug}`, {
 			headers: ownerHeaders,

--- a/apps/api/src/test/migrations.ts
+++ b/apps/api/src/test/migrations.ts
@@ -44,6 +44,7 @@ import m0040 from "../../../../packages/db/migrations/0040_provisioning_removals
 import m0041 from "../../../../packages/db/migrations/0041_wiki_slug_unique.sql?raw";
 import m0042 from "../../../../packages/db/migrations/0042_wiki_revision_title_summary.sql?raw";
 import m0043 from "../../../../packages/db/migrations/0043_wiki_fts.sql?raw";
+import m0044 from "../../../../packages/db/migrations/0044_wiki_links.sql?raw";
 
 export const MIGRATIONS = [
 	m0000,
@@ -90,4 +91,5 @@ export const MIGRATIONS = [
 	m0041,
 	m0042,
 	m0043,
+	m0044,
 ];

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -798,7 +798,7 @@ describe("Wiki API", () => {
 			headers: ownerHeaders,
 		});
 		expect(delRes.status).toBe(200);
-		expect(await delRes.json()).toEqual({ ok: true, deletedCount: 1 });
+		expect(await delRes.json()).toEqual({ ok: true, deletedCount: 1, linkedByCount: 0 });
 
 		const childPageRes = await SELF.fetch(`http://localhost/api/wiki/${child.slug}`, {
 			headers: ownerHeaders,
@@ -837,7 +837,7 @@ describe("Wiki API", () => {
 			headers: ownerHeaders,
 		});
 		expect(delRes.status).toBe(200);
-		expect(await delRes.json()).toEqual({ ok: true, deletedCount: 3 });
+		expect(await delRes.json()).toEqual({ ok: true, deletedCount: 3, linkedByCount: 0 });
 
 		await env.DB.prepare("DELETE FROM rate_limit").run();
 		for (const s of [parent.slug, child.slug, grandchild.slug]) {
@@ -1570,5 +1570,310 @@ describe("wiki slug dedup algorithm (0041_wiki_slug_unique.sql)", () => {
 			expect(results.find((r) => r.id === "p1")?.slug).toBe("operations");
 			expect(results.find((r) => r.id === "p3")?.slug).toBe("operations-2");
 		});
+	});
+});
+
+describe("Wiki link graph and backlinks (PROJ-485)", () => {
+	let token: string;
+	let slug: string;
+
+	beforeEach(async () => {
+		const fixture = await seedFixture();
+		token = fixture.token;
+		slug = fixture.workspace.slug;
+	});
+
+	async function createPage(title: string, content: string) {
+		const res = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title, content }),
+		});
+		return (await res.json()) as { id: string; slug: string };
+	}
+
+	it("[[Target]] and [[Target|label]] both resolve a backlink to the target page", async () => {
+		const target = await createPage("Runbook", "how to page");
+		await createPage("Alpha", "see [[Runbook]] for details");
+		await createPage("Beta", "see [[Runbook|the runbook]] for details");
+
+		const res = await SELF.fetch(`http://localhost/api/wiki/${target.slug}/backlinks`, {
+			headers: authHeaders(token, slug),
+		});
+		expect(res.status).toBe(200);
+		const backlinks = (await res.json()) as Array<{ slug: string; title: string }>;
+		expect(backlinks.map((b) => b.slug).sort()).toEqual(["alpha", "beta"]);
+	});
+
+	it("a same-workspace wiki URL link resolves a backlink", async () => {
+		const target = await createPage("Handbook", "contents");
+		await createPage("Gamma", `[link](/wiki/${target.slug})`);
+
+		const res = await SELF.fetch(`http://localhost/api/wiki/${target.slug}/backlinks`, {
+			headers: authHeaders(token, slug),
+		});
+		const backlinks = (await res.json()) as Array<{ slug: string }>;
+		expect(backlinks.map((b) => b.slug)).toEqual(["gamma"]);
+	});
+
+	it("an unresolved [[Target]] is stored as a broken link, not a backlink", async () => {
+		await createPage("Delta", "see [[Nonexistent Page]] for details");
+
+		const brokenRes = await SELF.fetch("http://localhost/api/wiki/broken-links", {
+			headers: authHeaders(token, slug),
+		});
+		const broken = (await brokenRes.json()) as Array<{ sourceSlug: string; targetTitle: string }>;
+		expect(broken).toContainEqual(
+			expect.objectContaining({ sourceSlug: "delta", targetTitle: "Nonexistent Page" })
+		);
+	});
+
+	it("get_backlinks (MCP) returns the same result as REST", async () => {
+		const fixture = await seedFixture();
+		const target = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(fixture.token, fixture.workspace.slug),
+			body: JSON.stringify({ title: "MCP Target", content: "x" }),
+		}).then((r) => r.json() as Promise<{ slug: string }>);
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(fixture.token, fixture.workspace.slug),
+			body: JSON.stringify({ title: "MCP Source", content: "[[MCP Target]]" }),
+		});
+
+		const result = await mcpCall<{ content: Array<{ text: string }> }>(
+			fixture.workspace.id,
+			"get_backlinks",
+			{ slug: target.slug },
+			authHeaders(fixture.token, fixture.workspace.slug)
+		);
+		const backlinks = mcpData<Array<{ slug: string }>>(result);
+		expect(backlinks).toEqual([expect.objectContaining({ slug: "mcp-source" })]);
+	});
+
+	it("list_broken_wiki_links (MCP) matches REST", async () => {
+		const fixture = await seedFixture();
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(fixture.token, fixture.workspace.slug),
+			body: JSON.stringify({ title: "Epsilon", content: "[[Missing Target]]" }),
+		});
+
+		const result = await mcpCall<{ content: Array<{ text: string }> }>(
+			fixture.workspace.id,
+			"list_broken_wiki_links",
+			{},
+			authHeaders(fixture.token, fixture.workspace.slug)
+		);
+		const broken = mcpData<Array<{ targetTitle: string }>>(result);
+		expect(broken).toContainEqual(expect.objectContaining({ targetTitle: "Missing Target" }));
+	});
+
+	it("renaming the target page's slug doesn't break an existing backlink (id-backed)", async () => {
+		const target = await createPage("Original Name", "content");
+		await createPage("Linker", "see [[Original Name]]");
+
+		await SELF.fetch(`http://localhost/api/wiki/${target.slug}`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ slug: "renamed-slug" }),
+		});
+
+		const res = await SELF.fetch("http://localhost/api/wiki/renamed-slug/backlinks", {
+			headers: authHeaders(token, slug),
+		});
+		const backlinks = (await res.json()) as Array<{ slug: string }>;
+		expect(backlinks.map((b) => b.slug)).toEqual(["linker"]);
+	});
+
+	it("editing content to remove a link removes the backlink; a new link adds one", async () => {
+		const target = await createPage("Stable Target", "x");
+		const linker = await createPage("Changing Source", "see [[Stable Target]]");
+
+		let res = await SELF.fetch(`http://localhost/api/wiki/${target.slug}/backlinks`, {
+			headers: authHeaders(token, slug),
+		});
+		expect(((await res.json()) as unknown[]).length).toBe(1);
+
+		await SELF.fetch(`http://localhost/api/wiki/${linker.slug}`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "no more links here" }),
+		});
+
+		res = await SELF.fetch(`http://localhost/api/wiki/${target.slug}/backlinks`, {
+			headers: authHeaders(token, slug),
+		});
+		expect(await res.json()).toEqual([]);
+	});
+
+	it("a title-only update (no content change) leaves the link graph untouched", async () => {
+		const target = await createPage("Untouched Target", "x");
+		const linker = await createPage("Title Change Source", "see [[Untouched Target]]");
+
+		await SELF.fetch(`http://localhost/api/wiki/${linker.slug}`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Renamed Title Only" }),
+		});
+
+		const res = await SELF.fetch(`http://localhost/api/wiki/${target.slug}/backlinks`, {
+			headers: authHeaders(token, slug),
+		});
+		const backlinks = (await res.json()) as Array<{ slug: string }>;
+		expect(backlinks.map((b) => b.slug)).toEqual(["title-change-source"]);
+	});
+
+	it("DELETE surfaces linkedByCount as a non-blocking warning and still deletes the page", async () => {
+		const owner = await seedFixture({ role: "owner" });
+		const target = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(owner.token, owner.workspace.slug),
+			body: JSON.stringify({ title: "Linked Target", content: "x" }),
+		}).then((r) => r.json() as Promise<{ slug: string }>);
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(owner.token, owner.workspace.slug),
+			body: JSON.stringify({ title: "Linker One", content: "[[Linked Target]]" }),
+		});
+
+		const res = await SELF.fetch(`http://localhost/api/wiki/${target.slug}`, {
+			method: "DELETE",
+			headers: authHeaders(owner.token, owner.workspace.slug),
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { ok: boolean; linkedByCount: number };
+		expect(body.linkedByCount).toBe(1);
+
+		const getRes = await SELF.fetch(`http://localhost/api/wiki/${target.slug}`, {
+			headers: authHeaders(owner.token, owner.workspace.slug),
+		});
+		expect(getRes.status).toBe(404);
+
+		// The now-deleted target turns the surviving linker's outgoing link into a broken
+		// link (target_page_id set null) rather than silently vanishing.
+		const brokenRes = await SELF.fetch("http://localhost/api/wiki/broken-links", {
+			headers: authHeaders(owner.token, owner.workspace.slug),
+		});
+		const broken = (await brokenRes.json()) as Array<{ targetTitle: string }>;
+		expect(broken).toContainEqual(expect.objectContaining({ targetTitle: "Linked Target" }));
+	});
+
+	it("cascade-deleting a subtree cleans up outgoing links for every deleted page", async () => {
+		const owner = await seedFixture({ role: "owner" });
+		const parentRes = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(owner.token, owner.workspace.slug),
+			body: JSON.stringify({ title: "Cascade Parent", content: "[[Nonexistent A]]" }),
+		});
+		const parent = (await parentRes.json()) as { id: string; slug: string };
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(owner.token, owner.workspace.slug),
+			body: JSON.stringify({
+				title: "Cascade Child",
+				content: "[[Nonexistent B]]",
+				parentId: parent.id,
+			}),
+		});
+
+		await SELF.fetch(`http://localhost/api/wiki/${parent.slug}?cascade=true`, {
+			method: "DELETE",
+			headers: authHeaders(owner.token, owner.workspace.slug),
+		});
+
+		const brokenRes = await SELF.fetch("http://localhost/api/wiki/broken-links", {
+			headers: authHeaders(owner.token, owner.workspace.slug),
+		});
+		const broken = (await brokenRes.json()) as Array<{ targetTitle: string }>;
+		expect(broken.some((b) => b.targetTitle === "Nonexistent A")).toBe(false);
+		expect(broken.some((b) => b.targetTitle === "Nonexistent B")).toBe(false);
+	});
+
+	it("backlinks and broken links never cross workspace boundaries", async () => {
+		const workspaceA = await seedFixture();
+		const workspaceB = await seedFixture();
+
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(workspaceA.token, workspaceA.workspace.slug),
+			body: JSON.stringify({ title: "Shared Title", content: "x" }),
+		});
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(workspaceB.token, workspaceB.workspace.slug),
+			body: JSON.stringify({ title: "B Source", content: "see [[Shared Title]]" }),
+		});
+
+		// workspace B's link can only resolve against workspace B's own pages, so it's
+		// unresolved there (no "Shared Title" page exists in B) — never leaking a match
+		// against workspace A's page of the same title.
+		const brokenB = await SELF.fetch("http://localhost/api/wiki/broken-links", {
+			headers: authHeaders(workspaceB.token, workspaceB.workspace.slug),
+		});
+		expect(
+			((await brokenB.json()) as Array<{ targetTitle: string }>).some(
+				(b) => b.targetTitle === "Shared Title"
+			)
+		).toBe(true);
+
+		const sharedA = await SELF.fetch("http://localhost/api/wiki/shared-title", {
+			headers: authHeaders(workspaceA.token, workspaceA.workspace.slug),
+		});
+		const target = (await sharedA.json()) as { id: string };
+		const backlinksA = await SELF.fetch(`http://localhost/api/wiki/${target.id}/backlinks`, {
+			headers: authHeaders(workspaceA.token, workspaceA.workspace.slug),
+		});
+		expect(await backlinksA.json()).toEqual([]);
+	});
+
+	it("backfill_wiki_links (MCP, owner-only) recomputes links for pre-existing content", async () => {
+		const owner = await seedFixture({ role: "owner" });
+		// Seed pages directly at the DB layer, bypassing reindexWikiLinks, to simulate
+		// pre-PROJ-485 content that predates the link graph.
+		const now = Math.floor(Date.now() / 1000);
+		await env.DB.prepare(
+			"INSERT INTO wiki_pages (id, workspace_id, slug, title, content, created_by_id, updated_by_id, created_at, updated_at) " +
+				"VALUES ('legacy-target', ?, 'legacy-target', 'Legacy Target', 'x', ?, ?, ?, ?)"
+		)
+			.bind(owner.workspace.id, owner.user.id, owner.user.id, now, now)
+			.run();
+		await env.DB.prepare(
+			"INSERT INTO wiki_pages (id, workspace_id, slug, title, content, created_by_id, updated_by_id, created_at, updated_at) " +
+				"VALUES ('legacy-source', ?, 'legacy-source', 'Legacy Source', '[[Legacy Target]]', ?, ?, ?, ?)"
+		)
+			.bind(owner.workspace.id, owner.user.id, owner.user.id, now, now)
+			.run();
+
+		const preBacklinks = await SELF.fetch("http://localhost/api/wiki/legacy-target/backlinks", {
+			headers: authHeaders(owner.token, owner.workspace.slug),
+		});
+		expect(await preBacklinks.json()).toEqual([]);
+
+		const result = await mcpCall<{ content: Array<{ text: string }> }>(
+			owner.workspace.id,
+			"backfill_wiki_links",
+			{},
+			authHeaders(owner.token, owner.workspace.slug)
+		);
+		const backfillResult = mcpData<{ pagesProcessed: number }>(result);
+		expect(backfillResult.pagesProcessed).toBeGreaterThanOrEqual(2);
+
+		const postBacklinks = await SELF.fetch("http://localhost/api/wiki/legacy-target/backlinks", {
+			headers: authHeaders(owner.token, owner.workspace.slug),
+		});
+		const backlinks = (await postBacklinks.json()) as Array<{ slug: string }>;
+		expect(backlinks.map((b) => b.slug)).toEqual(["legacy-source"]);
+	});
+
+	it("backfill_wiki_links is rejected for a non-admin member", async () => {
+		const member = await seedFixture({ role: "member" });
+		const result = await mcpCall(
+			member.workspace.id,
+			"backfill_wiki_links",
+			{},
+			authHeaders(member.token, member.workspace.slug)
+		);
+		expect(isMcpError(result)).toBe(true);
 	});
 });

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -1616,6 +1616,20 @@ describe("Wiki link graph and backlinks (PROJ-485)", () => {
 		expect(backlinks.map((b) => b.slug)).toEqual(["gamma"]);
 	});
 
+	it("an absolute cross-host URL is never indexed as a same-workspace link", async () => {
+		const target = await createPage("Epsilon", "contents");
+		await createPage(
+			"Zeta",
+			`[external](https://example.com/wiki/${target.slug}) and [also](//other-host/wiki/${target.slug})`
+		);
+
+		const res = await SELF.fetch(`http://localhost/api/wiki/${target.slug}/backlinks`, {
+			headers: authHeaders(token, slug),
+		});
+		const backlinks = (await res.json()) as Array<{ slug: string }>;
+		expect(backlinks).toEqual([]);
+	});
+
 	it("an unresolved [[Target]] is stored as a broken link, not a backlink", async () => {
 		await createPage("Delta", "see [[Nonexistent Page]] for details");
 

--- a/apps/docs/src/content/docs/agents/tool-catalog.md
+++ b/apps/docs/src/content/docs/agents/tool-catalog.md
@@ -140,7 +140,7 @@ running server.
 | `delete_wiki_page` | Delete a wiki page by slug (not allowed for viewers). By default any child pages are promoted to the deleted page's parent; pass cascade=true to delete the whole subtree instead. |
 | `wiki_tree` | Get the wiki page hierarchy as a nested tree, optionally filtered by project |
 | `get_backlinks` | List pages that link to the given page via a resolved [[wikilink]] or same-workspace URL (id-backed, so renames never break a backlink). Each result includes a snippet of the citing text when it can still be located in the source page's current content. |
-| `list_broken_wiki_links` | List unresolved wiki links in the workspace — [[Target]]/URL links whose target title or slug didn't match any page at write time. Useful as a maintenance queue. |
+| `list_broken_wiki_links` | List unresolved wiki links in the workspace — [[Target]]/URL links whose target title or slug didn't match any page at write time. Useful as a maintenance queue. Note: a broken link does not auto-re-resolve if the missing page is created later — only backfill_wiki_links (or re-saving the linking page) re-resolves it. |
 | `backfill_wiki_links` | One-time (idempotent, safe to re-run) recompute of the wiki_links graph for every existing page in the workspace. Owner/admin only. |
 | `list_wiki_revisions` | List revision history for a wiki page |
 | `get_wiki_revision` | Get the content of a specific wiki revision by its ID |

--- a/apps/docs/src/content/docs/agents/tool-catalog.md
+++ b/apps/docs/src/content/docs/agents/tool-catalog.md
@@ -11,7 +11,7 @@ running server.
 
 <!-- gen-mcp-catalog:start - generated block; run `pnpm --filter @projektor/api gen:catalog` to refresh -->
 
-**90 tools across 21 domains.**
+**93 tools across 21 domains.**
 
 ## Coordination
 
@@ -139,6 +139,9 @@ running server.
 | `update_wiki_page` | Update a wiki page by id or slug (saves a revision when content changes). Pass baseRevisionId (the current revision id from list_wiki_revisions/get_wiki_revision, or null if the page has never been revised) for conflict-safe writes: if the page advanced since baseRevisionId, the write is rejected with a structured conflict (currentRevisionId + a unified diff) instead of silently overwriting. Omitting baseRevisionId is DEPRECATED — it keeps today's last-write-wins behavior during the transition and will be rejected in a future version. |
 | `delete_wiki_page` | Delete a wiki page by slug (not allowed for viewers). By default any child pages are promoted to the deleted page's parent; pass cascade=true to delete the whole subtree instead. |
 | `wiki_tree` | Get the wiki page hierarchy as a nested tree, optionally filtered by project |
+| `get_backlinks` | List pages that link to the given page via a resolved [[wikilink]] or same-workspace URL (id-backed, so renames never break a backlink). Each result includes a snippet of the citing text when it can still be located in the source page's current content. |
+| `list_broken_wiki_links` | List unresolved wiki links in the workspace — [[Target]]/URL links whose target title or slug didn't match any page at write time. Useful as a maintenance queue. |
+| `backfill_wiki_links` | One-time (idempotent, safe to re-run) recompute of the wiki_links graph for every existing page in the workspace. Owner/admin only. |
 | `list_wiki_revisions` | List revision history for a wiki page |
 | `get_wiki_revision` | Get the content of a specific wiki revision by its ID |
 

--- a/apps/docs/src/generated/mcp-stats.json
+++ b/apps/docs/src/generated/mcp-stats.json
@@ -1,4 +1,4 @@
 {
-	"tools": 90,
+	"tools": 93,
 	"domains": 21
 }

--- a/packages/db/migrations/0044_wiki_links.sql
+++ b/packages/db/migrations/0044_wiki_links.sql
@@ -1,0 +1,28 @@
+-- 0044: server-side wiki link graph (PROJ-485)
+--
+-- Recomputed (delete-then-reinsert) on every wiki page content write —
+-- services/wiki-links.ts#reindexWikiLinks. target_page_id is nullable: null means
+-- the [[Target]]/URL link's title/slug didn't resolve to a page in the workspace at
+-- write time (broken link). target_title always holds the raw parsed text, even when
+-- resolved, so it survives a later rename of the target page (id-backed) and remains
+-- available for broken-link reporting/re-resolution.
+--
+-- target_page_id uses ON DELETE SET NULL rather than CASCADE: deleting the target page
+-- should turn outgoing links to it into broken links (still visible via target_title),
+-- not silently vanish the link row. source_page_id uses ON DELETE CASCADE since a
+-- source page's outgoing links have no meaning once the source itself is gone (mirrors
+-- the delete-then-reinsert reindex pattern — the row set is owned by the source page).
+
+CREATE TABLE `wiki_links` (
+	`id` text PRIMARY KEY NOT NULL,
+	`workspace_id` text NOT NULL REFERENCES `workspaces`(`id`) ON DELETE CASCADE,
+	`source_page_id` text NOT NULL REFERENCES `wiki_pages`(`id`) ON DELETE CASCADE,
+	`target_page_id` text REFERENCES `wiki_pages`(`id`) ON DELETE SET NULL,
+	`target_title` text NOT NULL,
+	`created_at` integer NOT NULL
+);
+
+CREATE INDEX `wiki_links_source_page_idx` ON `wiki_links` (`source_page_id`);
+-- Backlinks lookup (get_backlinks) and broken-link reporting (target_page_id IS NULL)
+-- both filter by workspace_id + target_page_id.
+CREATE INDEX `wiki_links_workspace_target_idx` ON `wiki_links` (`workspace_id`, `target_page_id`);

--- a/packages/db/src/schema/wiki.ts
+++ b/packages/db/src/schema/wiki.ts
@@ -78,3 +78,28 @@ export const wikiRedirects = sqliteTable(
 		pageIdIdx: index("wiki_redirects_page_id_idx").on(t.pageId),
 	})
 );
+
+// PROJ-485: server-side wiki link graph. Recomputed (delete-then-reinsert) on every
+// content write by services/wiki-links.ts#reindexWikiLinks. targetPageId is nullable —
+// null means the parsed [[Target]]/URL link didn't resolve to a page in this workspace
+// at write time (a broken link); targetTitle always holds the raw parsed text so it
+// survives later renames and stays available for broken-link reporting/re-resolution.
+export const wikiLinks = sqliteTable(
+	"wiki_links",
+	{
+		id: text("id").primaryKey(),
+		workspaceId: text("workspace_id")
+			.notNull()
+			.references(() => workspaces.id, { onDelete: "cascade" }),
+		sourcePageId: text("source_page_id")
+			.notNull()
+			.references(() => wikiPages.id, { onDelete: "cascade" }),
+		targetPageId: text("target_page_id").references(() => wikiPages.id, { onDelete: "set null" }),
+		targetTitle: text("target_title").notNull(),
+		createdAt: integer("created_at").notNull(),
+	},
+	(t) => ({
+		sourcePageIdx: index("wiki_links_source_page_idx").on(t.sourcePageId),
+		workspaceTargetIdx: index("wiki_links_workspace_target_idx").on(t.workspaceId, t.targetPageId),
+	})
+);


### PR DESCRIPTION
## Summary
Parses `[[Target]]`/`[[Target|label]]` wikilinks and same-workspace wiki URLs out of page content on every write into a new `wiki_links` table (id-backed target, so renames never break a link).

- `get_backlinks` (MCP + REST `GET /:slug/backlinks`) — "what links here"
- `list_broken_wiki_links` (MCP + REST `GET /broken-links`) — unresolved link targets, per-workspace/project
- `backfill_wiki_links` (MCP + REST `POST /backfill-links`, owner/admin only) — idempotent recompute for pre-existing content, since D1 migrations can't run the JS parsing this needs
- `deleteWikiPage` now returns `linkedByCount` (non-blocking delete warning) and defensively cleans up outgoing link rows

Links are recomputed (delete-then-reinsert) on every content write, mirroring the `wiki_fts` reindex pattern from PROJ-486.

Part of the agent-first wiki epic (PROJ-482). Depends on PROJ-483 (merged — unique slugs).

## Test plan
CI green locally: `pnpm gen:docs` (no diff), `pnpm lint`, `pnpm turbo type-check`, `pnpm --filter @projektor/db test`, `pnpm --filter @projektor/api test:coverage`, `pnpm --filter @projektor/web test:coverage`, `pnpm --filter @projektor/web build`, `pnpm --filter @projektor/docs build`. Pre-push hooks (lint/api/web tests) passed on push.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>