### PR TITLE
PROJ-494: inline images — paste/drag upload + member-resolvable render path (R12)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,5 @@
 import type { Env, HonoEnv } from "@projektor/types";
+import type { Context, Next } from "hono";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { logger } from "hono/logger";
@@ -230,6 +231,17 @@ app.use("/api/issue-links/*", authMiddleware, workspaceMiddleware);
 app.use("/api/wiki", authMiddleware, workspaceMiddleware);
 app.use("/api/wiki/*", authMiddleware, workspaceMiddleware);
 app.use("/mcp/*", authMiddleware, workspaceMiddleware);
+// PROJ-494: an inline image embedded in rendered wiki content (`<img src="/api/files/:id?workspace=...">`)
+// is a plain browser subresource load — it can't attach the X-Workspace-Slug header apiFetch
+// normally sends, so GET here also accepts `?workspace=` as a resolution fallback (see
+// middleware/workspace.ts). Scoped to GET only; POST/DELETE always go through apiFetch, which
+// already sends the header.
+const allowFilesQueryWorkspaceFallback = async (c: Context<HonoEnv>, next: Next) => {
+	if (c.req.method === "GET") c.set("allowQueryWorkspaceFallback", true);
+	await next();
+};
+app.use("/api/files", allowFilesQueryWorkspaceFallback);
+app.use("/api/files/*", allowFilesQueryWorkspaceFallback);
 app.use("/api/files", authMiddleware, workspaceMiddleware);
 app.use("/api/files/*", authMiddleware, workspaceMiddleware);
 app.use("/api/task-types", authMiddleware, workspaceMiddleware);

--- a/apps/api/src/middleware/workspace.ts
+++ b/apps/api/src/middleware/workspace.ts
@@ -77,16 +77,31 @@ async function missingWorkspaceResponse(
 }
 
 // Workspace resolved from the X-Workspace-Slug header, or (opt-in) the Host header's
-// subdomain. See WORKSPACE_SUBDOMAIN_ROUTING in packages/types/src/env.ts. (PROJ-267)
+// subdomain, or (opt-in, PROJ-494) a `?workspace=` query param. See
+// WORKSPACE_SUBDOMAIN_ROUTING in packages/types/src/env.ts. (PROJ-267)
 // PROJ-348: falls back to the MCP path's workspace UUID when no slug was resolved.
 // The token-workspace-scope check in workspaceMiddleware is unchanged and remains
 // the security boundary — a token minted for another workspace is still rejected there.
+//
+// PROJ-494: the query-param fallback exists for GET requests a browser makes as a
+// subresource load (an inline `<img src="/api/files/:id?workspace=...">` in rendered
+// wiki content) — those can't attach a custom header the way apiFetch does. It's the
+// lowest-precedence source and only consulted when index.ts has explicitly opted the
+// route in via allowQueryWorkspaceFallback (GET on /api/files* only) — see AGENTS.md's
+// workspace-scoping invariant and the PROJ-494 PR description for why this is scoped
+// that narrowly rather than applied to workspaceMiddleware generally.
 function resolveWorkspaceTarget(
 	c: Context<HonoEnv>,
 	headerSlug: string | undefined,
 	routingEnabled: boolean
 ): { slug: string | undefined; mcpWorkspaceId: string | undefined } {
-	const slug = headerSlug ?? (routingEnabled ? c.req.header("host")?.split(".")[0] : undefined);
+	const queryFallback = c.get("allowQueryWorkspaceFallback")
+		? (c.req.query("workspace") ?? undefined)
+		: undefined;
+	const slug =
+		headerSlug ??
+		(routingEnabled ? c.req.header("host")?.split(".")[0] : undefined) ??
+		queryFallback;
 	const mcpWorkspaceId = slug ? undefined : mcpWorkspaceIdFromPath(c.req.path);
 	return { slug, mcpWorkspaceId };
 }

--- a/apps/api/src/test/files.test.ts
+++ b/apps/api/src/test/files.test.ts
@@ -190,6 +190,46 @@ describe("Files API", () => {
 		expect(getRes.status).toBe(404);
 	});
 
+	// PROJ-494: an inline <img> tag rendering an attachment in wiki content can't set a
+	// custom X-Workspace-Slug header, so GET falls back to a `?workspace=` query param.
+	it("GET /api/files/:id resolves the workspace from a ?workspace= query param when no header is sent", async () => {
+		const uploadRes = await makeUploadRequest(token, slug, "query-param content", "q.txt");
+		const { id } = (await uploadRes.json()) as { id: string };
+
+		const getRes = await SELF.fetch(`http://localhost/api/files/${id}?workspace=${slug}`, {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		expect(getRes.status).toBe(200);
+		expect(await getRes.text()).toBe("query-param content");
+	});
+
+	it("GET /api/files/:id via ?workspace= still 404s for a file in a different workspace", async () => {
+		const uploadRes = await makeUploadRequest(token, slug, "content", "q2.txt");
+		const { id } = (await uploadRes.json()) as { id: string };
+
+		const other = await seedFixture();
+		const getRes = await SELF.fetch(
+			`http://localhost/api/files/${id}?workspace=${other.workspace.slug}`,
+			{
+				headers: { Authorization: `Bearer ${other.token}` },
+			}
+		);
+		expect(getRes.status).toBe(404);
+	});
+
+	it("POST /api/files does not honor ?workspace= — the header is still required", async () => {
+		const form = new FormData();
+		form.append("file", new File(["data"], "f.txt", { type: "text/plain" }));
+		form.append("entityType", "issue");
+		form.append("entityId", ENTITY_ID);
+		const res = await SELF.fetch(`http://localhost/api/files?workspace=${slug}`, {
+			method: "POST",
+			headers: { Authorization: `Bearer ${token}` },
+			body: form,
+		});
+		expect(res.status).toBe(400);
+	});
+
 	it("GET /api/files/:id returns 404 for a different workspace", async () => {
 		const uploadRes = await makeUploadRequest(token, slug);
 		const { id } = (await uploadRes.json()) as { id: string };

--- a/apps/api/src/test/workspace-subdomain-routing.test.ts
+++ b/apps/api/src/test/workspace-subdomain-routing.test.ts
@@ -79,6 +79,19 @@ describe("workspace subdomain routing (WORKSPACE_SUBDOMAIN_ROUTING)", () => {
 		expect(res.status).toBe(200);
 	});
 
+	// PROJ-494: the `?workspace=` query-param fallback is opt-in per route (only GET
+	// /api/files*, see index.ts) — everything else must keep requiring the header.
+	it("a ?workspace= query param is ignored on routes that didn't opt in", async () => {
+		const fixture = await seedFixture();
+		const res = await SELF.fetch(
+			`http://localhost/api/task-types?workspace=${fixture.workspace.slug}`,
+			{
+				headers: { Authorization: `Bearer ${fixture.token}` },
+			}
+		);
+		expect(res.status).toBe(400);
+	});
+
 	it("flag off + no header + a resolvable subdomain warns before the 400", async () => {
 		const fixture = await seedFixture();
 		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/apps/web/src/islands/LazyMarkdownEditor.tsx
+++ b/apps/web/src/islands/LazyMarkdownEditor.tsx
@@ -5,6 +5,7 @@ interface Props {
 	value: string;
 	onChange: (value: string) => void;
 	minHeight?: string;
+	onImageFile?: (file: File) => Promise<string | null>;
 }
 
 // PROJ-431: MarkdownEditor pulls in CodeMirror — 486 KiB raw / 168 KiB gzip, 76% of

--- a/apps/web/src/islands/MarkdownEditor.test.tsx
+++ b/apps/web/src/islands/MarkdownEditor.test.tsx
@@ -7,7 +7,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fireEvent, render, screen, waitFor } from "@testing-library/preact";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import MarkdownEditor from "./MarkdownEditor";
+import MarkdownEditor, { PASTE_IMAGE_TYPES } from "./MarkdownEditor";
 
 describe("MarkdownEditor", () => {
 	it("renders the formatting toolbar with core buttons", () => {
@@ -151,5 +151,105 @@ describe("MarkdownEditor — mobile ergonomics (PROJ-431)", () => {
 		expect(source).toMatch(
 			/"@media \(min-width: 640px\)":\s*\{\s*"\.cm-content":\s*\{\s*fontSize:\s*"0\.875rem"\s*\}/
 		);
+	});
+});
+
+// ─── PROJ-494: paste/drag-drop image upload ────────────────────────────────
+
+function findCmContent(container: Element): HTMLElement {
+	const el = container.querySelector(".cm-content");
+	if (!el) throw new Error("cm-content not found");
+	return el as HTMLElement;
+}
+
+describe("MarkdownEditor — inline image paste/drop (PROJ-494)", () => {
+	it("mirrors the backend's INLINE_TYPES (SVG excluded)", () => {
+		expect([...PASTE_IMAGE_TYPES].sort()).toEqual([
+			"image/gif",
+			"image/jpeg",
+			"image/png",
+			"image/webp",
+		]);
+	});
+
+	it("uploads a pasted image via onImageFile and inserts markdown at the cursor", async () => {
+		const onChange = vi.fn();
+		const onImageFile = vi.fn().mockResolvedValue("/api/files/abc123");
+		const { container } = render(
+			<MarkdownEditor value="" onChange={onChange} onImageFile={onImageFile} />
+		);
+		const file = new File(["fake"], "screenshot.png", { type: "image/png" });
+		const clipboardData = {
+			items: [{ kind: "file", type: "image/png", getAsFile: () => file }],
+			files: [file],
+			getData: () => "",
+		};
+		fireEvent.paste(findCmContent(container), { clipboardData });
+
+		await waitFor(() => expect(onImageFile).toHaveBeenCalledWith(file));
+		await waitFor(() =>
+			expect(onChange).toHaveBeenCalledWith(
+				expect.stringContaining("![screenshot.png](/api/files/abc123)")
+			)
+		);
+	});
+
+	it("ignores a pasted file whose type isn't an inline-renderable image", async () => {
+		const onImageFile = vi.fn();
+		const { container } = render(
+			<MarkdownEditor value="" onChange={() => {}} onImageFile={onImageFile} />
+		);
+		const file = new File(["data"], "doc.pdf", { type: "application/pdf" });
+		const clipboardData = {
+			items: [{ kind: "file", type: "application/pdf", getAsFile: () => file }],
+			files: [file],
+			getData: () => "",
+		};
+		fireEvent.paste(findCmContent(container), { clipboardData });
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(onImageFile).not.toHaveBeenCalled();
+	});
+
+	it("does not intercept paste when onImageFile is not provided", () => {
+		const { container } = render(<MarkdownEditor value="" onChange={() => {}} />);
+		const file = new File(["fake"], "a.png", { type: "image/png" });
+		const clipboardData = {
+			items: [{ kind: "file", type: "image/png", getAsFile: () => file }],
+			files: [file],
+			getData: () => "",
+		};
+		expect(() => fireEvent.paste(findCmContent(container), { clipboardData })).not.toThrow();
+	});
+
+	it("uploads a dropped image via onImageFile and inserts markdown", async () => {
+		const onChange = vi.fn();
+		const onImageFile = vi.fn().mockResolvedValue("/api/files/xyz789");
+		const { container } = render(
+			<MarkdownEditor value="" onChange={onChange} onImageFile={onImageFile} />
+		);
+		const file = new File(["fake"], "drop.gif", { type: "image/gif" });
+		const dataTransfer = { files: [file], items: [], getData: () => "" };
+		fireEvent.drop(findCmContent(container), { dataTransfer, clientX: 0, clientY: 0 });
+
+		await waitFor(() => expect(onImageFile).toHaveBeenCalledWith(file));
+		await waitFor(() =>
+			expect(onChange).toHaveBeenCalledWith(
+				expect.stringContaining("![drop.gif](/api/files/xyz789)")
+			)
+		);
+	});
+
+	it("ignores a dropped file whose type isn't an inline-renderable image", async () => {
+		const onImageFile = vi.fn();
+		const { container } = render(
+			<MarkdownEditor value="" onChange={() => {}} onImageFile={onImageFile} />
+		);
+		const file = new File(["data"], "doc.zip", { type: "application/zip" });
+		const dataTransfer = { files: [file], items: [], getData: () => "" };
+		fireEvent.drop(findCmContent(container), { dataTransfer, clientX: 0, clientY: 0 });
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(onImageFile).not.toHaveBeenCalled();
 	});
 });

--- a/apps/web/src/islands/MarkdownEditor.tsx
+++ b/apps/web/src/islands/MarkdownEditor.tsx
@@ -9,6 +9,57 @@ interface Props {
 	value: string;
 	onChange: (value: string) => void;
 	minHeight?: string;
+	// PROJ-494: paste/drag-drop an image into the editor. Returning the URL to embed
+	// inserts `![filename](url)` at the cursor/drop position; returning null (upload
+	// failed, or the caller has no entity to attach to yet, e.g. the create-page form)
+	// leaves the editor untouched. Undefined disables image interception entirely —
+	// paste/drop of non-image content is never affected either way.
+	onImageFile?: (file: File) => Promise<string | null>;
+}
+
+// Mirrors services/files.ts's INLINE_TYPES on the API side — the set of image types the
+// API will actually serve inline (SVG is excluded there for script-execution risk, so
+// pasting one falls through to a manual "Attach file" upload instead of auto-embedding).
+export const PASTE_IMAGE_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
+
+function imageFilesFromClipboard(data: DataTransfer | null): File[] {
+	if (!data) return [];
+	const files: File[] = [];
+	for (const item of Array.from(data.items)) {
+		if (item.kind === "file" && PASTE_IMAGE_TYPES.has(item.type)) {
+			const file = item.getAsFile();
+			if (file) files.push(file);
+		}
+	}
+	return files;
+}
+
+function imageFilesFromDrop(data: DataTransfer | null): File[] {
+	if (!data) return [];
+	return Array.from(data.files).filter((f) => PASTE_IMAGE_TYPES.has(f.type));
+}
+
+// Uploads sequentially and inserts each `![name](url)` right after the previous one, so a
+// multi-file paste/drop lands as consecutive image refs instead of racing to overlapping
+// positions. A file whose upload fails (onImageFile resolves null) is silently skipped.
+async function insertUploadedImages(
+	view: EditorView,
+	files: File[],
+	pos: number,
+	onImageFile: (file: File) => Promise<string | null>
+): Promise<void> {
+	let insertAt = pos;
+	for (const file of files) {
+		const url = await onImageFile(file);
+		if (!url) continue;
+		const insert = `![${file.name}](${url})\n`;
+		view.dispatch({
+			changes: { from: insertAt, insert },
+			selection: EditorSelection.cursor(insertAt + insert.length),
+		});
+		insertAt += insert.length;
+	}
+	view.focus();
 }
 
 // Sub-640px gets a 44px-square touch target (the toolbar was ~24px tall, well under
@@ -179,10 +230,16 @@ function PreviewPane({ preview, mobilePreview }: { preview: string; mobilePrevie
 function useMarkdownEditorView(
 	value: string,
 	onChange: (value: string) => void,
-	minHeight: string
+	minHeight: string,
+	onImageFile: ((file: File) => Promise<string | null>) | undefined
 ) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const viewRef = useRef<EditorView | null>(null);
+	// The domEventHandlers extension below is installed once, in the mount effect — read
+	// through a ref (updated every render, not just on mount) so it always calls whichever
+	// onImageFile the latest render passed, rather than closing over the first one forever.
+	const onImageFileRef = useRef(onImageFile);
+	onImageFileRef.current = onImageFile;
 	// The last doc content WE emitted via onChange. The "sync externally-driven value"
 	// effect below compares the incoming `value` prop against this — not against the
 	// live doc — so a same-tick echo of our own change (however delayed by Preact's
@@ -239,6 +296,27 @@ function useMarkdownEditorView(
 					".cm-cursor": { borderLeftColor: "var(--text)" },
 				}),
 				EditorView.lineWrapping,
+				EditorView.domEventHandlers({
+					paste(event, view) {
+						const handler = onImageFileRef.current;
+						const files = imageFilesFromClipboard(event.clipboardData);
+						if (!handler || files.length === 0) return false;
+						event.preventDefault();
+						insertUploadedImages(view, files, view.state.selection.main.from, handler);
+						return true;
+					},
+					drop(event, view) {
+						const handler = onImageFileRef.current;
+						const files = imageFilesFromDrop(event.dataTransfer);
+						if (!handler || files.length === 0) return false;
+						event.preventDefault();
+						const pos =
+							view.posAtCoords({ x: event.clientX, y: event.clientY }) ??
+							view.state.selection.main.from;
+						insertUploadedImages(view, files, pos, handler);
+						return true;
+					},
+				}),
 			],
 		});
 
@@ -315,7 +393,12 @@ function useMarkdownCommands(viewRef: { current: EditorView | null }) {
 	return { bold, italic, heading, link, codeBlock, bulletList, numberedList };
 }
 
-export default function MarkdownEditor({ value, onChange, minHeight = "240px" }: Props) {
+export default function MarkdownEditor({
+	value,
+	onChange,
+	minHeight = "240px",
+	onImageFile,
+}: Props) {
 	const [mobilePreview, setMobilePreview] = useState(false);
 	const [preview, setPreview] = useState("");
 
@@ -326,7 +409,7 @@ export default function MarkdownEditor({ value, onChange, minHeight = "240px" }:
 		return () => clearTimeout(timer);
 	}, [value]);
 
-	const { containerRef, viewRef } = useMarkdownEditorView(value, onChange, minHeight);
+	const { containerRef, viewRef } = useMarkdownEditorView(value, onChange, minHeight, onImageFile);
 	const { bold, italic, heading, link, codeBlock, bulletList, numberedList } =
 		useMarkdownCommands(viewRef);
 

--- a/apps/web/src/islands/WikiPage.test.tsx
+++ b/apps/web/src/islands/WikiPage.test.tsx
@@ -1074,3 +1074,91 @@ describe("revision history: diff view + restore (PROJ-492)", () => {
 		});
 	});
 });
+
+// PROJ-494: inline image paste/drag upload + attachment referenced/orphaned badge.
+describe("WikiPage — inline images & attachment badges (PROJ-494)", () => {
+	const REFERENCED_ID = "att-referenced";
+	const ORPHAN_ID = "att-orphan";
+	const PAGE_WITH_IMAGE = {
+		...PAGE,
+		content: `See ![screenshot](/api/files/${REFERENCED_ID}?workspace=acme) here.`,
+	};
+	const ATTACHMENTS = [
+		{
+			id: REFERENCED_ID,
+			filename: "screenshot.png",
+			contentType: "image/png",
+			size: 1024,
+			createdAt: 1,
+		},
+		{ id: ORPHAN_ID, filename: "old.txt", contentType: "text/plain", size: 512, createdAt: 2 },
+	];
+
+	function mockFetchWithAttachments(uploadSpy?: (form: FormData) => void) {
+		return vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+			const u = String(url);
+			if (u.includes("/revisions")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			}
+			if (u.includes("/tree")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			}
+			if (u.includes("/api/files")) {
+				if (init?.method === "POST") {
+					uploadSpy?.(init.body as FormData);
+					return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: "att-new" }) });
+				}
+				return Promise.resolve({ ok: true, json: () => Promise.resolve(ATTACHMENTS) });
+			}
+			return Promise.resolve({ ok: true, json: () => Promise.resolve(PAGE_WITH_IMAGE) });
+		});
+	}
+
+	it("badges an attachment referenced in the page content as 'In page'", async () => {
+		vi.stubGlobal("fetch", mockFetchWithAttachments());
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+
+		await screen.findByText("screenshot.png");
+		const referencedRow = screen.getByText("screenshot.png").closest("div");
+		expect(referencedRow?.textContent).toContain("In page");
+	});
+
+	it("badges an attachment not referenced in the content as 'Unreferenced'", async () => {
+		vi.stubGlobal("fetch", mockFetchWithAttachments());
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+
+		await screen.findByText("old.txt");
+		const orphanRow = screen.getByText("old.txt").closest("div");
+		expect(orphanRow?.textContent).toContain("Unreferenced");
+	});
+
+	it("uploads a pasted image via the existing attachment endpoint and inserts a markdown ref", async () => {
+		const uploadSpy = vi.fn();
+		const fetchMock = mockFetchWithAttachments(uploadSpy);
+		vi.stubGlobal("fetch", fetchMock);
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+
+		fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+		const content = await waitFor(() => {
+			const el = document.querySelector(".cm-content");
+			if (!el) throw new Error("cm-content not found");
+			return el as HTMLElement;
+		});
+
+		const file = new File(["fake"], "pasted.png", { type: "image/png" });
+		const clipboardData = {
+			items: [{ kind: "file", type: "image/png", getAsFile: () => file }],
+			files: [file],
+			getData: () => "",
+		};
+		fireEvent.paste(content, { clipboardData });
+
+		await waitFor(() => expect(uploadSpy).toHaveBeenCalled());
+		const form = uploadSpy.mock.calls[0][0] as FormData;
+		expect(form.get("entityType")).toBe("wiki_page");
+		expect(form.get("entityId")).toBe(PAGE.id);
+	});
+});

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -1199,13 +1199,27 @@ function RevisionsHistory({
 	);
 }
 
+// PROJ-494: whether an attachment's id appears anywhere in the page's current markdown
+// (e.g. as part of an inline `![alt](/api/files/:id...)` ref). A plain substring check —
+// good enough to tell "referenced" from "orphaned" without parsing markdown image syntax,
+// and it also catches an id pasted into a manual link or wiki_ref-style reference.
+function isReferenced(attachmentId: string, content: string): boolean {
+	return content.includes(attachmentId);
+}
+
+const REFERENCED_BADGE_CLASS =
+	"inline-flex items-center px-2 py-[0.1rem] rounded-full text-[0.72rem] font-semibold " +
+	"uppercase tracking-wide shrink-0";
+
 function AttachmentEntry({
 	attachment,
 	workspaceSlug,
+	referenced,
 	onDelete,
 }: {
 	attachment: Attachment;
 	workspaceSlug?: string;
+	referenced: boolean;
 	onDelete: (attachmentId: string) => void;
 }) {
 	const qs = workspaceSlug ? `?workspace=${workspaceSlug}` : "";
@@ -1219,6 +1233,16 @@ function AttachmentEntry({
 			>
 				{attachment.filename}
 			</a>
+			<span
+				class={REFERENCED_BADGE_CLASS}
+				style={
+					referenced
+						? { background: "rgba(22, 163, 74, 0.12)", color: "var(--status-done)" }
+						: { background: "var(--priority-low-bg)", color: "var(--priority-low-text)" }
+				}
+			>
+				{referenced ? "In page" : "Unreferenced"}
+			</span>
 			<span class="text-xs text-text-muted shrink-0">{formatBytes(attachment.size)}</span>
 			<button
 				type="button"
@@ -1280,6 +1304,7 @@ function AttachmentUploadForm({
 function AttachmentsPanel({
 	attachments,
 	workspaceSlug,
+	content,
 	uploadFormOpen,
 	uploadFile,
 	uploading,
@@ -1292,6 +1317,7 @@ function AttachmentsPanel({
 }: {
 	attachments: Attachment[];
 	workspaceSlug?: string;
+	content: string;
 	uploadFormOpen: boolean;
 	uploadFile: File | null;
 	uploading: boolean;
@@ -1315,6 +1341,7 @@ function AttachmentsPanel({
 							key={a.id}
 							attachment={a}
 							workspaceSlug={workspaceSlug}
+							referenced={isReferenced(a.id, content)}
 							onDelete={onDeleteAttachment}
 						/>
 					))}
@@ -1398,6 +1425,7 @@ interface PageArticleProps {
 	onUpload: () => void;
 	onCancelUpload: () => void;
 	onDeleteAttachment: (attachmentId: string) => void;
+	onUploadInlineImage: (file: File) => Promise<string | null>;
 }
 
 function PageArticleMeta(
@@ -1526,6 +1554,7 @@ function PageArticle(props: PageArticleProps) {
 							value={props.editContent}
 							onChange={props.onEditContentChange}
 							minHeight="320px"
+							onImageFile={props.onUploadInlineImage}
 						/>
 					</div>
 				) : (
@@ -1551,6 +1580,7 @@ function PageArticle(props: PageArticleProps) {
 				<AttachmentsPanel
 					attachments={props.attachments}
 					workspaceSlug={props.workspaceSlug}
+					content={props.editing ? props.editContent : page.content}
 					uploadFormOpen={props.uploadFormOpen}
 					uploadFile={props.uploadFile}
 					uploading={props.uploading}
@@ -2067,6 +2097,31 @@ function useWikiAttachments(workspaceSlug: string | undefined, page: WikiPageDat
 		}
 	}
 
+	// PROJ-494: paste/drag-drop image upload, passed to MarkdownEditor as onImageFile.
+	// Reuses the same upload endpoint as the "Attach file" form above — an inline image is
+	// just an attachment that also gets a markdown ref auto-inserted. Returns a URL carrying
+	// `?workspace=` so the <img> tag rendering it (a plain browser subresource load, no
+	// custom headers) can still resolve the workspace — see middleware/workspace.ts.
+	async function uploadInlineImage(file: File): Promise<string | null> {
+		if (!page) return null;
+		try {
+			const form = new FormData();
+			form.append("file", file);
+			form.append("entityType", "wiki_page");
+			form.append("entityId", page.id);
+			const result = await apiFetch<{ id: string }>("/api/files", {
+				workspaceSlug,
+				method: "POST",
+				body: form,
+			});
+			await fetchAttachments(page.id);
+			const qs = workspaceSlug ? `?workspace=${encodeURIComponent(workspaceSlug)}` : "";
+			return `/api/files/${result.id}${qs}`;
+		} catch {
+			return null;
+		}
+	}
+
 	return {
 		attachments,
 		uploadFormOpen,
@@ -2078,6 +2133,7 @@ function useWikiAttachments(workspaceSlug: string | undefined, page: WikiPageDat
 		uploadAttachment,
 		cancelUpload,
 		deleteAttachment,
+		uploadInlineImage,
 	};
 }
 
@@ -2846,6 +2902,7 @@ function buildArticleProps(article: {
 		onUpload: article.attach.uploadAttachment,
 		onCancelUpload: article.attach.cancelUpload,
 		onDeleteAttachment: article.attach.deleteAttachment,
+		onUploadInlineImage: article.attach.uploadInlineImage,
 		moving: article.move.moving,
 		moveOptions: article.moveOptions,
 		moveTargetId: article.move.moveTargetId,

--- a/packages/types/src/env.ts
+++ b/packages/types/src/env.ts
@@ -72,6 +72,10 @@ export interface Variables {
 	// (Cloudflare Access / dev bypass => "human", Bearer API token => "agent") — not a
 	// caller-declared field like the deprecated agent_sessions.kind (PROJ-336).
 	authKind: "human" | "agent";
+	// PROJ-494: opt-in, set by index.ts ahead of workspaceMiddleware for GET requests
+	// that a browser subresource load (e.g. an <img> tag rendering an inline attachment)
+	// can't attach a custom X-Workspace-Slug header to. See middleware/workspace.ts.
+	allowQueryWorkspaceFallback: boolean | undefined;
 }
 
 export type HonoEnv = { Bindings: Env; Variables: Variables };


### PR DESCRIPTION
## Summary

- Paste/drag-drop an image into the wiki editor uploads it through the **existing** attachment endpoint (`services/files.ts`) and auto-inserts a markdown `![alt](url)` ref at the cursor/drop position — no parallel upload path. Interception is restricted to `PASTE_IMAGE_TYPES` (mirrors the backend's `INLINE_TYPES`: png/jpeg/gif/webp, SVG excluded); the general attachment panel still accepts any file type.
- `/api/files/:id` requires auth, and a browser `<img>` subresource load can't set a custom `X-Workspace-Slug` header the way `apiFetch` does. Browsers only ever authenticate via the CF Access cookie or the header-free dev bypass (never a bearer token) — so the actual gap was workspace *resolution*, not authentication. Fixed with an opt-in `?workspace=` query-param fallback in `workspaceMiddleware`, wired up narrowly (GET-only, `/api/files*`-only, via an explicit `allowQueryWorkspaceFallback` context flag set in `index.ts`) rather than applied to the shared middleware globally — a signed URL/param on a state-changing route would reintroduce a CSRF-style risk the header-only requirement was implicitly preventing. Attachment access itself stays fully workspace/role-scoped through the normal membership check either way (a stray query param can't view a file you're not a member of); the param only supplies which workspace to resolve.
- The attachments panel now badges each attachment **"In page"** or **"Unreferenced"** based on a substring match of the attachment id against the page's current content — good enough to distinguish referenced from orphaned attachments without a full markdown-image-syntax parse.

## Design notes / accepted tradeoffs

- Reused the existing attachment system end-to-end (same upload endpoint, same `attachments` table, same `entityType: "wiki_page"` association) — an inline image is just an attachment with an auto-inserted markdown ref, not a new subsystem.
- The `?workspace=` fallback is the lowest-precedence workspace-resolution source and only active where `index.ts` explicitly opts a route in — verified by a test asserting it's ignored on a route that didn't opt in.
- Known scope limit: inline paste/drop is only wired into the edit-existing-page flow (`WikiPage.tsx`), not `CreatePageForm` — a not-yet-created page has no `page.id` to attach uploads to.
- "Referenced" detection is a substring check, not a markdown parser — it will also count an id pasted into a manual link, which is an acceptable false-broadening for a "don't accidentally delete something in use" signal.

## Test plan

- [x] `pnpm exec biome check .`
- [x] `pnpm turbo type-check`
- [x] `pnpm --filter @projektor/db test`
- [x] `pnpm --filter @projektor/api test:coverage` (1034/1034 passing; one coverage run hit an unrelated resource-contention timeout on a re-run, confirmed flaky by a clean retry)
- [x] `pnpm --filter @projektor/web test:coverage` (508/508 passing, includes new paste/drop and referenced-badge coverage)
- [x] `pnpm --filter @projektor/web build`
- [x] `pnpm --filter @projektor/docs build`
- [x] `pnpm gen:docs` — no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEDgBK1Gu79i6TtKM9z9N9