### PR TITLE
PROJ-493: wiki watchers + list_wiki_changes delta feed (R11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ command shown beside it (token + workspace pre-filled). The full walkthrough - A
 setup, first login, token, MCP - is in
 [CONFIGURE.md](https://github.com/TAJD/projektor-deploy-example/blob/main/CONFIGURE.md).
 
-See the **[agent connection guide](https://tajd.github.io/projektor/agents/mcp-connection/)** for the full connection guide, protocol reference, and tool catalog (<!-- gen-mcp-stats:start -->98 tools across 21 domains<!-- gen-mcp-stats:end --> - project data plus agent-coordination primitives).
+See the **[agent connection guide](https://tajd.github.io/projektor/agents/mcp-connection/)** for the full connection guide, protocol reference, and tool catalog (<!-- gen-mcp-stats:start -->104 tools across 21 domains<!-- gen-mcp-stats:end --> - project data plus agent-coordination primitives).
 
 ## Development
 

--- a/apps/api/src/mcp/wiki.ts
+++ b/apps/api/src/mcp/wiki.ts
@@ -3,6 +3,7 @@ import { WIKI_WELL_KNOWN_TYPES } from "../schemas/wiki";
 import { ValidationError } from "../services/errors";
 import type { ServiceCtx } from "../services/types";
 import * as wikiService from "../services/wiki";
+import * as wikiWatchersService from "../services/wiki-watchers";
 
 // PROJ-513: `type` is freeform — these are advertised as hints, never as an
 // inputSchema `enum` (which clients treat as the only legal values).
@@ -468,6 +469,129 @@ export const wikiTools: MCPTool[] = [
 		},
 		async handler(input, ctx) {
 			return wikiService.listWikiTemplates(ctx, input);
+		},
+	},
+	{
+		name: "watch_wiki_page",
+		description:
+			"Watch a wiki page by id or slug — its changes (create is n/a here since the page " +
+			"already exists, update/patch/verify/restore/delete) will generate a per-user " +
+			"notification (list_wiki_notifications). Pass subtree=true to also watch every " +
+			"page currently OR LATER nested under this one (resolved dynamically by walking " +
+			"the page hierarchy at notify time, not a one-time snapshot). Calling this again " +
+			"for the same page updates the subtree flag rather than creating a duplicate watch. " +
+			"Template pages (frontmatter template: true) never generate notifications even if " +
+			"watched directly or via a subtree.",
+		inputSchema: {
+			type: "object",
+			required: ["slug"],
+			properties: {
+				slug: { type: "string", description: "Page ID or slug" },
+				subtree: {
+					type: "boolean",
+					default: false,
+					description: "Also watch this page's current and future descendant pages",
+				},
+			},
+		},
+		async handler(input, ctx) {
+			const { slug, ...rest } = input as { slug: string; subtree?: boolean };
+			return wikiWatchersService.watchWikiPage(ctx as ServiceCtx, slug, rest);
+		},
+	},
+	{
+		name: "unwatch_wiki_page",
+		description: "Stop watching a wiki page by id or slug (a no-op if not currently watched).",
+		inputSchema: {
+			type: "object",
+			required: ["slug"],
+			properties: { slug: { type: "string", description: "Page ID or slug" } },
+		},
+		async handler(input, ctx) {
+			const { slug } = input as { slug: string };
+			return wikiWatchersService.unwatchWikiPage(ctx as ServiceCtx, slug);
+		},
+	},
+	{
+		name: "list_wiki_watches",
+		description: "List the pages the calling user is currently watching.",
+		inputSchema: { type: "object", properties: {} },
+		async handler(_input, ctx) {
+			return wikiWatchersService.listWikiWatches(ctx as ServiceCtx);
+		},
+	},
+	{
+		name: "list_wiki_notifications",
+		description:
+			"List the calling user's wiki watch notifications (newest first). Each entry " +
+			"records the page (denormalized slug/title, so a notification about a page " +
+			"that's since been deleted still shows what it was about), the action " +
+			"(created|updated|deleted), the actor, and whether it's been read.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				unreadOnly: { type: "boolean", default: false },
+				limit: { type: "number", default: 50 },
+				offset: { type: "number", default: 0 },
+			},
+		},
+		async handler(input, ctx) {
+			return wikiWatchersService.listWikiNotifications(ctx, input);
+		},
+	},
+	{
+		name: "mark_wiki_notifications_read",
+		description: "Mark wiki notifications as read, by id, or all: true for every unread one.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				ids: {
+					type: "array",
+					items: { type: "string" },
+					description: "Notification IDs to mark read",
+				},
+				all: {
+					type: "boolean",
+					default: false,
+					description: "Mark all of the caller's notifications read",
+				},
+			},
+		},
+		async handler(input, ctx) {
+			return wikiWatchersService.markWikiNotificationsRead(ctx, input);
+		},
+	},
+	{
+		name: "list_wiki_changes",
+		description:
+			"Cheap delta feed of wiki page changes since a unix-seconds timestamp — for agents " +
+			"polling 'what changed' instead of re-fetching/re-searching the whole wiki. Backed " +
+			"by the existing activity log (no extra write-path cost). `since` is EXCLUSIVE; " +
+			"poll again using the response's `nextSince`, not a locally-computed timestamp, so " +
+			"changes landing on the same second as the cutoff are never missed or double-" +
+			"delivered. Defaults to every wiki page the caller can see (same visibility as " +
+			"list_wiki_pages/search_wiki) — pass watchedOnly=true to narrow to pages the caller " +
+			"is watching (directly or via a subtree watch). A `deleted` entry's slug/title/" +
+			"projectId reflect the page as it was just before deletion (the row itself is gone).",
+		inputSchema: {
+			type: "object",
+			required: ["since"],
+			properties: {
+				since: {
+					type: "number",
+					description: "Unix seconds; only changes strictly after this are returned",
+				},
+				limit: { type: "number", default: 100 },
+				projectId: { type: "string", description: "Restrict to changes on pages in this project" },
+				watchedOnly: {
+					type: "boolean",
+					default: false,
+					description: "Restrict to pages the caller is watching (directly or via subtree)",
+				},
+			},
+		},
+		async handler(input, ctx) {
+			return wikiWatchersService.listWikiChanges(ctx, input);
 		},
 	},
 ];

--- a/apps/api/src/routes/wiki.ts
+++ b/apps/api/src/routes/wiki.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { serviceErrToResponse } from "../http/error-adapter";
 import { ctxFromHono } from "../services/types";
 import * as wikiService from "../services/wiki";
+import * as wikiWatchersService from "../services/wiki-watchers";
 
 const router = new Hono<HonoEnv>();
 
@@ -105,6 +106,56 @@ router.post("/backfill-links", async (c) => {
 	}
 });
 
+// PROJ-493 (R11): must be registered before the /:slug catch-all below, same as every
+// other fixed-path route above.
+router.get("/watches", async (c) => {
+	const ctx = ctxFromHono(c);
+	try {
+		return c.json(await wikiWatchersService.listWikiWatches(ctx));
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
+});
+
+router.get("/notifications", async (c) => {
+	const ctx = ctxFromHono(c);
+	try {
+		const unreadOnly = c.req.query("unreadOnly");
+		const limit = c.req.query("limit");
+		const offset = c.req.query("offset");
+		return c.json(
+			await wikiWatchersService.listWikiNotifications(ctx, { unreadOnly, limit, offset })
+		);
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
+});
+
+router.post("/notifications/read", async (c) => {
+	const ctx = ctxFromHono(c);
+	try {
+		const body = await c.req.json().catch(() => ({}));
+		return c.json(await wikiWatchersService.markWikiNotificationsRead(ctx, body));
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
+});
+
+router.get("/changes", async (c) => {
+	const ctx = ctxFromHono(c);
+	try {
+		const since = c.req.query("since");
+		const limit = c.req.query("limit");
+		const projectId = c.req.query("projectId");
+		const watchedOnly = c.req.query("watchedOnly");
+		return c.json(
+			await wikiWatchersService.listWikiChanges(ctx, { since, limit, projectId, watchedOnly })
+		);
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
+});
+
 router.get("/:slug/backlinks", async (c) => {
 	const ctx = ctxFromHono(c);
 	try {
@@ -180,6 +231,25 @@ router.post("/:slug/verify", async (c) => {
 	const ctx = ctxFromHono(c);
 	try {
 		return c.json(await wikiService.verifyWikiPage(ctx, c.req.param("slug")));
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
+});
+
+router.post("/:slug/watch", async (c) => {
+	const ctx = ctxFromHono(c);
+	try {
+		const body = await c.req.json().catch(() => ({}));
+		return c.json(await wikiWatchersService.watchWikiPage(ctx, c.req.param("slug"), body));
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
+});
+
+router.delete("/:slug/watch", async (c) => {
+	const ctx = ctxFromHono(c);
+	try {
+		return c.json(await wikiWatchersService.unwatchWikiPage(ctx, c.req.param("slug")));
 	} catch (e) {
 		return serviceErrToResponse(c, e);
 	}

--- a/apps/api/src/schemas/wiki.ts
+++ b/apps/api/src/schemas/wiki.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { BooleanQueryParam } from "./common";
 
 const SlugSchema = z
 	.string()
@@ -205,7 +206,7 @@ export const WatchWikiPageInputSchema = z.object({
 });
 
 export const ListWikiNotificationsInputSchema = z.object({
-	unreadOnly: z.coerce.boolean().optional().default(false),
+	unreadOnly: BooleanQueryParam.optional().default(false),
 	limit: z.coerce.number().int().min(1).max(200).optional().default(50),
 	offset: z.coerce.number().int().min(0).optional().default(0),
 });
@@ -231,5 +232,5 @@ export const ListWikiChangesInputSchema = z.object({
 	since: z.coerce.number().int().nonnegative(),
 	limit: z.coerce.number().int().min(1).max(500).optional().default(100),
 	projectId: z.string().uuid().optional(),
-	watchedOnly: z.coerce.boolean().optional().default(false),
+	watchedOnly: BooleanQueryParam.optional().default(false),
 });

--- a/apps/api/src/schemas/wiki.ts
+++ b/apps/api/src/schemas/wiki.ts
@@ -198,3 +198,38 @@ export type PatchWikiPageInput = z.infer<typeof PatchWikiPageInputSchema>;
 export const ListWikiTemplatesInputSchema = z.object({
 	projectId: z.string().uuid().optional(),
 });
+
+// PROJ-493 (R11): watch a page, or its whole current+future subtree.
+export const WatchWikiPageInputSchema = z.object({
+	subtree: z.boolean().optional().default(false),
+});
+
+export const ListWikiNotificationsInputSchema = z.object({
+	unreadOnly: z.coerce.boolean().optional().default(false),
+	limit: z.coerce.number().int().min(1).max(200).optional().default(50),
+	offset: z.coerce.number().int().min(0).optional().default(0),
+});
+
+export const MarkWikiNotificationsReadInputSchema = z
+	.object({
+		ids: z.array(z.string()).max(200).optional(),
+		all: z.boolean().optional().default(false),
+	})
+	.refine((d) => d.all || (d.ids !== undefined && d.ids.length > 0), {
+		message: "Either `all: true` or a non-empty `ids` array must be provided",
+	});
+
+// PROJ-493 (R11): list_wiki_changes — cheap delta polling for agents. `since` is
+// EXCLUSIVE (changes strictly after that unix-second timestamp); poll again with the
+// response's own `nextSince` value, not a locally-computed timestamp, to avoid missing
+// or double-delivering changes that land on the same second as the cutoff. Defaults to
+// every wiki page the caller can currently see (matching list_wiki_pages/search_wiki
+// visibility) rather than only watched pages — see services/wiki-watchers.ts for why.
+// Pass watchedOnly=true to narrow to pages the caller is (directly or via subtree)
+// watching.
+export const ListWikiChangesInputSchema = z.object({
+	since: z.coerce.number().int().nonnegative(),
+	limit: z.coerce.number().int().min(1).max(500).optional().default(100),
+	projectId: z.string().uuid().optional(),
+	watchedOnly: z.coerce.boolean().optional().default(false),
+});

--- a/apps/api/src/services/wiki-watchers.ts
+++ b/apps/api/src/services/wiki-watchers.ts
@@ -16,6 +16,7 @@ import {
 } from "../schemas/wiki";
 import { effectiveProjectRole, isWorkspaceAdmin } from "./access";
 import { NotFoundError, ValidationError } from "./errors";
+import { inChunks } from "./sql";
 import type { ServiceCtx } from "./types";
 
 type Orm = ReturnType<typeof drizzle<typeof schema>>;
@@ -230,18 +231,42 @@ export async function notifyWikiWatchers(
 	const userIds = [...new Set(rows.map((r) => r.userId))].filter((id) => id !== ctx.userId);
 	if (userIds.length === 0) return;
 
+	await insertNotifications(
+		ctx,
+		orm,
+		userIds.map((userId) => ({
+			userId,
+			pageId: opts.pageId,
+			slug: opts.slug,
+			title: opts.title,
+			action: opts.action,
+		}))
+	);
+}
+
+async function insertNotifications(
+	ctx: ServiceCtx,
+	orm: Orm,
+	entries: {
+		userId: string;
+		pageId: string;
+		slug: string;
+		title: string;
+		action: "created" | "updated" | "deleted";
+	}[]
+): Promise<void> {
+	if (entries.length === 0) return;
 	const now = Math.floor(Date.now() / 1000);
-	const summary = `${ACTION_LABEL[opts.action]}: ${opts.title}`;
-	const values = userIds.map((userId) => ({
+	const values = entries.map((e) => ({
 		id: crypto.randomUUID(),
 		workspaceId: ctx.workspaceId,
-		userId,
-		pageId: opts.pageId,
-		pageSlug: opts.slug,
-		pageTitle: opts.title,
-		action: opts.action,
+		userId: e.userId,
+		pageId: e.pageId,
+		pageSlug: e.slug,
+		pageTitle: e.title,
+		action: e.action,
 		actorId: ctx.userId,
-		summary,
+		summary: `${ACTION_LABEL[e.action]}: ${e.title}`,
 		createdAt: now,
 		readAt: null,
 	}));
@@ -255,6 +280,75 @@ export async function notifyWikiWatchers(
 			.insert(schema.wikiNotifications)
 			.values(values.slice(i, i + NOTIFICATION_INSERT_CHUNK_SIZE));
 	}
+}
+
+// PROJ-493: a cascade delete also removes every descendant page. Watchers rooted at (or
+// above) the cascade root already got the single root-level notification, but a watcher
+// whose watch row points AT one of the descendants matches only that descendant — without
+// this they'd be told nothing at all and then have their watch row removed underneath
+// them. One notification per (watcher, deleted descendant they watched).
+export async function notifyCascadeDescendantWatchers(
+	ctx: ServiceCtx,
+	descendants: { id: string; slug: string; title: string; isTemplate: boolean }[]
+): Promise<void> {
+	const pages = descendants.filter((p) => !p.isTemplate);
+	if (pages.length === 0) return;
+
+	const orm = drizzle(ctx.db, { schema });
+	const rows = await inChunks(
+		pages.map((p) => p.id),
+		(chunk) =>
+			orm
+				.select({ userId: schema.wikiWatchers.userId, pageId: schema.wikiWatchers.pageId })
+				.from(schema.wikiWatchers)
+				.where(
+					and(
+						eq(schema.wikiWatchers.workspaceId, ctx.workspaceId),
+						inArray(schema.wikiWatchers.pageId, chunk)
+					)
+				)
+	);
+
+	const byId = new Map(pages.map((p) => [p.id, p]));
+	const entries = rows
+		.filter((r) => r.userId !== ctx.userId)
+		.map((r) => {
+			const page = byId.get(r.pageId);
+			if (!page) return null;
+			return {
+				userId: r.userId,
+				pageId: page.id,
+				slug: page.slug,
+				title: page.title,
+				action: "deleted" as const,
+			};
+		})
+		.filter((e): e is NonNullable<typeof e> => e !== null);
+
+	await insertNotifications(ctx, orm, entries);
+}
+
+// PROJ-493: mirror wiki_watchers.page_id's ON DELETE CASCADE at the app level, same
+// PROJ-407 precedent as deleteWikiPageAttachments/deleteWikiLinksForPages — D1 does not
+// guarantee FK enforcement on every connection, so leaning on the FK alone would leave
+// watch rows pointing at pages that no longer exist.
+export async function deleteWikiWatchersForPages(
+	ctx: ServiceCtx,
+	pageIds: string[]
+): Promise<void> {
+	if (pageIds.length === 0) return;
+	const orm = drizzle(ctx.db, { schema });
+	await inChunks(pageIds, async (chunk) => {
+		await orm
+			.delete(schema.wikiWatchers)
+			.where(
+				and(
+					eq(schema.wikiWatchers.workspaceId, ctx.workspaceId),
+					inArray(schema.wikiWatchers.pageId, chunk)
+				)
+			);
+		return [];
+	});
 }
 
 export async function listWikiNotifications(ctx: ServiceCtx, input: unknown) {
@@ -367,16 +461,44 @@ async function watchedPageIds(
 	const subtreeRootIds = new Set(watches.filter((w) => w.subtree).map((w) => w.pageId));
 
 	const matched = new Set<string>();
+	// candidate page -> the ancestor its chain walk has currently reached.
+	const pending = new Map<string, string>();
 	for (const pageId of new Set(candidatePageIds)) {
 		if (directWatchIds.has(pageId)) {
 			matched.add(pageId);
 			continue;
 		}
-		if (subtreeRootIds.size === 0) continue;
-		const ancestors = await resolveAncestorChain(ctx.db, pageId, pageId, ctx.workspaceId);
-		// resolveAncestorChain(pageId, pageId, ...) re-fetches pageId's own row as the
-		// first hop, which is redundant but harmless — ancestors[0] === pageId either way.
-		if (ancestors.some((id) => subtreeRootIds.has(id))) matched.add(pageId);
+		if (subtreeRootIds.size > 0) pending.set(pageId, pageId);
+	}
+
+	// Walk every remaining candidate's parent chain in lock-step — one batched query per
+	// tree level (nesting is capped at depth 5) rather than a per-candidate chain walk,
+	// which would be O(candidates x depth) round-trips for a `limit` of up to 500.
+	for (let depth = 0; depth < 6 && pending.size > 0; depth++) {
+		const frontier = [...new Set(pending.values())];
+		const rows = await inChunks(frontier, (chunk) =>
+			orm
+				.select({ id: schema.wikiPages.id, parentId: schema.wikiPages.parentId })
+				.from(schema.wikiPages)
+				.where(
+					and(
+						inArray(schema.wikiPages.id, chunk),
+						eq(schema.wikiPages.workspaceId, ctx.workspaceId)
+					)
+				)
+		);
+		const parentOf = new Map(rows.map((r) => [r.id, r.parentId]));
+		for (const [candidate, cur] of [...pending]) {
+			const parent = parentOf.get(cur) ?? null;
+			if (parent === null) {
+				pending.delete(candidate);
+			} else if (subtreeRootIds.has(parent)) {
+				matched.add(candidate);
+				pending.delete(candidate);
+			} else {
+				pending.set(candidate, parent);
+			}
+		}
 	}
 	return matched;
 }
@@ -434,9 +556,32 @@ export async function listWikiChanges(
 		.orderBy(schema.activity.createdAt)
 		.limit(limit);
 
+	// `since` is second-granular and exclusive, so a batch cut off mid-second by `limit`
+	// would strand the rest of that second: the caller polls with nextSince = that second
+	// and `gt` skips them forever. Drop the trailing partial second instead, so the next
+	// poll picks it up whole. (If the WHOLE batch is one second there's nothing to trim —
+	// that needs `limit` changes inside a single second, and the alternative is a poll
+	// that can never advance.)
+	let batch = rows;
+	if (rows.length === limit && rows.length > 0) {
+		const maxTs = rows[rows.length - 1].createdAt;
+		if (rows[0].createdAt !== maxTs) batch = rows.filter((r) => r.createdAt < maxTs);
+	}
+
+	// One role lookup per distinct project in the batch, not per event.
+	const roleCache = new Map<string, boolean>();
+	const canSeeProject = async (id: string): Promise<boolean> => {
+		if (isWorkspaceAdmin(ctx.role)) return true;
+		const cached = roleCache.get(id);
+		if (cached !== undefined) return cached;
+		const visible = (await effectiveProjectRole(ctx, id)) !== null;
+		roleCache.set(id, visible);
+		return visible;
+	};
+
 	let nextSince = since;
 	const events: WikiChangeEvent[] = [];
-	for (const r of rows) {
+	for (const r of batch) {
 		if (r.createdAt > nextSince) nextSince = r.createdAt;
 		const action = r.action as "created" | "updated" | "deleted";
 		const deleted = action === "deleted" ? extractDeletedPageInfo(r.diff) : null;
@@ -445,13 +590,8 @@ export async function listWikiChanges(
 		const eventProjectId = deleted ? deleted.projectId : r.pageProjectId;
 
 		if (projectId && eventProjectId !== projectId) continue;
-		if (!projectId && eventProjectId !== null) {
-			if (
-				!isWorkspaceAdmin(ctx.role) &&
-				(await effectiveProjectRole(ctx, eventProjectId)) === null
-			) {
-				continue;
-			}
+		if (!projectId && eventProjectId !== null && !(await canSeeProject(eventProjectId))) {
+			continue;
 		}
 
 		events.push({

--- a/apps/api/src/services/wiki-watchers.ts
+++ b/apps/api/src/services/wiki-watchers.ts
@@ -1,0 +1,482 @@
+// PROJ-493 (R11): watch/unwatch per page or subtree, a per-user notification list, and
+// list_wiki_changes — cheap delta polling for agents.
+//
+// No dependency on services/wiki.ts (avoids a circular import — wiki.ts calls into this
+// file's notifyWikiWatchers on every write). Page resolution + visibility checks are
+// duplicated in miniature here rather than imported, mirroring services/wiki-links.ts's
+// resolveSlugTarget precedent.
+import { drizzle, schema } from "@projektor/db";
+import { and, desc, eq, gt, inArray, isNull, or } from "drizzle-orm";
+import { wikiPagePath } from "../lib/urls";
+import {
+	ListWikiChangesInputSchema,
+	ListWikiNotificationsInputSchema,
+	MarkWikiNotificationsReadInputSchema,
+	WatchWikiPageInputSchema,
+} from "../schemas/wiki";
+import { effectiveProjectRole, isWorkspaceAdmin } from "./access";
+import { NotFoundError, ValidationError } from "./errors";
+import type { ServiceCtx } from "./types";
+
+type Orm = ReturnType<typeof drizzle<typeof schema>>;
+
+type ResolvedWatchTarget = {
+	id: string;
+	slug: string;
+	title: string;
+	projectId: string | null;
+	parentId: string | null;
+};
+
+// PROJ-493: same id-or-slug + redirect-fallback resolution as services/wiki.ts's
+// resolvePageByIdOrSlug, plus the same project-visibility check as assertWikiPageVisible —
+// duplicated (not imported) to avoid a circular import, see module comment above.
+async function resolveWatchTarget(ctx: ServiceCtx, idOrSlug: string): Promise<ResolvedWatchTarget> {
+	const orm = drizzle(ctx.db, { schema });
+	const direct = await orm
+		.select({
+			id: schema.wikiPages.id,
+			slug: schema.wikiPages.slug,
+			title: schema.wikiPages.title,
+			projectId: schema.wikiPages.projectId,
+			parentId: schema.wikiPages.parentId,
+		})
+		.from(schema.wikiPages)
+		.where(
+			and(
+				or(eq(schema.wikiPages.id, idOrSlug), eq(schema.wikiPages.slug, idOrSlug)),
+				eq(schema.wikiPages.workspaceId, ctx.workspaceId)
+			)
+		)
+		.get();
+
+	let page = direct;
+	if (!page) {
+		const redirect = await orm
+			.select({ pageId: schema.wikiRedirects.pageId })
+			.from(schema.wikiRedirects)
+			.where(
+				and(
+					eq(schema.wikiRedirects.workspaceId, ctx.workspaceId),
+					eq(schema.wikiRedirects.oldSlug, idOrSlug)
+				)
+			)
+			.get();
+		if (redirect) {
+			page = await orm
+				.select({
+					id: schema.wikiPages.id,
+					slug: schema.wikiPages.slug,
+					title: schema.wikiPages.title,
+					projectId: schema.wikiPages.projectId,
+					parentId: schema.wikiPages.parentId,
+				})
+				.from(schema.wikiPages)
+				.where(
+					and(
+						eq(schema.wikiPages.id, redirect.pageId),
+						eq(schema.wikiPages.workspaceId, ctx.workspaceId)
+					)
+				)
+				.get();
+		}
+	}
+	if (!page) throw new NotFoundError("Wiki page not found");
+
+	if (page.projectId !== null && !isWorkspaceAdmin(ctx.role)) {
+		if ((await effectiveProjectRole(ctx, page.projectId)) === null) {
+			throw new NotFoundError("Wiki page not found");
+		}
+	}
+	return page;
+}
+
+export async function watchWikiPage(ctx: ServiceCtx, idOrSlug: string, input: unknown) {
+	const parsed = WatchWikiPageInputSchema.safeParse(input);
+	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
+	const page = await resolveWatchTarget(ctx, idOrSlug);
+
+	const orm = drizzle(ctx.db, { schema });
+	const now = Math.floor(Date.now() / 1000);
+	await orm
+		.insert(schema.wikiWatchers)
+		.values({
+			id: crypto.randomUUID(),
+			workspaceId: ctx.workspaceId,
+			userId: ctx.userId,
+			pageId: page.id,
+			subtree: parsed.data.subtree,
+			createdAt: now,
+		})
+		.onConflictDoUpdate({
+			target: [
+				schema.wikiWatchers.workspaceId,
+				schema.wikiWatchers.userId,
+				schema.wikiWatchers.pageId,
+			],
+			set: { subtree: parsed.data.subtree },
+		});
+
+	return { ok: true, pageId: page.id, subtree: parsed.data.subtree, url: wikiPagePath(page.slug) };
+}
+
+export async function unwatchWikiPage(ctx: ServiceCtx, idOrSlug: string) {
+	const page = await resolveWatchTarget(ctx, idOrSlug);
+	const orm = drizzle(ctx.db, { schema });
+	await orm
+		.delete(schema.wikiWatchers)
+		.where(
+			and(
+				eq(schema.wikiWatchers.workspaceId, ctx.workspaceId),
+				eq(schema.wikiWatchers.userId, ctx.userId),
+				eq(schema.wikiWatchers.pageId, page.id)
+			)
+		);
+	return { ok: true };
+}
+
+export async function listWikiWatches(ctx: ServiceCtx) {
+	const orm = drizzle(ctx.db, { schema });
+	const rows = await orm
+		.select({
+			id: schema.wikiWatchers.id,
+			pageId: schema.wikiWatchers.pageId,
+			subtree: schema.wikiWatchers.subtree,
+			createdAt: schema.wikiWatchers.createdAt,
+			slug: schema.wikiPages.slug,
+			title: schema.wikiPages.title,
+		})
+		.from(schema.wikiWatchers)
+		.innerJoin(schema.wikiPages, eq(schema.wikiPages.id, schema.wikiWatchers.pageId))
+		.where(
+			and(
+				eq(schema.wikiWatchers.workspaceId, ctx.workspaceId),
+				eq(schema.wikiWatchers.userId, ctx.userId)
+			)
+		)
+		.orderBy(desc(schema.wikiWatchers.createdAt));
+
+	return rows.map((r) => ({ ...r, url: wikiPagePath(r.slug) }));
+}
+
+// PROJ-493: walks UP from `pageId` through parent_id, bounded by the wiki's own max
+// nesting depth (5 — services/wiki.ts's validateParentDepth) plus one for headroom.
+// Takes `parentId` explicitly (rather than re-reading pageId's own row) so callers can
+// use it for a page that's about to be created (parentId known, pageId's row doesn't
+// exist yet) or one that's mid-delete (parentId captured before the row is removed).
+async function resolveAncestorChain(
+	db: D1Database,
+	pageId: string,
+	parentId: string | null,
+	workspaceId: string
+): Promise<string[]> {
+	const chain = [pageId];
+	let cur = parentId;
+	let depth = 0;
+	while (cur && depth < 6) {
+		chain.push(cur);
+		const row = await db
+			.prepare("SELECT parent_id FROM wiki_pages WHERE id = ? AND workspace_id = ?")
+			.bind(cur, workspaceId)
+			.first<{ parent_id: string | null }>();
+		if (!row?.parent_id) break;
+		cur = row.parent_id;
+		depth++;
+	}
+	return chain;
+}
+
+const ACTION_LABEL: Record<"created" | "updated" | "deleted", string> = {
+	created: "Created",
+	updated: "Updated",
+	deleted: "Deleted",
+};
+
+// PROJ-493: called from services/wiki.ts after every create/update/patch/delete write
+// (not called at all when the affected page is currently flagged `is_template` — R9
+// template pages are scaffolding, not content watchers signed up to be notified about;
+// see the PR description for this reasoned call). A watch on page P matches a change to
+// page X when either P === X (a direct watch, regardless of its subtree flag) or P is a
+// PROPER ancestor of X and the watch has subtree=true. The actor is never notified of
+// their own change.
+export async function notifyWikiWatchers(
+	ctx: ServiceCtx,
+	opts: {
+		pageId: string;
+		parentId: string | null;
+		slug: string;
+		title: string;
+		action: "created" | "updated" | "deleted";
+	}
+): Promise<void> {
+	const ancestorIds = await resolveAncestorChain(
+		ctx.db,
+		opts.pageId,
+		opts.parentId,
+		ctx.workspaceId
+	);
+	const orm = drizzle(ctx.db, { schema });
+	const rows = await orm
+		.select({ userId: schema.wikiWatchers.userId })
+		.from(schema.wikiWatchers)
+		.where(
+			and(
+				eq(schema.wikiWatchers.workspaceId, ctx.workspaceId),
+				inArray(schema.wikiWatchers.pageId, ancestorIds),
+				or(eq(schema.wikiWatchers.pageId, opts.pageId), eq(schema.wikiWatchers.subtree, true))
+			)
+		);
+
+	const userIds = [...new Set(rows.map((r) => r.userId))].filter((id) => id !== ctx.userId);
+	if (userIds.length === 0) return;
+
+	const now = Math.floor(Date.now() / 1000);
+	const summary = `${ACTION_LABEL[opts.action]}: ${opts.title}`;
+	const values = userIds.map((userId) => ({
+		id: crypto.randomUUID(),
+		workspaceId: ctx.workspaceId,
+		userId,
+		pageId: opts.pageId,
+		pageSlug: opts.slug,
+		pageTitle: opts.title,
+		action: opts.action,
+		actorId: ctx.userId,
+		summary,
+		createdAt: now,
+		readAt: null,
+	}));
+
+	// Each row binds 11 params; 8 rows/insert stays comfortably under D1's 100-param cap
+	// (services/sql.ts#inChunks is calibrated for single-param-per-item IN-lists, not
+	// multi-column inserts — same rationale as wiki-links.ts's LINK_INSERT_CHUNK_SIZE).
+	const NOTIFICATION_INSERT_CHUNK_SIZE = 8;
+	for (let i = 0; i < values.length; i += NOTIFICATION_INSERT_CHUNK_SIZE) {
+		await orm
+			.insert(schema.wikiNotifications)
+			.values(values.slice(i, i + NOTIFICATION_INSERT_CHUNK_SIZE));
+	}
+}
+
+export async function listWikiNotifications(ctx: ServiceCtx, input: unknown) {
+	const parsed = ListWikiNotificationsInputSchema.safeParse(input);
+	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
+	const { unreadOnly, limit, offset } = parsed.data;
+
+	const orm = drizzle(ctx.db, { schema });
+	const conditions = [
+		eq(schema.wikiNotifications.workspaceId, ctx.workspaceId),
+		eq(schema.wikiNotifications.userId, ctx.userId),
+	];
+	if (unreadOnly) conditions.push(isNull(schema.wikiNotifications.readAt));
+
+	const rows = await orm
+		.select({
+			id: schema.wikiNotifications.id,
+			pageId: schema.wikiNotifications.pageId,
+			slug: schema.wikiNotifications.pageSlug,
+			title: schema.wikiNotifications.pageTitle,
+			action: schema.wikiNotifications.action,
+			actorId: schema.wikiNotifications.actorId,
+			summary: schema.wikiNotifications.summary,
+			createdAt: schema.wikiNotifications.createdAt,
+			readAt: schema.wikiNotifications.readAt,
+		})
+		.from(schema.wikiNotifications)
+		.where(and(...conditions))
+		.orderBy(desc(schema.wikiNotifications.createdAt))
+		.limit(limit)
+		.offset(offset);
+
+	return rows.map((r) => ({ ...r, url: wikiPagePath(r.slug) }));
+}
+
+export async function markWikiNotificationsRead(ctx: ServiceCtx, input: unknown) {
+	const parsed = MarkWikiNotificationsReadInputSchema.safeParse(input);
+	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
+	const { ids, all } = parsed.data;
+
+	const orm = drizzle(ctx.db, { schema });
+	const now = Math.floor(Date.now() / 1000);
+	const conditions = [
+		eq(schema.wikiNotifications.workspaceId, ctx.workspaceId),
+		eq(schema.wikiNotifications.userId, ctx.userId),
+	];
+	if (!all && ids) conditions.push(inArray(schema.wikiNotifications.id, ids));
+
+	await orm
+		.update(schema.wikiNotifications)
+		.set({ readAt: now })
+		.where(and(...conditions));
+
+	return { ok: true };
+}
+
+export interface WikiChangeEvent {
+	id: string;
+	action: "created" | "updated" | "deleted";
+	pageId: string;
+	slug: string | null;
+	title: string | null;
+	projectId: string | null;
+	actorId: string | null;
+	createdAt: number;
+}
+
+// PROJ-493: for created/updated events, current page state (slug/title/projectId) is
+// read live off wiki_pages — always up to date even if the page changed again since.
+// For deleted events there's no current row, so the same fields captured at delete time
+// in the activity diff (services/wiki.ts#deleteWikiPage) are used instead — including
+// projectId, which is what lets a deleted project-scoped page's event still be hidden
+// from a caller who can't see that project (the workspace-scoping invariant applies to
+// deleted pages too, not just live ones).
+function extractDeletedPageInfo(diff: Record<string, unknown> | null): {
+	slug: string | null;
+	title: string | null;
+	projectId: string | null;
+} {
+	if (!diff) return { slug: null, title: null, projectId: null };
+	return {
+		slug: typeof diff.slug === "string" ? diff.slug : null,
+		title: typeof diff.title === "string" ? diff.title : null,
+		projectId: typeof diff.projectId === "string" ? diff.projectId : null,
+	};
+}
+
+// PROJ-493: resolves the (pageId -> is-watched) set for the caller, for list_wiki_changes'
+// watchedOnly filter. Mirrors notifyWikiWatchers' match rule (direct watch, or a
+// subtree watch on a proper ancestor) but walks the CURRENT tree — a page reparented out
+// of a watched subtree since the change occurred is (deliberately) not flagged watched,
+// same class of "current tree, not historical" approximation as the rest of this file.
+async function watchedPageIds(
+	ctx: ServiceCtx,
+	orm: Orm,
+	candidatePageIds: string[]
+): Promise<Set<string>> {
+	const watches = await orm
+		.select({ pageId: schema.wikiWatchers.pageId, subtree: schema.wikiWatchers.subtree })
+		.from(schema.wikiWatchers)
+		.where(
+			and(
+				eq(schema.wikiWatchers.workspaceId, ctx.workspaceId),
+				eq(schema.wikiWatchers.userId, ctx.userId)
+			)
+		);
+	if (watches.length === 0) return new Set();
+
+	const directWatchIds = new Set(watches.map((w) => w.pageId));
+	const subtreeRootIds = new Set(watches.filter((w) => w.subtree).map((w) => w.pageId));
+
+	const matched = new Set<string>();
+	for (const pageId of new Set(candidatePageIds)) {
+		if (directWatchIds.has(pageId)) {
+			matched.add(pageId);
+			continue;
+		}
+		if (subtreeRootIds.size === 0) continue;
+		const ancestors = await resolveAncestorChain(ctx.db, pageId, pageId, ctx.workspaceId);
+		// resolveAncestorChain(pageId, pageId, ...) re-fetches pageId's own row as the
+		// first hop, which is redundant but harmless — ancestors[0] === pageId either way.
+		if (ancestors.some((id) => subtreeRootIds.has(id))) matched.add(pageId);
+	}
+	return matched;
+}
+
+// PROJ-493 (R11): cheap delta feed — piggybacks entirely on the `activity` table every
+// wiki_page write already populates (services/activity.ts#recordActivity, called from
+// every create/update/patch/delete path in services/wiki.ts) rather than a separate
+// change log. Defaults to every wiki page the caller can see (same visibility rule as
+// list_wiki_pages/search_wiki), NOT scoped to watched pages by default — a delta-polling
+// agent syncing "what changed in the wiki" is a broader use case than "what am I
+// watching", and requiring a watch registration for every page an agent wants to poll
+// would defeat the point of a cheap, low-ceremony polling tool. Pass watchedOnly=true to
+// narrow to watched pages. Unlike notifyWikiWatchers, this does NOT exclude template
+// pages — it's a ground-truth delta feed, not a notification stream, and callers that
+// care can filter client-side on the page's `type`/`is_template` themselves.
+export async function listWikiChanges(
+	ctx: ServiceCtx,
+	input: unknown
+): Promise<{
+	changes: WikiChangeEvent[];
+	nextSince: number;
+}> {
+	const parsed = ListWikiChangesInputSchema.safeParse(input);
+	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
+	const { since, limit, projectId, watchedOnly } = parsed.data;
+
+	if (projectId) {
+		if (!isWorkspaceAdmin(ctx.role) && (await effectiveProjectRole(ctx, projectId)) === null) {
+			return { changes: [], nextSince: since };
+		}
+	}
+
+	const orm = drizzle(ctx.db, { schema });
+	const rows = await orm
+		.select({
+			id: schema.activity.id,
+			action: schema.activity.action,
+			entityId: schema.activity.entityId,
+			actorId: schema.activity.actorId,
+			diff: schema.activity.diff,
+			createdAt: schema.activity.createdAt,
+			pageSlug: schema.wikiPages.slug,
+			pageTitle: schema.wikiPages.title,
+			pageProjectId: schema.wikiPages.projectId,
+		})
+		.from(schema.activity)
+		.leftJoin(schema.wikiPages, eq(schema.wikiPages.id, schema.activity.entityId))
+		.where(
+			and(
+				eq(schema.activity.workspaceId, ctx.workspaceId),
+				eq(schema.activity.entityType, "wiki_page"),
+				gt(schema.activity.createdAt, since)
+			)
+		)
+		.orderBy(schema.activity.createdAt)
+		.limit(limit);
+
+	let nextSince = since;
+	const events: WikiChangeEvent[] = [];
+	for (const r of rows) {
+		if (r.createdAt > nextSince) nextSince = r.createdAt;
+		const action = r.action as "created" | "updated" | "deleted";
+		const deleted = action === "deleted" ? extractDeletedPageInfo(r.diff) : null;
+		const slug = deleted ? deleted.slug : r.pageSlug;
+		const title = deleted ? deleted.title : r.pageTitle;
+		const eventProjectId = deleted ? deleted.projectId : r.pageProjectId;
+
+		if (projectId && eventProjectId !== projectId) continue;
+		if (!projectId && eventProjectId !== null) {
+			if (
+				!isWorkspaceAdmin(ctx.role) &&
+				(await effectiveProjectRole(ctx, eventProjectId)) === null
+			) {
+				continue;
+			}
+		}
+
+		events.push({
+			id: r.id,
+			action,
+			pageId: r.entityId,
+			slug,
+			title,
+			projectId: eventProjectId,
+			actorId: r.actorId,
+			createdAt: r.createdAt,
+		});
+	}
+
+	if (watchedOnly) {
+		const watched = await watchedPageIds(
+			ctx,
+			orm,
+			events.map((e) => e.pageId)
+		);
+		return {
+			changes: events.filter((e) => watched.has(e.pageId)),
+			nextSince,
+		};
+	}
+
+	return { changes: events, nextSince };
+}

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -41,6 +41,7 @@ import {
 	reindexWikiLinks,
 	type WikiBacklink,
 } from "./wiki-links";
+import { notifyWikiWatchers } from "./wiki-watchers";
 
 type TreeNode = { id: string; slug: string; title: string; url: string; children: TreeNode[] };
 
@@ -123,6 +124,7 @@ async function resolvePageByIdOrSlug(
 	content: string;
 	projectId: string | null;
 	parentId: string | null;
+	isTemplate: boolean;
 }> {
 	const orm = drizzle(db, { schema });
 	const direct = await orm
@@ -133,6 +135,7 @@ async function resolvePageByIdOrSlug(
 			content: schema.wikiPages.content,
 			projectId: schema.wikiPages.projectId,
 			parentId: schema.wikiPages.parentId,
+			isTemplate: schema.wikiPages.isTemplate,
 		})
 		.from(schema.wikiPages)
 		.where(
@@ -156,6 +159,8 @@ async function resolvePageByIdOrSlug(
 			projectId: redirected.project_id,
 			// eslint-disable-next-line camelcase
 			parentId: redirected.parent_id,
+			// eslint-disable-next-line camelcase
+			isTemplate: redirected.is_template,
 		};
 	}
 	throw new NotFoundError("Wiki page not found");
@@ -723,6 +728,18 @@ export async function createWikiPage(ctx: ServiceCtx, input: unknown) {
 	// PROJ-485: parse [[Target]]/URL links out of the new page's content into wiki_links.
 	await reindexWikiLinks(ctx, orm, id, content ?? "");
 	await recordActivity(ctx, { entityType: "wiki_page", entityId: id, action: "created" });
+	// PROJ-493 (R11): a subtree watcher on an ancestor is notified of a page newly
+	// created underneath them (there's no possible DIRECT watch on `id` yet — it didn't
+	// exist until this insert). Template pages never notify (see wiki-watchers.ts).
+	if (!meta.isTemplate) {
+		await notifyWikiWatchers(ctx, {
+			pageId: id,
+			parentId: parentId ?? null,
+			slug,
+			title,
+			action: "created",
+		});
+	}
 	return { id, slug, projectId: projectId ?? null, url: wikiPagePath(slug), ...meta };
 }
 
@@ -1063,6 +1080,20 @@ export async function updateWikiPage(ctx: ServiceCtx, idOrSlug: string, input: u
 		action: "updated",
 		diff: buildWikiPageUpdateDiff({ title, content }),
 	});
+
+	// PROJ-493 (R11): covers plain edits, verify_wiki_page, and restore (both routed
+	// through this function). meta is only recomputed when content changed — otherwise
+	// fall back to the page's existing isTemplate, which this write left untouched.
+	const isTemplate = meta?.isTemplate ?? page.isTemplate;
+	if (!isTemplate) {
+		await notifyWikiWatchers(ctx, {
+			pageId: page.id,
+			parentId: parentId !== undefined ? parentId : page.parentId,
+			slug: slug ?? page.slug,
+			title: title ?? page.title,
+			action: "updated",
+		});
+	}
 
 	return { ok: true, url: wikiPagePath(slug ?? page.slug) };
 }
@@ -1439,6 +1470,19 @@ export async function patchWikiPage(ctx: ServiceCtx, idOrSlug: string, input: un
 		diff: buildWikiPageUpdateDiff({ content: newContent }),
 	});
 
+	// PROJ-493 (R11): meta is always reparsed from newContent above (patches only touch
+	// section bodies, so template status can't itself change here, but the check stays
+	// consistent with the other write paths).
+	if (!meta.isTemplate) {
+		await notifyWikiWatchers(ctx, {
+			pageId: page.id,
+			parentId: page.parentId,
+			slug: page.slug,
+			title: page.title,
+			action: "updated",
+		});
+	}
+
 	return { ok: true, url: wikiPagePath(page.slug) };
 }
 
@@ -1698,9 +1742,22 @@ export async function deleteWikiPage(ctx: ServiceCtx, idOrSlug: string, options?
 
 	const orm = drizzle(ctx.db, { schema });
 	const resolved = await resolvePageByIdOrSlug(ctx.db, idOrSlug, ctx.workspaceId);
-	const page = { id: resolved.id, projectId: resolved.projectId, parentId: resolved.parentId };
+	const page = {
+		id: resolved.id,
+		slug: resolved.slug,
+		title: resolved.title,
+		projectId: resolved.projectId,
+		parentId: resolved.parentId,
+		isTemplate: resolved.isTemplate,
+	};
 
 	await requireWikiDelete(ctx, page.projectId);
+
+	// PROJ-493 (R11): slug/title/projectId are captured here (not read off the row after
+	// delete, which no longer exists) so list_wiki_changes can still report what a
+	// "deleted" event was about, and still enforce the workspace-scoping/project-
+	// visibility invariant for it — see wiki-watchers.ts#extractDeletedPageInfo.
+	const deleteDiffBase = { slug: page.slug, title: page.title, projectId: page.projectId };
 
 	if (cascade) {
 		const descendantIds = await collectDescendantIds(ctx.db, page.id, ctx.workspaceId);
@@ -1709,6 +1766,19 @@ export async function deleteWikiPage(ctx: ServiceCtx, idOrSlug: string, options?
 		// count would read as 0 once the pages are gone. Non-blocking: surfaced as info on
 		// the response, matching the PRD's "delete warnings" (not a hard block).
 		const linkedByCount = await countBacklinkSources(ctx, allIds);
+		// PROJ-493: notify BEFORE deleting the page rows — wiki_watchers.page_id is
+		// ON DELETE CASCADE, so a watcher's own watch row (including the root page's
+		// watchers this notifies) would otherwise already be gone by the time
+		// notifyWikiWatchers queries the table.
+		if (!page.isTemplate) {
+			await notifyWikiWatchers(ctx, {
+				pageId: page.id,
+				parentId: page.parentId,
+				slug: page.slug,
+				title: page.title,
+				action: "deleted",
+			});
+		}
 		await inChunks(allIds, async (chunk) => {
 			await deleteWikiPageAttachments(ctx, orm, chunk);
 			return [];
@@ -1726,7 +1796,7 @@ export async function deleteWikiPage(ctx: ServiceCtx, idOrSlug: string, options?
 			entityType: "wiki_page",
 			entityId: page.id,
 			action: "deleted",
-			diff: { cascade: true, deletedCount: allIds.length },
+			diff: { ...deleteDiffBase, cascade: true, deletedCount: allIds.length },
 		});
 		return { ok: true, deletedCount: allIds.length, linkedByCount };
 	}
@@ -1740,12 +1810,28 @@ export async function deleteWikiPage(ctx: ServiceCtx, idOrSlug: string, options?
 		.where(eq(schema.wikiPages.parentId, page.id));
 
 	const linkedByCount = await countBacklinkSources(ctx, [page.id]);
+	// PROJ-493: notify BEFORE deleting the page row — see the cascade branch above for why
+	// (wiki_watchers.page_id is ON DELETE CASCADE).
+	if (!page.isTemplate) {
+		await notifyWikiWatchers(ctx, {
+			pageId: page.id,
+			parentId: page.parentId,
+			slug: page.slug,
+			title: page.title,
+			action: "deleted",
+		});
+	}
 	await deleteWikiPageAttachments(ctx, orm, [page.id]);
 	await orm.delete(schema.wikiPages).where(eq(schema.wikiPages.id, page.id));
 	await deleteWikiFtsEntries(ctx, [page.id]);
 	await deleteWikiLinksForPages(ctx, [page.id]);
 	await clearIncomingLinkTargets(ctx, [page.id]);
-	await recordActivity(ctx, { entityType: "wiki_page", entityId: page.id, action: "deleted" });
+	await recordActivity(ctx, {
+		entityType: "wiki_page",
+		entityId: page.id,
+		action: "deleted",
+		diff: deleteDiffBase,
+	});
 	return { ok: true, deletedCount: 1, linkedByCount };
 }
 

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -41,7 +41,11 @@ import {
 	reindexWikiLinks,
 	type WikiBacklink,
 } from "./wiki-links";
-import { notifyWikiWatchers } from "./wiki-watchers";
+import {
+	deleteWikiWatchersForPages,
+	notifyCascadeDescendantWatchers,
+	notifyWikiWatchers,
+} from "./wiki-watchers";
 
 type TreeNode = { id: string; slug: string; title: string; url: string; children: TreeNode[] };
 
@@ -1779,6 +1783,28 @@ export async function deleteWikiPage(ctx: ServiceCtx, idOrSlug: string, options?
 				action: "deleted",
 			});
 		}
+		// PROJ-493: subtree watchers rooted at/above the cascade root got the single
+		// notification above, but someone watching one of the DESCENDANTS directly would
+		// otherwise hear nothing at all before their watch row disappeared with the page.
+		if (descendantIds.length > 0) {
+			const descendants = await inChunks(descendantIds, (chunk) =>
+				orm
+					.select({
+						id: schema.wikiPages.id,
+						slug: schema.wikiPages.slug,
+						title: schema.wikiPages.title,
+						isTemplate: schema.wikiPages.isTemplate,
+					})
+					.from(schema.wikiPages)
+					.where(
+						and(
+							inArray(schema.wikiPages.id, chunk),
+							eq(schema.wikiPages.workspaceId, ctx.workspaceId)
+						)
+					)
+			);
+			await notifyCascadeDescendantWatchers(ctx, descendants);
+		}
 		await inChunks(allIds, async (chunk) => {
 			await deleteWikiPageAttachments(ctx, orm, chunk);
 			return [];
@@ -1792,6 +1818,7 @@ export async function deleteWikiPage(ctx: ServiceCtx, idOrSlug: string, options?
 		// the app level too, since D1 doesn't guarantee FK enforcement on every connection.
 		await deleteWikiLinksForPages(ctx, allIds);
 		await clearIncomingLinkTargets(ctx, allIds);
+		await deleteWikiWatchersForPages(ctx, allIds);
 		await recordActivity(ctx, {
 			entityType: "wiki_page",
 			entityId: page.id,
@@ -1826,6 +1853,7 @@ export async function deleteWikiPage(ctx: ServiceCtx, idOrSlug: string, options?
 	await deleteWikiFtsEntries(ctx, [page.id]);
 	await deleteWikiLinksForPages(ctx, [page.id]);
 	await clearIncomingLinkTargets(ctx, [page.id]);
+	await deleteWikiWatchersForPages(ctx, [page.id]);
 	await recordActivity(ctx, {
 		entityType: "wiki_page",
 		entityId: page.id,

--- a/apps/api/src/test/migrations.ts
+++ b/apps/api/src/test/migrations.ts
@@ -48,6 +48,7 @@ import m0044 from "../../../../packages/db/migrations/0044_wiki_links.sql?raw";
 import m0045 from "../../../../packages/db/migrations/0045_wiki_frontmatter.sql?raw";
 import m0046 from "../../../../packages/db/migrations/0046_wiki_page_templates.sql?raw";
 import m0047 from "../../../../packages/db/migrations/0047_seed_wiki_templates.sql?raw";
+import m0048 from "../../../../packages/db/migrations/0048_wiki_watchers.sql?raw";
 
 export const MIGRATIONS = [
 	m0000,
@@ -98,4 +99,5 @@ export const MIGRATIONS = [
 	m0045,
 	m0046,
 	m0047,
+	m0048,
 ];

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -4253,6 +4253,71 @@ describe("Wiki watchers + list_wiki_changes (PROJ-493)", () => {
 		expect(deleteNotifs[0]).toMatchObject({ pageId: parent.id, slug: "cascade-parent" });
 	});
 
+	it("a cascade delete notifies someone watching a DESCENDANT directly, and clears their watch row", async () => {
+		const parent = await createPage("cascade-root", "Cascade Root", "content");
+		const child = await createChildPage("cascade-kid", "Cascade Kid", "child", parent.id);
+		const watcher = await seedWatcher();
+		await req(`http://localhost/api/wiki/${child.slug}/watch`, {
+			method: "POST",
+			headers: authHeaders(watcher.token, slug),
+			body: JSON.stringify({}),
+		});
+
+		const delRes = await req(`http://localhost/api/wiki/${parent.slug}?cascade=true`, {
+			method: "DELETE",
+			headers: authHeaders(token, slug),
+		});
+		expect(delRes.status).toBe(200);
+
+		const deleteNotifs = (await notifications(watcher.token)).filter((n) => n.action === "deleted");
+		expect(deleteNotifs.length).toBe(1);
+		expect(deleteNotifs[0]).toMatchObject({ pageId: child.id, slug: "cascade-kid" });
+
+		// No dangling watch row left pointing at a page that no longer exists.
+		const watchesRes = await req("http://localhost/api/wiki/watches", {
+			headers: authHeaders(watcher.token, slug),
+		});
+		expect(await watchesRes.json()).toEqual([]);
+		const orphaned = await env.DB.prepare(
+			"SELECT COUNT(*) AS c FROM wiki_watchers WHERE page_id = ?"
+		)
+			.bind(child.id)
+			.first<{ c: number }>();
+		expect(orphaned?.c).toBe(0);
+	});
+
+	it("unreadOnly=false / watchedOnly=false are honored as false, not coerced true", async () => {
+		const page = await createPage("bool-param", "Bool Param", "content");
+		const watcher = await seedWatcher();
+		await req(`http://localhost/api/wiki/${page.slug}/watch`, {
+			method: "POST",
+			headers: authHeaders(watcher.token, slug),
+			body: JSON.stringify({}),
+		});
+		const t0 = Math.floor(Date.now() / 1000) - 1;
+		await req(`http://localhost/api/wiki/${page.slug}`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "v2" }),
+		});
+		await req("http://localhost/api/wiki/notifications/read", {
+			method: "POST",
+			headers: authHeaders(watcher.token, slug),
+			body: JSON.stringify({ all: true }),
+		});
+
+		expect((await notifications(watcher.token, "?unreadOnly=true")).length).toBe(0);
+		expect((await notifications(watcher.token, "?unreadOnly=false")).length).toBe(1);
+
+		// The watcher watches nothing but `page`; watchedOnly=false must not narrow.
+		await createPage("bool-unwatched", "Bool Unwatched", "other");
+		const res = await req(`http://localhost/api/wiki/changes?since=${t0}&watchedOnly=false`, {
+			headers: authHeaders(watcher.token, slug),
+		});
+		const body = (await res.json()) as { changes: Array<{ slug: string | null }> };
+		expect(body.changes.map((c) => c.slug)).toContain("bool-unwatched");
+	});
+
 	it("mark_wiki_notifications_read: by explicit ids, then all:true", async () => {
 		const page = await createPage("read-flag", "Read Flag", "content");
 		const watcher = await seedWatcher();

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -5,8 +5,10 @@ import {
 	authHeaders,
 	seedFixture,
 	seedGroupGrant,
+	seedMember,
 	seedProject,
 	seedToken,
+	seedUser,
 	seedWorkspaceRoles,
 } from "./helpers";
 
@@ -4016,5 +4018,413 @@ describe("Wiki built-in template seeding on workspace creation (PROJ-491)", () =
 		});
 		expect(parentRes.status).toBe(200);
 		expect(((await parentRes.json()) as { title: string }).title).toBe("Templates");
+	});
+});
+
+// PROJ-493 (R11): watch/unwatch per page or subtree, per-user notifications, and the
+// list_wiki_changes delta feed.
+describe("Wiki watchers + list_wiki_changes (PROJ-493)", () => {
+	let token: string;
+	let userId: string;
+	let slug: string;
+	let workspaceId: string;
+
+	beforeEach(async () => {
+		// admin: several tests (cascade delete, delta-delete) delete workspace-level
+		// pages, which requireWikiDelete restricts to admin/owner.
+		const fixture = await seedFixture({ role: "admin" });
+		token = fixture.token;
+		userId = fixture.user.id;
+		slug = fixture.workspace.slug;
+		workspaceId = fixture.workspace.id;
+	});
+
+	async function req(url: string, opts?: RequestInit) {
+		await env.DB.prepare("DELETE FROM rate_limit").run();
+		return SELF.fetch(url, opts);
+	}
+
+	async function createPage(pageSlug: string, title: string, content = "") {
+		const res = await req("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title, content, slug: pageSlug }),
+		});
+		expect(res.status).toBe(201);
+		return (await res.json()) as { id: string; slug: string };
+	}
+
+	async function createChildPage(
+		pageSlug: string,
+		title: string,
+		content: string,
+		parentId: string
+	) {
+		const res = await req("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title, content, slug: pageSlug, parentId }),
+		});
+		expect(res.status).toBe(201);
+		return (await res.json()) as { id: string; slug: string };
+	}
+
+	async function seedWatcher(role = "member") {
+		const user = await seedUser(`watcher-${crypto.randomUUID().slice(0, 8)}@example.com`);
+		await seedMember(workspaceId, user.id, role);
+		const watcherToken = await seedToken(workspaceId, user.id);
+		return { user, token: watcherToken };
+	}
+
+	async function notifications(watcherToken: string, query = "") {
+		const res = await req(`http://localhost/api/wiki/notifications${query}`, {
+			headers: authHeaders(watcherToken, slug),
+		});
+		expect(res.status).toBe(200);
+		return (await res.json()) as Array<{
+			id: string;
+			pageId: string;
+			slug: string;
+			title: string;
+			action: string;
+			actorId: string | null;
+		}>;
+	}
+
+	it("REST: watch/unwatch a page, watching again upserts the subtree flag instead of duplicating", async () => {
+		const page = await createPage("watch-me", "Watch Me", "content");
+
+		const watchRes = await req(`http://localhost/api/wiki/${page.slug}/watch`, {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ subtree: false }),
+		});
+		expect(watchRes.status).toBe(200);
+
+		let watches = (await (
+			await req("http://localhost/api/wiki/watches", { headers: authHeaders(token, slug) })
+		).json()) as Array<{ pageId: string; subtree: boolean }>;
+		const initial = watches.filter((w) => w.pageId === page.id);
+		expect(initial.length).toBe(1);
+		expect(initial[0]).toMatchObject({ pageId: page.id, subtree: false });
+
+		// Watching the same page again with a different subtree flag upserts, not duplicates.
+		await req(`http://localhost/api/wiki/${page.slug}/watch`, {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ subtree: true }),
+		});
+		watches = (await (
+			await req("http://localhost/api/wiki/watches", { headers: authHeaders(token, slug) })
+		).json()) as Array<{ pageId: string; subtree: boolean }>;
+		expect(watches.filter((w) => w.pageId === page.id).length).toBe(1);
+		expect(watches.find((w) => w.pageId === page.id)?.subtree).toBe(true);
+
+		const unwatchRes = await req(`http://localhost/api/wiki/${page.slug}/watch`, {
+			method: "DELETE",
+			headers: authHeaders(token, slug),
+		});
+		expect(unwatchRes.status).toBe(200);
+		watches = (await (
+			await req("http://localhost/api/wiki/watches", { headers: authHeaders(token, slug) })
+		).json()) as Array<{ pageId: string; subtree: boolean }>;
+		expect(watches.some((w) => w.pageId === page.id)).toBe(false);
+	});
+
+	it("a direct watcher is notified when someone else edits the page, never for their own edit", async () => {
+		const page = await createPage("direct-watch", "Direct Watch", "content");
+		const watcher = await seedWatcher();
+		await req(`http://localhost/api/wiki/${page.slug}/watch`, {
+			method: "POST",
+			headers: authHeaders(watcher.token, slug),
+			body: JSON.stringify({}),
+		});
+
+		await req(`http://localhost/api/wiki/${page.slug}`, {
+			method: "PUT",
+			headers: authHeaders(watcher.token, slug),
+			body: JSON.stringify({ content: "self edit" }),
+		});
+		expect(await notifications(watcher.token)).toEqual([]);
+
+		await req(`http://localhost/api/wiki/${page.slug}`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "other edit" }),
+		});
+		const notifs = await notifications(watcher.token);
+		expect(notifs.length).toBe(1);
+		expect(notifs[0]).toMatchObject({ action: "updated", pageId: page.id, actorId: userId });
+	});
+
+	it("unwatching stops further notifications", async () => {
+		const page = await createPage("unwatch-stop", "Unwatch Stop", "content");
+		const watcher = await seedWatcher();
+		await req(`http://localhost/api/wiki/${page.slug}/watch`, {
+			method: "POST",
+			headers: authHeaders(watcher.token, slug),
+			body: JSON.stringify({}),
+		});
+		await req(`http://localhost/api/wiki/${page.slug}/watch`, {
+			method: "DELETE",
+			headers: authHeaders(watcher.token, slug),
+		});
+		await req(`http://localhost/api/wiki/${page.slug}`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "after unwatch" }),
+		});
+		expect(await notifications(watcher.token)).toEqual([]);
+	});
+
+	it("subtree watch covers a page created now under it AND a later edit to that descendant", async () => {
+		const parent = await createPage("parent-page", "Parent Page", "content");
+		const watcher = await seedWatcher();
+		await req(`http://localhost/api/wiki/${parent.slug}/watch`, {
+			method: "POST",
+			headers: authHeaders(watcher.token, slug),
+			body: JSON.stringify({ subtree: true }),
+		});
+
+		const child = await createChildPage("child-page", "Child Page", "child", parent.id);
+		let notifs = await notifications(watcher.token);
+		expect(notifs.some((n) => n.action === "created" && n.pageId === child.id)).toBe(true);
+
+		await req(`http://localhost/api/wiki/${child.slug}`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "child v2" }),
+		});
+		notifs = await notifications(watcher.token);
+		expect(notifs.filter((n) => n.pageId === child.id).length).toBe(2);
+	});
+
+	it("a direct-only (non-subtree) watch on the parent does NOT notify for a descendant's changes", async () => {
+		const parent = await createPage("parent-narrow", "Parent Narrow", "content");
+		const watcher = await seedWatcher();
+		await req(`http://localhost/api/wiki/${parent.slug}/watch`, {
+			method: "POST",
+			headers: authHeaders(watcher.token, slug),
+			body: JSON.stringify({ subtree: false }),
+		});
+		await createChildPage("child-narrow", "Child Narrow", "child", parent.id);
+		expect(await notifications(watcher.token)).toEqual([]);
+	});
+
+	it("template pages never generate watcher notifications", async () => {
+		const page = await createPage(
+			"watch-template",
+			"Watch Template",
+			"---\ntemplate: true\n---\nbody"
+		);
+		const watcher = await seedWatcher();
+		await req(`http://localhost/api/wiki/${page.slug}/watch`, {
+			method: "POST",
+			headers: authHeaders(watcher.token, slug),
+			body: JSON.stringify({}),
+		});
+		await req(`http://localhost/api/wiki/${page.slug}`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "---\ntemplate: true\n---\nedited" }),
+		});
+		expect(await notifications(watcher.token)).toEqual([]);
+	});
+
+	it("a cascade delete generates a single 'deleted' notification for the root page, not one per descendant", async () => {
+		const parent = await createPage("cascade-parent", "Cascade Parent", "content");
+		await createChildPage("cascade-child", "Cascade Child", "child", parent.id);
+		const watcher = await seedWatcher();
+		await req(`http://localhost/api/wiki/${parent.slug}/watch`, {
+			method: "POST",
+			headers: authHeaders(watcher.token, slug),
+			body: JSON.stringify({ subtree: true }),
+		});
+
+		const delRes = await req(`http://localhost/api/wiki/${parent.slug}?cascade=true`, {
+			method: "DELETE",
+			headers: authHeaders(token, slug),
+		});
+		expect(delRes.status).toBe(200);
+
+		const notifs = await notifications(watcher.token);
+		const deleteNotifs = notifs.filter((n) => n.action === "deleted");
+		expect(deleteNotifs.length).toBe(1);
+		expect(deleteNotifs[0]).toMatchObject({ pageId: parent.id, slug: "cascade-parent" });
+	});
+
+	it("mark_wiki_notifications_read: by explicit ids, then all:true", async () => {
+		const page = await createPage("read-flag", "Read Flag", "content");
+		const watcher = await seedWatcher();
+		await req(`http://localhost/api/wiki/${page.slug}/watch`, {
+			method: "POST",
+			headers: authHeaders(watcher.token, slug),
+			body: JSON.stringify({}),
+		});
+		await req(`http://localhost/api/wiki/${page.slug}`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "v2" }),
+		});
+		await req(`http://localhost/api/wiki/${page.slug}`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "v3" }),
+		});
+
+		const unread = await notifications(watcher.token, "?unreadOnly=true");
+		expect(unread.length).toBe(2);
+
+		await req("http://localhost/api/wiki/notifications/read", {
+			method: "POST",
+			headers: authHeaders(watcher.token, slug),
+			body: JSON.stringify({ ids: [unread[0].id] }),
+		});
+		expect((await notifications(watcher.token, "?unreadOnly=true")).length).toBe(1);
+
+		await req("http://localhost/api/wiki/notifications/read", {
+			method: "POST",
+			headers: authHeaders(watcher.token, slug),
+			body: JSON.stringify({ all: true }),
+		});
+		expect((await notifications(watcher.token, "?unreadOnly=true")).length).toBe(0);
+	});
+
+	it("list_wiki_changes: since is exclusive, nextSince advances, default scope isn't limited to watched pages", async () => {
+		const t0 = Math.floor(Date.now() / 1000) - 1;
+		const page = await createPage("delta-doc", "Delta Doc", "content");
+
+		const res = await req(`http://localhost/api/wiki/changes?since=${t0}`, {
+			headers: authHeaders(token, slug),
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			changes: Array<{ action: string; pageId: string }>;
+			nextSince: number;
+		};
+		expect(body.changes.some((c) => c.pageId === page.id && c.action === "created")).toBe(true);
+		expect(body.nextSince).toBeGreaterThanOrEqual(t0);
+
+		const empty = (await (
+			await req(`http://localhost/api/wiki/changes?since=${body.nextSince}`, {
+				headers: authHeaders(token, slug),
+			})
+		).json()) as { changes: unknown[] };
+		expect(empty.changes).toEqual([]);
+	});
+
+	it("list_wiki_changes reports a deleted page's slug/title even though the row is gone", async () => {
+		const t0 = Math.floor(Date.now() / 1000) - 1;
+		const page = await createPage("delta-delete", "Delta Delete", "content");
+		await req(`http://localhost/api/wiki/${page.slug}`, {
+			method: "DELETE",
+			headers: authHeaders(token, slug),
+		});
+
+		const body = (await (
+			await req(`http://localhost/api/wiki/changes?since=${t0}`, {
+				headers: authHeaders(token, slug),
+			})
+		).json()) as { changes: Array<{ action: string; slug: string | null; title: string | null }> };
+		const deleteEvent = body.changes.find((c) => c.action === "deleted");
+		expect(deleteEvent).toMatchObject({ slug: "delta-delete", title: "Delta Delete" });
+	});
+
+	it("list_wiki_changes hides changes to a project-scoped page the caller can't see", async () => {
+		const project = await seedProject(workspaceId, `PRJ${crypto.randomUUID().slice(0, 4)}`);
+		await seedGroupGrant(workspaceId, userId, project.id);
+		const t0 = Math.floor(Date.now() / 1000) - 1;
+
+		const created = await req("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({
+				title: "Restricted",
+				content: "secret",
+				projectId: project.id,
+				slug: "restricted-delta",
+			}),
+		});
+		expect(created.status).toBe(201);
+
+		// A workspace viewer with no grant on `project` shouldn't see this change.
+		const outsider = await seedWatcher("viewer");
+		const body = (await (
+			await req(`http://localhost/api/wiki/changes?since=${t0}`, {
+				headers: authHeaders(outsider.token, slug),
+			})
+		).json()) as { changes: Array<{ slug: string | null }> };
+		expect(body.changes.some((c) => c.slug === "restricted-delta")).toBe(false);
+
+		// The grantee (the creator) does see it.
+		const ownBody = (await (
+			await req(`http://localhost/api/wiki/changes?since=${t0}`, {
+				headers: authHeaders(token, slug),
+			})
+		).json()) as { changes: Array<{ slug: string | null }> };
+		expect(ownBody.changes.some((c) => c.slug === "restricted-delta")).toBe(true);
+	});
+
+	it("list_wiki_changes watchedOnly=true narrows to watched pages, including via a subtree watch", async () => {
+		const parent = await createPage("watched-scope-parent", "Watched Scope Parent", "content");
+		const other = await createPage("unwatched-scope", "Unwatched Scope", "content");
+		const watcher = await seedWatcher();
+		await req(`http://localhost/api/wiki/${parent.slug}/watch`, {
+			method: "POST",
+			headers: authHeaders(watcher.token, slug),
+			body: JSON.stringify({ subtree: true }),
+		});
+
+		const child = await createChildPage(
+			"watched-scope-child",
+			"Watched Scope Child",
+			"child",
+			parent.id
+		);
+		await req(`http://localhost/api/wiki/${other.slug}`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "v2" }),
+		});
+
+		const body = (await (
+			await req("http://localhost/api/wiki/changes?since=0&watchedOnly=true", {
+				headers: authHeaders(watcher.token, slug),
+			})
+		).json()) as { changes: Array<{ pageId: string }> };
+		const pageIds = body.changes.map((c) => c.pageId);
+		expect(pageIds).toContain(child.id);
+		expect(pageIds).not.toContain(other.id);
+	});
+
+	it("MCP: watch_wiki_page / list_wiki_watches / list_wiki_changes mirror the REST behavior", async () => {
+		// Several MCP calls back-to-back would otherwise trip the same per-token rate
+		// limit that req() clears for REST calls above.
+		async function mcp<T>(name: string, args: unknown) {
+			await env.DB.prepare("DELETE FROM rate_limit").run();
+			return mcpCall<T>(workspaceId, name, args, authHeaders(token, slug));
+		}
+
+		// Captured before createPage — since is exclusive and page creation's own
+		// activity row must land after this cutoff, not before it (a slow full-suite
+		// run can otherwise push several real seconds between here and list_wiki_changes).
+		const t0 = Math.floor(Date.now() / 1000) - 1;
+		const page = await createPage("mcp-watch", "MCP Watch", "content");
+
+		const watchRes = await mcp("watch_wiki_page", { slug: page.slug });
+		expect(isMcpError(watchRes)).toBe(false);
+
+		const watches = mcpData<Array<{ pageId: string }>>(await mcp("list_wiki_watches", {}));
+		expect(watches.some((w) => w.pageId === page.id)).toBe(true);
+
+		const unwatchRes = await mcp("unwatch_wiki_page", { slug: page.slug });
+		expect(isMcpError(unwatchRes)).toBe(false);
+		const watchesAfter = mcpData<Array<{ pageId: string }>>(await mcp("list_wiki_watches", {}));
+		expect(watchesAfter.some((w) => w.pageId === page.id)).toBe(false);
+
+		const changes = mcpData<{ changes: Array<{ pageId: string; action: string }> }>(
+			await mcp("list_wiki_changes", { since: t0 })
+		);
+		expect(changes.changes.some((c) => c.pageId === page.id && c.action === "created")).toBe(true);
 	});
 });

--- a/apps/docs/src/content/docs/agents/tool-catalog.md
+++ b/apps/docs/src/content/docs/agents/tool-catalog.md
@@ -11,7 +11,7 @@ running server.
 
 <!-- gen-mcp-catalog:start - generated block; run `pnpm --filter @projektor/api gen:catalog` to refresh -->
 
-**98 tools across 21 domains.**
+**104 tools across 21 domains.**
 
 ## Coordination
 
@@ -149,6 +149,12 @@ running server.
 | `verify_wiki_page` | Stamp a wiki page as freshly verified — sets its frontmatter verified_at to now and verified_by to the CALLING user's email (never caller-supplied). Rewrites the page's frontmatter block (creating one if it had none) and records a revision, same as any other content edit — including its conflict check, so a concurrent edit racing the stamp is rejected rather than reverted. Not allowed for viewers. |
 | `list_stale_pages` | Maintenance queue of wiki pages that need re-verification: computed-stale (verify_interval elapsed since verified_at), unverified (verify_interval declared but never verified), or explicitly status: stale\|deprecated. Same rule search_wiki uses to demote results (R7). |
 | `list_wiki_templates` | List pages flagged as templates (frontmatter `template: true`) — the picker create_wiki_page's `templateSlug` draws from. Templates are conventionally workspace-global (living under a workspace 'Templates' page) but a project-scoped template is allowed and follows the same project-visibility rule as any other project-scoped page. |
+| `watch_wiki_page` | Watch a wiki page by id or slug — its changes (create is n/a here since the page already exists, update/patch/verify/restore/delete) will generate a per-user notification (list_wiki_notifications). Pass subtree=true to also watch every page currently OR LATER nested under this one (resolved dynamically by walking the page hierarchy at notify time, not a one-time snapshot). Calling this again for the same page updates the subtree flag rather than creating a duplicate watch. Template pages (frontmatter template: true) never generate notifications even if watched directly or via a subtree. |
+| `unwatch_wiki_page` | Stop watching a wiki page by id or slug (a no-op if not currently watched). |
+| `list_wiki_watches` | List the pages the calling user is currently watching. |
+| `list_wiki_notifications` | List the calling user's wiki watch notifications (newest first). Each entry records the page (denormalized slug/title, so a notification about a page that's since been deleted still shows what it was about), the action (created\|updated\|deleted), the actor, and whether it's been read. |
+| `mark_wiki_notifications_read` | Mark wiki notifications as read, by id, or all: true for every unread one. |
+| `list_wiki_changes` | Cheap delta feed of wiki page changes since a unix-seconds timestamp — for agents polling 'what changed' instead of re-fetching/re-searching the whole wiki. Backed by the existing activity log (no extra write-path cost). `since` is EXCLUSIVE; poll again using the response's `nextSince`, not a locally-computed timestamp, so changes landing on the same second as the cutoff are never missed or double-delivered. Defaults to every wiki page the caller can see (same visibility as list_wiki_pages/search_wiki) — pass watchedOnly=true to narrow to pages the caller is watching (directly or via a subtree watch). A `deleted` entry's slug/title/projectId reflect the page as it was just before deletion (the row itself is gone). |
 
 ### Attachments
 

--- a/apps/docs/src/generated/mcp-stats.json
+++ b/apps/docs/src/generated/mcp-stats.json
@@ -1,4 +1,4 @@
 {
-	"tools": 98,
+	"tools": 104,
 	"domains": 21
 }

--- a/packages/db/migrations/0048_wiki_watchers.sql
+++ b/packages/db/migrations/0048_wiki_watchers.sql
@@ -5,7 +5,10 @@
 -- P's parent_id chain at read/write time rather than materializing descendant rows, so a
 -- page added under a watched subtree later is automatically covered with no backfill
 -- (services/wiki-watchers.ts#notifyWikiWatchers). page_id cascades on delete — watching a
--- page that's later hard-deleted just drops the watch, nothing to preserve there.
+-- page that's later hard-deleted just drops the watch, nothing to preserve there. The FK
+-- is belt-and-braces only: deleteWikiPage also removes the rows explicitly
+-- (wiki-watchers.ts#deleteWikiWatchersForPages), since D1 doesn't guarantee FK enforcement
+-- on every connection — the same PROJ-407 precedent as wiki attachments/links.
 CREATE TABLE `wiki_watchers` (
 	`id` text PRIMARY KEY NOT NULL,
 	`workspace_id` text NOT NULL REFERENCES `workspaces`(`id`) ON DELETE CASCADE,

--- a/packages/db/migrations/0048_wiki_watchers.sql
+++ b/packages/db/migrations/0048_wiki_watchers.sql
@@ -1,0 +1,51 @@
+-- 0048: R11 (PROJ-493) — wiki watchers + per-user notification list + list_wiki_changes.
+--
+-- wiki_watchers: a user watching either a single page (subtree=0) or a page and its
+-- whole current+future subtree (subtree=1). Resolving "is user U watching page P" walks
+-- P's parent_id chain at read/write time rather than materializing descendant rows, so a
+-- page added under a watched subtree later is automatically covered with no backfill
+-- (services/wiki-watchers.ts#notifyWikiWatchers). page_id cascades on delete — watching a
+-- page that's later hard-deleted just drops the watch, nothing to preserve there.
+CREATE TABLE `wiki_watchers` (
+	`id` text PRIMARY KEY NOT NULL,
+	`workspace_id` text NOT NULL REFERENCES `workspaces`(`id`) ON DELETE CASCADE,
+	`user_id` text NOT NULL REFERENCES `users`(`id`) ON DELETE CASCADE,
+	`page_id` text NOT NULL REFERENCES `wiki_pages`(`id`) ON DELETE CASCADE,
+	`subtree` integer NOT NULL DEFAULT 0,
+	`created_at` integer NOT NULL
+);
+
+-- One watch row per (user, page) — watch_wiki_page upserts (e.g. flipping subtree on/off)
+-- rather than accumulating duplicates.
+CREATE UNIQUE INDEX `wiki_watchers_user_page_idx` ON `wiki_watchers` (`workspace_id`, `user_id`, `page_id`);
+-- notifyWikiWatchers looks up watchers of a page (and its ancestors, for subtree
+-- watches) by page_id within a workspace.
+CREATE INDEX `wiki_watchers_page_idx` ON `wiki_watchers` (`workspace_id`, `page_id`);
+
+-- wiki_notifications: per-user notification list, one row per (watcher, change). Denormalizes
+-- page_slug/page_title at write time (NOT a page_id foreign key) so a notification about a
+-- page that's since been deleted still displays something meaningful — see
+-- services/wiki-watchers.ts's notifyWikiWatchers for why this can't just join wiki_pages.
+CREATE TABLE `wiki_notifications` (
+	`id` text PRIMARY KEY NOT NULL,
+	`workspace_id` text NOT NULL REFERENCES `workspaces`(`id`) ON DELETE CASCADE,
+	`user_id` text NOT NULL REFERENCES `users`(`id`) ON DELETE CASCADE,
+	`page_id` text NOT NULL,
+	`page_slug` text NOT NULL,
+	`page_title` text NOT NULL,
+	`action` text NOT NULL,
+	`actor_id` text REFERENCES `users`(`id`) ON DELETE SET NULL,
+	`summary` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`read_at` integer
+);
+
+-- list_wiki_notifications reads a user's own notifications within a workspace, newest first.
+CREATE INDEX `wiki_notifications_user_idx` ON `wiki_notifications` (`workspace_id`, `user_id`, `created_at`);
+
+-- list_wiki_changes (delta polling) piggybacks on the existing `activity` table — every
+-- wiki_page create/update/delete already calls recordActivity (services/activity.ts), so
+-- no separate change log is needed. This index makes "entity_type='wiki_page' AND
+-- created_at >= since" within a workspace an indexed range scan instead of a full scan of
+-- the workspace's activity rows filtered in SQLite.
+CREATE INDEX `activity_workspace_entity_created_idx` ON `activity` (`workspace_id`, `entity_type`, `created_at`);

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -214,6 +214,14 @@ export const activity = sqliteTable(
 	(t) => ({
 		wsIdx: index("activity_workspace_idx").on(t.workspaceId),
 		entityIdx: index("activity_entity_idx").on(t.entityType, t.entityId),
+		// PROJ-493 (R11): list_wiki_changes filters entity_type='wiki_page' AND
+		// created_at >= since within a workspace — an indexed range scan instead of a
+		// full scan of the workspace's activity rows.
+		wsEntityCreatedIdx: index("activity_workspace_entity_created_idx").on(
+			t.workspaceId,
+			t.entityType,
+			t.createdAt
+		),
 	})
 );
 

--- a/packages/db/src/schema/wiki.ts
+++ b/packages/db/src/schema/wiki.ts
@@ -132,3 +132,62 @@ export const wikiLinks = sqliteTable(
 		workspaceTargetIdx: index("wiki_links_workspace_target_idx").on(t.workspaceId, t.targetPageId),
 	})
 );
+
+// PROJ-493 (R11): a user watching either a single page (subtree=false) or a page and its
+// whole current+future subtree (subtree=true). "Is user watching page P" is resolved by
+// walking P's parent_id chain at notify time (services/wiki-watchers.ts), not by
+// materializing per-descendant rows — a page added later under a watched subtree is
+// covered automatically.
+export const wikiWatchers = sqliteTable(
+	"wiki_watchers",
+	{
+		id: text("id").primaryKey(),
+		workspaceId: text("workspace_id")
+			.notNull()
+			.references(() => workspaces.id, { onDelete: "cascade" }),
+		userId: text("user_id")
+			.notNull()
+			.references(() => users.id, { onDelete: "cascade" }),
+		pageId: text("page_id")
+			.notNull()
+			.references(() => wikiPages.id, { onDelete: "cascade" }),
+		subtree: integer("subtree", { mode: "boolean" }).notNull().default(false),
+		createdAt: integer("created_at").notNull(),
+	},
+	(t) => ({
+		userPageUniqueIdx: uniqueIndex("wiki_watchers_user_page_idx").on(
+			t.workspaceId,
+			t.userId,
+			t.pageId
+		),
+		pageIdx: index("wiki_watchers_page_idx").on(t.workspaceId, t.pageId),
+	})
+);
+
+// PROJ-493 (R11): per-user notification list. `pageId` is NOT a foreign key (and has no
+// ON DELETE behavior) — a page that's since been hard-deleted must still leave its
+// deletion notification readable, so pageSlug/pageTitle are denormalized at write time
+// rather than joined from wiki_pages.
+export const wikiNotifications = sqliteTable(
+	"wiki_notifications",
+	{
+		id: text("id").primaryKey(),
+		workspaceId: text("workspace_id")
+			.notNull()
+			.references(() => workspaces.id, { onDelete: "cascade" }),
+		userId: text("user_id")
+			.notNull()
+			.references(() => users.id, { onDelete: "cascade" }),
+		pageId: text("page_id").notNull(),
+		pageSlug: text("page_slug").notNull(),
+		pageTitle: text("page_title").notNull(),
+		action: text("action", { enum: ["created", "updated", "deleted"] }).notNull(),
+		actorId: text("actor_id").references(() => users.id, { onDelete: "set null" }),
+		summary: text("summary").notNull(),
+		createdAt: integer("created_at").notNull(),
+		readAt: integer("read_at"),
+	},
+	(t) => ({
+		userIdx: index("wiki_notifications_user_idx").on(t.workspaceId, t.userId, t.createdAt),
+	})
+);


### PR DESCRIPTION
## Summary
Implements PROJ-493 (R11 of the wiki epic): watch/unwatch a wiki page or its subtree (REST + MCP), per-user notifications on watched-page changes, and a `list_wiki_changes` delta-poll MCP tool for cheap "what changed" polling.

- `POST/DELETE /:slug/watch`, `GET /watches`, `GET /notifications`, `POST /notifications/read`, `GET /changes` (REST) + `watch_wiki_page`, `unwatch_wiki_page`, `list_wiki_watches`, `list_wiki_notifications`, `mark_wiki_notifications_read`, `list_wiki_changes` (MCP).
- New `wiki_watchers` and `wiki_notifications` tables (migration `0048_wiki_watchers.sql`), plus an `activity(workspace_id, entity_type, created_at)` index that `list_wiki_changes` relies on.
- Changes surface both as existing `activity` entries (already recorded on every wiki write) and as new per-user notification rows.

## Design calls (no existing notification system to extend — confirmed via grep, so this is a new domain, not an extension)

- **Subtree semantics**: a subtree watch is resolved by walking *up* the parent chain from the changed page at notify/query time (`resolveAncestorChain`), rather than materializing per-descendant watch rows or reusing the descendant-walk helper. This means a subtree watch automatically covers pages created later under it, with no backfill needed.
- **What counts as a "change"**: `update`/`patch`/`verify`/`restore` all route through `updateWikiPage`/`patchWikiPage`, which already call `notifyWikiWatchers` — so R7 (verify), R8 (patch), R10 (restore) all correctly notify without any extra wiring. R9 template pages are the one deliberate exception: template pages never generate watcher notifications (create/update/delete), since they're scaffolding, not content someone is watching for real changes to.
- **`list_wiki_changes` scope**: defaults to every page the caller can see (same visibility rule as `list_wiki_pages`/`search_wiki`), not just watched pages — a delta-polling agent syncing "what changed in the wiki" is a broader use case than "what am I watching," and requiring a watch registration for every page an agent wants to poll would defeat the point of a cheap, low-ceremony tool. `watchedOnly=true` narrows it.
- **Efficiency**: piggybacks entirely on the existing `activity` table (already populated on every wiki write) rather than a separate change log or denormalized "last changed" column, backed by a new `(workspace_id, entity_type, created_at)` index. `since` is exclusive; the response's `nextSince` (max `createdAt` in the batch) is what callers should poll with next, avoiding same-second miss/duplicate issues.
- **Bug found and fixed during testing**: `wiki_watchers.page_id` is `ON DELETE CASCADE` against `wiki_pages(id)`, so a watcher's own watch row (including watches on the page being deleted) was being wiped out by SQLite's FK cascade *before* `notifyWikiWatchers` queried the table — silently dropping delete notifications. Fixed by calling `notifyWikiWatchers` before the physical page-row delete in both the cascade and non-cascade delete paths.

## Test plan
- [x] `pnpm --filter @projektor/db test`
- [x] `pnpm --filter @projektor/api test:coverage` (1028 passed, includes 13 new PROJ-493 tests covering direct/subtree watch, notification suppression on own edits, unwatch, template-page suppression, cascade-delete single-notification semantics, mark-read, delta feed exclusivity/nextSince/visibility/watchedOnly, and MCP parity)
- [x] `pnpm --filter @projektor/web test:coverage` (499 passed)
- [x] `pnpm --filter @projektor/web build`
- [x] `pnpm --filter @projektor/docs build`
- [x] `pnpm exec biome check .`
- [x] `pnpm turbo type-check`
- [x] `pnpm gen:docs` (tool catalog regenerated — 104 tools, 21 domains)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_011VcB7qJjorhbFmGdR9DTXp