### PR TITLE
PROJ-492: revision diff view + one-click restore (R10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ command shown beside it (token + workspace pre-filled). The full walkthrough - A
 setup, first login, token, MCP - is in
 [CONFIGURE.md](https://github.com/TAJD/projektor-deploy-example/blob/main/CONFIGURE.md).
 
-See the **[agent connection guide](https://tajd.github.io/projektor/agents/mcp-connection/)** for the full connection guide, protocol reference, and tool catalog (<!-- gen-mcp-stats:start -->97 tools across 21 domains<!-- gen-mcp-stats:end --> - project data plus agent-coordination primitives).
+See the **[agent connection guide](https://tajd.github.io/projektor/agents/mcp-connection/)** for the full connection guide, protocol reference, and tool catalog (<!-- gen-mcp-stats:start -->98 tools across 21 domains<!-- gen-mcp-stats:end --> - project data plus agent-coordination primitives).
 
 ## Development
 

--- a/apps/api/src/mcp/wiki.ts
+++ b/apps/api/src/mcp/wiki.ts
@@ -379,6 +379,35 @@ export const wikiTools: MCPTool[] = [
 		},
 	},
 	{
+		name: "get_wiki_revision_diff",
+		description:
+			"Server-side unified diff between one revision (revisionId) and either another " +
+			"revision or the page's current content. `against` is a revision id or the literal " +
+			'string "current" (default when omitted). Same unified diff format as ' +
+			"update_wiki_page/patch_wiki_page's conflict responses (--- base / +++ current, " +
+			"@@ hunk headers).",
+		inputSchema: {
+			type: "object",
+			required: ["slug", "revisionId"],
+			properties: {
+				slug: { type: "string" },
+				revisionId: { type: "string" },
+				against: {
+					type: "string",
+					description: 'Another revision id, or "current" (default)',
+				},
+			},
+		},
+		async handler(input, ctx) {
+			const { slug, revisionId, against } = input as {
+				slug: string;
+				revisionId: string;
+				against?: string;
+			};
+			return wikiService.getWikiRevisionDiff(ctx as ServiceCtx, slug, revisionId, { against });
+		},
+	},
+	{
 		name: "verify_wiki_page",
 		description:
 			"Stamp a wiki page as freshly verified — sets its frontmatter verified_at to now and " +

--- a/apps/api/src/routes/wiki.ts
+++ b/apps/api/src/routes/wiki.ts
@@ -125,6 +125,19 @@ router.get("/:slug/revisions/:revisionId", async (c) => {
 	}
 });
 
+router.get("/:slug/revisions/:revisionId/diff", async (c) => {
+	const ctx = ctxFromHono(c);
+	try {
+		return c.json(
+			await wikiService.getWikiRevisionDiff(ctx, c.req.param("slug"), c.req.param("revisionId"), {
+				against: c.req.query("against"),
+			})
+		);
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
+});
+
 router.get("/:slug/revisions", async (c) => {
 	const ctx = ctxFromHono(c);
 	try {

--- a/apps/api/src/schemas/wiki.ts
+++ b/apps/api/src/schemas/wiki.ts
@@ -129,6 +129,12 @@ export const SearchWikiInputSchema = z.object({
 	status: WikiStatusFilterSchema,
 });
 
+// PROJ-492 (R10): `against` is either another revision id or the literal string
+// "current" (default) meaning the page's live content.
+export const WikiRevisionDiffInputSchema = z.object({
+	against: z.string().min(1).optional().default("current"),
+});
+
 export const DeleteWikiPageOptionsSchema = z.object({
 	// Default (false): children are promoted to the deleted page's parent. true: the
 	// deleted page's entire subtree is removed too.

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -12,6 +12,7 @@ import {
 	PatchWikiPageInputSchema,
 	SearchWikiInputSchema,
 	UpdatePageSchema,
+	WikiRevisionDiffInputSchema,
 } from "../schemas/wiki";
 import {
 	canWriteProject,
@@ -849,7 +850,7 @@ function computeLineDiff(oldLines: string[], newLines: string[]): DiffOp[] {
 // PROJ-484: renders a standard unified diff (`--- base` / `+++ current`, `@@ -a,b +c,d @@`
 // hunks with 3 lines of context) between a conflicting write's base content and the
 // page's current content, so an agent can see exactly what changed and rebase.
-function buildUnifiedDiff(baseContent: string, currentContent: string): string {
+export function buildUnifiedDiff(baseContent: string, currentContent: string): string {
 	if (baseContent === currentContent) return "";
 	const oldLines = baseContent.split("\n");
 	const newLines = currentContent.split("\n");
@@ -1850,4 +1851,48 @@ export async function getWikiRevision(ctx: ServiceCtx, idOrSlug: string, revisio
 	if (!revision) throw new NotFoundError("Revision not found");
 
 	return revision;
+}
+
+// PROJ-492 (R10): server-side unified diff between one revision (`revisionId`) and either
+// another revision or the page's current content (`against`, defaulting to "current").
+// Reuses buildUnifiedDiff (PROJ-484) — same format as update_wiki_page/patch_wiki_page's
+// conflict responses, so the UI/agent can render both with one diff renderer. Each
+// revision's own `content` column already IS the snapshot at that point in time (unlike
+// resolveBaseContent's off-by-one lookahead, which exists only to answer "what did the
+// caller actually have"), so both sides are read directly with no shifting.
+export async function getWikiRevisionDiff(
+	ctx: ServiceCtx,
+	idOrSlug: string,
+	revisionId: string,
+	input: unknown
+) {
+	const parsed = WikiRevisionDiffInputSchema.safeParse(input);
+	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
+	const { against } = parsed.data;
+
+	const page = await resolvePageByIdOrSlug(ctx.db, idOrSlug, ctx.workspaceId);
+	await assertWikiPageVisible(ctx, page.projectId);
+	const orm = drizzle(ctx.db, { schema });
+
+	const fromRevision = await orm
+		.select({ content: schema.wikiRevisions.content })
+		.from(schema.wikiRevisions)
+		.where(and(eq(schema.wikiRevisions.id, revisionId), eq(schema.wikiRevisions.pageId, page.id)))
+		.get();
+	if (!fromRevision) throw new NotFoundError("Revision not found");
+
+	let toContent: string;
+	if (against === "current") {
+		toContent = page.content;
+	} else {
+		const toRevision = await orm
+			.select({ content: schema.wikiRevisions.content })
+			.from(schema.wikiRevisions)
+			.where(and(eq(schema.wikiRevisions.id, against), eq(schema.wikiRevisions.pageId, page.id)))
+			.get();
+		if (!toRevision) throw new NotFoundError("Revision not found");
+		toContent = toRevision.content;
+	}
+
+	return { from: revisionId, to: against, diff: buildUnifiedDiff(fromRevision.content, toContent) };
 }

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -2396,6 +2396,93 @@ describe("Wiki revision diff (PROJ-492)", () => {
 		expect(revisions[0].id).not.toBe(latest.id);
 		expect(revisions.map((r) => r.id)).toContain(latest.id);
 	});
+
+	it("restore with a baseRevisionId that went stale while history was open is a 409, not a silent overwrite", async () => {
+		await req("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Raced Restore Doc", content: "original content" }),
+		});
+		await req("http://localhost/api/wiki/raced-restore-doc", {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "mistaken edit" }),
+		});
+		// What the restore UI froze when the history panel loaded.
+		const [staleLatest] = await getRevisions("raced-restore-doc");
+
+		// Someone else saves before the user clicks Restore.
+		await req("http://localhost/api/wiki/raced-restore-doc", {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "a colleague's edit" }),
+		});
+
+		const restoreRes = await req("http://localhost/api/wiki/raced-restore-doc", {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({
+				content: "original content",
+				baseRevisionId: staleLatest.id,
+				summary: "Restored from an old revision",
+			}),
+		});
+		expect(restoreRes.status).toBe(409);
+		const conflict = (await restoreRes.json()) as { currentRevisionId: string; diff: string };
+		expect(conflict.currentRevisionId).not.toBe(staleLatest.id);
+
+		// The colleague's edit survives untouched and no restore revision was written.
+		const pageRes = await req("http://localhost/api/wiki/raced-restore-doc", {
+			headers: authHeaders(token, slug),
+		});
+		expect(((await pageRes.json()) as { content: string }).content).toBe("a colleague's edit");
+		expect((await getRevisions("raced-restore-doc")).length).toBe(2);
+	});
+
+	it("restoring a revision whose frontmatter no longer validates fails cleanly — 400, no partial write", async () => {
+		await req("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Legacy Frontmatter Doc", content: "first body" }),
+		});
+		await req("http://localhost/api/wiki/legacy-frontmatter-doc", {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "second body" }),
+		});
+		const [latest] = await getRevisions("legacy-frontmatter-doc");
+
+		// Simulate a snapshot taken before R6's frontmatter validation existed, carrying a
+		// `status` value outside today's closed enum. Written straight to the revision row
+		// because the API (correctly) refuses to create such content in the first place.
+		await env.DB.prepare("UPDATE wiki_revisions SET content = ? WHERE id = ?")
+			.bind("---\nstatus: archived\n---\n\nlegacy body", latest.id)
+			.run();
+
+		const revRes = await req(
+			`http://localhost/api/wiki/legacy-frontmatter-doc/revisions/${latest.id}`,
+			{ headers: authHeaders(token, slug) }
+		);
+		const oldRevision = (await revRes.json()) as { content: string };
+
+		const restoreRes = await req("http://localhost/api/wiki/legacy-frontmatter-doc", {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({
+				content: oldRevision.content,
+				baseRevisionId: latest.id,
+				summary: "Restored from a legacy revision",
+			}),
+		});
+		expect(restoreRes.status).toBe(400);
+
+		// The live page is untouched and no half-written revision was left behind.
+		const pageRes = await req("http://localhost/api/wiki/legacy-frontmatter-doc", {
+			headers: authHeaders(token, slug),
+		});
+		expect(((await pageRes.json()) as { content: string }).content).toBe("second body");
+		expect((await getRevisions("legacy-frontmatter-doc")).length).toBe(1);
+	});
 });
 
 // PROJ-490: section-addressed patch operations (R8). Disjoint-section writes must

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -2194,6 +2194,210 @@ describe("Wiki optimistic locking (PROJ-484)", () => {
 	});
 });
 
+// PROJ-492 (R10): revision diff endpoint + restore-via-update_wiki_page. Restore is
+// deliberately NOT a dedicated endpoint — it's a client-side convenience that reads an
+// old revision's content and re-submits it through update_wiki_page/PUT with a
+// baseRevisionId, so it gets normal optimistic-locking/frontmatter/FTS/link-reindex
+// treatment for free (see PR description for the design rationale).
+describe("Wiki revision diff (PROJ-492)", () => {
+	let token: string;
+	let slug: string;
+	let workspaceId: string;
+
+	beforeEach(async () => {
+		const fixture = await seedFixture();
+		token = fixture.token;
+		slug = fixture.workspace.slug;
+		workspaceId = fixture.workspace.id;
+	});
+
+	async function req(url: string, opts?: RequestInit) {
+		await env.DB.prepare("DELETE FROM rate_limit").run();
+		return SELF.fetch(url, opts);
+	}
+
+	async function mcp<T>(name: string, args: unknown) {
+		await env.DB.prepare("DELETE FROM rate_limit").run();
+		return mcpCall<T>(workspaceId, name, args, authHeaders(token, slug));
+	}
+
+	async function getRevisions(pageSlug: string) {
+		const res = await req(`http://localhost/api/wiki/${pageSlug}/revisions`, {
+			headers: authHeaders(token, slug),
+		});
+		return (await res.json()) as Array<{ id: string; created_at: number }>;
+	}
+
+	it("REST: diff against current defaults when `against` is omitted", async () => {
+		await req("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Diffable Doc", content: "line one\nline two" }),
+		});
+		await req("http://localhost/api/wiki/diffable-doc", {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "line one\nline THREE" }),
+		});
+		const [latest] = await getRevisions("diffable-doc");
+
+		const res = await req(`http://localhost/api/wiki/diffable-doc/revisions/${latest.id}/diff`, {
+			headers: authHeaders(token, slug),
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { from: string; to: string; diff: string };
+		expect(body.from).toBe(latest.id);
+		expect(body.to).toBe("current");
+		expect(body.diff).toContain("-line two");
+		expect(body.diff).toContain("+line THREE");
+	});
+
+	it("REST: diff between two explicit revisions", async () => {
+		await req("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Multi Rev Doc", content: "v1" }),
+		});
+		await req("http://localhost/api/wiki/multi-rev-doc", {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "v2" }),
+		});
+		await req("http://localhost/api/wiki/multi-rev-doc", {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "v3" }),
+		});
+		const [v2Revision, v1Revision] = await getRevisions("multi-rev-doc");
+
+		const res = await req(
+			`http://localhost/api/wiki/multi-rev-doc/revisions/${v1Revision.id}/diff?against=${v2Revision.id}`,
+			{ headers: authHeaders(token, slug) }
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { diff: string };
+		expect(body.diff).toContain("-v1");
+		expect(body.diff).toContain("+v2");
+	});
+
+	it("REST: identical revisions diff to an empty string", async () => {
+		await req("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Unchanged Doc", content: "same" }),
+		});
+		await req("http://localhost/api/wiki/unchanged-doc", {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "same" }),
+		});
+		const [latest] = await getRevisions("unchanged-doc");
+
+		const res = await req(
+			`http://localhost/api/wiki/unchanged-doc/revisions/${latest.id}/diff?against=current`,
+			{ headers: authHeaders(token, slug) }
+		);
+		expect(res.status).toBe(200);
+		expect(((await res.json()) as { diff: string }).diff).toBe("");
+	});
+
+	it("REST: an unknown `against` revision id 404s", async () => {
+		await req("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Unknown Against Doc", content: "v1" }),
+		});
+		await req("http://localhost/api/wiki/unknown-against-doc", {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "v2" }),
+		});
+		const [latest] = await getRevisions("unknown-against-doc");
+
+		const res = await req(
+			`http://localhost/api/wiki/unknown-against-doc/revisions/${latest.id}/diff?against=${crypto.randomUUID()}`,
+			{ headers: authHeaders(token, slug) }
+		);
+		expect(res.status).toBe(404);
+	});
+
+	it("REST: an unknown revisionId 404s", async () => {
+		await req("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "No Such Revision Doc", content: "v1" }),
+		});
+
+		const res = await req(
+			`http://localhost/api/wiki/no-such-revision-doc/revisions/${crypto.randomUUID()}/diff`,
+			{ headers: authHeaders(token, slug) }
+		);
+		expect(res.status).toBe(404);
+	});
+
+	it("MCP: get_wiki_revision_diff parity with REST", async () => {
+		const created = mcpData<{ slug: string }>(
+			await mcp("create_wiki_page", { title: "MCP Diff Doc", content: "alpha" })
+		);
+		await mcp("update_wiki_page", { slug: created.slug, content: "beta" });
+		const [latest] = mcpData<Array<{ id: string }>>(
+			await mcp("list_wiki_revisions", { slug: created.slug })
+		);
+
+		const result = mcpData<{ from: string; to: string; diff: string }>(
+			await mcp("get_wiki_revision_diff", { slug: created.slug, revisionId: latest.id })
+		);
+		expect(result.to).toBe("current");
+		expect(result.diff).toContain("-alpha");
+		expect(result.diff).toContain("+beta");
+	});
+
+	it("restore is a plain update_wiki_page call with the old revision's content — creates a new revision, never rewrites history", async () => {
+		await req("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Restorable Doc", content: "original content" }),
+		});
+		await req("http://localhost/api/wiki/restorable-doc", {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "mistaken edit" }),
+		});
+		const [latest] = await getRevisions("restorable-doc");
+
+		// Fetch the old revision's content (what the restore UI does) and resubmit it.
+		const revRes = await req(`http://localhost/api/wiki/restorable-doc/revisions/${latest.id}`, {
+			headers: authHeaders(token, slug),
+		});
+		const oldRevision = (await revRes.json()) as { content: string };
+		expect(oldRevision.content).toBe("original content");
+
+		const restoreRes = await req("http://localhost/api/wiki/restorable-doc", {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({
+				content: oldRevision.content,
+				baseRevisionId: latest.id,
+				summary: `Restored from revision ${latest.id}`,
+			}),
+		});
+		expect(restoreRes.status).toBe(200);
+
+		const pageRes = await req("http://localhost/api/wiki/restorable-doc", {
+			headers: authHeaders(token, slug),
+		});
+		expect(((await pageRes.json()) as { content: string }).content).toBe("original content");
+
+		// Restoring created a NEW (third) revision snapshotting the pre-restore "mistaken
+		// edit" content — it never rewrote or deleted the original "original content"
+		// revision, which is still present in history.
+		const revisions = await getRevisions("restorable-doc");
+		expect(revisions.length).toBe(2);
+		expect(revisions[0].id).not.toBe(latest.id);
+		expect(revisions.map((r) => r.id)).toContain(latest.id);
+	});
+});
+
 // PROJ-490: section-addressed patch operations (R8). Disjoint-section writes must
 // never conflict — that's the headline behavior a naive whole-page baseRevisionId
 // check would break.

--- a/apps/docs/src/content/docs/agents/tool-catalog.md
+++ b/apps/docs/src/content/docs/agents/tool-catalog.md
@@ -11,7 +11,7 @@ running server.
 
 <!-- gen-mcp-catalog:start - generated block; run `pnpm --filter @projektor/api gen:catalog` to refresh -->
 
-**97 tools across 21 domains.**
+**98 tools across 21 domains.**
 
 ## Coordination
 
@@ -145,6 +145,7 @@ running server.
 | `backfill_wiki_links` | One-time (idempotent, safe to re-run) recompute of the wiki_links graph for every existing page in the workspace. Owner/admin only. |
 | `list_wiki_revisions` | List revision history for a wiki page |
 | `get_wiki_revision` | Get the content of a specific wiki revision by its ID |
+| `get_wiki_revision_diff` | Server-side unified diff between one revision (revisionId) and either another revision or the page's current content. `against` is a revision id or the literal string "current" (default when omitted). Same unified diff format as update_wiki_page/patch_wiki_page's conflict responses (--- base / +++ current, @@ hunk headers). |
 | `verify_wiki_page` | Stamp a wiki page as freshly verified — sets its frontmatter verified_at to now and verified_by to the CALLING user's email (never caller-supplied). Rewrites the page's frontmatter block (creating one if it had none) and records a revision, same as any other content edit — including its conflict check, so a concurrent edit racing the stamp is rejected rather than reverted. Not allowed for viewers. |
 | `list_stale_pages` | Maintenance queue of wiki pages that need re-verification: computed-stale (verify_interval elapsed since verified_at), unverified (verify_interval declared but never verified), or explicitly status: stale\|deprecated. Same rule search_wiki uses to demote results (R7). |
 | `list_wiki_templates` | List pages flagged as templates (frontmatter `template: true`) — the picker create_wiki_page's `templateSlug` draws from. Templates are conventionally workspace-global (living under a workspace 'Templates' page) but a project-scoped template is allowed and follows the same project-visibility rule as any other project-scoped page. |

--- a/apps/docs/src/generated/mcp-stats.json
+++ b/apps/docs/src/generated/mcp-stats.json
@@ -1,4 +1,4 @@
 {
-	"tools": 97,
+	"tools": 98,
 	"domains": 21
 }

--- a/apps/web/src/islands/WikiPage.test.tsx
+++ b/apps/web/src/islands/WikiPage.test.tsx
@@ -952,3 +952,110 @@ describe("WikiPage — create page template picker (PROJ-491)", () => {
 		expect(screen.queryByRole("combobox", { name: /Seed content from template/i })).toBeNull();
 	});
 });
+
+// PROJ-492 (R10): revision diff view + one-click restore.
+describe("revision history: diff view + restore (PROJ-492)", () => {
+	const REVISION_WITH_SUMMARY = {
+		id: "rev-old",
+		author_id: "u1",
+		author_name: "Ann",
+		created_at: 500,
+		summary: "Fixed a typo",
+	};
+
+	function mockFetchWithRevision(opts: {
+		diff?: { from: string; to: string; diff: string };
+		oldRevisionContent?: string;
+		putResponse?: { ok: boolean; status?: number };
+	}) {
+		return vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+			const u = String(url);
+			if (u.includes("/diff")) {
+				return Promise.resolve({
+					ok: true,
+					json: () =>
+						Promise.resolve(
+							opts.diff ?? { from: "rev-old", to: "current", diff: "-old line\n+new line" }
+						),
+				});
+			}
+			if (/\/revisions\/rev-old$/.test(u)) {
+				return Promise.resolve({
+					ok: true,
+					json: () =>
+						Promise.resolve({
+							...REVISION_WITH_SUMMARY,
+							content: opts.oldRevisionContent ?? "old content",
+						}),
+				});
+			}
+			if (u.includes("/revisions")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([REVISION_WITH_SUMMARY]) });
+			}
+			if (u.includes("/tree")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			}
+			if (init?.method === "PUT") {
+				const putResponse = opts.putResponse ?? { ok: true };
+				return putResponse.ok
+					? Promise.resolve({ ok: true, json: () => Promise.resolve({ ...PAGE }) })
+					: Promise.resolve({ ok: false, status: putResponse.status });
+			}
+			return Promise.resolve({ ok: true, json: () => Promise.resolve(PAGE) });
+		});
+	}
+
+	it("shows the revision's summary in the history list", async () => {
+		vi.stubGlobal("fetch", mockFetchWithRevision({}));
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+
+		fireEvent.click(screen.getByRole("button", { name: /History/i }));
+		expect(await screen.findByText("Fixed a typo")).toBeTruthy();
+	});
+
+	it("fetches and renders the diff against current when 'Diff vs current' is clicked", async () => {
+		vi.stubGlobal("fetch", mockFetchWithRevision({}));
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+
+		fireEvent.click(screen.getByRole("button", { name: /History/i }));
+		fireEvent.click(await screen.findByRole("button", { name: "Diff vs current" }));
+
+		expect(await screen.findByText("-old line")).toBeTruthy();
+		expect(screen.getByText("+new line")).toBeTruthy();
+	});
+
+	it("restore re-submits the old revision's content through update_wiki_page and refreshes the page", async () => {
+		vi.spyOn(window, "confirm").mockReturnValue(true);
+		const fetchMock = mockFetchWithRevision({ oldRevisionContent: "the original content" });
+		vi.stubGlobal("fetch", fetchMock);
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+
+		fireEvent.click(screen.getByRole("button", { name: /History/i }));
+		fireEvent.click(await screen.findByRole("button", { name: "Restore" }));
+
+		await waitFor(() => {
+			const putCall = fetchMock.mock.calls.find(([, init]) => init?.method === "PUT");
+			expect(putCall).toBeTruthy();
+			expect(JSON.parse(putCall?.[1].body)).toMatchObject({
+				content: "the original content",
+				baseRevisionId: "rev-old",
+			});
+		});
+	});
+
+	it("does not restore when the confirm dialog is dismissed", async () => {
+		vi.spyOn(window, "confirm").mockReturnValue(false);
+		const fetchMock = mockFetchWithRevision({});
+		vi.stubGlobal("fetch", fetchMock);
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+
+		fireEvent.click(screen.getByRole("button", { name: /History/i }));
+		fireEvent.click(await screen.findByRole("button", { name: "Restore" }));
+
+		expect(fetchMock.mock.calls.some(([, init]) => init?.method === "PUT")).toBe(false);
+	});
+});

--- a/apps/web/src/islands/WikiPage.test.tsx
+++ b/apps/web/src/islands/WikiPage.test.tsx
@@ -1058,4 +1058,19 @@ describe("revision history: diff view + restore (PROJ-492)", () => {
 
 		expect(fetchMock.mock.calls.some(([, init]) => init?.method === "PUT")).toBe(false);
 	});
+
+	it("surfaces a distinct message when the page changed since history was loaded (409)", async () => {
+		vi.spyOn(window, "confirm").mockReturnValue(true);
+		const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+		vi.stubGlobal("fetch", mockFetchWithRevision({ putResponse: { ok: false, status: 409 } }));
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+
+		fireEvent.click(screen.getByRole("button", { name: /History/i }));
+		fireEvent.click(await screen.findByRole("button", { name: "Restore" }));
+
+		await waitFor(() => {
+			expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining("changed by someone else"));
+		});
+	});
 });

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -252,6 +252,7 @@ interface WikiRevision {
 	author_id: string | null;
 	author_name: string | null;
 	created_at: number;
+	summary: string | null;
 }
 
 interface Attachment {
@@ -1053,14 +1054,126 @@ function DraftRestoreBanner({
 	);
 }
 
+// PROJ-492 (R10): renders the server's unified diff text (--- base / +++ current, @@
+// hunks, +/- lines) with per-line coloring. An empty diff means the two sides are
+// identical (services/wiki.ts#buildUnifiedDiff returns "" in that case).
+function RevisionDiffView({ diff }: { diff: string }) {
+	if (diff === "") {
+		return <p class="mt-2 mb-1 text-[0.75rem] text-text-muted italic">No changes.</p>;
+	}
+	return (
+		<pre class="mt-2 mb-1 p-2 bg-surface border border-border rounded-md text-[0.75rem] overflow-x-auto leading-snug whitespace-pre-wrap">
+			{diff.split("\n").map((line, i) => {
+				const cls = line.startsWith("+")
+					? "text-green-600"
+					: line.startsWith("-")
+						? "text-red-600"
+						: "text-text-muted";
+				return (
+					<div key={`${i}-${line}`} class={cls}>
+						{line.length > 0 ? line : " "}
+					</div>
+				);
+			})}
+		</pre>
+	);
+}
+
+function RevisionRow({
+	revision,
+	workspaceSlug,
+	pageSlug,
+	onRestore,
+	restoring,
+}: {
+	revision: WikiRevision;
+	workspaceSlug: string | undefined;
+	pageSlug: string;
+	onRestore: (revision: WikiRevision) => void;
+	restoring: boolean;
+}) {
+	const [diffOpen, setDiffOpen] = useState(false);
+	const [diff, setDiff] = useState<string | null>(null);
+	const [diffError, setDiffError] = useState<string | null>(null);
+	const [diffLoading, setDiffLoading] = useState(false);
+
+	async function toggleDiff() {
+		if (diffOpen) {
+			setDiffOpen(false);
+			return;
+		}
+		setDiffOpen(true);
+		if (diff !== null || diffLoading) return;
+		setDiffLoading(true);
+		setDiffError(null);
+		try {
+			const result = await apiFetch<{ diff: string }>(
+				`/api/wiki/${encodeURIComponent(pageSlug)}/revisions/${revision.id}/diff?against=current`,
+				{ workspaceSlug }
+			);
+			setDiff(result.diff);
+		} catch (e) {
+			setDiffError(String(e));
+		} finally {
+			setDiffLoading(false);
+		}
+	}
+
+	return (
+		<li class="py-[0.375rem] border-b border-border text-[0.8rem] text-text-muted">
+			<div class="flex items-center flex-wrap gap-2">
+				<span>
+					<strong class="text-text-base">{revision.author_name ?? "Unknown"}</strong>
+					{" — "}
+					{new Date(revision.created_at * 1000).toLocaleString()}
+				</span>
+				<button
+					type="button"
+					onClick={toggleDiff}
+					class="btn btn-outline btn-sm text-text-muted py-0 px-2"
+				>
+					{diffOpen ? "Hide diff" : "Diff vs current"}
+				</button>
+				<button
+					type="button"
+					onClick={() => onRestore(revision)}
+					disabled={restoring}
+					class="btn btn-outline btn-sm text-text-muted py-0 px-2"
+				>
+					{restoring ? "Restoring…" : "Restore"}
+				</button>
+			</div>
+			{revision.summary && <p class="mt-1 mb-0 italic">{revision.summary}</p>}
+			{diffOpen &&
+				(diffLoading ? (
+					<p class="mt-2 mb-1 text-[0.75rem]">Loading diff…</p>
+				) : diffError ? (
+					<p role="alert" class="mt-2 mb-1 text-[0.75rem] text-[var(--danger-text)]">
+						{diffError}
+					</p>
+				) : (
+					<RevisionDiffView diff={diff ?? ""} />
+				))}
+		</li>
+	);
+}
+
 function RevisionsHistory({
 	revisions,
 	showHistory,
 	onToggle,
+	workspaceSlug,
+	pageSlug,
+	onRestore,
+	restoringId,
 }: {
 	revisions: WikiRevision[];
 	showHistory: boolean;
 	onToggle: () => void;
+	workspaceSlug: string | undefined;
+	pageSlug: string;
+	onRestore: (revision: WikiRevision) => void;
+	restoringId: string | null;
 }) {
 	if (revisions.length === 0) return null;
 	return (
@@ -1071,14 +1184,14 @@ function RevisionsHistory({
 			{showHistory && (
 				<ul class="mt-3 list-none p-0">
 					{revisions.map((r) => (
-						<li
+						<RevisionRow
 							key={r.id}
-							class="py-[0.375rem] border-b border-border text-[0.8rem] text-text-muted"
-						>
-							<strong class="text-text-base">{r.author_name ?? "Unknown"}</strong>
-							{" — "}
-							{new Date(r.created_at * 1000).toLocaleString()}
-						</li>
+							revision={r}
+							workspaceSlug={workspaceSlug}
+							pageSlug={pageSlug}
+							onRestore={onRestore}
+							restoring={restoringId === r.id}
+						/>
 					))}
 				</ul>
 			)}
@@ -1272,6 +1385,8 @@ interface PageArticleProps {
 	revisions: WikiRevision[];
 	showHistory: boolean;
 	onToggleHistory: () => void;
+	onRestoreRevision: (revision: WikiRevision) => void;
+	restoringRevisionId: string | null;
 	attachments: Attachment[];
 	workspaceSlug?: string;
 	uploadFormOpen: boolean;
@@ -1427,6 +1542,10 @@ function PageArticle(props: PageArticleProps) {
 					revisions={props.revisions}
 					showHistory={props.showHistory}
 					onToggle={props.onToggleHistory}
+					workspaceSlug={props.workspaceSlug}
+					pageSlug={page.slug}
+					onRestore={props.onRestoreRevision}
+					restoringId={props.restoringRevisionId}
 				/>
 
 				<AttachmentsPanel
@@ -2157,6 +2276,63 @@ function useWikiEditing(
 	};
 }
 
+// PROJ-492 (R10): one-click restore is a client-side convenience — it reads the old
+// revision's content, then resubmits it through the SAME update_wiki_page write path as
+// a normal edit (baseRevisionId + summary), so it gets ordinary optimistic-locking/
+// frontmatter/FTS/link-reindex treatment for free and creates a new revision rather than
+// rewriting history. No dedicated restore endpoint.
+function useWikiRestore(
+	workspaceSlug: string | undefined,
+	page: WikiPageData | null,
+	latestRevisionId: string | null | undefined,
+	fetchPage: (s: string) => Promise<void>,
+	fetchRevisions: (s: string) => Promise<void>
+) {
+	const [restoringId, setRestoringId] = useState<string | null>(null);
+
+	async function restore(revision: WikiRevision) {
+		if (!page) return;
+		const when = new Date(revision.created_at * 1000).toLocaleString();
+		if (
+			!window.confirm(
+				`Restore this page to the version from ${when}? This creates a new revision — no history is lost.`
+			)
+		) {
+			return;
+		}
+		setRestoringId(revision.id);
+		try {
+			const old = await apiFetch<{ content: string }>(
+				`/api/wiki/${encodeURIComponent(page.slug)}/revisions/${revision.id}`,
+				{ workspaceSlug }
+			);
+			await apiFetch(`/api/wiki/${encodeURIComponent(page.slug)}`, {
+				method: "PUT",
+				workspaceSlug,
+				body: {
+					content: old.content,
+					baseRevisionId: latestRevisionId ?? null,
+					summary: `Restored from revision dated ${when}`,
+				},
+			});
+			await fetchPage(page.slug);
+			await fetchRevisions(page.slug);
+		} catch (e) {
+			if (String(e).endsWith("failed: 409")) {
+				alert(
+					"This page was changed by someone else since you loaded it. Reload the page before restoring."
+				);
+			} else {
+				alert(`Restore failed: ${String(e)}`);
+			}
+		} finally {
+			setRestoringId(null);
+		}
+	}
+
+	return { restoringId, restore };
+}
+
 // PROJ-237: re-parent a page from the page menu. Backend validation (cycle guard,
 // workspace scoping) already exists on PUT /api/wiki/:slug — this is UI-only.
 function useMovePage(
@@ -2620,6 +2796,8 @@ function buildArticleProps(article: {
 	revisions: WikiRevision[];
 	showHistory: boolean;
 	setShowHistory: (updater: (h: boolean) => boolean) => void;
+	onRestoreRevision: (revision: WikiRevision) => void;
+	restoringRevisionId: string | null;
 	attach: ReturnType<typeof useWikiAttachments>;
 	workspaceSlug: string | undefined;
 	move: ReturnType<typeof useMovePage>;
@@ -2655,6 +2833,8 @@ function buildArticleProps(article: {
 		revisions: article.revisions,
 		showHistory: article.showHistory,
 		onToggleHistory: () => article.setShowHistory((h) => !h),
+		onRestoreRevision: article.onRestoreRevision,
+		restoringRevisionId: article.restoringRevisionId,
 		attachments: article.attach.attachments,
 		workspaceSlug: article.workspaceSlug,
 		uploadFormOpen: article.attach.uploadFormOpen,
@@ -2714,6 +2894,13 @@ export default function WikiPage({
 	const wikiTemplates = useWikiTemplates(workspaceSlug);
 	const move = useMovePage(workspaceSlug, pageData.page, pageData.fetchPage, fetchTree);
 	const verify = useWikiVerify(workspaceSlug, pageData.page, pageData.fetchPage);
+	const restoreState = useWikiRestore(
+		workspaceSlug,
+		pageData.page,
+		pageData.revisionsLoaded ? (pageData.revisions[0]?.id ?? null) : undefined,
+		pageData.fetchPage,
+		pageData.fetchRevisions
+	);
 
 	const { navigateTo, startCreate, submitCreate, deletePage } = createWikiActions({
 		workspaceSlug,
@@ -2785,6 +2972,8 @@ export default function WikiPage({
 		revisions: pageData.revisions,
 		showHistory: pageData.showHistory,
 		setShowHistory: pageData.setShowHistory,
+		onRestoreRevision: restoreState.restore,
+		restoringRevisionId: restoreState.restoringId,
 		attach,
 		workspaceSlug,
 		move,


### PR DESCRIPTION
## Summary

Implements PROJ-492 (Phase 3 R10 of the wiki epic): server-side revision diffing, a diff view in the history UI, one-click restore, and revision summaries in the list.

### API

- `GET /api/wiki/:slug/revisions/:revisionId/diff?against=<revisionId|current>` (REST) and `get_wiki_revision_diff` (MCP) — server-side unified diff between one revision and either another revision or the page's live content. `against` defaults to `"current"` when omitted.
- Reuses PROJ-484's `buildUnifiedDiff` (now exported from `services/wiki.ts`) — same `--- base` / `+++ current` / `@@` hunk format already used by `update_wiki_page`/`patch_wiki_page` conflict responses, so callers get one diff format everywhere.
- Each revision's own `content` column already snapshots that point in time, so no `resolveBaseContent` off-by-one lookahead is needed here (unlike the conflict-diff path, which answers a different question — "what did the caller actually have").
- 404s if `revisionId` or `against` doesn't resolve to a revision on this page.

### UI (`WikiPage.tsx`)

- Revision history rows now show the `summary` edit message (the API already returned it — `list_wiki_revisions` was never wired to the frontend type).
- Each row gets a "Diff vs current" toggle that lazy-fetches and renders the unified diff with +/- line coloring.
- Each row gets a "Restore" button (confirm dialog, matching the existing delete-page convention in this file).

### Design decisions

1. **Restore is NOT a new endpoint.** It's a client-side convenience (`useWikiRestore` in `WikiPage.tsx`): fetch the old revision's content via the existing revision-get endpoint, then resubmit it through the *same* `update_wiki_page`/PUT write path with `baseRevisionId` (the page's current latest revision) and an auto-generated `summary`. This means restore automatically gets normal optimistic-locking, frontmatter parsing, FTS reindex, and link-graph reindex — for free, with zero new server code — and always creates a new revision rather than rewriting history (verified by a test asserting revision count increases and the pre-restore revision is untouched).
2. **API shape mirrors existing revision routes**: `/:slug/revisions/:revisionId/diff` sits alongside `/:slug/revisions/:revisionId` and `/:slug/revisions`, and resolves `slug` via the same id-or-slug + redirect-fallback path as `get_wiki_revision`.
3. **"Diff against current" needs no special-casing** even if the page has since been restructured — it's a plain unified diff of two text blobs either way, which is intuitive in the UI (it just shows more red/green than a small edit would).

### Testing

- `apps/api/src/test/wiki.test.ts`: new `describe("Wiki revision diff (PROJ-492)")` — diff-against-current default, diff between two explicit revisions, identical-content diff is empty, unknown `against`/`revisionId` 404, MCP/REST parity, and a restore-flow test asserting history is preserved (2 revisions after restore, original revision still present, new revision on top).
- `apps/web/src/islands/WikiPage.test.tsx`: new `describe("revision history: diff view + restore (PROJ-492)")` — summary rendering, diff fetch+render, restore PUT payload, and confirm-dialog cancellation.

### Follow-ups noticed but out of scope

- None found beyond the ticket's own scope.

## Test plan

- [x] `pnpm gen:docs` — no diff beyond the expected tool-count bump (97 → 98)
- [x] `pnpm exec biome check .`
- [x] `pnpm turbo type-check`
- [x] `pnpm --filter @projektor/db test`
- [x] `pnpm --filter @projektor/api test:coverage` (1013 tests passing)
- [x] `pnpm --filter @projektor/web test:coverage` (498 tests passing)
- [x] `pnpm --filter @projektor/web build`
- [x] `pnpm --filter @projektor/docs build`

https://claude.ai/code/session_014EYjUZG9d4YrXTfJ6Xr3Rj