### PR TITLE
PROJ-509: resolve wiki revisions/delete by id-or-slug with redirect fallback

### DIFF
--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -98,7 +98,14 @@ async function resolvePageByIdOrSlug(
 	db: D1Database,
 	idOrSlug: string,
 	workspaceId: string
-): Promise<{ id: string; slug: string; title: string; content: string; projectId: string | null }> {
+): Promise<{
+	id: string;
+	slug: string;
+	title: string;
+	content: string;
+	projectId: string | null;
+	parentId: string | null;
+}> {
 	const orm = drizzle(db, { schema });
 	const direct = await orm
 		.select({
@@ -107,6 +114,7 @@ async function resolvePageByIdOrSlug(
 			title: schema.wikiPages.title,
 			content: schema.wikiPages.content,
 			projectId: schema.wikiPages.projectId,
+			parentId: schema.wikiPages.parentId,
 		})
 		.from(schema.wikiPages)
 		.where(
@@ -128,6 +136,8 @@ async function resolvePageByIdOrSlug(
 			content: redirected.content,
 			// eslint-disable-next-line camelcase
 			projectId: redirected.project_id,
+			// eslint-disable-next-line camelcase
+			parentId: redirected.parent_id,
 		};
 	}
 	throw new NotFoundError("Wiki page not found");
@@ -898,8 +908,12 @@ async function deleteWikiPageAttachments(
 	await orm.delete(schema.attachments).where(inArray(schema.attachments.linkedWikiPageId, pageIds));
 }
 
-export async function deleteWikiPage(ctx: ServiceCtx, slug: string, options?: unknown) {
-	const idCheck = IdSchema.safeParse(slug);
+// PROJ-509: resolved via resolvePageByIdOrSlug (id-or-slug + redirect fallback), same
+// as getWikiPage/updateWikiPage/getWikiBacklinks/listWikiRevisions/getWikiRevision —
+// a delete-by-old-slug-after-rename request resolves to the same page rather than
+// 404ing, for consistency across every other page-reference entry point.
+export async function deleteWikiPage(ctx: ServiceCtx, idOrSlug: string, options?: unknown) {
+	const idCheck = IdSchema.safeParse(idOrSlug);
 	if (!idCheck.success)
 		throw new ValidationError({ formErrors: idCheck.error.flatten().formErrors, fieldErrors: {} });
 	const parsedOptions = DeleteWikiPageOptionsSchema.safeParse(options ?? {});
@@ -907,16 +921,8 @@ export async function deleteWikiPage(ctx: ServiceCtx, slug: string, options?: un
 	const { cascade } = parsedOptions.data;
 
 	const orm = drizzle(ctx.db, { schema });
-	const page = await orm
-		.select({
-			id: schema.wikiPages.id,
-			projectId: schema.wikiPages.projectId,
-			parentId: schema.wikiPages.parentId,
-		})
-		.from(schema.wikiPages)
-		.where(and(eq(schema.wikiPages.slug, slug), eq(schema.wikiPages.workspaceId, ctx.workspaceId)))
-		.get();
-	if (!page) throw new NotFoundError("Wiki page not found");
+	const resolved = await resolvePageByIdOrSlug(ctx.db, idOrSlug, ctx.workspaceId);
+	const page = { id: resolved.id, projectId: resolved.projectId, parentId: resolved.parentId };
 
 	// PROJ-311: workspace-level pages need a workspace admin/owner; a project-scoped
 	// page can also be deleted by someone with a project-admin grant.
@@ -1022,15 +1028,14 @@ export async function getWikiTree(ctx: ServiceCtx, projectId?: string): Promise<
 	return roots;
 }
 
-export async function listWikiRevisions(ctx: ServiceCtx, slug: string) {
-	const orm = drizzle(ctx.db, { schema });
-	const page = await orm
-		.select({ id: schema.wikiPages.id, projectId: schema.wikiPages.projectId })
-		.from(schema.wikiPages)
-		.where(and(eq(schema.wikiPages.slug, slug), eq(schema.wikiPages.workspaceId, ctx.workspaceId)))
-		.get();
-	if (!page) throw new NotFoundError("Wiki page not found");
+// PROJ-509: resolves via resolvePageByIdOrSlug (id-or-slug + redirect fallback) so a
+// renamed page's old slug still resolves here, matching getWikiPage/updateWikiPage/
+// getWikiBacklinks instead of 404ing on the exact reference PROJ-484's optimistic-
+// locking workflow tells agents to fetch.
+export async function listWikiRevisions(ctx: ServiceCtx, idOrSlug: string) {
+	const page = await resolvePageByIdOrSlug(ctx.db, idOrSlug, ctx.workspaceId);
 	await assertWikiPageVisible(ctx, page.projectId);
+	const orm = drizzle(ctx.db, { schema });
 
 	return (
 		orm
@@ -1055,15 +1060,11 @@ export async function listWikiRevisions(ctx: ServiceCtx, slug: string) {
 	);
 }
 
-export async function getWikiRevision(ctx: ServiceCtx, slug: string, revisionId: string) {
-	const orm = drizzle(ctx.db, { schema });
-	const page = await orm
-		.select({ id: schema.wikiPages.id, projectId: schema.wikiPages.projectId })
-		.from(schema.wikiPages)
-		.where(and(eq(schema.wikiPages.slug, slug), eq(schema.wikiPages.workspaceId, ctx.workspaceId)))
-		.get();
-	if (!page) throw new NotFoundError("Wiki page not found");
+// PROJ-509: same id-or-slug + redirect resolution as listWikiRevisions above.
+export async function getWikiRevision(ctx: ServiceCtx, idOrSlug: string, revisionId: string) {
+	const page = await resolvePageByIdOrSlug(ctx.db, idOrSlug, ctx.workspaceId);
 	await assertWikiPageVisible(ctx, page.projectId);
+	const orm = drizzle(ctx.db, { schema });
 
 	const revision = await orm
 		.select({

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -1315,6 +1315,169 @@ describe("Wiki slug uniqueness and redirects (PROJ-483)", () => {
 	});
 });
 
+// PROJ-509: list_wiki_revisions/get_wiki_revision/delete_wiki_page resolve via
+// id-or-slug + redirect fallback, matching get_wiki_page/update_wiki_page/
+// get_wiki_backlinks — a renamed page's old slug must keep working for every entry
+// point, not just get_wiki_page (PROJ-484's optimistic-locking workflow fetches
+// baseRevisionId via list_wiki_revisions using whatever reference the caller holds).
+describe("Wiki revisions/delete resolve by old slug after rename (PROJ-509)", () => {
+	let token: string;
+	let slug: string;
+	let workspaceId: string;
+
+	beforeEach(async () => {
+		const fixture = await seedFixture();
+		token = fixture.token;
+		slug = fixture.workspace.slug;
+		workspaceId = fixture.workspace.id;
+	});
+
+	it("REST: GET /:slug/revisions resolves via an old (pre-rename) slug", async () => {
+		const createRes = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Runbook", content: "v1" }),
+		});
+		expect(createRes.status).toBe(201);
+
+		const editRes = await SELF.fetch("http://localhost/api/wiki/runbook", {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "v2" }),
+		});
+		expect(editRes.status).toBe(200);
+
+		const renameRes = await SELF.fetch("http://localhost/api/wiki/runbook", {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ slug: "operations-runbook" }),
+		});
+		expect(renameRes.status).toBe(200);
+		await env.DB.prepare("DELETE FROM rate_limit").run();
+
+		// "runbook" is now only a redirect — the old slug must still resolve here, same
+		// as GET /:slug (getWikiPage).
+		const revRes = await SELF.fetch("http://localhost/api/wiki/runbook/revisions", {
+			headers: authHeaders(token, slug),
+		});
+		expect(revRes.status).toBe(200);
+		const revisions = (await revRes.json()) as Array<{ id: string; title: string }>;
+		expect(revisions).toHaveLength(1);
+		expect(revisions[0].title).toBe("Runbook");
+	});
+
+	it("REST: GET /:slug/revisions/:revisionId resolves via an old (pre-rename) slug", async () => {
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Playbook", content: "v1" }),
+		});
+		await SELF.fetch("http://localhost/api/wiki/playbook", {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "v2" }),
+		});
+		const revRes = await SELF.fetch("http://localhost/api/wiki/playbook/revisions", {
+			headers: authHeaders(token, slug),
+		});
+		const [revision] = (await revRes.json()) as Array<{ id: string }>;
+
+		await SELF.fetch("http://localhost/api/wiki/playbook", {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ slug: "team-playbook" }),
+		});
+		await env.DB.prepare("DELETE FROM rate_limit").run();
+
+		const detailRes = await SELF.fetch(
+			`http://localhost/api/wiki/playbook/revisions/${revision.id}`,
+			{ headers: authHeaders(token, slug) }
+		);
+		expect(detailRes.status).toBe(200);
+		const detail = (await detailRes.json()) as { id: string; content: string };
+		expect(detail.id).toBe(revision.id);
+		expect(detail.content).toBe("v1");
+	});
+
+	it("MCP: list_wiki_revisions and get_wiki_revision resolve via an old (pre-rename) slug", async () => {
+		const created = mcpData<{ slug: string }>(
+			await mcpCall(
+				workspaceId,
+				"create_wiki_page",
+				{ title: "Charter", content: "v1" },
+				authHeaders(token, slug)
+			)
+		);
+		await mcpCall(
+			workspaceId,
+			"update_wiki_page",
+			{ slug: created.slug, content: "v2" },
+			authHeaders(token, slug)
+		);
+		await env.DB.prepare("DELETE FROM rate_limit").run();
+		await mcpCall(
+			workspaceId,
+			"update_wiki_page",
+			{ slug: created.slug, newSlug: "team-charter" },
+			authHeaders(token, slug)
+		);
+		await env.DB.prepare("DELETE FROM rate_limit").run();
+
+		const revisions = mcpData<Array<{ id: string; title: string }>>(
+			await mcpCall(
+				workspaceId,
+				"list_wiki_revisions",
+				{ slug: created.slug },
+				authHeaders(token, slug)
+			)
+		);
+		expect(revisions).toHaveLength(1);
+		expect(revisions[0].title).toBe("Charter");
+
+		const revision = mcpData<{ id: string; content: string }>(
+			await mcpCall(
+				workspaceId,
+				"get_wiki_revision",
+				{ slug: created.slug, revisionId: revisions[0].id },
+				authHeaders(token, slug)
+			)
+		);
+		expect(revision.content).toBe("v1");
+	});
+
+	it("REST: DELETE /:slug resolves via an old (pre-rename) slug", async () => {
+		// Deleting a workspace-level page requires admin/owner (services/wiki.ts).
+		const owner = await seedFixture({ role: "owner" });
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(owner.token, owner.workspace.slug),
+			body: JSON.stringify({ title: "Draft Notes", content: "v1" }),
+		});
+		await SELF.fetch("http://localhost/api/wiki/draft-notes", {
+			method: "PUT",
+			headers: authHeaders(owner.token, owner.workspace.slug),
+			body: JSON.stringify({ slug: "archived-notes" }),
+		});
+		await env.DB.prepare("DELETE FROM rate_limit").run();
+
+		// "draft-notes" is now only a redirect — deleting by the old slug should resolve
+		// to the same (renamed) page rather than 404ing.
+		const deleteRes = await SELF.fetch("http://localhost/api/wiki/draft-notes", {
+			method: "DELETE",
+			headers: authHeaders(owner.token, owner.workspace.slug),
+		});
+		expect(deleteRes.status).toBe(200);
+		const body = (await deleteRes.json()) as { ok: boolean; deletedCount: number };
+		expect(body.ok).toBe(true);
+		expect(body.deletedCount).toBe(1);
+
+		const getRes = await SELF.fetch("http://localhost/api/wiki/archived-notes", {
+			headers: authHeaders(owner.token, owner.workspace.slug),
+		});
+		expect(getRes.status).toBe(404);
+	});
+});
+
 // PROJ-484: optimistic locking (baseRevisionId + conflict diff) on wiki writes
 describe("Wiki optimistic locking (PROJ-484)", () => {
 	let token: string;


### PR DESCRIPTION
Fixes PROJ-509, filed during the Phase 1 fable checkpoint.

listWikiRevisions/getWikiRevision resolved by live slug only, with no page-id lookup or redirect fallback — unlike getWikiPage/updateWikiPage/getWikiBacklinks. After a rename, an agent holding the old slug could still get_wiki_page but list_wiki_revisions/get_wiki_revision would 404, breaking the PROJ-484 optimistic-locking workflow (which tells agents to fetch baseRevisionId via list_wiki_revisions).

Routes both through the existing id-or-slug + redirect resolution helper. Also addresses deleteWikiPage's slug-only resolution for consistency.