### PR TITLE
PROJ-507: send baseRevisionId on wiki page save

### DIFF
--- a/apps/web/src/islands/WikiPage.test.tsx
+++ b/apps/web/src/islands/WikiPage.test.tsx
@@ -411,3 +411,88 @@ describe("draft autosave (PROJ-227) — restore banner", () => {
 		expect(localStorage.getItem("wiki-draft:w1")).toBeNull();
 	});
 });
+
+// PROJ-507: PROJ-484 added optimistic locking to PUT /api/wiki/:slug (an optional
+// baseRevisionId that must match the page's current latest revision, else a 409), but
+// the save path here never sent it — silently defeating the whole feature. These
+// tests cover that the loaded revision id is now sent, and that a 409 is surfaced
+// rather than swallowed.
+describe("optimistic locking (PROJ-507)", () => {
+	const REVISION = { id: "rev-1", author_id: "u1", author_name: "Ann", created_at: 500 };
+
+	function mockFetchWikiWithRevision(putResponse: { ok: boolean; status?: number }) {
+		return vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+			const u = String(url);
+			if (u.includes("/revisions")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([REVISION]) });
+			}
+			if (u.includes("/tree")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			}
+			if (init?.method === "PUT") {
+				return putResponse.ok
+					? Promise.resolve({ ok: true, json: () => Promise.resolve({ ...PAGE }) })
+					: Promise.resolve({ ok: false, status: putResponse.status });
+			}
+			return Promise.resolve({ ok: true, json: () => Promise.resolve(PAGE) });
+		});
+	}
+
+	it("sends the loaded revision's id as baseRevisionId on save", async () => {
+		const fetchMock = mockFetchWikiWithRevision({ ok: true });
+		vi.stubGlobal("fetch", fetchMock);
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+
+		fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+		fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+		await waitFor(() => {
+			const putCall = fetchMock.mock.calls.find(([, init]) => init?.method === "PUT");
+			expect(putCall).toBeTruthy();
+			expect(JSON.parse(putCall?.[1].body)).toMatchObject({ baseRevisionId: "rev-1" });
+		});
+	});
+
+	it("sends baseRevisionId: null when the page has never been revised", async () => {
+		const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+			const u = String(url);
+			if (u.includes("/revisions")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			}
+			if (u.includes("/tree")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			}
+			if (init?.method === "PUT") {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({ ...PAGE }) });
+			}
+			return Promise.resolve({ ok: true, json: () => Promise.resolve(PAGE) });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+
+		fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+		fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+		await waitFor(() => {
+			const putCall = fetchMock.mock.calls.find(([, init]) => init?.method === "PUT");
+			expect(putCall).toBeTruthy();
+			expect(JSON.parse(putCall?.[1].body)).toMatchObject({ baseRevisionId: null });
+		});
+	});
+
+	it("surfaces a conflict message instead of silently clobbering on a 409", async () => {
+		const fetchMock = mockFetchWikiWithRevision({ ok: false, status: 409 });
+		vi.stubGlobal("fetch", fetchMock);
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+
+		fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+		fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+		expect(await screen.findByText(/changed by someone else since you loaded it/i)).toBeTruthy();
+		// Still in edit mode — the save was rejected, not applied.
+		expect(screen.getByRole("button", { name: "Save" })).toBeTruthy();
+	});
+});

--- a/apps/web/src/islands/WikiPage.test.tsx
+++ b/apps/web/src/islands/WikiPage.test.tsx
@@ -495,4 +495,112 @@ describe("optimistic locking (PROJ-507)", () => {
 		// Still in edit mode — the save was rejected, not applied.
 		expect(screen.getByRole("button", { name: "Save" })).toBeTruthy();
 	});
+
+	it("reports an unrelated failure generically even when the slug contains 409", async () => {
+		const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+			const u = String(url);
+			if (u.includes("/revisions")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([REVISION]) });
+			}
+			if (u.includes("/tree")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			}
+			if (init?.method === "PUT") {
+				return Promise.resolve({ ok: false, status: 500 });
+			}
+			return Promise.resolve({
+				ok: true,
+				json: () => Promise.resolve({ ...PAGE, slug: "proj-409-notes" }),
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+		render(<WikiPage slug="proj-409-notes" />);
+		await screen.findByText("My Page");
+
+		fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+		fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+		expect(await screen.findByText(/Save failed/i)).toBeTruthy();
+		expect(screen.queryByText(/changed by someone else/i)).toBeNull();
+	});
+
+	// Sending `null` for "we haven't loaded the revisions yet" would assert the page has
+	// never been revised, and the server would reject every save on an already-revised
+	// page as a conflict. Omit the field instead.
+	it("omits baseRevisionId when the revision list hasn't loaded yet", async () => {
+		const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+			const u = String(url);
+			if (u.includes("/revisions")) {
+				return new Promise(() => {});
+			}
+			if (u.includes("/tree")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			}
+			if (init?.method === "PUT") {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({ ...PAGE }) });
+			}
+			return Promise.resolve({ ok: true, json: () => Promise.resolve(PAGE) });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+
+		fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+		fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+		await waitFor(() => {
+			const putCall = fetchMock.mock.calls.find(([, init]) => init?.method === "PUT");
+			expect(putCall).toBeTruthy();
+			expect(Object.keys(JSON.parse(putCall?.[1].body))).not.toContain("baseRevisionId");
+		});
+		// Let the post-save refetches settle so they don't render after teardown.
+		await screen.findByRole("button", { name: "Edit" });
+	});
+
+	// A move refetches the page; the revision list must survive that, or the next save
+	// looks like an unrevised page and gets rejected as a conflict.
+	it("still sends baseRevisionId after a move has refreshed the page", async () => {
+		const OTHER_PAGE_NODE = { id: "w2", slug: "other-page", title: "Other Page", children: [] };
+		const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+			const u = String(url);
+			if (u.includes("/revisions")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([REVISION]) });
+			}
+			if (u.includes("/tree")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([OTHER_PAGE_NODE]) });
+			}
+			if (init?.method === "PUT") {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({ ...PAGE }) });
+			}
+			return Promise.resolve({ ok: true, json: () => Promise.resolve(PAGE) });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+
+		fireEvent.click(screen.getByRole("button", { name: "Move" }));
+		fireEvent.click(await screen.findByRole("combobox", { name: /new parent page/i }));
+		fireEvent.click(await screen.findByRole("option", { name: "Other Page" }));
+		const moveButtons = screen.getAllByRole("button", { name: "Move" });
+		fireEvent.click(moveButtons[moveButtons.length - 1]);
+		// The move's page refetch is what used to wipe the revision list — wait for it to
+		// land before editing, or the test races past the bug.
+		await waitFor(() => {
+			const pageGets = fetchMock.mock.calls.filter(
+				([u, init]) => init?.method !== "PUT" && String(u).endsWith("/api/wiki/my-page")
+			);
+			expect(pageGets).toHaveLength(2);
+		});
+
+		fireEvent.click(await screen.findByRole("button", { name: "Edit" }));
+		fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+		await waitFor(() => {
+			const puts = fetchMock.mock.calls.filter(([, init]) => init?.method === "PUT");
+			expect(puts).toHaveLength(2);
+			expect(JSON.parse(puts[1][1].body)).toMatchObject({ baseRevisionId: "rev-1" });
+		});
+		// Let the post-save refetches settle so they don't render after teardown.
+		await screen.findByRole("button", { name: "Edit" });
+	});
 });

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -1494,7 +1494,8 @@ function useWikiEditing(
 	workspaceSlug: string | undefined,
 	page: WikiPageData | null,
 	fetchPage: (s: string) => Promise<void>,
-	fetchRevisions: (s: string) => Promise<void>
+	fetchRevisions: (s: string) => Promise<void>,
+	latestRevisionId: string | null
 ) {
 	const [editing, setEditing] = useState(false);
 	const [editTitle, setEditTitle] = useState("");
@@ -1506,6 +1507,12 @@ function useWikiEditing(
 		content: string;
 		savedAt: number;
 	} | null>(null);
+	// PROJ-507: the revision id of the content the user actually started editing,
+	// frozen at startEdit() time — sent back as baseRevisionId so the server can
+	// detect a concurrent edit landing between load and save (PROJ-484's optimistic
+	// lock). Using the live `latestRevisionId` at save time instead would defeat the
+	// check, since it tracks whatever the page's latest revision is *right now*.
+	const [baseRevisionId, setBaseRevisionId] = useState<string | null>(null);
 
 	const skipLeaveFlushRef = useDraftAutosave(editing, editTitle, editContent, page, draftBanner);
 
@@ -1513,6 +1520,7 @@ function useWikiEditing(
 		if (!page) return;
 		setSaveError(null);
 		setDraftBanner(null);
+		setBaseRevisionId(latestRevisionId);
 		setEditTitle(page.title);
 		setEditContent(page.content);
 		try {
@@ -1562,7 +1570,7 @@ function useWikiEditing(
 			await apiFetch(`/api/wiki/${encodeURIComponent(page.slug)}`, {
 				method: "PUT",
 				workspaceSlug,
-				body: { title: editTitle, content: editContent },
+				body: { title: editTitle, content: editContent, baseRevisionId },
 			});
 			try {
 				localStorage.removeItem(draftKey(page.id));
@@ -1574,7 +1582,17 @@ function useWikiEditing(
 			skipLeaveFlushRef.current = true;
 			setEditing(false);
 		} catch (e) {
-			setSaveError(`Save failed: ${String(e)}`);
+			// PROJ-507: a 409 means someone else saved this page after we loaded it
+			// (PROJ-484's optimistic lock rejected our stale baseRevisionId) — surface
+			// that distinctly rather than the generic failure message, so the user
+			// knows to reload instead of retrying the same save.
+			if (String(e).includes("409")) {
+				setSaveError(
+					"This page was changed by someone else since you loaded it. Reload the page before saving to avoid overwriting their changes."
+				);
+			} else {
+				setSaveError(`Save failed: ${String(e)}`);
+			}
 		} finally {
 			setSaving(false);
 		}
@@ -2068,7 +2086,8 @@ export default function WikiPage({
 		workspaceSlug,
 		pageData.page,
 		pageData.fetchPage,
-		pageData.fetchRevisions
+		pageData.fetchRevisions,
+		pageData.revisions[0]?.id ?? null
 	);
 	const createForm = useCreatePageForm(workspaceSlug, projectId, fetchTree);
 	const move = useMovePage(workspaceSlug, pageData.page, pageData.fetchPage, fetchTree);

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -1190,6 +1190,11 @@ function useWikiPageData(workspaceSlug: string | undefined, slug: string) {
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [revisions, setRevisions] = useState<WikiRevision[]>([]);
+	// PROJ-507: whether `revisions` reflects a completed fetch for this page. An empty
+	// list means two very different things to the optimistic lock — "this page has never
+	// been revised" (baseRevisionId: null) vs "we don't know yet" — and conflating them
+	// makes a legitimate save look like a conflict.
+	const [revisionsLoaded, setRevisionsLoaded] = useState(false);
 	const [showHistory, setShowHistory] = useState(false);
 	const contentRef = useRef<HTMLDivElement>(null);
 
@@ -1198,8 +1203,6 @@ function useWikiPageData(workspaceSlug: string | undefined, slug: string) {
 			if (!s) return;
 			setLoading(true);
 			setError(null);
-			setRevisions([]);
-			setShowHistory(false);
 			try {
 				setPage(
 					await apiFetch<WikiPageData>(`/api/wiki/${encodeURIComponent(s)}`, { workspaceSlug })
@@ -1223,6 +1226,7 @@ function useWikiPageData(workspaceSlug: string | undefined, slug: string) {
 					}
 				);
 				setRevisions(Array.isArray(data) ? data : []);
+				setRevisionsLoaded(true);
 			} catch {
 				// non-fatal
 			}
@@ -1230,7 +1234,13 @@ function useWikiPageData(workspaceSlug: string | undefined, slug: string) {
 		[workspaceSlug]
 	);
 
+	// Revisions belong to the page the `slug` prop points at, so they're reset when it
+	// changes — not on every fetchPage(), which also runs as a same-page refresh (after
+	// a save or a move) and would leave the list empty until something refetched it.
 	useEffect(() => {
+		setRevisions([]);
+		setRevisionsLoaded(false);
+		setShowHistory(false);
 		if (slug) {
 			fetchPage(slug);
 			fetchRevisions(slug);
@@ -1244,6 +1254,7 @@ function useWikiPageData(workspaceSlug: string | undefined, slug: string) {
 		error,
 		setError,
 		revisions,
+		revisionsLoaded,
 		fetchRevisions,
 		showHistory,
 		setShowHistory,
@@ -1495,7 +1506,7 @@ function useWikiEditing(
 	page: WikiPageData | null,
 	fetchPage: (s: string) => Promise<void>,
 	fetchRevisions: (s: string) => Promise<void>,
-	latestRevisionId: string | null
+	latestRevisionId: string | null | undefined
 ) {
 	const [editing, setEditing] = useState(false);
 	const [editTitle, setEditTitle] = useState("");
@@ -1512,7 +1523,10 @@ function useWikiEditing(
 	// detect a concurrent edit landing between load and save (PROJ-484's optimistic
 	// lock). Using the live `latestRevisionId` at save time instead would defeat the
 	// check, since it tracks whatever the page's latest revision is *right now*.
-	const [baseRevisionId, setBaseRevisionId] = useState<string | null>(null);
+	// `undefined` (revisions not loaded when editing started) omits the field, which
+	// the server treats as the transitional last-write-wins path — sending `null` there
+	// would instead assert "this page has no revisions" and fail every save.
+	const [baseRevisionId, setBaseRevisionId] = useState<string | null | undefined>(undefined);
 
 	const skipLeaveFlushRef = useDraftAutosave(editing, editTitle, editContent, page, draftBanner);
 
@@ -1586,7 +1600,9 @@ function useWikiEditing(
 			// (PROJ-484's optimistic lock rejected our stale baseRevisionId) — surface
 			// that distinctly rather than the generic failure message, so the user
 			// knows to reload instead of retrying the same save.
-			if (String(e).includes("409")) {
+			// Match the tail of apiFetch's message, not a bare "409" — the request path is
+			// part of it, and slugs like "proj-409-notes" would otherwise read as conflicts.
+			if (String(e).endsWith("failed: 409")) {
 				setSaveError(
 					"This page was changed by someone else since you loaded it. Reload the page before saving to avoid overwriting their changes."
 				);
@@ -2087,7 +2103,7 @@ export default function WikiPage({
 		pageData.page,
 		pageData.fetchPage,
 		pageData.fetchRevisions,
-		pageData.revisions[0]?.id ?? null
+		pageData.revisionsLoaded ? (pageData.revisions[0]?.id ?? null) : undefined
 	);
 	const createForm = useCreatePageForm(workspaceSlug, projectId, fetchTree);
 	const move = useMovePage(workspaceSlug, pageData.page, pageData.fetchPage, fetchTree);


### PR DESCRIPTION
Fixes PROJ-507, filed during PROJ-484 review.

WikiPage.tsx's save path never sent baseRevisionId on PUT, making the PROJ-484 optimistic-locking feature dead code from the web UI's perspective — two users editing the same page concurrently would silently clobber each other with no conflict warning.

Tracks the loaded page's revision id and sends it as baseRevisionId on save; surfaces a 409 conflict response to the user instead of silently ignoring it.