### PR TITLE
PROJ-489: wiki freshness model (verification stamps + staleness surfacing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ command shown beside it (token + workspace pre-filled). The full walkthrough - A
 setup, first login, token, MCP - is in
 [CONFIGURE.md](https://github.com/TAJD/projektor-deploy-example/blob/main/CONFIGURE.md).
 
-See the **[agent connection guide](https://tajd.github.io/projektor/agents/mcp-connection/)** for the full connection guide, protocol reference, and tool catalog (<!-- gen-mcp-stats:start -->93 tools across 21 domains<!-- gen-mcp-stats:end --> - project data plus agent-coordination primitives).
+See the **[agent connection guide](https://tajd.github.io/projektor/agents/mcp-connection/)** for the full connection guide, protocol reference, and tool catalog (<!-- gen-mcp-stats:start -->95 tools across 21 domains<!-- gen-mcp-stats:end --> - project data plus agent-coordination primitives).
 
 ## Development
 

--- a/apps/api/src/mcp/wiki.ts
+++ b/apps/api/src/mcp/wiki.ts
@@ -46,9 +46,12 @@ export const wikiTools: MCPTool[] = [
 		name: "search_wiki",
 		description:
 			"Full-text search over wiki pages (FTS5, BM25-ranked, title weighted above body). " +
-			"Returns match-anchored snippets highlighted with ** markers. type/status/tags filter " +
-			"on the denormalized frontmatter columns (R6); status here is unrelated to the " +
-			"freshness/staleness ranking work (R7, PROJ-489), which hasn't landed yet.",
+			"Returns match-anchored snippets highlighted with ** markers, plus a computed " +
+			"`freshness` ({state, staleSince} or null if the page has no verify_interval/status " +
+			"signal) per result. type/status/tags filter on the denormalized frontmatter columns " +
+			"(R6). Results are demoted (ranked below everything else, ties broken by bm25 within " +
+			"each tier) when the page is computed-stale/unverified OR has an explicit " +
+			"status: stale|deprecated (R7).",
 		inputSchema: {
 			type: "object",
 			required: ["query"],
@@ -300,6 +303,47 @@ export const wikiTools: MCPTool[] = [
 		async handler(input, ctx) {
 			const { slug, revisionId } = input as { slug: string; revisionId: string };
 			return wikiService.getWikiRevision(ctx as ServiceCtx, slug, revisionId);
+		},
+	},
+	{
+		name: "verify_wiki_page",
+		description:
+			"Stamp a wiki page as freshly verified — sets its frontmatter verified_at to now and " +
+			"verified_by to the CALLING user's email (never caller-supplied). Rewrites the page's " +
+			"frontmatter block (creating one if it had none) and records a revision, same as any " +
+			"other content edit. Not allowed for viewers.",
+		inputSchema: {
+			type: "object",
+			required: ["slug"],
+			properties: {
+				slug: { type: "string", description: "Page ID or slug" },
+			},
+		},
+		async handler(input, ctx) {
+			const { slug } = input as { slug: string };
+			return wikiService.verifyWikiPage(ctx as ServiceCtx, slug);
+		},
+	},
+	{
+		name: "list_stale_pages",
+		description:
+			"Maintenance queue of wiki pages that need re-verification: computed-stale " +
+			"(verify_interval elapsed since verified_at), unverified (verify_interval declared but " +
+			"never verified), or explicitly status: stale|deprecated. Same rule search_wiki uses to " +
+			"demote results (R7).",
+		inputSchema: {
+			type: "object",
+			properties: {
+				projectId: {
+					type: "string",
+					description: "Restrict to pages belonging to this project ID",
+				},
+				limit: { type: "number", default: 50 },
+				offset: { type: "number", default: 0 },
+			},
+		},
+		async handler(input, ctx) {
+			return wikiService.listStaleWikiPages(ctx, input);
 		},
 	},
 ];

--- a/apps/api/src/mcp/wiki.ts
+++ b/apps/api/src/mcp/wiki.ts
@@ -311,7 +311,8 @@ export const wikiTools: MCPTool[] = [
 			"Stamp a wiki page as freshly verified — sets its frontmatter verified_at to now and " +
 			"verified_by to the CALLING user's email (never caller-supplied). Rewrites the page's " +
 			"frontmatter block (creating one if it had none) and records a revision, same as any " +
-			"other content edit. Not allowed for viewers.",
+			"other content edit — including its conflict check, so a concurrent edit racing the " +
+			"stamp is rejected rather than reverted. Not allowed for viewers.",
 		inputSchema: {
 			type: "object",
 			required: ["slug"],

--- a/apps/api/src/routes/wiki.ts
+++ b/apps/api/src/routes/wiki.ts
@@ -70,6 +70,20 @@ router.get("/broken-links", async (c) => {
 	}
 });
 
+// PROJ-489 (R7): must be registered before the /:slug catch-all below, same as
+// /tree, /search, /broken-links above.
+router.get("/stale-pages", async (c) => {
+	const ctx = ctxFromHono(c);
+	try {
+		const projectId = c.req.query("projectId");
+		const limit = c.req.query("limit");
+		const offset = c.req.query("offset");
+		return c.json(await wikiService.listStaleWikiPages(ctx, { projectId, limit, offset }));
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
+});
+
 router.post("/backfill-links", async (c) => {
 	const ctx = ctxFromHono(c);
 	try {
@@ -132,6 +146,15 @@ router.put("/:slug", async (c) => {
 	try {
 		const body = await c.req.json();
 		return c.json(await wikiService.updateWikiPage(ctx, c.req.param("slug"), body));
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
+});
+
+router.post("/:slug/verify", async (c) => {
+	const ctx = ctxFromHono(c);
+	try {
+		return c.json(await wikiService.verifyWikiPage(ctx, c.req.param("slug")));
 	} catch (e) {
 		return serviceErrToResponse(c, e);
 	}

--- a/apps/api/src/schemas/wiki.ts
+++ b/apps/api/src/schemas/wiki.ts
@@ -123,3 +123,11 @@ export const DeleteWikiPageOptionsSchema = z.object({
 export const ListBrokenWikiLinksInputSchema = z.object({
 	projectId: z.string().uuid().optional(),
 });
+
+// PROJ-489 (R7): the maintenance queue of computed-stale/unverified/explicitly stale-or-
+// deprecated pages (services/wiki.ts#listStaleWikiPages).
+export const ListStaleWikiPagesInputSchema = z.object({
+	projectId: z.string().uuid().optional(),
+	limit: z.coerce.number().int().min(1).max(200).optional().default(50),
+	offset: z.coerce.number().int().min(0).optional().default(0),
+});

--- a/apps/api/src/services/wiki-freshness.ts
+++ b/apps/api/src/services/wiki-freshness.ts
@@ -1,0 +1,66 @@
+// PROJ-489 (R7): freshness is a derived/computed property, not a stored column — it
+// depends on "now" at read time, so the same page can flip from fresh to stale between
+// two reads with no write happening in between. This is intentionally a pure function
+// (no ctx/db) so it's trivially unit-testable and reusable verbatim across every surface
+// that needs it: search ranking + result serialization (services/wiki.ts#searchWiki),
+// the page-detail response (services/wiki.ts#getWikiPage, for the UI header), and
+// list_stale_pages' filter logic mirrors the same rule in SQL (kept in lockstep by hand,
+// see services/wiki.ts#staleWikiPageCondition).
+
+export type WikiFreshnessState = "fresh" | "stale" | "unverified";
+
+export interface WikiFreshness {
+	state: WikiFreshnessState;
+	// Unix seconds the page became (or would become) stale — the verify_interval due
+	// date, when that's what drove the "stale" state. null when staleness came from an
+	// explicit status (no time-based due date to report) or the state isn't "stale".
+	staleSince: number | null;
+}
+
+export interface ComputeFreshnessInput {
+	verifiedAt: number | null;
+	verifyInterval: number | null;
+	status: string | null;
+	// Unix seconds; defaults to the real current time. Overridable for tests.
+	now?: number;
+}
+
+const SECONDS_PER_DAY = 86400;
+
+// PROJ-489: null means the page carries neither frontmatter signal (no verify_interval,
+// no status) at all — never fabricate a freshness state for a page that never opted
+// into verification tracking. This mirrors the "field present but null, never
+// fabricated" convention the pre-R7 placeholder in wiki.test.ts established for the
+// `freshness` response field, which this function's return value now serializes into
+// directly (`freshness: computeFreshness(...)`).
+export function computeFreshness(input: ComputeFreshnessInput): WikiFreshness | null {
+	const { verifiedAt, verifyInterval, status } = input;
+	const hasSignal = status !== null || verifyInterval !== null;
+	if (!hasSignal) return null;
+
+	const now = input.now ?? Math.floor(Date.now() / 1000);
+	const dueAt =
+		verifyInterval !== null && verifiedAt !== null
+			? verifiedAt + verifyInterval * SECONDS_PER_DAY
+			: null;
+
+	// PRD R7: "status: stale/deprecated" is an independent, explicit staleness signal —
+	// it wins outright regardless of whether a verify_interval due date has technically
+	// been reached yet (a page can be manually flagged stale/deprecated ahead of its
+	// scheduled re-verification).
+	if (status === "stale" || status === "deprecated") {
+		return { state: "stale", staleSince: dueAt !== null && dueAt <= now ? dueAt : null };
+	}
+
+	// A verify_interval was declared but the page has never been verified at all —
+	// distinct from "verified, but overdue" (below).
+	if (verifyInterval !== null && verifiedAt === null) {
+		return { state: "unverified", staleSince: null };
+	}
+
+	if (dueAt !== null && dueAt <= now) {
+		return { state: "stale", staleSince: dueAt };
+	}
+
+	return { state: "fresh", staleSince: null };
+}

--- a/apps/api/src/services/wiki-frontmatter.ts
+++ b/apps/api/src/services/wiki-frontmatter.ts
@@ -1,4 +1,4 @@
-import { parse as parseYaml } from "yaml";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { WikiFrontmatterSchema } from "../schemas/wiki";
 import { ValidationError } from "./errors";
 
@@ -102,4 +102,33 @@ export function parseWikiFrontmatter(content: string): WikiFrontmatterMeta {
 		owners: d.owners ?? [],
 		verifyInterval: d.verify_interval ?? null,
 	};
+}
+
+// PROJ-489 (R7): markdown + frontmatter is the canonical source (PRD principle 1) — the
+// denormalized wiki_pages.verified_at/verified_by columns exist purely for filtering, so
+// verify_wiki_page must stamp the *content's* frontmatter block, not just those columns.
+// Otherwise the next content-only edit would re-parse the page's still-stale frontmatter
+// (parseWikiFrontmatter above) and silently wipe out the verification stamp. Preserves
+// every other existing frontmatter key untouched; adds a frontmatter block (with only
+// verified_at/verified_by) to a page that previously had none at all.
+export function stampWikiFrontmatterVerification(
+	content: string,
+	verifiedAtSeconds: number,
+	verifiedBy: string
+): string {
+	const match = FRONTMATTER_RE.exec(content);
+	const rest = match ? content.slice(match[0].length) : content;
+
+	let raw: Record<string, unknown> = {};
+	if (match) {
+		const parsedRaw = parseYaml(match[1]);
+		if (parsedRaw && typeof parsedRaw === "object" && !Array.isArray(parsedRaw)) {
+			raw = { ...(parsedRaw as Record<string, unknown>) };
+		}
+	}
+	raw.verified_at = new Date(verifiedAtSeconds * 1000).toISOString();
+	raw.verified_by = verifiedBy;
+
+	const yamlText = stringifyYaml(raw).trimEnd();
+	return `---\n${yamlText}\n---\n${rest}`;
 }

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -1036,9 +1036,18 @@ export async function verifyWikiPage(ctx: ServiceCtx, idOrSlug: string) {
 		.get();
 	if (!user) throw new NotFoundError("Calling user not found");
 
+	// PROJ-489: stamping the frontmatter is a read-modify-write of the WHOLE content, so
+	// without a base revision a content edit landing between the read and the write would
+	// be silently reverted by a verification click — exactly the loss PROJ-484 added
+	// optimistic locking for. Read the base revision id BEFORE the content it describes:
+	// a writer racing us either lands before both reads (we stamp on top of their edit) or
+	// bumps the latest revision past our base (updateWikiPage rejects with a conflict).
+	const baseRevisionId = await getLatestRevisionId(ctx.db, page.id);
+	const current = await resolvePageByIdOrSlug(ctx.db, page.id, ctx.workspaceId);
+
 	const now = Math.floor(Date.now() / 1000);
-	const newContent = stampWikiFrontmatterVerification(page.content, now, user.email);
-	await updateWikiPage(ctx, page.id, { content: newContent, summary: "Verified" });
+	const newContent = stampWikiFrontmatterVerification(current.content, now, user.email);
+	await updateWikiPage(ctx, page.id, { content: newContent, summary: "Verified", baseRevisionId });
 
 	// Re-derive from the same frontmatter just written, so the response matches exactly
 	// what a subsequent read would parse back out (rather than re-fetching the page).

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -6,6 +6,7 @@ import {
 	CreatePageSchema,
 	DeleteWikiPageOptionsSchema,
 	ListPagesInputSchema,
+	ListStaleWikiPagesInputSchema,
 	SearchWikiInputSchema,
 	UpdatePageSchema,
 } from "../schemas/wiki";
@@ -21,7 +22,12 @@ import { recordActivity } from "./activity";
 import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from "./errors";
 import { inChunks } from "./sql";
 import type { ServiceCtx } from "./types";
-import { parseWikiFrontmatter, type WikiFrontmatterMeta } from "./wiki-frontmatter";
+import { computeFreshness } from "./wiki-freshness";
+import {
+	parseWikiFrontmatter,
+	stampWikiFrontmatterVerification,
+	type WikiFrontmatterMeta,
+} from "./wiki-frontmatter";
 import {
 	backlinksForResolvedPage,
 	clearIncomingLinkTargets,
@@ -289,6 +295,26 @@ function tagsFilterCondition(tags: string[]) {
 	)}))`;
 }
 
+// PROJ-489 (R7): a page is "stale" for maintenance-queue/ranking-demotion purposes when
+// EITHER an explicit `status: stale|deprecated` is set, OR a `verify_interval` was
+// declared and the page is either never-verified or overdue. This is the SQL-side
+// mirror of computeFreshness's stale/unverified branches (services/wiki-freshness.ts) —
+// kept in lockstep by hand since this needs to run inside SQL (ORDER BY / WHERE) rather
+// than per-row in JS. `now` is passed in as a bound parameter (not `strftime('%s','now')`)
+// so ranking and the freshness computed for the same response agree on one instant.
+function staleWikiPageCondition(now: number) {
+	return sql`(
+		${schema.wikiPages.status} IN ('stale', 'deprecated')
+		OR (
+			${schema.wikiPages.verifyInterval} IS NOT NULL
+			AND (
+				${schema.wikiPages.verifiedAt} IS NULL
+				OR (${schema.wikiPages.verifiedAt} + ${schema.wikiPages.verifyInterval} * 86400) <= ${now}
+			)
+		)
+	)`;
+}
+
 export async function listWikiPages(ctx: ServiceCtx, input: unknown) {
 	const parsed = ListPagesInputSchema.safeParse(input);
 	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
@@ -435,18 +461,28 @@ export async function searchWiki(ctx: ServiceCtx, input: unknown) {
 		params.push(...tags);
 	}
 
+	// PROJ-489 (R7): demote computed-stale/unverified/explicitly-stale-or-deprecated pages
+	// below everything else, THEN rank by bm25 within each tier. `now` is bound once and
+	// reused below for the freshness computed on each returned row, so the ordering and
+	// the displayed freshness state always agree.
+	const now = Math.floor(Date.now() / 1000);
 	// PROJ-486: bm25() alone ties on equal-rank rows, which makes LIMIT/OFFSET
 	// paging non-deterministic (duplicate/skip results across pages) — break
 	// ties by page id for a stable order.
-	q += ` ORDER BY bm25(wiki_fts, ${WIKI_FTS_BM25_WEIGHTS}), p.id LIMIT ? OFFSET ?`;
-	params.push(limit, offset);
+	q += ` ORDER BY (CASE WHEN (
+	              p.status IN ('stale', 'deprecated')
+	              OR (
+	                p.verify_interval IS NOT NULL
+	                AND (p.verified_at IS NULL OR (p.verified_at + p.verify_interval * 86400) <= ?)
+	              )
+	            ) THEN 1 ELSE 0 END),
+	          bm25(wiki_fts, ${WIKI_FTS_BM25_WEIGHTS}), p.id LIMIT ? OFFSET ?`;
+	params.push(now, limit, offset);
 
 	const { results } = await ctx.db
 		.prepare(q)
 		.bind(...params)
 		.all();
-	// PROJ-489 (R7, not landed): no freshness model exists yet, so freshness is
-	// omitted-as-null rather than fabricated.
 	return (results as Array<Record<string, unknown>>).map((r) => ({
 		...r,
 		// PROJ-488: this is a raw D1 query, so the JSON-array columns come back as the
@@ -455,7 +491,14 @@ export async function searchWiki(ctx: ServiceCtx, input: unknown) {
 		// tags/owners with the same shape.
 		tags: decodeJsonArrayColumn(r.tags),
 		owners: decodeJsonArrayColumn(r.owners),
-		freshness: null,
+		// PROJ-489 (R7): null when the page has no verify_interval/status signal at all —
+		// never fabricated (services/wiki-freshness.ts).
+		freshness: computeFreshness({
+			verifiedAt: r.verified_at as number | null,
+			verifyInterval: r.verify_interval as number | null,
+			status: r.status as string | null,
+			now,
+		}),
 	}));
 }
 
@@ -529,7 +572,16 @@ export async function getWikiPage(ctx: ServiceCtx, slugOrId: string) {
 	const page = direct ?? (await resolveWikiPageByRedirect(orm, ctx.workspaceId, slugOrId));
 	if (!page) throw new NotFoundError("Wiki page not found");
 	await assertWikiPageVisible(ctx, page.project_id);
-	return { ...page, url: wikiPagePath(page.slug) };
+	return {
+		...page,
+		url: wikiPagePath(page.slug),
+		// PROJ-489 (R7): computed/derived, not a stored column — surfaced for the page header.
+		freshness: computeFreshness({
+			verifiedAt: page.verified_at,
+			verifyInterval: page.verify_interval,
+			status: page.status,
+		}),
+	};
 }
 
 // PROJ-485: "what links here" — pages that link to `slugOrId` via a resolved wiki_links
@@ -961,6 +1013,117 @@ export async function updateWikiPage(ctx: ServiceCtx, idOrSlug: string, input: u
 	});
 
 	return { ok: true, url: wikiPagePath(slug ?? page.slug) };
+}
+
+// PROJ-489 (R7): stamps verified_at/verified_by using the CALLING user's identity —
+// never a caller-supplied value, so an agent can't backdate/forge another user's
+// verification. Frontmatter (not just the denormalized columns) is the canonical source
+// (PRD principle 1), so this rewrites the page's content frontmatter block and routes
+// through updateWikiPage's normal content-write path (revision snapshot, frontmatter
+// re-parse into columns, FTS/link reindex, activity log) rather than UPDATE-ing the
+// verified_at/verified_by columns directly — that would drift out of sync with content
+// the moment someone next makes an unrelated content-only edit (parseWikiFrontmatter
+// would re-parse the page's still-stale frontmatter and silently wipe the stamp).
+export async function verifyWikiPage(ctx: ServiceCtx, idOrSlug: string) {
+	const page = await resolvePageByIdOrSlug(ctx.db, idOrSlug, ctx.workspaceId);
+	await requireWikiWrite(ctx, page.projectId);
+
+	const orm = drizzle(ctx.db, { schema });
+	const user = await orm
+		.select({ email: schema.users.email })
+		.from(schema.users)
+		.where(eq(schema.users.id, ctx.userId))
+		.get();
+	if (!user) throw new NotFoundError("Calling user not found");
+
+	const now = Math.floor(Date.now() / 1000);
+	const newContent = stampWikiFrontmatterVerification(page.content, now, user.email);
+	await updateWikiPage(ctx, page.id, { content: newContent, summary: "Verified" });
+
+	// Re-derive from the same frontmatter just written, so the response matches exactly
+	// what a subsequent read would parse back out (rather than re-fetching the page).
+	const meta = parseWikiFrontmatter(newContent);
+	return {
+		ok: true,
+		verifiedAt: meta.verifiedAt,
+		verifiedBy: meta.verifiedBy,
+		url: wikiPagePath(page.slug),
+		freshness: computeFreshness({
+			verifiedAt: meta.verifiedAt,
+			verifyInterval: meta.verifyInterval,
+			status: meta.status,
+			now,
+		}),
+	};
+}
+
+// PROJ-489 (R7): the maintenance queue — pages that are computed-stale (verify_interval
+// elapsed), unverified (verify_interval declared but never verified), or explicitly
+// `status: stale|deprecated`. Same condition as searchWiki's ranking demotion
+// (staleWikiPageCondition above), so "what search demotes" and "what this queue lists"
+// never disagree.
+export async function listStaleWikiPages(ctx: ServiceCtx, input: unknown) {
+	const parsed = ListStaleWikiPagesInputSchema.safeParse(input);
+	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
+	const { projectId, limit, offset } = parsed.data;
+
+	if (projectId) {
+		// PROJ-311: same as searchWiki — querying a project the caller can't see returns nothing.
+		if (!isWorkspaceAdmin(ctx.role) && (await effectiveProjectRole(ctx, projectId)) === null) {
+			return [];
+		}
+	}
+
+	const orm = drizzle(ctx.db, { schema });
+	const now = Math.floor(Date.now() / 1000);
+	const conditions = [
+		eq(schema.wikiPages.workspaceId, ctx.workspaceId),
+		staleWikiPageCondition(now),
+	];
+	if (projectId) {
+		conditions.push(eq(schema.wikiPages.projectId, projectId));
+	} else {
+		// PROJ-311: workspace-wide, exclude project-scoped pages the caller isn't granted.
+		const visible = visibleProjectPredicate(ctx, schema.wikiPages.projectId);
+		if (visible) {
+			const cond = or(isNull(schema.wikiPages.projectId), visible);
+			if (cond) conditions.push(cond);
+		}
+	}
+
+	const rows = await orm
+		.select({
+			id: schema.wikiPages.id,
+			slug: schema.wikiPages.slug,
+			title: schema.wikiPages.title,
+			// eslint-disable-next-line camelcase
+			project_id: schema.wikiPages.projectId,
+			status: schema.wikiPages.status,
+			// eslint-disable-next-line camelcase
+			verified_at: schema.wikiPages.verifiedAt,
+			// eslint-disable-next-line camelcase
+			verified_by: schema.wikiPages.verifiedBy,
+			// eslint-disable-next-line camelcase
+			verify_interval: schema.wikiPages.verifyInterval,
+			// eslint-disable-next-line camelcase
+			updated_at: schema.wikiPages.updatedAt,
+		})
+		.from(schema.wikiPages)
+		.where(and(...conditions))
+		.orderBy(asc(schema.wikiPages.updatedAt))
+		.limit(limit)
+		.offset(offset);
+
+	return rows.map((r) => ({
+		...r,
+		url: wikiPagePath(r.slug),
+		freshness: computeFreshness({
+			verifiedAt: r.verified_at,
+			verifyInterval: r.verify_interval,
+			status: r.status,
+			now,
+		}),
+	}));
 }
 
 // PROJ-238: breadth-first walk of parent_id children, chunked to stay under D1's

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -2786,6 +2786,35 @@ describe("Wiki freshness model (PROJ-489)", () => {
 		expect(afterRevisions.length).toBe(beforeRevisions.length + 1);
 	});
 
+	// PROJ-489: verifying rewrites the whole content (frontmatter stamp + body), so it must
+	// stamp the CURRENT content — a stale read would silently revert the edit before it.
+	it("POST /api/wiki/:slug/verify stamps on top of the latest content, never a stale snapshot", async () => {
+		const createRes = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Edited Then Verified", content: overdueContent() }),
+		});
+		const created = (await createRes.json()) as { slug: string };
+
+		await SELF.fetch(`http://localhost/api/wiki/${created.slug}`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: `${overdueContent()}\n\nBrand new paragraph.` }),
+		});
+
+		await SELF.fetch(`http://localhost/api/wiki/${created.slug}/verify`, {
+			method: "POST",
+			headers: authHeaders(token, slug),
+		});
+
+		const pageRes = await SELF.fetch(`http://localhost/api/wiki/${created.slug}`, {
+			headers: authHeaders(token, slug),
+		});
+		const page = (await pageRes.json()) as { content: string; verified_by: string };
+		expect(page.content).toContain("Brand new paragraph.");
+		expect(page.verified_by).toBe(userEmail);
+	});
+
 	it("POST /api/wiki/:slug/verify is rejected for a viewer", async () => {
 		const roles = await seedWorkspaceRoles();
 		const createRes = await SELF.fetch("http://localhost/api/wiki", {

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -1,5 +1,6 @@
 import { env, SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
+import { computeFreshness } from "../services/wiki-freshness";
 import {
 	authHeaders,
 	seedFixture,
@@ -204,9 +205,10 @@ describe("Wiki API", () => {
 		expect(results[0].title).toBe("Deployment Guide");
 	});
 
-	// PROJ-486: freshness (R7, PROJ-489) hasn't landed — the field is present but null,
-	// never fabricated.
-	it("GET /api/wiki/search returns freshness: null (R7 not yet implemented)", async () => {
+	// PROJ-489 (R7): a page with no verify_interval/status frontmatter signal at all gets
+	// `freshness: null` — never fabricated. (R7 landed; full freshness behavior is
+	// exercised in the "Wiki freshness model (PROJ-489)" describe block below.)
+	it("GET /api/wiki/search returns freshness: null for a page with no verification signal", async () => {
 		await SELF.fetch("http://localhost/api/wiki", {
 			method: "POST",
 			headers: authHeaders(token, slug),
@@ -2607,5 +2609,333 @@ describe("Wiki link graph and backlinks (PROJ-485)", () => {
 			authHeaders(member.token, member.workspace.slug)
 		);
 		expect(isMcpError(result)).toBe(true);
+	});
+});
+
+// PROJ-489 (R7): verification stamps + computed staleness surfacing.
+describe("computeFreshness (PROJ-489)", () => {
+	it("returns null when the page has neither verify_interval nor status", () => {
+		expect(computeFreshness({ verifiedAt: null, verifyInterval: null, status: null })).toBeNull();
+	});
+
+	it("returns 'unverified' when verify_interval is set but verified_at is null", () => {
+		expect(
+			computeFreshness({ verifiedAt: null, verifyInterval: 30, status: null, now: 1_000_000 })
+		).toEqual({ state: "unverified", staleSince: null });
+	});
+
+	it("returns 'fresh' when verify_interval hasn't elapsed since verified_at", () => {
+		const now = 1_000_000;
+		const verifiedAt = now - 10 * 86400; // 10 days ago
+		expect(computeFreshness({ verifiedAt, verifyInterval: 30, status: null, now })).toEqual({
+			state: "fresh",
+			staleSince: null,
+		});
+	});
+
+	it("returns 'stale' with staleSince once verify_interval has elapsed since verified_at", () => {
+		const now = 1_000_000;
+		const verifiedAt = now - 40 * 86400; // 40 days ago
+		const dueAt = verifiedAt + 30 * 86400;
+		expect(computeFreshness({ verifiedAt, verifyInterval: 30, status: null, now })).toEqual({
+			state: "stale",
+			staleSince: dueAt,
+		});
+	});
+
+	it("treats an explicit status: stale as stale regardless of verify_interval", () => {
+		expect(
+			computeFreshness({ verifiedAt: null, verifyInterval: null, status: "stale", now: 1_000_000 })
+		).toEqual({ state: "stale", staleSince: null });
+	});
+
+	it("treats an explicit status: deprecated as stale even when verify_interval hasn't elapsed yet", () => {
+		const now = 1_000_000;
+		const verifiedAt = now - 1 * 86400; // verified yesterday
+		expect(
+			computeFreshness({ verifiedAt, verifyInterval: 365, status: "deprecated", now })
+		).toEqual({ state: "stale", staleSince: null });
+	});
+
+	it("treats status: current with no verify_interval as fresh", () => {
+		expect(
+			computeFreshness({
+				verifiedAt: null,
+				verifyInterval: null,
+				status: "current",
+				now: 1_000_000,
+			})
+		).toEqual({ state: "fresh", staleSince: null });
+	});
+});
+
+describe("Wiki freshness model (PROJ-489)", () => {
+	let token: string;
+	let slug: string;
+	let workspaceId: string;
+	let userEmail: string;
+
+	beforeEach(async () => {
+		const fixture = await seedFixture();
+		token = fixture.token;
+		slug = fixture.workspace.slug;
+		workspaceId = fixture.workspace.id;
+		userEmail = fixture.user.email;
+	});
+
+	const today = () => new Date().toISOString().slice(0, 10);
+
+	function overdueContent(intervalDays = 30) {
+		return [
+			"---",
+			`verify_interval: ${intervalDays}`,
+			"verified_at: 2020-01-01",
+			"---",
+			"# Overdue page",
+		].join("\n");
+	}
+
+	function freshContent(intervalDays = 365) {
+		return [
+			"---",
+			`verify_interval: ${intervalDays}`,
+			`verified_at: ${today()}`,
+			"---",
+			"# Fresh page",
+		].join("\n");
+	}
+
+	function unverifiedContent(intervalDays = 30) {
+		return ["---", `verify_interval: ${intervalDays}`, "---", "# Never verified page"].join("\n");
+	}
+
+	function explicitStatusContent(status: "stale" | "deprecated") {
+		return ["---", `status: ${status}`, "---", "# Explicitly flagged page"].join("\n");
+	}
+
+	it("REST GET /api/wiki/:slug returns computed freshness in the page header", async () => {
+		const createRes = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Overdue Runbook", content: overdueContent() }),
+		});
+		const created = (await createRes.json()) as { slug: string };
+
+		const res = await SELF.fetch(`http://localhost/api/wiki/${created.slug}`, {
+			headers: authHeaders(token, slug),
+		});
+		const page = (await res.json()) as { freshness: { state: string; staleSince: number | null } };
+		expect(page.freshness.state).toBe("stale");
+		expect(page.freshness.staleSince).not.toBeNull();
+	});
+
+	it("REST POST /api/wiki/:slug/verify stamps verified_at/verified_by using the CALLING user's identity", async () => {
+		const createRes = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Needs Verification", content: overdueContent() }),
+		});
+		const created = (await createRes.json()) as { slug: string };
+
+		const verifyRes = await SELF.fetch(`http://localhost/api/wiki/${created.slug}/verify`, {
+			method: "POST",
+			headers: authHeaders(token, slug),
+		});
+		expect(verifyRes.status).toBe(200);
+		const verified = (await verifyRes.json()) as {
+			verifiedBy: string;
+			verifiedAt: number;
+			freshness: { state: string };
+		};
+		expect(verified.verifiedBy).toBe(userEmail);
+		// The page was overdue (verified_at 2020-01-01); verifying it now resets the clock.
+		expect(verified.freshness.state).toBe("fresh");
+
+		// The stamp is written into the page's frontmatter (not just the denormalized
+		// columns), so a subsequent read reflects it without needing an unrelated edit.
+		const pageRes = await SELF.fetch(`http://localhost/api/wiki/${created.slug}`, {
+			headers: authHeaders(token, slug),
+		});
+		const page = (await pageRes.json()) as { verified_by: string; content: string };
+		expect(page.verified_by).toBe(userEmail);
+		expect(page.content).toContain(`verified_by: ${userEmail}`);
+	});
+
+	it("verify_wiki_page records a revision, same as any other content edit", async () => {
+		const createRes = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Revision Check", content: overdueContent() }),
+		});
+		const created = (await createRes.json()) as { slug: string };
+
+		const before = await SELF.fetch(`http://localhost/api/wiki/${created.slug}/revisions`, {
+			headers: authHeaders(token, slug),
+		});
+		const beforeRevisions = (await before.json()) as unknown[];
+
+		await SELF.fetch(`http://localhost/api/wiki/${created.slug}/verify`, {
+			method: "POST",
+			headers: authHeaders(token, slug),
+		});
+
+		const after = await SELF.fetch(`http://localhost/api/wiki/${created.slug}/revisions`, {
+			headers: authHeaders(token, slug),
+		});
+		const afterRevisions = (await after.json()) as unknown[];
+		expect(afterRevisions.length).toBe(beforeRevisions.length + 1);
+	});
+
+	it("POST /api/wiki/:slug/verify is rejected for a viewer", async () => {
+		const roles = await seedWorkspaceRoles();
+		const createRes = await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(roles.owner.token, roles.workspace.slug),
+			body: JSON.stringify({ title: "Viewer Guard", content: overdueContent() }),
+		});
+		const created = (await createRes.json()) as { slug: string };
+
+		const res = await SELF.fetch(`http://localhost/api/wiki/${created.slug}/verify`, {
+			method: "POST",
+			headers: authHeaders(roles.viewer.token, roles.workspace.slug),
+		});
+		expect(res.status).toBe(403);
+	});
+
+	it("MCP verify_wiki_page stamps verified_at/verified_by, parity with REST", async () => {
+		const created = mcpData<{ slug: string }>(
+			await mcpCall(
+				workspaceId,
+				"create_wiki_page",
+				{ title: "MCP Verify Target", content: overdueContent() },
+				authHeaders(token, slug)
+			)
+		);
+
+		const result = mcpData<{ verifiedBy: string; freshness: { state: string } }>(
+			await mcpCall(
+				workspaceId,
+				"verify_wiki_page",
+				{ slug: created.slug },
+				authHeaders(token, slug)
+			)
+		);
+		expect(result.verifiedBy).toBe(userEmail);
+		expect(result.freshness.state).toBe("fresh");
+	});
+
+	it("GET /api/wiki/search demotes a computed-stale page below a fresh page matching the same query", async () => {
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({
+				title: "Stale Deploy Guide",
+				content: `${overdueContent()}\ndeploy keyword`,
+			}),
+		});
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({
+				title: "Fresh Deploy Guide",
+				content: `${freshContent()}\ndeploy keyword`,
+			}),
+		});
+
+		const res = await SELF.fetch("http://localhost/api/wiki/search?q=deploy", {
+			headers: authHeaders(token, slug),
+		});
+		const results = (await res.json()) as Array<{
+			title: string;
+			freshness: { state: string } | null;
+		}>;
+		expect(results.map((r) => r.title)).toEqual(["Fresh Deploy Guide", "Stale Deploy Guide"]);
+		expect(results[0].freshness?.state).toBe("fresh");
+		expect(results[1].freshness?.state).toBe("stale");
+	});
+
+	it("GET /api/wiki/search demotes an explicitly status: deprecated page too", async () => {
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({
+				title: "Deprecated Onboarding",
+				content: `${explicitStatusContent("deprecated")}\nonboardingkeyword`,
+			}),
+		});
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Current Onboarding", content: "onboardingkeyword" }),
+		});
+
+		const res = await SELF.fetch("http://localhost/api/wiki/search?q=onboardingkeyword", {
+			headers: authHeaders(token, slug),
+		});
+		const results = (await res.json()) as Array<{ title: string }>;
+		expect(results.map((r) => r.title)).toEqual(["Current Onboarding", "Deprecated Onboarding"]);
+	});
+
+	it("GET /api/wiki/stale-pages lists computed-stale, unverified, and explicitly stale/deprecated pages, excluding fresh ones", async () => {
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Overdue Page", content: overdueContent() }),
+		});
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Never Verified Page", content: unverifiedContent() }),
+		});
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({
+				title: "Explicitly Stale Page",
+				content: explicitStatusContent("stale"),
+			}),
+		});
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Fresh Page", content: freshContent() }),
+		});
+		await SELF.fetch("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "No Signal Page", content: "plain markdown" }),
+		});
+
+		// PROJ-489: 5 creates already used up this token's test-env rate limit
+		// (wrangler.test.toml RATE_LIMIT_API_MAX=5) — reset before the read below.
+		await env.DB.prepare("DELETE FROM rate_limit").run();
+		const res = await SELF.fetch("http://localhost/api/wiki/stale-pages", {
+			headers: authHeaders(token, slug),
+		});
+		expect(res.status).toBe(200);
+		const results = (await res.json()) as Array<{ title: string }>;
+		const titles = results.map((r) => r.title).sort();
+		expect(titles).toEqual(["Explicitly Stale Page", "Never Verified Page", "Overdue Page"]);
+	});
+
+	it("MCP list_stale_pages returns the same result shape as REST", async () => {
+		await mcpCall(
+			workspaceId,
+			"create_wiki_page",
+			{ title: "MCP Overdue Page", content: overdueContent() },
+			authHeaders(token, slug)
+		);
+		await mcpCall(
+			workspaceId,
+			"create_wiki_page",
+			{ title: "MCP Fresh Page", content: freshContent() },
+			authHeaders(token, slug)
+		);
+
+		const result = mcpData<Array<{ title: string }>>(
+			await mcpCall(workspaceId, "list_stale_pages", {}, authHeaders(token, slug))
+		);
+		expect(result.map((r) => r.title)).toContain("MCP Overdue Page");
+		expect(result.map((r) => r.title)).not.toContain("MCP Fresh Page");
 	});
 });

--- a/apps/docs/src/content/docs/agents/tool-catalog.md
+++ b/apps/docs/src/content/docs/agents/tool-catalog.md
@@ -11,7 +11,7 @@ running server.
 
 <!-- gen-mcp-catalog:start - generated block; run `pnpm --filter @projektor/api gen:catalog` to refresh -->
 
-**93 tools across 21 domains.**
+**95 tools across 21 domains.**
 
 ## Coordination
 
@@ -133,7 +133,7 @@ running server.
 | Tool | Description |
 |------|-------------|
 | `list_wiki_pages` | List wiki pages in the workspace, optionally filtered by parent, project, frontmatter type/status, or tags (any-of match) |
-| `search_wiki` | Full-text search over wiki pages (FTS5, BM25-ranked, title weighted above body). Returns match-anchored snippets highlighted with ** markers. type/status/tags filter on the denormalized frontmatter columns (R6); status here is unrelated to the freshness/staleness ranking work (R7, PROJ-489), which hasn't landed yet. |
+| `search_wiki` | Full-text search over wiki pages (FTS5, BM25-ranked, title weighted above body). Returns match-anchored snippets highlighted with ** markers, plus a computed `freshness` ({state, staleSince} or null if the page has no verify_interval/status signal) per result. type/status/tags filter on the denormalized frontmatter columns (R6). Results are demoted (ranked below everything else, ties broken by bm25 within each tier) when the page is computed-stale/unverified OR has an explicit status: stale\|deprecated (R7). |
 | `get_wiki_page` | Get a wiki page by slug, including full content |
 | `create_wiki_page` | Create a new wiki page. `content` may start with an optional YAML frontmatter block (`---\ntype: runbook\ntags: [foo]\nstatus: draft\n---\n...`) — type (freeform; well-known values runbook\|adr\|spec\|note), tags[], status (draft\|current\|stale\|deprecated), verified_at, verified_by, owners[], verify_interval (days) are parsed and denormalized for filtering. Invalid frontmatter (bad status/enum value, wrong field type, unrecognized key) is rejected with a structured validation error, not silently ignored. |
 | `update_wiki_page` | Update a wiki page by id or slug (saves a revision when content changes). Pass baseRevisionId (the current revision id from list_wiki_revisions/get_wiki_revision, or null if the page has never been revised) for conflict-safe writes: if the page advanced since baseRevisionId, the write is rejected with a structured conflict (currentRevisionId + a unified diff) instead of silently overwriting. Omitting baseRevisionId is DEPRECATED — it keeps today's last-write-wins behavior during the transition and will be rejected in a future version. `content` may include a YAML frontmatter block (see create_wiki_page); it's re-parsed on every content edit, replacing the page's previously-stored metadata. Omitting `content` leaves the page's existing frontmatter metadata unchanged. |
@@ -144,6 +144,8 @@ running server.
 | `backfill_wiki_links` | One-time (idempotent, safe to re-run) recompute of the wiki_links graph for every existing page in the workspace. Owner/admin only. |
 | `list_wiki_revisions` | List revision history for a wiki page |
 | `get_wiki_revision` | Get the content of a specific wiki revision by its ID |
+| `verify_wiki_page` | Stamp a wiki page as freshly verified — sets its frontmatter verified_at to now and verified_by to the CALLING user's email (never caller-supplied). Rewrites the page's frontmatter block (creating one if it had none) and records a revision, same as any other content edit. Not allowed for viewers. |
+| `list_stale_pages` | Maintenance queue of wiki pages that need re-verification: computed-stale (verify_interval elapsed since verified_at), unverified (verify_interval declared but never verified), or explicitly status: stale\|deprecated. Same rule search_wiki uses to demote results (R7). |
 
 ### Attachments
 

--- a/apps/docs/src/content/docs/agents/tool-catalog.md
+++ b/apps/docs/src/content/docs/agents/tool-catalog.md
@@ -144,7 +144,7 @@ running server.
 | `backfill_wiki_links` | One-time (idempotent, safe to re-run) recompute of the wiki_links graph for every existing page in the workspace. Owner/admin only. |
 | `list_wiki_revisions` | List revision history for a wiki page |
 | `get_wiki_revision` | Get the content of a specific wiki revision by its ID |
-| `verify_wiki_page` | Stamp a wiki page as freshly verified — sets its frontmatter verified_at to now and verified_by to the CALLING user's email (never caller-supplied). Rewrites the page's frontmatter block (creating one if it had none) and records a revision, same as any other content edit. Not allowed for viewers. |
+| `verify_wiki_page` | Stamp a wiki page as freshly verified — sets its frontmatter verified_at to now and verified_by to the CALLING user's email (never caller-supplied). Rewrites the page's frontmatter block (creating one if it had none) and records a revision, same as any other content edit — including its conflict check, so a concurrent edit racing the stamp is rejected rather than reverted. Not allowed for viewers. |
 | `list_stale_pages` | Maintenance queue of wiki pages that need re-verification: computed-stale (verify_interval elapsed since verified_at), unverified (verify_interval declared but never verified), or explicitly status: stale\|deprecated. Same rule search_wiki uses to demote results (R7). |
 
 ### Attachments

--- a/apps/docs/src/generated/mcp-stats.json
+++ b/apps/docs/src/generated/mcp-stats.json
@@ -1,4 +1,4 @@
 {
-	"tools": 93,
+	"tools": 95,
 	"domains": 21
 }

--- a/apps/web/src/islands/WikiPage.test.tsx
+++ b/apps/web/src/islands/WikiPage.test.tsx
@@ -10,6 +10,11 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/preact";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import WikiPage from "./WikiPage";
 
+interface WikiFreshness {
+	state: "fresh" | "stale" | "unverified";
+	staleSince: number | null;
+}
+
 interface WikiPageData {
 	id: string;
 	slug: string;
@@ -24,6 +29,7 @@ interface WikiPageData {
 	verified_by: string | null;
 	owners: string[];
 	verify_interval: number | null;
+	freshness: WikiFreshness | null;
 }
 
 const PAGE: WikiPageData = {
@@ -40,6 +46,7 @@ const PAGE: WikiPageData = {
 	verified_by: null,
 	owners: [],
 	verify_interval: null,
+	freshness: null,
 };
 
 function mockFetchWiki(page: WikiPageData | null, ok = true, status = 404) {
@@ -719,5 +726,143 @@ describe("WikiPage frontmatter metadata (PROJ-488)", () => {
 				)
 			).toBe(true);
 		});
+	});
+});
+
+// PROJ-489 (R7): Verify button + computed staleness badge in the metadata header card.
+describe("WikiPage freshness model (PROJ-489)", () => {
+	const STALE_PAGE: WikiPageData = {
+		...PAGE,
+		verify_interval: 30,
+		verified_at: 1_000_000,
+		freshness: { state: "stale", staleSince: 1_000_000 + 30 * 86400 },
+	};
+
+	const FRESH_PAGE: WikiPageData = {
+		...PAGE,
+		verify_interval: 365,
+		verified_at: 1_000_000,
+		freshness: { state: "fresh", staleSince: null },
+	};
+
+	it("renders a Verify button and a Stale badge for a computed-stale page", async () => {
+		mockFetchWiki(STALE_PAGE);
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+
+		expect(screen.getByRole("button", { name: "Verify" })).toBeTruthy();
+		expect(screen.getByText("Stale")).toBeTruthy();
+	});
+
+	it("does not render a staleness badge for a fresh page", async () => {
+		mockFetchWiki(FRESH_PAGE);
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+
+		expect(screen.getByRole("button", { name: "Verify" })).toBeTruthy();
+		expect(screen.queryByText("Stale")).toBeNull();
+		expect(screen.queryByText("Unverified")).toBeNull();
+	});
+
+	it("renders no Verify button for a page with no verification signal at all", async () => {
+		mockFetchWiki(PAGE);
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+
+		expect(screen.queryByRole("button", { name: "Verify" })).toBeNull();
+	});
+
+	it("clicking Verify POSTs to /verify and refetches the page", async () => {
+		let verifyCalled = false;
+		const verifiedPage: WikiPageData = {
+			...STALE_PAGE,
+			verified_at: 2_000_000,
+			verified_by: "me@example.com",
+			freshness: { state: "fresh", staleSince: null },
+		};
+		const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+			const u = String(url);
+			if (u.includes("/revisions")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			}
+			if (u.includes("/tree")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			}
+			if (u.includes("/verify") && init?.method === "POST") {
+				verifyCalled = true;
+				return Promise.resolve({
+					ok: true,
+					json: () =>
+						Promise.resolve({
+							ok: true,
+							verifiedAt: 2_000_000,
+							verifiedBy: "me@example.com",
+							freshness: { state: "fresh", staleSince: null },
+						}),
+				});
+			}
+			return Promise.resolve({
+				ok: true,
+				json: () => Promise.resolve(verifyCalled ? verifiedPage : STALE_PAGE),
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+
+		fireEvent.click(screen.getByRole("button", { name: "Verify" }));
+
+		await waitFor(() => {
+			expect(
+				fetchMock.mock.calls.some(
+					([u, init]) => String(u).includes("/verify") && init?.method === "POST"
+				)
+			).toBe(true);
+		});
+		await waitFor(() => {
+			expect(screen.queryByText("Stale")).toBeNull();
+		});
+	});
+
+	it("renders a staleness badge in search results for a stale match", async () => {
+		const fetchMock = vi.fn().mockImplementation((url: string) => {
+			const u = String(url);
+			if (u.includes("/revisions")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			}
+			if (u.includes("/tree")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			}
+			if (u.includes("/api/wiki/search")) {
+				return Promise.resolve({
+					ok: true,
+					json: () =>
+						Promise.resolve([
+							{
+								id: "w2",
+								slug: "stale-runbook",
+								title: "Stale Runbook",
+								project_id: null,
+								excerpt: null,
+								type: null,
+								status: null,
+								tags: [],
+								freshness: { state: "stale", staleSince: 123 },
+							},
+						]),
+				});
+			}
+			return Promise.resolve({ ok: true, json: () => Promise.resolve(PAGE) });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+
+		fireEvent.input(screen.getByLabelText(/Search wiki pages/i), {
+			target: { value: "runbook" },
+		});
+
+		expect(await screen.findByText("Stale Runbook")).toBeTruthy();
+		expect(screen.getByText("Stale")).toBeTruthy();
 	});
 });

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -14,6 +14,13 @@ interface ProjectOption {
 	name: string;
 }
 
+// PROJ-489 (R7): computed/derived at read time, never stored — null when the page has
+// no verify_interval/status frontmatter signal at all.
+interface WikiFreshness {
+	state: "fresh" | "stale" | "unverified";
+	staleSince: number | null;
+}
+
 interface SearchResult {
 	id: string;
 	slug: string;
@@ -24,6 +31,9 @@ interface SearchResult {
 	type: string | null;
 	status: string | null;
 	tags: string[];
+	// PROJ-489 (R7): search demotes stale/deprecated results — surfaced here so the UI
+	// can show why a result ranks low.
+	freshness: WikiFreshness | null;
 }
 
 interface WikiPageData {
@@ -41,6 +51,16 @@ interface WikiPageData {
 	verified_by: string | null;
 	owners: string[];
 	verify_interval: number | null;
+	// PROJ-489 (R7): computed freshness, surfaced in the page header.
+	freshness: WikiFreshness | null;
+}
+
+// PROJ-489 (R7): the list_stale_pages maintenance queue shape.
+interface StalePageItem {
+	id: string;
+	slug: string;
+	title: string;
+	freshness: WikiFreshness | null;
 }
 
 // PROJ-488: shape returned by GET /api/wiki (listWikiPages) — used for the sidebar's
@@ -93,6 +113,31 @@ function WikiStatusPill({ status }: { status: string }) {
 	);
 }
 
+// PROJ-489 (R7): "fresh" renders nothing — only stale/unverified pages need a visual
+// nudge; a page with no freshness signal at all (`null`) also renders nothing (handled
+// by the caller, not this component).
+const WIKI_FRESHNESS_BADGE_STYLE: Record<string, { bg: string; color: string; label: string }> = {
+	stale: { bg: "var(--priority-high-bg)", color: "var(--priority-high-text)", label: "Stale" },
+	unverified: {
+		bg: "var(--priority-low-bg)",
+		color: "var(--priority-low-text)",
+		label: "Unverified",
+	},
+};
+
+function WikiFreshnessBadge({ state }: { state: WikiFreshness["state"] }) {
+	const style = WIKI_FRESHNESS_BADGE_STYLE[state];
+	if (!style) return null;
+	return (
+		<span
+			class="inline-flex items-center px-2 py-[0.1rem] rounded-full text-[0.72rem] font-semibold uppercase tracking-wide"
+			style={{ background: style.bg, color: style.color }}
+		>
+			{style.label}
+		</span>
+	);
+}
+
 const WIKI_TAG_CHIP_CLASS =
 	"inline-flex items-center px-2 py-[0.1rem] mr-1 mb-1 rounded-full text-[0.72rem] " +
 	"bg-bg border border-border text-text-base";
@@ -113,14 +158,29 @@ function TagChips({ tags }: { tags: string[] | undefined | null }) {
 // PROJ-488: header card summarizing a page's frontmatter metadata (type/status/tags/
 // owners/verification). Omitted entirely for a page with no frontmatter at all, so
 // pages predating this feature (or that simply don't use it) render exactly as before.
-function WikiMetadataCard({ page }: { page: WikiPageData }) {
+//
+// PROJ-489 (R7): the Verify button/freshness badge only render when the page has opted
+// into verification tracking (a verify_interval or a status set) — a page with neither
+// has freshness: null and nothing meaningful to verify against.
+function WikiMetadataCard({
+	page,
+	onVerify,
+	verifying,
+	verifyError,
+}: {
+	page: WikiPageData;
+	onVerify: () => void;
+	verifying: boolean;
+	verifyError: string | null;
+}) {
 	const hasMetadata =
 		Boolean(page.type) ||
 		Boolean(page.status) ||
 		page.tags.length > 0 ||
 		page.owners.length > 0 ||
 		Boolean(page.verified_at);
-	if (!hasMetadata) return null;
+	const hasVerificationSignal = Boolean(page.verify_interval) || Boolean(page.status);
+	if (!hasMetadata && !hasVerificationSignal) return null;
 
 	return (
 		<div class="flex flex-wrap items-center gap-2 mb-4 p-3 border border-border rounded-lg bg-surface text-[0.8rem] text-text-muted">
@@ -130,12 +190,30 @@ function WikiMetadataCard({ page }: { page: WikiPageData }) {
 				</span>
 			)}
 			{page.status && <WikiStatusPill status={page.status} />}
+			{page.freshness && page.freshness.state !== "fresh" && (
+				<WikiFreshnessBadge state={page.freshness.state} />
+			)}
 			<TagChips tags={page.tags} />
 			{page.owners.length > 0 && <span>Owners: {page.owners.join(", ")}</span>}
 			{page.verified_at && (
 				<span>
 					Verified {new Date(page.verified_at * 1000).toLocaleDateString()}
 					{page.verified_by ? ` by ${page.verified_by}` : ""}
+				</span>
+			)}
+			{hasVerificationSignal && (
+				<button
+					type="button"
+					class="btn btn-outline btn-sm"
+					onClick={onVerify}
+					disabled={verifying}
+				>
+					{verifying ? "Verifying…" : "Verify"}
+				</button>
+			)}
+			{verifyError && (
+				<span role="alert" class="text-[var(--danger-text)]">
+					{verifyError}
 				</span>
 			)}
 		</div>
@@ -300,15 +378,54 @@ function SearchResultsList({
 				<li key={r.id}>
 					<button type="button" class={SEARCH_RESULT_BUTTON_CLASS} onClick={() => onSelect(r.slug)}>
 						<span class="font-medium">{r.title}</span>
-						{(r.type || r.status || (r.tags?.length ?? 0) > 0) && (
+						{(r.type ||
+							r.status ||
+							(r.tags?.length ?? 0) > 0 ||
+							(r.freshness && r.freshness.state !== "fresh")) && (
 							<span class="block mt-[0.15rem]">
 								{r.status && <WikiStatusPill status={r.status} />}
+								{r.freshness && r.freshness.state !== "fresh" && (
+									<WikiFreshnessBadge state={r.freshness.state} />
+								)}
 								<TagChips tags={r.tags} />
 							</span>
 						)}
 						{r.excerpt && (
 							<span class="block text-[0.75rem] text-text-muted truncate">
 								{renderHighlightedExcerpt(r.excerpt)}
+							</span>
+						)}
+					</button>
+				</li>
+			))}
+		</ul>
+	);
+}
+
+// PROJ-489 (R7): the list_stale_pages maintenance queue — a simple flat list, matching
+// FilteredPagesList's styling below (no existing "maintenance queue" UI precedent to
+// follow elsewhere in this codebase).
+function StalePagesList({
+	loading,
+	results,
+	onSelect,
+}: {
+	loading: boolean;
+	results: StalePageItem[];
+	onSelect: (slug: string) => void;
+}) {
+	if (loading) return <p class="text-[0.8rem] text-text-muted m-0">Loading…</p>;
+	if (results.length === 0)
+		return <p class="text-[0.8rem] text-text-muted m-0">Nothing needs verification</p>;
+	return (
+		<ul class="list-none m-0 p-0">
+			{results.map((r) => (
+				<li key={r.id}>
+					<button type="button" class={SEARCH_RESULT_BUTTON_CLASS} onClick={() => onSelect(r.slug)}>
+						<span class="font-medium">{r.title}</span>
+						{r.freshness && (
+							<span class="block mt-[0.15rem]">
+								<WikiFreshnessBadge state={r.freshness.state} />
 							</span>
 						)}
 					</button>
@@ -488,6 +605,10 @@ function WikiSidebar({
 	hasActiveFilters,
 	filteredResults,
 	filteredLoading,
+	staleOpen,
+	onToggleStale,
+	stalePages,
+	staleLoading,
 }: {
 	workspaceSlug: string | undefined;
 	projectId: string;
@@ -509,6 +630,10 @@ function WikiSidebar({
 	hasActiveFilters: boolean;
 	filteredResults: WikiListItem[];
 	filteredLoading: boolean;
+	staleOpen: boolean;
+	onToggleStale: (open: boolean) => void;
+	stalePages: StalePageItem[];
+	staleLoading: boolean;
 }) {
 	const asideClass = [
 		"w-[240px] shrink-0 bg-surface border-r border-border p-4 overflow-y-auto",
@@ -558,6 +683,19 @@ function WikiSidebar({
 			) : (
 				<PageTreeList loading={treeLoading} tree={pageTree} slug={slug} onNavigate={onNavigate} />
 			)}
+			<details
+				class="mt-3 pt-3 border-t border-border"
+				open={staleOpen}
+				// biome-ignore lint/suspicious/noExplicitAny: Preact's JSX types don't declare onToggle on <details>
+				onToggle={((e: any) => onToggleStale(e.currentTarget.open)) as any}
+			>
+				<summary class="cursor-pointer text-[0.8rem] text-text-muted select-none">
+					Needs verification
+				</summary>
+				<div class="pt-2">
+					<StalePagesList loading={staleLoading} results={stalePages} onSelect={onNavigate} />
+				</div>
+			</details>
 		</aside>
 	);
 }
@@ -1059,6 +1197,10 @@ interface PageArticleProps {
 	onStartEdit: () => void;
 	onStartCreateChild: (pageId: string) => void;
 	onDelete: () => void;
+	// PROJ-489 (R7): the metadata header card's Verify button.
+	onVerify: () => void;
+	verifying: boolean;
+	verifyError: string | null;
 	moving: boolean;
 	moveOptions: SelectOption[];
 	moveTargetId: string;
@@ -1110,6 +1252,9 @@ function PageArticleMeta(
 		| "onStartEdit"
 		| "onStartCreateChild"
 		| "onDelete"
+		| "onVerify"
+		| "verifying"
+		| "verifyError"
 		| "moving"
 		| "moveOptions"
 		| "moveTargetId"
@@ -1156,7 +1301,14 @@ function PageArticleMeta(
 				onDelete={props.onDelete}
 			/>
 
-			{!props.editing && <WikiMetadataCard page={props.page} />}
+			{!props.editing && (
+				<WikiMetadataCard
+					page={props.page}
+					onVerify={props.onVerify}
+					verifying={props.verifying}
+					verifyError={props.verifyError}
+				/>
+			)}
 
 			{props.moving && (
 				<MovePageForm
@@ -1383,6 +1535,36 @@ function useWikiTree(workspaceSlug: string | undefined, projectId: string) {
 	}, [fetchTree]);
 
 	return { pageTree, pageMap, treeLoading, fetchTree };
+}
+
+// PROJ-489 (R7): the list_stale_pages maintenance queue, shown as a collapsible section
+// in the sidebar — fetched lazily (only once expanded) since most sessions won't open it.
+function useWikiStalePages(workspaceSlug: string | undefined, projectId: string) {
+	const [staleOpen, setStaleOpen] = useState(false);
+	const [stalePages, setStalePages] = useState<StalePageItem[]>([]);
+	const [staleLoading, setStaleLoading] = useState(false);
+
+	useEffect(() => {
+		if (!staleOpen) return;
+		let cancelled = false;
+		setStaleLoading(true);
+		const qs = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
+		apiFetch<StalePageItem[]>(`/api/wiki/stale-pages${qs}`, { workspaceSlug })
+			.then((data) => {
+				if (!cancelled) setStalePages(Array.isArray(data) ? data : []);
+			})
+			.catch(() => {
+				if (!cancelled) setStalePages([]);
+			})
+			.finally(() => {
+				if (!cancelled) setStaleLoading(false);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [staleOpen, workspaceSlug, projectId]);
+
+	return { staleOpen, setStaleOpen, stalePages, staleLoading };
 }
 
 // PROJ-488: type/status/tags filters shared between the sidebar's filtered browse view
@@ -1978,6 +2160,37 @@ function useMovePage(
 	};
 }
 
+// PROJ-489 (R7): stamps verified_at/verified_by (server resolves the CALLING user's
+// identity — nothing to pass here) and refetches the page so the header reflects the
+// new freshness state immediately.
+function useWikiVerify(
+	workspaceSlug: string | undefined,
+	page: WikiPageData | null,
+	fetchPage: (s: string) => Promise<void>
+) {
+	const [verifying, setVerifying] = useState(false);
+	const [verifyError, setVerifyError] = useState<string | null>(null);
+
+	async function verifyPage() {
+		if (!page) return;
+		setVerifying(true);
+		setVerifyError(null);
+		try {
+			await apiFetch(`/api/wiki/${encodeURIComponent(page.slug)}/verify`, {
+				method: "POST",
+				workspaceSlug,
+			});
+			await fetchPage(page.slug);
+		} catch (e) {
+			setVerifyError(`Verify failed: ${String(e)}`);
+		} finally {
+			setVerifying(false);
+		}
+	}
+
+	return { verifying, verifyError, verifyPage };
+}
+
 function useCreatePageForm(
 	workspaceSlug: string | undefined,
 	projectId: string,
@@ -2201,6 +2414,7 @@ function WikiPageShell(props: {
 	onNavigate: (slug: string) => void;
 	onCreate: () => void;
 	filters: ReturnType<typeof useWikiFilters>;
+	stale: ReturnType<typeof useWikiStalePages>;
 	mainContentProps: {
 		creating: boolean;
 		createProps: CreateFormProps;
@@ -2235,6 +2449,10 @@ function WikiPageShell(props: {
 				hasActiveFilters={props.filters.hasActiveFilters}
 				filteredResults={props.filters.filteredResults}
 				filteredLoading={props.filters.filteredLoading}
+				staleOpen={props.stale.staleOpen}
+				onToggleStale={props.stale.setStaleOpen}
+				stalePages={props.stale.stalePages}
+				staleLoading={props.stale.staleLoading}
 			/>
 
 			<main class="flex-1 p-8 min-w-0">
@@ -2314,6 +2532,9 @@ function buildArticleProps(article: {
 	startEdit: () => void;
 	startCreate: (parentId: string | null) => void;
 	deletePage: () => void;
+	onVerify: () => void;
+	verifying: boolean;
+	verifyError: string | null;
 	latestRevision: WikiRevision | null;
 	saveError: string | null;
 	draftBanner: { title: string; content: string; savedAt: number } | null;
@@ -2346,6 +2567,9 @@ function buildArticleProps(article: {
 		onStartEdit: article.startEdit,
 		onStartCreateChild: article.startCreate,
 		onDelete: article.deletePage,
+		onVerify: article.onVerify,
+		verifying: article.verifying,
+		verifyError: article.verifyError,
 		latestRevision: article.latestRevision,
 		saveError: article.saveError,
 		draftBanner: article.draftBanner,
@@ -2389,6 +2613,7 @@ export default function WikiPage({
 	const { slug, setSlug, projectId } = useWikiUrlState(projectIdProp, slugProp);
 	const { pageTree, pageMap, treeLoading, fetchTree } = useWikiTree(workspaceSlug, projectId);
 	const filters = useWikiFilters(workspaceSlug, projectId);
+	const stale = useWikiStalePages(workspaceSlug, projectId);
 	const { searchQuery, setSearchQuery, searchResults, searchLoading } = useWikiSearch(
 		workspaceSlug,
 		projectId,
@@ -2413,6 +2638,7 @@ export default function WikiPage({
 	);
 	const createForm = useCreatePageForm(workspaceSlug, projectId, fetchTree);
 	const move = useMovePage(workspaceSlug, pageData.page, pageData.fetchPage, fetchTree);
+	const verify = useWikiVerify(workspaceSlug, pageData.page, pageData.fetchPage);
 
 	const { navigateTo, startCreate, submitCreate, deletePage } = createWikiActions({
 		workspaceSlug,
@@ -2467,6 +2693,9 @@ export default function WikiPage({
 		startEdit,
 		startCreate,
 		deletePage,
+		onVerify: verify.verifyPage,
+		verifying: verify.verifying,
+		verifyError: verify.verifyError,
 		latestRevision,
 		saveError: editState.saveError,
 		draftBanner: editState.draftBanner,
@@ -2500,6 +2729,7 @@ export default function WikiPage({
 			onNavigate={navigateTo}
 			onCreate={() => startCreate(null)}
 			filters={filters}
+			stale={stale}
 			mainContentProps={{
 				creating: createForm.creating,
 				createProps,


### PR DESCRIPTION
## Summary

Implements R7 (freshness model) from the agent-first wiki PRD, on top of R6/PROJ-488 (frontmatter metadata) and R4/PROJ-486.

- **`verify_wiki_page`** (MCP tool + `POST /api/wiki/:slug/verify`): stamps the page's frontmatter `verified_at`/`verified_by` using the *calling* user's identity (email, looked up server-side — never caller-supplied). Rewrites the frontmatter block (creating one if none existed) and routes through the existing `updateWikiPage` write path, so it records a normal revision.
- **Computed freshness** (`apps/api/src/services/wiki-freshness.ts`): a pure function `computeFreshness({ verifiedAt, verifyInterval, status, now })` → `{ state: "fresh" | "stale" | "unverified", staleSince } | null`. This is *not* a stored column — it's derived at read time and reused in three places: search result serialization, page-detail response, and `list_stale_pages`. Also mirrored by hand as a SQL condition (`staleWikiPageCondition`) where filtering/ordering must happen in SQL (flagged in-code as needing to be kept in lockstep with the TS version).
- **Search ranking demotion** (`searchWiki`): results are now ordered into two tiers ahead of bm25 — computed-fresh/no-signal pages first, computed-stale/unverified/explicit-stale-or-deprecated pages demoted to the bottom (ties within each tier broken by bm25 as before).
- **`list_stale_pages`** (MCP tool + `GET /api/wiki/stale-pages`): maintenance queue of pages that are computed-stale, unverified (verify_interval declared, never verified), or explicitly `status: stale`/`status: deprecated`.
- **UI** (`apps/web/src/islands/WikiPage.tsx`): a "Verify" button in the page metadata card (shown only when the page declares a `verify_interval` or `status` signal), a staleness badge in the page header and in search results, and a "Needs verification" collapsible list in the wiki sidebar backed by `list_stale_pages`.

## Design decisions

- **status vs. computed freshness**: rather than two separate demotion/filter rules, `computeFreshness` absorbs both signals into one `state` — explicit `status: stale|deprecated` always yields `state: "stale"` regardless of `verify_interval`/`verified_at`. Every consumer (search ranking, page header, stale-pages queue) reads this single computed value, so the two concepts can't drift out of sync.
- **`freshness: null`** means the page has no verify_interval/status signal at all (matches the pre-existing placeholder test's convention of "field present but null, never fabricated"), not "we don't know."
- **Verification rewrites frontmatter, not just DB columns** — per the PRD's "content is canonical" principle, so a verification stamp survives later content-only edits instead of being silently discarded on next frontmatter re-parse.
- **`verify_wiki_page` intentionally omits `baseRevisionId`** (last-write-wins), unlike `update_wiki_page`'s optional optimistic-locking path — kept deliberately frictionless since verification is a low-stakes, idempotent-ish stamp. Flagged as a possible future enhancement if concurrent-edit races around verification become a real problem.

## Gaps noticed (not implemented, flagging only)

- No UI exists yet for the R3/R5 "broken wiki links" maintenance queue (`list_broken_wiki_links` has REST/MCP but no island) — the new "Needs verification" sidebar list is the first UI precedent for this kind of queue; broken-links UI remains open.
- Backend allows `verify_wiki_page` on any page regardless of whether it has a `verify_interval`/`status` signal — only the UI conditionally hides the button. Intentional (agents may still want to stamp verification via MCP on any page) but worth noting as a deliberate frontend/backend asymmetry.

## Test plan

- [x] `pnpm gen:docs` (no diff)
- [x] `pnpm exec biome check .`
- [x] `pnpm turbo type-check`
- [x] `pnpm --filter @projektor/db test`
- [x] `pnpm --filter @projektor/api test:coverage`
- [x] `pnpm --filter @projektor/web test:coverage`
- [x] `pnpm --filter @projektor/web build`
- [x] `pnpm --filter @projektor/docs build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)