### PR TITLE
PROJ-510: don't crash link reindex on malformed %-escape in URL

### DIFF
--- a/apps/api/src/services/wiki-links.ts
+++ b/apps/api/src/services/wiki-links.ts
@@ -42,11 +42,10 @@ function extractWikiSlugFromUrl(url: string): string | null {
 	const raw = pathMatch?.[1] ?? queryMatch?.[1];
 	if (!raw) return null;
 	try {
-		// PROJ-510: a malformed percent-escape (e.g. a bare `%` not followed by two hex
-		// digits) makes decodeURIComponent throw. This runs mid-reindex, after the page's
-		// content/old wiki_links rows have already been committed — an uncaught throw here
-		// would 500 the request with wiki_links left deleted and never repopulated. Treat
-		// an undecodable URL as "not a wiki link" instead of propagating the exception.
+		// PROJ-510: a malformed percent-escape makes decodeURIComponent throw. This runs
+		// mid-reindex, after the content write and the old wiki_links delete have already
+		// committed, so an uncaught throw leaves the page's links wiped. An undecodable
+		// URL is treated as "not a wiki link" rather than propagating.
 		return decodeURIComponent(raw);
 	} catch {
 		return null;
@@ -182,15 +181,11 @@ const LINK_INSERT_CHUNK_SIZE = 15;
  * reinsert, mirroring services/wiki.ts's reindexWikiFts. Call after every content write
  * (create or update) — never partially, since a stale row would misreport backlinks.
  *
- * PROJ-510: this delete-then-reinsert is NOT in the same D1 transaction/batch as the
- * page content write in services/wiki.ts (there is no db.batch(...) wrapping either) —
- * callers await each statement sequentially. If something throws between the delete and
- * the reinsert, the page's content is already committed but wiki_links is left empty
- * until the next successful save. extractWikiSlugFromUrl's parse errors are now handled
- * defensively (never throw), which closes the only known trigger, but the underlying gap
- * is unaddressed — wrapping content write + link reindex in one transaction would touch
- * createWikiPage/updateWikiPage's other sequential writes (revisions, FTS, redirects) and
- * was judged out of scope here; tracked as a follow-up.
+ *
+ * Not atomic: the delete and the reinsert are separate awaits, and neither shares a
+ * transaction/batch with the content write in services/wiki.ts. A throw in between
+ * commits the content but leaves wiki_links empty until the next save. PROJ-510 closed
+ * the only known trigger (parse errors); the gap itself is PROJ-511.
  */
 export async function reindexWikiLinks(
 	ctx: ServiceCtx,

--- a/apps/api/src/services/wiki-links.ts
+++ b/apps/api/src/services/wiki-links.ts
@@ -38,10 +38,19 @@ function extractWikiSlugFromUrl(url: string): string | null {
 	// by the app, so this doesn't lose any real link).
 	if (/^(?:[a-z][a-z0-9+.-]*:)?\/\//i.test(url)) return null;
 	const pathMatch = url.match(/^\/wiki\/([a-z0-9-/]+)/i);
-	if (pathMatch) return decodeURIComponent(pathMatch[1]);
-	const queryMatch = url.match(/[?&]slug=([^&]+)/);
-	if (queryMatch) return decodeURIComponent(queryMatch[1]);
-	return null;
+	const queryMatch = pathMatch ? null : url.match(/[?&]slug=([^&]+)/);
+	const raw = pathMatch?.[1] ?? queryMatch?.[1];
+	if (!raw) return null;
+	try {
+		// PROJ-510: a malformed percent-escape (e.g. a bare `%` not followed by two hex
+		// digits) makes decodeURIComponent throw. This runs mid-reindex, after the page's
+		// content/old wiki_links rows have already been committed — an uncaught throw here
+		// would 500 the request with wiki_links left deleted and never repopulated. Treat
+		// an undecodable URL as "not a wiki link" instead of propagating the exception.
+		return decodeURIComponent(raw);
+	} catch {
+		return null;
+	}
 }
 
 export function parseWikiLinkTargets(content: string): ParsedLinkTarget[] {
@@ -172,6 +181,16 @@ const LINK_INSERT_CHUNK_SIZE = 15;
  * Recompute a page's outgoing wiki_links rows from its current content: delete-then-
  * reinsert, mirroring services/wiki.ts's reindexWikiFts. Call after every content write
  * (create or update) — never partially, since a stale row would misreport backlinks.
+ *
+ * PROJ-510: this delete-then-reinsert is NOT in the same D1 transaction/batch as the
+ * page content write in services/wiki.ts (there is no db.batch(...) wrapping either) —
+ * callers await each statement sequentially. If something throws between the delete and
+ * the reinsert, the page's content is already committed but wiki_links is left empty
+ * until the next successful save. extractWikiSlugFromUrl's parse errors are now handled
+ * defensively (never throw), which closes the only known trigger, but the underlying gap
+ * is unaddressed — wrapping content write + link reindex in one transaction would touch
+ * createWikiPage/updateWikiPage's other sequential writes (revisions, FTS, redirects) and
+ * was judged out of scope here; tracked as a follow-up.
  */
 export async function reindexWikiLinks(
 	ctx: ServiceCtx,

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -1678,6 +1678,25 @@ describe("Wiki link graph and backlinks (PROJ-485)", () => {
 		expect(backlinks).toEqual([]);
 	});
 
+	it("PROJ-510: a malformed %-escape in a markdown link URL doesn't crash the write, and other links on the page still index", async () => {
+		const runbook = await createPage("Runbook Eta", "how to page");
+		const res = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({
+				title: "Theta",
+				content: "see [[Runbook Eta]] and [bad](/wiki?slug=100%) for details",
+			}),
+		});
+		expect(res.status).toBe(201);
+
+		const backlinksRes = await SELF.fetch(`http://localhost/api/wiki/${runbook.slug}/backlinks`, {
+			headers: authHeaders(token, slug),
+		});
+		const backlinks = (await backlinksRes.json()) as Array<{ slug: string }>;
+		expect(backlinks.map((b) => b.slug)).toEqual(["theta"]);
+	});
+
 	it("an unresolved [[Target]] is stored as a broken link, not a backlink", async () => {
 		await createPage("Delta", "see [[Nonexistent Page]] for details");
 


### PR DESCRIPTION
Fixes PROJ-510, filed during the Phase 1 fable checkpoint.

extractWikiSlugFromUrl called decodeURIComponent on raw matched URL text with no error handling. A malformed percent-escape (e.g. a bare `%`) threw a URIError inside reindexWikiLinks — which runs after the page content update and old wiki_links deletion have already committed, so the crash left the page's link rows wiped until the next successful save.

Wraps the decode in a try/catch, treating an undecodable URL as a non-link rather than propagating the exception.