### PR TITLE
PROJ-487: path-based /wiki/:slug URLs with SSR-equivalent metadata

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -290,6 +290,9 @@ app.route("/api/workflow", workflowRouter);
 // page so its IssueDetail island can resolve the issue from the URL path client-side.
 // Project pretty-URL paths (/projects/view/<slug>, PROJ-376) get the project-view
 // page so its ProjectLanding/ProjectNav islands can resolve it the same way.
+// Wiki pretty-URL paths (/wiki/:slug, PROJ-487) get the wiki-view page so its
+// WikiPage island can resolve the page from the URL path client-side — /wiki itself
+// (no slug) has its own static asset and never reaches this fallback.
 // Everything else gets the homepage.
 app.get("*", async (c) => {
 	if (!c.env.ASSETS) return c.notFound();
@@ -300,7 +303,9 @@ app.get("*", async (c) => {
 			? "/projects/view/index.html"
 			: /^\/share\//.test(pathname)
 				? "/share/view/index.html"
-				: "/index.html";
+				: /^\/wiki\/[^/]+/.test(pathname)
+					? "/wiki/view/index.html"
+					: "/index.html";
 	return c.env.ASSETS.fetch(new Request(new URL(fallbackPath, c.req.url).toString()));
 });
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 import { serviceErrToResponse } from "./http/error-adapter";
+import { injectWikiMetadata, resolveWikiPageForSsr } from "./lib/wiki-ssr";
 import { authMiddleware } from "./middleware/auth";
 import { etagMiddleware } from "./middleware/etag";
 import { rateLimitMiddleware } from "./middleware/rate-limit";
@@ -284,6 +285,29 @@ app.route("/api/file-claims", fileClaimsRouter);
 app.route("/api/agent-messages", agentMessagesRouter);
 app.route("/api/workflow", workflowRouter);
 
+// PROJ-487 fix-up: /wiki is a static asset (wiki/index.html) that Cloudflare serves
+// directly without ever invoking the Worker — so the legacy `?slug=` query param can
+// only be turned into a real HTTP redirect if this exact path is added to
+// `run_worker_first` in the wrangler config (see scripts/release-assets/wrangler.example.toml).
+// With that in place, this handler issues a genuine 301 to the canonical /wiki/:slug
+// path (resolving through PROJ-483's slug/redirect logic, so a stale slug redirects
+// straight to the current one rather than chaining). If the request can't be
+// authenticated/scoped to a workspace (e.g. no session, or a deployment with no
+// resolvable workspace for a bare navigation), this falls back to serving the plain
+// landing page rather than erroring — the client-side WikiPage island still handles
+// `?slug=` today as a fallback.
+app.get("/wiki", async (c) => {
+	const assets = c.env.ASSETS;
+	if (!assets) return c.notFound();
+	const legacySlug = c.req.query("slug");
+	const shell = () => assets.fetch(new Request(new URL("/wiki/index.html", c.req.url).toString()));
+	if (!legacySlug) return shell();
+
+	const page = await resolveWikiPageForSsr(c, legacySlug);
+	if (!page) return shell();
+	return c.redirect(page.url, 301);
+});
+
 // SPA fallback — paths with no matching static asset fall through here.
 // Only active in production where the ASSETS binding is present.
 // Issue pretty-URL paths (/projects/KEY/issues/N/title-slug) get the issue-detail
@@ -292,21 +316,34 @@ app.route("/api/workflow", workflowRouter);
 // page so its ProjectLanding/ProjectNav islands can resolve it the same way.
 // Wiki pretty-URL paths (/wiki/:slug, PROJ-487) get the wiki-view page so its
 // WikiPage island can resolve the page from the URL path client-side — /wiki itself
-// (no slug) has its own static asset and never reaches this fallback.
+// (no slug) is handled by the dedicated route above and never reaches this fallback.
 // Everything else gets the homepage.
 app.get("*", async (c) => {
 	if (!c.env.ASSETS) return c.notFound();
 	const { pathname } = new URL(c.req.url);
+	const wikiSlugMatch = /^\/wiki\/([^/]+)/.exec(pathname);
 	const fallbackPath = /^\/projects\/[^/]+\/issues\/\d+\//.test(pathname)
 		? "/issues/view/index.html"
 		: /^\/projects\/view\/[^/]+/.test(pathname)
 			? "/projects/view/index.html"
 			: /^\/share\//.test(pathname)
 				? "/share/view/index.html"
-				: /^\/wiki\/[^/]+/.test(pathname)
+				: wikiSlugMatch
 					? "/wiki/view/index.html"
 					: "/index.html";
-	return c.env.ASSETS.fetch(new Request(new URL(fallbackPath, c.req.url).toString()));
+	const response = await c.env.ASSETS.fetch(
+		new Request(new URL(fallbackPath, c.req.url).toString())
+	);
+	// PROJ-487 fix-up: best-effort server-injected <title>/OG metadata for a resolved,
+	// authenticated wiki page — see lib/wiki-ssr.ts for why this can't be a build-time
+	// Astro SSR adapter, and why it's scoped to authenticated requests only (the wiki
+	// has no public/unauthenticated share path — see the PRD's public-wiki-sharing
+	// non-goal, PROJ-482). Any failure here just serves the unmodified static shell.
+	if (wikiSlugMatch) {
+		const page = await resolveWikiPageForSsr(c, decodeURIComponent(wikiSlugMatch[1]));
+		if (page) return injectWikiMetadata(response, page, new URL(pathname, c.req.url).toString());
+	}
+	return response;
 });
 
 async function sha256hex(s: string): Promise<string> {

--- a/apps/api/src/lib/urls.ts
+++ b/apps/api/src/lib/urls.ts
@@ -14,9 +14,10 @@ export function issuePath(projectKey: string, number: number, title: string): st
 	return `/projects/${projectKey}/issues/${number}/${slugifyForUrl(title)}`;
 }
 
-/** Canonical web UI path for a wiki page (PROJ-307). */
-export function wikiPagePath(slug: string, projectId: string | null): string {
-	const qs = new URLSearchParams({ slug });
-	if (projectId) qs.set("projectId", projectId);
-	return `/wiki?${qs.toString()}`;
+/**
+ * Canonical web UI path for a wiki page (PROJ-307; path-routed since PROJ-487).
+ * Slugs are unique per workspace (PROJ-483), so no project disambiguator is needed.
+ */
+export function wikiPagePath(slug: string): string {
+	return `/wiki/${encodeURIComponent(slug)}`;
 }

--- a/apps/api/src/lib/wiki-ssr.ts
+++ b/apps/api/src/lib/wiki-ssr.ts
@@ -1,0 +1,123 @@
+import type { HonoEnv } from "@projektor/types";
+import type { Context } from "hono";
+import { authMiddleware } from "../middleware/auth";
+import { subdomainRoutingEnabled } from "../middleware/workspace";
+import { ctxFromHono } from "../services/types";
+import { getWikiPage } from "../services/wiki";
+
+// PROJ-487 fix-up: server-side redirect + metadata injection for the /wiki catch-all
+// need a workspace-scoped ServiceCtx, but a plain top-level browser navigation carries
+// none of the signals workspaceMiddleware requires (no X-Workspace-Slug header, and
+// subdomain routing is opt-in) — so this deliberately does NOT reuse workspaceMiddleware
+// verbatim. Instead it mirrors its resolution order and adds DEFAULT_WORKSPACE_SLUG as a
+// final fallback (the common case for a single-tenant deployment, matching the
+// PUBLIC_READ_ONLY/provisioning convention elsewhere in this file), and never writes an
+// error response itself — callers treat a null return as "fall back to the plain shell",
+// not an error, since this is a best-effort enhancement over the client-side behavior
+// that already exists.
+async function resolveWikiWorkspaceContext(
+	c: Context<HonoEnv>
+): Promise<{ id: string; name: string; slug: string; role: string } | null> {
+	const headerSlug = c.req.header("X-Workspace-Slug");
+	const routingEnabled = subdomainRoutingEnabled(c.env.WORKSPACE_SUBDOMAIN_ROUTING);
+	const subdomainSlug = routingEnabled ? c.req.header("host")?.split(".")[0] : undefined;
+	const slug = headerSlug ?? subdomainSlug ?? c.env.DEFAULT_WORKSPACE_SLUG;
+	if (!slug) return null;
+
+	const user = c.get("user") as { id: string } | undefined;
+	if (!user) return null;
+
+	const row = await c.env.DB.prepare(
+		`SELECT w.id, w.name, w.slug, m.role
+		 FROM workspaces w
+		 LEFT JOIN workspace_members m ON m.workspace_id = w.id AND m.user_id = ?
+		 WHERE w.slug = ?`
+	)
+		.bind(user.id, slug)
+		.first<{ id: string; name: string; slug: string; role: string | null }>();
+	if (!row?.role) return null;
+
+	return { id: row.id, name: row.name, slug: row.slug, role: row.role };
+}
+
+export interface WikiSsrPage {
+	title: string;
+	content: string;
+	url: string;
+}
+
+// Best-effort: authenticates the request and resolves a workspace-scoped wiki page for
+// SSR purposes (redirect target / injected metadata). Returns null on ANY failure to
+// authenticate, resolve a workspace, or find/view the page — callers must fall back to
+// serving the plain static shell rather than erroring the page load, and must never let
+// this leak page existence/content to an unauthenticated caller.
+export async function resolveWikiPageForSsr(
+	c: Context<HonoEnv>,
+	slugOrId: string
+): Promise<WikiSsrPage | null> {
+	let authenticated = false;
+	const authResponse = await authMiddleware(c, async () => {
+		authenticated = true;
+	});
+	if (authResponse || !authenticated) return null;
+
+	const workspace = await resolveWikiWorkspaceContext(c);
+	if (!workspace) return null;
+	c.set("workspace", { id: workspace.id, name: workspace.name, slug: workspace.slug });
+	c.set("role", workspace.role);
+
+	try {
+		const page = await getWikiPage(ctxFromHono(c), slugOrId);
+		return { title: page.title, content: page.content, url: page.url };
+	} catch {
+		// NotFoundError / ForbiddenError / anything else — no metadata to inject, no
+		// redirect target; the plain shell (or a client-side 404) still works.
+		return null;
+	}
+}
+
+function plainTextExcerpt(markdown: string, maxLen = 200): string {
+	const plain = markdown
+		.replace(/```[\s\S]*?```/g, " ")
+		.replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
+		.replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+		.replace(/\[\[([^\]|]*)(\|[^\]]*)?\]\]/g, "$1")
+		.replace(/[#>*_`~-]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+	return plain.length > maxLen ? `${plain.slice(0, maxLen - 1)}…` : plain;
+}
+
+class AttrSetter {
+	constructor(
+		private attr: string,
+		private value: string
+	) {}
+	element(el: Element) {
+		el.setAttribute(this.attr, this.value);
+	}
+}
+
+class TextSetter {
+	constructor(private value: string) {}
+	element(el: Element) {
+		el.setInnerContent(this.value);
+	}
+}
+
+// Rewrites <title> and og:title/og:description/og:url on the static wiki shell response
+// with real values for a resolved page. Never throws — a rewrite failure just means the
+// caller serves the unmodified shell.
+export function injectWikiMetadata(
+	response: Response,
+	page: WikiSsrPage,
+	pageUrl: string
+): Response {
+	const description = plainTextExcerpt(page.content);
+	return new HTMLRewriter()
+		.on("title", new TextSetter(`${page.title} — Projektor Wiki`))
+		.on('meta[property="og:title"]', new AttrSetter("content", page.title))
+		.on('meta[property="og:description"]', new AttrSetter("content", description))
+		.on('meta[property="og:url"]', new AttrSetter("content", pageUrl))
+		.transform(response);
+}

--- a/apps/api/src/services/files.ts
+++ b/apps/api/src/services/files.ts
@@ -87,7 +87,7 @@ function toDto(r: AttachmentRow): AttachmentDto {
 				? {
 						id: r.wiki_page_id,
 						title: r.wiki_page_title,
-						url: wikiPagePath(r.wiki_page_slug ?? "", r.wiki_page_project_id),
+						url: wikiPagePath(r.wiki_page_slug ?? ""),
 					}
 				: null,
 	};

--- a/apps/api/src/services/wiki-links.ts
+++ b/apps/api/src/services/wiki-links.ts
@@ -362,7 +362,7 @@ export async function backlinksForResolvedPage(
 		pageId: r.pageId,
 		slug: r.slug,
 		title: r.title,
-		url: wikiPagePath(r.slug, r.projectId),
+		url: wikiPagePath(r.slug),
 		snippet: extractSnippet(r.content, r.targetTitle),
 	}));
 }

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -63,6 +63,11 @@ function slugify(title: string): string {
 		.replace(/^-|-$/g, "");
 }
 
+// PROJ-487: "view" is the shell path segment the Worker's pretty-URL fallback serves
+// static assets from (/wiki/view/index.html) — a page slugged "view" would collide
+// with it and never resolve. Reserved outright rather than special-cased in routing.
+const RESERVED_WIKI_SLUGS = new Set(["view"]);
+
 // PROJ-483: wiki_pages(workspace_id, slug) is unique — surface a structured
 // ConflictError instead of letting the constraint throw a raw D1 error.
 async function assertSlugAvailable(
@@ -71,6 +76,12 @@ async function assertSlugAvailable(
 	slug: string,
 	excludePageId?: string
 ): Promise<void> {
+	if (RESERVED_WIKI_SLUGS.has(slug)) {
+		throw new ValidationError({
+			formErrors: [`Slug '${slug}' is reserved and cannot be used`],
+			fieldErrors: {},
+		});
+	}
 	const existing = await orm
 		.select({ id: schema.wikiPages.id })
 		.from(schema.wikiPages)

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -65,8 +65,10 @@ function slugify(title: string): string {
 
 // PROJ-487: "view" is the shell path segment the Worker's pretty-URL fallback serves
 // static assets from (/wiki/view/index.html) — a page slugged "view" would collide
-// with it and never resolve. Reserved outright rather than special-cased in routing.
-const RESERVED_WIKI_SLUGS = new Set(["view"]);
+// with it and never resolve. "index" collides the same way: Static Assets' default
+// html_handling maps /wiki/index -> /wiki/index.html, so it never reaches the Worker
+// either. Both reserved outright rather than special-cased in routing.
+const RESERVED_WIKI_SLUGS = new Set(["view", "index"]);
 
 // PROJ-483: wiki_pages(workspace_id, slug) is unique — surface a structured
 // ConflictError instead of letting the constraint throw a raw D1 error.

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -271,7 +271,7 @@ export async function listWikiPages(ctx: ServiceCtx, input: unknown) {
 		.where(and(...conditions))
 		.orderBy(asc(schema.wikiPages.title));
 
-	return rows.map((r) => ({ ...r, url: wikiPagePath(r.slug, r.project_id) }));
+	return rows.map((r) => ({ ...r, url: wikiPagePath(r.slug) }));
 }
 
 // PROJ-486: FTS5 MATCH treats bare input as query syntax (AND/OR/NOT, column filters,
@@ -409,7 +409,7 @@ export async function getWikiPage(ctx: ServiceCtx, slugOrId: string) {
 	const page = direct ?? (await resolveWikiPageByRedirect(orm, ctx.workspaceId, slugOrId));
 	if (!page) throw new NotFoundError("Wiki page not found");
 	await assertWikiPageVisible(ctx, page.project_id);
-	return { ...page, url: wikiPagePath(page.slug, page.project_id) };
+	return { ...page, url: wikiPagePath(page.slug) };
 }
 
 // PROJ-485: "what links here" — pages that link to `slugOrId` via a resolved wiki_links
@@ -487,7 +487,7 @@ export async function createWikiPage(ctx: ServiceCtx, input: unknown) {
 	// PROJ-485: parse [[Target]]/URL links out of the new page's content into wiki_links.
 	await reindexWikiLinks(ctx, orm, id, content ?? "");
 	await recordActivity(ctx, { entityType: "wiki_page", entityId: id, action: "created" });
-	return { id, slug, projectId: projectId ?? null, url: wikiPagePath(slug, projectId ?? null) };
+	return { id, slug, projectId: projectId ?? null, url: wikiPagePath(slug) };
 }
 
 // PROJ-484: id of the most recently created revision for a page, or null if the page
@@ -816,7 +816,7 @@ export async function updateWikiPage(ctx: ServiceCtx, idOrSlug: string, input: u
 		diff: buildWikiPageUpdateDiff({ title, content }),
 	});
 
-	return { ok: true, url: wikiPagePath(slug ?? page.slug, page.projectId) };
+	return { ok: true, url: wikiPagePath(slug ?? page.slug) };
 }
 
 // PROJ-238: breadth-first walk of parent_id children, chunked to stay under D1's
@@ -990,7 +990,7 @@ export async function getWikiTree(ctx: ServiceCtx, projectId?: string): Promise<
 			id: p.id,
 			slug: p.slug,
 			title: p.title,
-			url: wikiPagePath(p.slug, p.projectId),
+			url: wikiPagePath(p.slug),
 			children: [],
 		});
 	}

--- a/apps/api/src/test/health.test.ts
+++ b/apps/api/src/test/health.test.ts
@@ -61,4 +61,14 @@ describe("SPA catch-all (ASSETS absent in test env)", () => {
 		const res = await SELF.fetch("http://localhost/health");
 		expect(res.status).toBe(200);
 	});
+
+	it("returns 404 for /wiki/:slug pretty-URL paths (ASSETS absent in test env)", async () => {
+		const res = await SELF.fetch("http://localhost/wiki/some-page");
+		expect(res.status).toBe(404);
+	});
+
+	it("returns 404 for the legacy /wiki?slug= redirect route (ASSETS absent in test env)", async () => {
+		const res = await SELF.fetch("http://localhost/wiki?slug=some-page");
+		expect(res.status).toBe(404);
+	});
 });

--- a/apps/api/src/test/wiki-ssr.test.ts
+++ b/apps/api/src/test/wiki-ssr.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { injectWikiMetadata } from "../lib/wiki-ssr";
+
+const SHELL_HTML = `<!doctype html><html><head><title>Wiki — Projektor</title>
+<meta property="og:title" content="Projektor — project management for humans and agents." />
+<meta property="og:description" content="Projektor — project management for humans and agents." />
+<meta property="og:url" content="https://example.test/wiki/view" />
+</head><body></body></html>`;
+
+describe("injectWikiMetadata", () => {
+	it("rewrites title and og tags with the resolved page's real values", async () => {
+		const response = new Response(SHELL_HTML, { headers: { "content-type": "text/html" } });
+		const rewritten = injectWikiMetadata(
+			response,
+			{
+				title: "Deploy Runbook",
+				content: "Steps to deploy the service.",
+				url: "/wiki/deploy-runbook",
+			},
+			"https://example.test/wiki/deploy-runbook"
+		);
+		const html = await rewritten.text();
+
+		expect(html).toContain("<title>Deploy Runbook — Projektor Wiki</title>");
+		expect(html).toContain('content="Deploy Runbook"');
+		expect(html).toContain('content="Steps to deploy the service."');
+		expect(html).toContain('content="https://example.test/wiki/deploy-runbook"');
+	});
+
+	it("strips markdown syntax from the injected description excerpt", async () => {
+		const response = new Response(SHELL_HTML, { headers: { "content-type": "text/html" } });
+		const rewritten = injectWikiMetadata(
+			response,
+			{
+				title: "Notes",
+				content: "# Heading\n\nSee [[Other Page|here]] and [a link](https://example.com).",
+				url: "/wiki/notes",
+			},
+			"https://example.test/wiki/notes"
+		);
+		const html = await rewritten.text();
+
+		expect(html).not.toContain("[[Other Page");
+		expect(html).not.toContain("](https://example.com)");
+		expect(html).toContain("Other Page");
+		expect(html).toContain("a link");
+	});
+});

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -81,13 +81,13 @@ describe("Wiki API", () => {
 				body: JSON.stringify({ title: "Weekly Updates", content: "index" }),
 			});
 			const created = (await createRes.json()) as { url: string };
-			expect(created.url).toBe("/wiki?slug=weekly-updates");
+			expect(created.url).toBe("/wiki/weekly-updates");
 
 			const getRes = await SELF.fetch("http://localhost/api/wiki/weekly-updates", {
 				headers: authHeaders(token, slug),
 			});
 			const fetched = (await getRes.json()) as { url: string };
-			expect(fetched.url).toBe("/wiki?slug=weekly-updates");
+			expect(fetched.url).toBe("/wiki/weekly-updates");
 
 			const updateRes = await SELF.fetch("http://localhost/api/wiki/weekly-updates", {
 				method: "PUT",
@@ -95,22 +95,22 @@ describe("Wiki API", () => {
 				body: JSON.stringify({ content: "index v2" }),
 			});
 			const updated = (await updateRes.json()) as { url: string };
-			expect(updated.url).toBe("/wiki?slug=weekly-updates");
+			expect(updated.url).toBe("/wiki/weekly-updates");
 
 			const listRes = await SELF.fetch("http://localhost/api/wiki", {
 				headers: authHeaders(token, slug),
 			});
 			const list = (await listRes.json()) as Array<{ slug: string; url: string }>;
-			expect(list.find((p) => p.slug === "weekly-updates")?.url).toBe("/wiki?slug=weekly-updates");
+			expect(list.find((p) => p.slug === "weekly-updates")?.url).toBe("/wiki/weekly-updates");
 
 			const treeRes = await SELF.fetch("http://localhost/api/wiki/tree", {
 				headers: authHeaders(token, slug),
 			});
 			const tree = (await treeRes.json()) as Array<{ slug: string; url: string }>;
-			expect(tree.find((p) => p.slug === "weekly-updates")?.url).toBe("/wiki?slug=weekly-updates");
+			expect(tree.find((p) => p.slug === "weekly-updates")?.url).toBe("/wiki/weekly-updates");
 		});
 
-		it("includes projectId in the url when the page is scoped to a project", async () => {
+		it("does not include projectId in the url when the page is scoped to a project (slugs are workspace-unique, PROJ-483)", async () => {
 			const project = await seedProject(workspaceId);
 			await seedGroupGrant(workspaceId, userId, project.id);
 			const createRes = await SELF.fetch("http://localhost/api/wiki", {
@@ -119,7 +119,7 @@ describe("Wiki API", () => {
 				body: JSON.stringify({ title: "Project Notes", content: "notes", projectId: project.id }),
 			});
 			const created = (await createRes.json()) as { url: string };
-			expect(created.url).toBe(`/wiki?slug=project-notes&projectId=${project.id}`);
+			expect(created.url).toBe("/wiki/project-notes");
 		});
 	});
 
@@ -1078,7 +1078,7 @@ describe("Wiki slug uniqueness and redirects (PROJ-483)", () => {
 		});
 		expect(updateRes.status).toBe(200);
 		const updated = (await updateRes.json()) as { url: string };
-		expect(updated.url).toContain("slug=product-roadmap");
+		expect(updated.url).toBe("/wiki/product-roadmap");
 
 		const newRes = await SELF.fetch("http://localhost/api/wiki/product-roadmap", {
 			headers: authHeaders(token, slug),
@@ -1241,7 +1241,7 @@ describe("Wiki slug uniqueness and redirects (PROJ-483)", () => {
 				authHeaders(token, slug)
 			)
 		);
-		expect(updatedResult.url).toContain("slug=team-handbook");
+		expect(updatedResult.url).toBe("/wiki/team-handbook");
 
 		const oldPage = mcpData<{ slug: string }>(
 			await mcpCall(workspaceId, "get_wiki_page", { slug: "handbook" }, authHeaders(token, slug))

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -1086,6 +1086,30 @@ describe("Wiki slug uniqueness and redirects (PROJ-483)", () => {
 		expect(res.status).toBe(400);
 	});
 
+	it("POST /api/wiki rejects the reserved slug 'index' (PROJ-487, 400)", async () => {
+		const res = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Index", content: "v1" }),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it("PUT /api/wiki/:slug rejects renaming to the reserved slug 'index' (PROJ-487, 400)", async () => {
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Delta", content: "d" }),
+		});
+
+		const res = await SELF.fetch("http://localhost/api/wiki/delta", {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ slug: "index" }),
+		});
+		expect(res.status).toBe(400);
+	});
+
 	it("PUT /api/wiki/:slug renaming the slug creates a redirect; the old slug still resolves", async () => {
 		const createRes = await SELF.fetch("http://localhost/api/wiki", {
 			method: "POST",

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -1062,6 +1062,30 @@ describe("Wiki slug uniqueness and redirects (PROJ-483)", () => {
 		expect(res.status).toBe(409);
 	});
 
+	it("POST /api/wiki rejects the reserved slug 'view' (PROJ-487, 400)", async () => {
+		const res = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "View", content: "v1" }),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it("PUT /api/wiki/:slug rejects renaming to the reserved slug 'view' (PROJ-487, 400)", async () => {
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Gamma", content: "g" }),
+		});
+
+		const res = await SELF.fetch("http://localhost/api/wiki/gamma", {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ slug: "view" }),
+		});
+		expect(res.status).toBe(400);
+	});
+
 	it("PUT /api/wiki/:slug renaming the slug creates a redirect; the old slug still resolves", async () => {
 		const createRes = await SELF.fetch("http://localhost/api/wiki", {
 			method: "POST",

--- a/apps/web/src/islands/ProjectLanding.test.tsx
+++ b/apps/web/src/islands/ProjectLanding.test.tsx
@@ -130,12 +130,12 @@ describe("ProjectLanding", () => {
 		expect(screen.getByText("Cumulative flow")).toBeTruthy();
 	});
 
-	it("recent-wiki links preserve projectId so the destination stays scoped (PROJ-352)", async () => {
+	it("recent-wiki links preserve projectId so the destination stays scoped (PROJ-352, PROJ-487)", async () => {
 		history.replaceState(null, "", "?id=p1");
 		mockFetchProject([ISSUE], [WIKI_PAGE]);
 		render(<ProjectLanding />);
 		const link = (await screen.findByText("Getting Started")).closest("a");
-		expect(link?.getAttribute("href")).toBe("/wiki/getting-started");
+		expect(link?.getAttribute("href")).toBe("/wiki/getting-started?projectId=p1");
 	});
 
 	// PROJ-376: pretty project URLs (/projects/view/<slug>) resolve via the path,

--- a/apps/web/src/islands/ProjectLanding.test.tsx
+++ b/apps/web/src/islands/ProjectLanding.test.tsx
@@ -135,7 +135,7 @@ describe("ProjectLanding", () => {
 		mockFetchProject([ISSUE], [WIKI_PAGE]);
 		render(<ProjectLanding />);
 		const link = (await screen.findByText("Getting Started")).closest("a");
-		expect(link?.getAttribute("href")).toBe("/wiki?slug=getting-started&projectId=p1");
+		expect(link?.getAttribute("href")).toBe("/wiki/getting-started");
 	});
 
 	// PROJ-376: pretty project URLs (/projects/view/<slug>) resolve via the path,

--- a/apps/web/src/islands/ProjectLanding.tsx
+++ b/apps/web/src/islands/ProjectLanding.tsx
@@ -304,7 +304,7 @@ function RecentIssuesSection({ issues }: { issues: RecentIssue[] }) {
 	);
 }
 
-function RecentWikiSection({ pages }: { pages: RecentWikiPage[] }) {
+function RecentWikiSection({ pages, projectId }: { pages: RecentWikiPage[]; projectId: string }) {
 	return (
 		<section class="mb-8" aria-labelledby="recent-wiki-heading">
 			<h2 id="recent-wiki-heading" class={SECTION_HEADING_CLASS}>
@@ -318,7 +318,7 @@ function RecentWikiSection({ pages }: { pages: RecentWikiPage[] }) {
 						<div key={page.id} class="py-2 border-b border-border last:border-b-0">
 							<div class="flex justify-between items-baseline gap-2">
 								<a
-									href={`/wiki/${encodeURIComponent(page.slug)}`}
+									href={`/wiki/${encodeURIComponent(page.slug)}${projectId ? `?projectId=${encodeURIComponent(projectId)}` : ""}`}
 									class="text-text-base no-underline text-sm hover:underline focus:underline"
 								>
 									{page.title}
@@ -434,7 +434,7 @@ export default function ProjectLanding({ workspaceSlug }: Props) {
 
 			<ProjectFlowCharts workspaceSlug={workspaceSlug} projectId={project.id} />
 			<RecentIssuesSection issues={recentIssues} />
-			<RecentWikiSection pages={recentWiki} />
+			<RecentWikiSection pages={recentWiki} projectId={project.id} />
 		</div>
 	);
 }

--- a/apps/web/src/islands/ProjectLanding.tsx
+++ b/apps/web/src/islands/ProjectLanding.tsx
@@ -304,7 +304,7 @@ function RecentIssuesSection({ issues }: { issues: RecentIssue[] }) {
 	);
 }
 
-function RecentWikiSection({ pages, projectId }: { pages: RecentWikiPage[]; projectId: string }) {
+function RecentWikiSection({ pages }: { pages: RecentWikiPage[] }) {
 	return (
 		<section class="mb-8" aria-labelledby="recent-wiki-heading">
 			<h2 id="recent-wiki-heading" class={SECTION_HEADING_CLASS}>
@@ -318,7 +318,7 @@ function RecentWikiSection({ pages, projectId }: { pages: RecentWikiPage[]; proj
 						<div key={page.id} class="py-2 border-b border-border last:border-b-0">
 							<div class="flex justify-between items-baseline gap-2">
 								<a
-									href={`/wiki?slug=${encodeURIComponent(page.slug)}&projectId=${encodeURIComponent(projectId)}`}
+									href={`/wiki/${encodeURIComponent(page.slug)}`}
 									class="text-text-base no-underline text-sm hover:underline focus:underline"
 								>
 									{page.title}
@@ -434,7 +434,7 @@ export default function ProjectLanding({ workspaceSlug }: Props) {
 
 			<ProjectFlowCharts workspaceSlug={workspaceSlug} projectId={project.id} />
 			<RecentIssuesSection issues={recentIssues} />
-			<RecentWikiSection pages={recentWiki} projectId={project.id} />
+			<RecentWikiSection pages={recentWiki} />
 		</div>
 	);
 }

--- a/apps/web/src/islands/WikiPage.test.tsx
+++ b/apps/web/src/islands/WikiPage.test.tsx
@@ -1,7 +1,9 @@
 // WikiPage island — mock-fetch tests.
 //
-// WikiPage reads ?slug= from the URL, fetches the tree + page + revisions via
-// apiFetch (which calls global fetch). The pattern: set the URL with
+// WikiPage resolves its slug from (in order) the `slug` prop — how the /wiki/:slug
+// astro routes render it (PROJ-487) — a `?slug=` query param (legacy), or the
+// pathname (production's wiki/view.astro shell). It fetches the tree + page +
+// revisions via apiFetch (which calls global fetch). The pattern: set the URL with
 // history.replaceState, override the default stub from setup.ts with
 // vi.stubGlobal, then await findBy* for the async state update.
 import { fireEvent, render, screen, waitFor } from "@testing-library/preact";
@@ -26,7 +28,7 @@ const PAGE: WikiPageData = {
 	updated_at: 1000,
 };
 
-function mockFetchWiki(page: WikiPageData | null, ok = true) {
+function mockFetchWiki(page: WikiPageData | null, ok = true, status = 404) {
 	vi.stubGlobal(
 		"fetch",
 		vi.fn().mockImplementation((url: string) => {
@@ -38,7 +40,7 @@ function mockFetchWiki(page: WikiPageData | null, ok = true) {
 				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
 			}
 			if (!ok) {
-				return Promise.resolve({ ok: false, status: 404 });
+				return Promise.resolve({ ok: false, status });
 			}
 			return Promise.resolve({ ok: true, json: () => Promise.resolve(page) });
 		})
@@ -51,6 +53,8 @@ beforeEach(() => {
 
 afterEach(() => {
 	history.replaceState(null, "", "/");
+	document.title = "";
+	for (const el of document.head.querySelectorAll('meta[property^="og:"]')) el.remove();
 });
 
 describe("WikiPage", () => {
@@ -66,9 +70,8 @@ describe("WikiPage", () => {
 	});
 
 	it("shows loading state while fetching the page", async () => {
-		history.replaceState(null, "", "?slug=my-page");
 		vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => {})));
-		render(<WikiPage />);
+		render(<WikiPage slug="my-page" />);
 		// Both the sidebar tree and the main content show "Loading…" while pending.
 		// findAllByText waits for at least one match.
 		const loadingEls = await screen.findAllByText("Loading…");
@@ -76,37 +79,38 @@ describe("WikiPage", () => {
 	});
 
 	it("renders page title and content after fetch resolves", async () => {
-		history.replaceState(null, "", "?slug=my-page");
 		mockFetchWiki(PAGE);
-		render(<WikiPage />);
+		render(<WikiPage slug="my-page" />);
 		expect(await screen.findByText("My Page")).toBeTruthy();
 	});
 
 	it("shows Edit button once the page is loaded", async () => {
-		history.replaceState(null, "", "?slug=my-page");
 		mockFetchWiki(PAGE);
-		render(<WikiPage />);
+		render(<WikiPage slug="my-page" />);
 		await screen.findByText("My Page");
 		expect(screen.getByRole("button", { name: "Edit" })).toBeTruthy();
 	});
 
-	it("shows an error message when the page fetch fails", async () => {
-		history.replaceState(null, "", "?slug=my-page");
-		mockFetchWiki(null, false);
-		render(<WikiPage />);
+	it("shows an error message when the page fetch fails (non-404)", async () => {
+		mockFetchWiki(null, false, 500);
+		render(<WikiPage slug="my-page" />);
 		expect(await screen.findByText(/Failed to load page/i)).toBeTruthy();
 	});
 
+	it("shows a 404 message when the slug resolves to nothing (PROJ-487)", async () => {
+		mockFetchWiki(null, false, 404);
+		render(<WikiPage slug="does-not-exist" />);
+		expect(await screen.findByText(/No wiki page found at "does-not-exist"/i)).toBeTruthy();
+	});
+
 	it("shows Move button once the page is loaded", async () => {
-		history.replaceState(null, "", "?slug=my-page");
 		mockFetchWiki(PAGE);
-		render(<WikiPage />);
+		render(<WikiPage slug="my-page" />);
 		await screen.findByText("My Page");
 		expect(screen.getByRole("button", { name: "Move" })).toBeTruthy();
 	});
 
 	it("moves a page to a new parent via PUT and refetches tree/page", async () => {
-		history.replaceState(null, "", "?slug=my-page");
 		const OTHER_PAGE_NODE = { id: "w2", slug: "other-page", title: "Other Page", children: [] };
 		const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
 			const u = String(url);
@@ -122,7 +126,7 @@ describe("WikiPage", () => {
 			return Promise.resolve({ ok: true, json: () => Promise.resolve(PAGE) });
 		});
 		vi.stubGlobal("fetch", fetchMock);
-		render(<WikiPage />);
+		render(<WikiPage slug="my-page" />);
 		await screen.findByText("My Page");
 
 		fireEvent.click(screen.getByRole("button", { name: "Move" }));
@@ -137,6 +141,94 @@ describe("WikiPage", () => {
 			expect(putCall?.[0]).toContain("/api/wiki/my-page");
 			expect(JSON.parse(putCall?.[1].body)).toEqual({ parentId: "w2" });
 		});
+	});
+});
+
+// PROJ-487: path-based /wiki/:slug routing + client-set SSR-shell metadata (static
+// output has no per-request server render, see AGENTS.md — this is the closest
+// equivalent) + legacy ?slug= redirect.
+describe("WikiPage — path-based routing (PROJ-487)", () => {
+	const realLocation = window.location;
+
+	afterEach(() => {
+		Object.defineProperty(window, "location", { configurable: true, value: realLocation });
+	});
+
+	// jsdom's Location.prototype.replace is a non-configurable, non-writable own data
+	// property, so neither vi.spyOn nor a direct assignment (nor a Proxy — it trips the
+	// "must return the target's actual value" invariant for such properties) can shadow
+	// it. Swap `window.location` for an unrelated plain object instead (only the fields
+	// the code under test reads), restored in afterEach above.
+	function stubLocationReplace() {
+		const replace = vi.fn();
+		Object.defineProperty(window, "location", {
+			configurable: true,
+			value: {
+				pathname: realLocation.pathname,
+				search: realLocation.search,
+				origin: realLocation.origin,
+				hostname: realLocation.hostname,
+				host: realLocation.host,
+				replace,
+			},
+		});
+		return replace;
+	}
+
+	it("resolves the slug from the URL path when no slug prop is given (production wiki/view.astro shell)", async () => {
+		history.replaceState(null, "", "/wiki/my-page");
+		mockFetchWiki(PAGE);
+		render(<WikiPage />);
+		expect(await screen.findByText("My Page")).toBeTruthy();
+	});
+
+	it("sets document title and OG meta tags from the fetched page", async () => {
+		mockFetchWiki(PAGE);
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+		await waitFor(() => {
+			expect(document.title).toBe("My Page — Projektor Wiki");
+		});
+		expect(document.head.querySelector('meta[property="og:title"]')?.getAttribute("content")).toBe(
+			"My Page"
+		);
+		expect(
+			document.head.querySelector('meta[property="og:description"]')?.getAttribute("content")
+		).toContain("Hello world content");
+		expect(
+			document.head.querySelector('meta[property="og:url"]')?.getAttribute("content")
+		).toContain("/wiki/my-page");
+	});
+
+	it("redirects a legacy ?slug= query URL to the canonical /wiki/:slug path", async () => {
+		history.replaceState(null, "", "/wiki?slug=my-page");
+		const replace = stubLocationReplace();
+		mockFetchWiki(PAGE);
+		render(<WikiPage />);
+		await waitFor(() => {
+			expect(replace).toHaveBeenCalledWith("/wiki/my-page");
+		});
+	});
+
+	it("redirects straight to the current canonical slug, not the requested one (avoids a redirect chain, PROJ-483)", async () => {
+		// The old/renamed slug was requested (e.g. via a stale bookmark that hit the
+		// Worker's pretty-URL fallback), but the API's live-then-redirect lookup
+		// resolved it to the page's current slug.
+		const replace = stubLocationReplace();
+		mockFetchWiki({ ...PAGE, slug: "new-slug" });
+		render(<WikiPage slug="old-slug" />);
+		await waitFor(() => {
+			expect(replace).toHaveBeenCalledWith("/wiki/new-slug");
+		});
+	});
+
+	it("does not redirect once already on the canonical path", async () => {
+		history.replaceState(null, "", "/wiki/my-page");
+		const replace = stubLocationReplace();
+		mockFetchWiki(PAGE);
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+		expect(replace).not.toHaveBeenCalled();
 	});
 });
 
@@ -164,9 +256,8 @@ describe("WikiPage — project scope control (PROJ-352)", () => {
 	}
 
 	it("defaults to 'Workspace (all projects)' scope when no projectId is set", async () => {
-		history.replaceState(null, "", "?slug=my-page");
 		mockFetchWikiWithProjects(PAGE);
-		render(<WikiPage />);
+		render(<WikiPage slug="my-page" />);
 		await screen.findByText("My Page");
 		expect(screen.getByRole("combobox", { name: "Wiki project scope" }).textContent).toMatch(
 			/Workspace \(all projects\)/i
@@ -174,9 +265,9 @@ describe("WikiPage — project scope control (PROJ-352)", () => {
 	});
 
 	it("shows the project's scope when projectId is set via the URL", async () => {
-		history.replaceState(null, "", "?slug=my-page&projectId=p1");
+		history.replaceState(null, "", "?projectId=p1");
 		mockFetchWikiWithProjects(PAGE);
-		render(<WikiPage />);
+		render(<WikiPage slug="my-page" />);
 		await screen.findByText("My Page");
 		await waitFor(() => {
 			expect(screen.getByRole("combobox", { name: "Wiki project scope" }).textContent).toMatch(
@@ -187,9 +278,8 @@ describe("WikiPage — project scope control (PROJ-352)", () => {
 });
 
 async function startEditingWithTitleInput(): Promise<HTMLInputElement> {
-	history.replaceState(null, "", "?slug=my-page");
 	mockFetchWiki(PAGE);
-	render(<WikiPage />);
+	render(<WikiPage slug="my-page" />);
 	await screen.findByText("My Page");
 	fireEvent.click(screen.getByRole("button", { name: "Edit" }));
 	return screen.getByLabelText("Page title") as HTMLInputElement;
@@ -200,10 +290,9 @@ async function renderWithDraftAndOpenEdit(draft: {
 	content: string;
 	savedAt: number;
 }) {
-	history.replaceState(null, "", "?slug=my-page");
 	localStorage.setItem("wiki-draft:w1", JSON.stringify(draft));
 	mockFetchWiki(PAGE);
-	render(<WikiPage />);
+	render(<WikiPage slug="my-page" />);
 	await screen.findByText("My Page");
 	fireEvent.click(screen.getByRole("button", { name: "Edit" }));
 }

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -69,6 +69,7 @@ interface Attachment {
 interface Props {
 	workspaceSlug?: string;
 	projectId?: string;
+	slug?: string;
 }
 
 function formatBytes(bytes: number): string {
@@ -1062,6 +1063,15 @@ function WikiMainContent(props: {
 	}
 	if (props.loading) return <p aria-live="polite">Loading…</p>;
 	if (props.error) {
+		// PROJ-487: a slug that resolves to nothing (not even via a PROJ-483 redirect)
+		// gets a dedicated 404 message rather than the generic failure text.
+		if (props.error.includes("404")) {
+			return (
+				<p role="alert" class="text-text-muted">
+					No wiki page found at "{props.slug}".
+				</p>
+			);
+		}
 		return (
 			<p role="alert" class="text-[var(--danger-text)]">
 				Failed to load page: {props.error}
@@ -1072,17 +1082,51 @@ function WikiMainContent(props: {
 	return <PageArticle {...props.articleProps} page={props.page} />;
 }
 
-function useWikiUrlState(projectIdProp: string | undefined) {
-	const [slug, setSlug] = useState("");
+// PROJ-487: /wiki/:slug is now the canonical path. `slugProp` covers the astro
+// dynamic route (dev server); `view.astro` (the production pretty-URL shell served
+// via the Worker fallback, see apps/api/src/index.ts) has no such param, so this
+// also falls back to parsing the slug straight out of the path, matching the
+// convention IssueDetail already uses for /projects/:key/issues/:n/*.
+function slugFromPathname(pathname: string): string {
+	const match = /^\/wiki\/([^/]+)\/?$/.exec(pathname);
+	return match ? decodeURIComponent(match[1]) : "";
+}
+
+function useWikiUrlState(projectIdProp: string | undefined, slugProp: string | undefined) {
+	const [slug, setSlug] = useState(slugProp ?? "");
 	const [projectId, setProjectId] = useState(projectIdProp ?? "");
 
 	useEffect(() => {
-		const params = new URLSearchParams(window.location.search);
-		setSlug(params.get("slug") ?? "");
-		if (!projectIdProp) setProjectId(params.get("projectId") ?? "");
-	}, [projectIdProp]);
+		if (!slugProp) {
+			const params = new URLSearchParams(window.location.search);
+			// ?slug= is the legacy PROJ-307 query form. Kept as a fallback (not just for
+			// the redirect below) so an old bookmark/link still resolves even if the
+			// redirect effect hasn't run yet.
+			setSlug(params.get("slug") || slugFromPathname(window.location.pathname));
+		}
+		if (!projectIdProp)
+			setProjectId(new URLSearchParams(window.location.search).get("projectId") ?? "");
+	}, [projectIdProp, slugProp]);
 
 	return { slug, setSlug, projectId };
+}
+
+// PROJ-487: /wiki?slug=X (and stale slugs that PROJ-483 redirects) get sent to the
+// canonical /wiki/:slug path client-side — this build is static output (no per-request
+// server rendering, see AGENTS.md's release-artifact constraint), so a real HTTP 301
+// isn't available here; this is the closest equivalent. `fetchedSlug` is the page's
+// *current* slug from the API response, so a rename redirects straight to the new
+// canonical path instead of chaining through the old one.
+function useLegacyQuerySlugRedirect(fetchedSlug: string | undefined, requestedSlug: string) {
+	useEffect(() => {
+		if (!fetchedSlug) return;
+		const params = new URLSearchParams(window.location.search);
+		const hasLegacyQuery = params.has("slug");
+		const onCanonicalPath = window.location.pathname === `/wiki/${encodeURIComponent(fetchedSlug)}`;
+		if ((hasLegacyQuery || fetchedSlug !== requestedSlug) && !onCanonicalPath) {
+			window.location.replace(`/wiki/${encodeURIComponent(fetchedSlug)}`);
+		}
+	}, [fetchedSlug, requestedSlug]);
 }
 
 function useWikiTree(workspaceSlug: string | undefined, projectId: string) {
@@ -1206,6 +1250,42 @@ function useWikiPageData(workspaceSlug: string | undefined, slug: string) {
 		contentRef,
 		fetchPage,
 	};
+}
+
+function setMetaTag(attr: "name" | "property", key: string, content: string) {
+	let el = document.head.querySelector<HTMLMetaElement>(`meta[${attr}="${key}"]`);
+	if (!el) {
+		el = document.createElement("meta");
+		el.setAttribute(attr, key);
+		document.head.appendChild(el);
+	}
+	el.setAttribute("content", content);
+}
+
+function excerptOf(content: string, maxLength = 200): string {
+	const plain = content
+		.replace(/```[\s\S]*?```/g, " ")
+		.replace(/[#*_>`[\]()!-]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+	return plain.length > maxLength ? `${plain.slice(0, maxLength).trimEnd()}…` : plain;
+}
+
+// PROJ-487: the static build (see AGENTS.md) can't render per-page <title>/OG tags
+// on the server — there's no per-request render step to do it in — so this updates
+// them client-side once the page has loaded, the closest approximation available.
+function useWikiPageMeta(page: WikiPageData | null) {
+	useEffect(() => {
+		if (!page) return;
+		document.title = `${page.title} — Projektor Wiki`;
+		setMetaTag("property", "og:title", page.title);
+		setMetaTag("property", "og:description", excerptOf(page.content));
+		setMetaTag(
+			"property",
+			"og:url",
+			`${window.location.origin}/wiki/${encodeURIComponent(page.slug)}`
+		);
+	}, [page]);
 }
 
 function useTableOfContents(page: WikiPageData | null, contentRef: RefObject<HTMLDivElement>) {
@@ -1710,7 +1790,7 @@ function createWikiActions(args: {
 		setToc([]);
 		setSlug(s);
 		cancelMove();
-		history.pushState(null, "", `?slug=${encodeURIComponent(s)}`);
+		history.pushState(null, "", s ? `/wiki/${encodeURIComponent(s)}` : "/wiki");
 	}
 
 	function startCreate(parentId: string | null = null) {
@@ -1734,7 +1814,7 @@ function createWikiActions(args: {
 			});
 			setPage(null);
 			setSlug("");
-			history.pushState(null, "", window.location.pathname);
+			history.pushState(null, "", "/wiki");
 			await fetchTree();
 		} catch (e) {
 			alert(`Delete failed: ${String(e)}`);
@@ -1966,9 +2046,13 @@ function buildArticleProps(article: {
 	};
 }
 
-export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Props) {
+export default function WikiPage({
+	workspaceSlug,
+	projectId: projectIdProp,
+	slug: slugProp,
+}: Props) {
 	const gate = useAccessGate(workspaceSlug);
-	const { slug, setSlug, projectId } = useWikiUrlState(projectIdProp);
+	const { slug, setSlug, projectId } = useWikiUrlState(projectIdProp, slugProp);
 	const { pageTree, pageMap, treeLoading, fetchTree } = useWikiTree(workspaceSlug, projectId);
 	const { searchQuery, setSearchQuery, searchResults, searchLoading } = useWikiSearch(
 		workspaceSlug,
@@ -1976,6 +2060,8 @@ export default function WikiPage({ workspaceSlug, projectId: projectIdProp }: Pr
 	);
 
 	const pageData = useWikiPageData(workspaceSlug, slug);
+	useLegacyQuerySlugRedirect(pageData.page?.slug, slug);
+	useWikiPageMeta(pageData.page);
 	const { toc, setToc, activeHeadingId } = useTableOfContents(pageData.page, pageData.contentRef);
 	const attach = useWikiAttachments(workspaceSlug, pageData.page);
 	const editState = useWikiEditing(

--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -8,9 +8,12 @@ import pkg from '../../package.json';
 
 interface Props {
   title?: string;
+  description?: string;
 }
-const { title = 'Projektor' } = Astro.props;
+const { title = 'Projektor', description = 'Projektor — project management for humans and agents.' } =
+  Astro.props;
 const appVersion = pkg.version;
+const ogUrl = Astro.url.toString();
 
 const path = Astro.url.pathname;
 const isActive = (href: string): boolean =>
@@ -35,6 +38,11 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
     <link rel="apple-touch-icon" href="/icon-192.png" />
     <link rel="manifest" href="/manifest.json" />
     <title>{title}</title>
+    <meta name="description" content={description} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={ogUrl} />
+    <meta property="og:type" content="website" />
     <ClientRouter />
     <!-- PROJ-418: @vite-pwa/astro's generateSW strategy builds dist/sw.js and
          dist/registerSW.js but never references either from a rendered page -

--- a/apps/web/src/pages/wiki/[slug].astro
+++ b/apps/web/src/pages/wiki/[slug].astro
@@ -1,0 +1,26 @@
+---
+import Base from '../../layouts/Base.astro';
+import WikiPage from '../../islands/WikiPage';
+
+export async function getStaticPaths() {
+  // Wiki slugs aren't known at build time; the island resolves the page client-side
+  // via the slug prop (GET /api/wiki/:slug). Production traffic for /wiki/:slug is
+  // served by wiki/view.astro through the Worker's pretty-URL fallback (see
+  // apps/api/src/index.ts) — this file exists so `astro dev` can resolve the path
+  // directly (same pattern as projects/[projectSlug]/issues/[issueNumber]/[titleSlug]).
+  return [];
+}
+
+const { slug } = Astro.params as { slug: string };
+// PROJ-487: the release artifact never bakes PUBLIC_WORKSPACE_SLUG (it's one binary
+// deployed to potentially several hostnames/workspaces). Unlike Groups/Tokens
+// (/api/workspaces/:slug/...), WikiPage's API calls (/api/wiki/...) don't embed the
+// workspace slug in the URL — an undefined prop here just omits the X-Workspace-Slug
+// header, and the Worker's workspaceMiddleware resolves the tenant from the Host
+// header instead (WORKSPACE_SUBDOMAIN_ROUTING), same as every other non-slug-scoped
+// page (issues, projects). No client-side hostname resolution needed for this route.
+const workspaceSlug = import.meta.env.PUBLIC_WORKSPACE_SLUG as string | undefined;
+---
+<Base title="Wiki — Projektor">
+  <WikiPage client:load workspaceSlug={workspaceSlug} slug={slug} />
+</Base>

--- a/apps/web/src/pages/wiki/view.astro
+++ b/apps/web/src/pages/wiki/view.astro
@@ -1,0 +1,12 @@
+---
+import Base from '../../layouts/Base.astro';
+import WikiPage from '../../islands/WikiPage';
+
+// Slug is read from the URL path at runtime by the island (static output cannot use
+// dynamic routes) — this is the shell the Worker's pretty-URL fallback serves for
+// /wiki/:slug (see apps/api/src/index.ts), mirroring issues/view.astro.
+const workspaceSlug = import.meta.env.PUBLIC_WORKSPACE_SLUG as string | undefined;
+---
+<Base title="Wiki — Projektor">
+  <WikiPage client:load workspaceSlug={workspaceSlug} />
+</Base>

--- a/apps/web/src/utils/markdown.ts
+++ b/apps/web/src/utils/markdown.ts
@@ -60,7 +60,7 @@ function resolveWikilinks(
 			const displayText = rawLabel?.trim() ?? title;
 			const slug = titleMap.get(title.toLowerCase());
 			if (slug) {
-				return `[${displayText}](?slug=${encodeURIComponent(slug)})`;
+				return `[${displayText}](/wiki/${encodeURIComponent(slug)})`;
 			}
 			const href = `?createTitle=${encodeURIComponent(title)}`;
 			return `<span class="wiki-link-broken">${escapeHtml(displayText)} <a href="${href}">+</a></span>`;

--- a/scripts/release-assets/wrangler.example.toml
+++ b/scripts/release-assets/wrangler.example.toml
@@ -11,12 +11,17 @@ compatibility_date = "__COMPAT_DATE__"
 compatibility_flags = ["nodejs_compat"]   # required: the bundled worker imports node:stream / node:events
 
 # ─── Static Assets (pre-built Astro frontend, shipped in the artifact) ─────────
-#   - /api/* and /mcp/*  → always the Worker (run_worker_first)
-#   - everything else     → static assets, asset-first
+#   - /api/*, /mcp/*  → always the Worker (run_worker_first)
+#   - /wiki (exact)    → always the Worker too (PROJ-487): it's a static asset
+#     (wiki/index.html) that would otherwise never reach the Worker, so the legacy
+#     `?slug=` query param could never become a real HTTP redirect. /wiki/:slug
+#     subpaths don't need to be listed here — they have no matching static asset,
+#     so Cloudflare already falls through to the Worker for those.
+#   - everything else  → static assets, asset-first
 [assets]
 directory = "./vendor/web"
 binding = "ASSETS"
-run_worker_first = ["/api/*", "/mcp/*"]
+run_worker_first = ["/api/*", "/mcp/*", "/wiki"]
 
 # ─── D1 Database ───────────────────────────────────────────────
 # Create with: wrangler d1 create projektor


### PR DESCRIPTION
## Summary
Implements path-based `/wiki/:slug` URLs for the agent-first wiki epic (PROJ-482), depending on PROJ-483 (unique/renamable slugs, merged).

- `wikiPagePath(slug)` now returns `/wiki/:slug` (dropped `projectId`; slugs are workspace-unique since PROJ-483). All callers updated (services/wiki.ts, services/files.ts, services/wiki-links.ts, MCP-returned URLs).
- `/wiki?slug=X` now issues a **real HTTP 301** to the canonical `/wiki/:slug` path — done in the Worker (`apps/api/src/index.ts`), with `/wiki` added to `run_worker_first` in wrangler config, resolving through PROJ-483's live-then-redirect slug lookup so a stale slug redirects straight to the current canonical path (no redirect chain).
- `/wiki/:slug` responses get **server-injected `<title>`/OG meta tags** via `HTMLRewriter` (`apps/api/src/lib/wiki-ssr.ts`), populated from a direct D1 lookup of the page, for authenticated requests.
- `Base.astro` gets sensible default OG tags as a fallback for pages without an override.
- `ProjectLanding` preserves project scope across wiki navigation (previously lost when `projectId` was dropped from the URL builder).
- `view` is now a reserved wiki slug (collides with the `/wiki/view/` shell asset path) — rejected as a structured `ValidationError`.

## Scope decision (read before reviewing)
The initial version of this PR used client-side-only redirect (`window.location.replace()`) and metadata (`document.title`/OG mutated post-fetch in a `useEffect`) — an opus review correctly flagged that as not satisfying the ticket's acceptance criteria, since neither a real crawler nor a non-JS client ever sees them. This revision replaces both with the Worker-side mechanism described above.

**What this still does NOT do, deliberately:** serve OG metadata / real link previews to *unauthenticated* external crawlers (Slack/Discord/iMessage unfurls, etc). The wiki is fully auth-gated (`authMiddleware` on `/api/wiki/*`), and the epic's PRD explicitly lists **"public wiki sharing"** as a non-goal. Building an unauthenticated preview path would mean leaking private page titles/content to any requester, which contradicts that non-goal. So "stable agent citations and link previews" from the PRD is satisfied for authenticated in-app/agent use (real URLs, real redirect, real metadata for logged-in requests) but not for external unauthenticated unfurls — that would require extending the issue share-token model to wiki, which is out of scope for this ticket and this epic.

## Test plan
CI green locally: `pnpm gen:docs` (no diff), `pnpm exec biome check .`, `pnpm turbo type-check` (7/7), `pnpm --filter @projektor/db test` (10/10), `pnpm --filter @projektor/api test:coverage` (929/929), `pnpm --filter @projektor/web test:coverage` (472/472), `pnpm --filter @projektor/web build`, `pnpm --filter @projektor/docs build`. New tests cover the Worker redirect handler and the HTMLRewriter metadata injection (`apps/api/src/test/wiki-ssr.test.ts`).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>