### PR TITLE
PROJ-495: R13 — server-side per-user wiki drafts, replacing localStorage autosave

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ command shown beside it (token + workspace pre-filled). The full walkthrough - A
 setup, first login, token, MCP - is in
 [CONFIGURE.md](https://github.com/TAJD/projektor-deploy-example/blob/main/CONFIGURE.md).
 
-See the **[agent connection guide](https://tajd.github.io/projektor/agents/mcp-connection/)** for the full connection guide, protocol reference, and tool catalog (<!-- gen-mcp-stats:start -->104 tools across 21 domains<!-- gen-mcp-stats:end --> - project data plus agent-coordination primitives).
+See the **[agent connection guide](https://tajd.github.io/projektor/agents/mcp-connection/)** for the full connection guide, protocol reference, and tool catalog (<!-- gen-mcp-stats:start -->107 tools across 21 domains<!-- gen-mcp-stats:end --> - project data plus agent-coordination primitives).
 
 ## Development
 

--- a/apps/api/src/mcp/wiki.ts
+++ b/apps/api/src/mcp/wiki.ts
@@ -3,6 +3,7 @@ import { WIKI_WELL_KNOWN_TYPES } from "../schemas/wiki";
 import { ValidationError } from "../services/errors";
 import type { ServiceCtx } from "../services/types";
 import * as wikiService from "../services/wiki";
+import * as wikiDraftsService from "../services/wiki-drafts";
 import * as wikiWatchersService from "../services/wiki-watchers";
 
 // PROJ-513: `type` is freeform — these are advertised as hints, never as an
@@ -592,6 +593,70 @@ export const wikiTools: MCPTool[] = [
 		},
 		async handler(input, ctx) {
 			return wikiWatchersService.listWikiChanges(ctx, input);
+		},
+	},
+	{
+		name: "get_wiki_draft",
+		description:
+			"Get the calling user's saved server-side draft for a wiki page by id or slug " +
+			"(PROJ-495/R13 — replaces the old localStorage-only autosave, so a draft survives " +
+			"a device switch). Returns null if there is no draft. `baseRevisionId` is the " +
+			"page's latest revision id as of when the draft was started — pass it straight " +
+			"through to update_wiki_page/patch_wiki_page's own baseRevisionId when publishing, " +
+			"so a stale draft hits the normal conflict response instead of silently clobbering " +
+			"someone else's newer edit.",
+		inputSchema: {
+			type: "object",
+			required: ["slug"],
+			properties: { slug: { type: "string", description: "Page ID or slug" } },
+		},
+		async handler(input, ctx) {
+			const { slug } = input as { slug: string };
+			return wikiDraftsService.getWikiDraft(ctx as ServiceCtx, slug);
+		},
+	},
+	{
+		name: "save_wiki_draft",
+		description:
+			"Save (upsert) the calling user's draft for a wiki page by id or slug. One draft " +
+			"per (page, user) — calling this again overwrites the previous draft rather than " +
+			"creating a new one. Not a revision and not visible to other users. Callers should " +
+			"debounce their own call frequency (e.g. ~1s after the last edit) — this tool does " +
+			"no server-side throttling.",
+		inputSchema: {
+			type: "object",
+			required: ["slug", "title", "content"],
+			properties: {
+				slug: { type: "string", description: "Page ID or slug" },
+				title: { type: "string" },
+				content: { type: "string" },
+				baseRevisionId: {
+					type: "string",
+					description:
+						"The page's latest revision id when this draft was started; null if the " +
+						"page had no revisions yet",
+				},
+			},
+		},
+		async handler(input, ctx) {
+			const { slug, ...rest } = input as { slug: string; title: string; content: string };
+			return wikiDraftsService.saveWikiDraft(ctx as ServiceCtx, slug, rest);
+		},
+	},
+	{
+		name: "discard_wiki_draft",
+		description:
+			"Delete the calling user's draft for a wiki page by id or slug (a no-op if there " +
+			"is none). Call this after a successful publish, or whenever the user explicitly " +
+			"discards unsaved changes.",
+		inputSchema: {
+			type: "object",
+			required: ["slug"],
+			properties: { slug: { type: "string", description: "Page ID or slug" } },
+		},
+		async handler(input, ctx) {
+			const { slug } = input as { slug: string };
+			return wikiDraftsService.discardWikiDraft(ctx as ServiceCtx, slug);
 		},
 	},
 ];

--- a/apps/api/src/routes/wiki.ts
+++ b/apps/api/src/routes/wiki.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { serviceErrToResponse } from "../http/error-adapter";
 import { ctxFromHono } from "../services/types";
 import * as wikiService from "../services/wiki";
+import * as wikiDraftsService from "../services/wiki-drafts";
 import * as wikiWatchersService from "../services/wiki-watchers";
 
 const router = new Hono<HonoEnv>();
@@ -250,6 +251,34 @@ router.delete("/:slug/watch", async (c) => {
 	const ctx = ctxFromHono(c);
 	try {
 		return c.json(await wikiWatchersService.unwatchWikiPage(ctx, c.req.param("slug")));
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
+});
+
+router.get("/:slug/draft", async (c) => {
+	const ctx = ctxFromHono(c);
+	try {
+		return c.json(await wikiDraftsService.getWikiDraft(ctx, c.req.param("slug")));
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
+});
+
+router.put("/:slug/draft", async (c) => {
+	const ctx = ctxFromHono(c);
+	try {
+		const body = await c.req.json();
+		return c.json(await wikiDraftsService.saveWikiDraft(ctx, c.req.param("slug"), body));
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
+});
+
+router.delete("/:slug/draft", async (c) => {
+	const ctx = ctxFromHono(c);
+	try {
+		return c.json(await wikiDraftsService.discardWikiDraft(ctx, c.req.param("slug")));
 	} catch (e) {
 		return serviceErrToResponse(c, e);
 	}

--- a/apps/api/src/schemas/wiki.ts
+++ b/apps/api/src/schemas/wiki.ts
@@ -237,10 +237,13 @@ export const ListWikiChangesInputSchema = z.object({
 
 // PROJ-495 (R13): server-side per-user draft, replacing the PROJ-227 localStorage
 // autosave. title/content are both required (a draft is always a full snapshot of the
-// editor state, not a partial patch) — baseRevisionId is optional/nullable with the
-// same convention as UpdatePageSchema: omitted keeps the caller's prior baseRevisionId
-// unset (unusual — the client always sends it), `null` means "the page had no
-// revisions yet when the draft was started".
+// editor state, not a partial patch). baseRevisionId is optional/nullable, but unlike
+// UpdatePageSchema's "omitted preserves last-write-wins" convention, a draft's
+// baseRevisionId column has no tri-state to preserve — saveWikiDraft (services/
+// wiki-drafts.ts) coerces an omitted value to `null` on every save (insert or upsert),
+// same as an explicit `null`, meaning "the page had no revisions yet when the draft was
+// started". Callers that want to keep the draft's existing baseRevisionId must resend it
+// explicitly (the WikiPage.tsx client always does).
 export const SaveWikiDraftInputSchema = z.object({
 	title: z.string().min(1).max(300),
 	content: z.string().max(500000),

--- a/apps/api/src/schemas/wiki.ts
+++ b/apps/api/src/schemas/wiki.ts
@@ -234,3 +234,15 @@ export const ListWikiChangesInputSchema = z.object({
 	projectId: z.string().uuid().optional(),
 	watchedOnly: BooleanQueryParam.optional().default(false),
 });
+
+// PROJ-495 (R13): server-side per-user draft, replacing the PROJ-227 localStorage
+// autosave. title/content are both required (a draft is always a full snapshot of the
+// editor state, not a partial patch) — baseRevisionId is optional/nullable with the
+// same convention as UpdatePageSchema: omitted keeps the caller's prior baseRevisionId
+// unset (unusual — the client always sends it), `null` means "the page had no
+// revisions yet when the draft was started".
+export const SaveWikiDraftInputSchema = z.object({
+	title: z.string().min(1).max(300),
+	content: z.string().max(500000),
+	baseRevisionId: z.string().nullable().optional(),
+});

--- a/apps/api/src/services/wiki-drafts.ts
+++ b/apps/api/src/services/wiki-drafts.ts
@@ -1,0 +1,176 @@
+// PROJ-495 (R13): server-side per-user drafts, replacing the PROJ-227 localStorage
+// autosave so an in-progress edit survives a device switch.
+//
+// No dependency on services/wiki.ts (avoids a circular import — wiki.ts calls into
+// this file's deleteWikiDraftsForPages on delete). Page resolution + visibility checks
+// are duplicated in miniature here rather than imported, mirroring
+// services/wiki-watchers.ts's resolveWatchTarget precedent.
+import { drizzle, schema } from "@projektor/db";
+import { and, eq, inArray, or } from "drizzle-orm";
+import { SaveWikiDraftInputSchema } from "../schemas/wiki";
+import { effectiveProjectRole, isWorkspaceAdmin } from "./access";
+import { NotFoundError, ValidationError } from "./errors";
+import { inChunks } from "./sql";
+import type { ServiceCtx } from "./types";
+
+type ResolvedDraftTarget = {
+	id: string;
+	slug: string;
+};
+
+// PROJ-495: same id-or-slug + redirect-fallback resolution as services/wiki.ts's
+// resolvePageByIdOrSlug, plus the same project-visibility check — duplicated (not
+// imported) to avoid a circular import, see module comment above.
+async function resolveDraftTarget(ctx: ServiceCtx, idOrSlug: string): Promise<ResolvedDraftTarget> {
+	const orm = drizzle(ctx.db, { schema });
+	const direct = await orm
+		.select({
+			id: schema.wikiPages.id,
+			slug: schema.wikiPages.slug,
+			projectId: schema.wikiPages.projectId,
+		})
+		.from(schema.wikiPages)
+		.where(
+			and(
+				or(eq(schema.wikiPages.id, idOrSlug), eq(schema.wikiPages.slug, idOrSlug)),
+				eq(schema.wikiPages.workspaceId, ctx.workspaceId)
+			)
+		)
+		.get();
+
+	let page = direct;
+	if (!page) {
+		const redirect = await orm
+			.select({ pageId: schema.wikiRedirects.pageId })
+			.from(schema.wikiRedirects)
+			.where(
+				and(
+					eq(schema.wikiRedirects.workspaceId, ctx.workspaceId),
+					eq(schema.wikiRedirects.oldSlug, idOrSlug)
+				)
+			)
+			.get();
+		if (redirect) {
+			page = await orm
+				.select({
+					id: schema.wikiPages.id,
+					slug: schema.wikiPages.slug,
+					projectId: schema.wikiPages.projectId,
+				})
+				.from(schema.wikiPages)
+				.where(
+					and(
+						eq(schema.wikiPages.id, redirect.pageId),
+						eq(schema.wikiPages.workspaceId, ctx.workspaceId)
+					)
+				)
+				.get();
+		}
+	}
+	if (!page) throw new NotFoundError("Wiki page not found");
+
+	if (page.projectId !== null && !isWorkspaceAdmin(ctx.role)) {
+		if ((await effectiveProjectRole(ctx, page.projectId)) === null) {
+			throw new NotFoundError("Wiki page not found");
+		}
+	}
+	return { id: page.id, slug: page.slug };
+}
+
+// PROJ-495: returns null (not 404) when the caller has no draft for this page — "no
+// draft yet" is the expected common case, not an error.
+export async function getWikiDraft(ctx: ServiceCtx, idOrSlug: string) {
+	const page = await resolveDraftTarget(ctx, idOrSlug);
+	const orm = drizzle(ctx.db, { schema });
+	const row = await orm
+		.select({
+			title: schema.wikiDrafts.title,
+			content: schema.wikiDrafts.content,
+			baseRevisionId: schema.wikiDrafts.baseRevisionId,
+			updatedAt: schema.wikiDrafts.updatedAt,
+		})
+		.from(schema.wikiDrafts)
+		.where(
+			and(
+				eq(schema.wikiDrafts.workspaceId, ctx.workspaceId),
+				eq(schema.wikiDrafts.userId, ctx.userId),
+				eq(schema.wikiDrafts.pageId, page.id)
+			)
+		)
+		.get();
+	return row ?? null;
+}
+
+// PROJ-495: upserts on (workspace, user, page) — a draft is scratch space, not
+// history, so a later autosave just overwrites the earlier one rather than
+// accumulating rows. Client-side debouncing is what keeps the call frequency
+// reasonable; this endpoint does no server-side throttling of its own.
+export async function saveWikiDraft(ctx: ServiceCtx, idOrSlug: string, input: unknown) {
+	const parsed = SaveWikiDraftInputSchema.safeParse(input);
+	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
+	const page = await resolveDraftTarget(ctx, idOrSlug);
+
+	const orm = drizzle(ctx.db, { schema });
+	const now = Math.floor(Date.now() / 1000);
+	await orm
+		.insert(schema.wikiDrafts)
+		.values({
+			id: crypto.randomUUID(),
+			workspaceId: ctx.workspaceId,
+			userId: ctx.userId,
+			pageId: page.id,
+			title: parsed.data.title,
+			content: parsed.data.content,
+			baseRevisionId: parsed.data.baseRevisionId ?? null,
+			updatedAt: now,
+		})
+		.onConflictDoUpdate({
+			target: [schema.wikiDrafts.workspaceId, schema.wikiDrafts.userId, schema.wikiDrafts.pageId],
+			set: {
+				title: parsed.data.title,
+				content: parsed.data.content,
+				baseRevisionId: parsed.data.baseRevisionId ?? null,
+				updatedAt: now,
+			},
+		});
+
+	return { ok: true, pageId: page.id, updatedAt: now };
+}
+
+// PROJ-495: a no-op (not an error) when the caller has no draft — called both after a
+// successful publish and on an explicit discard, either of which may race a second tab
+// that already cleared it.
+export async function discardWikiDraft(ctx: ServiceCtx, idOrSlug: string) {
+	const page = await resolveDraftTarget(ctx, idOrSlug);
+	const orm = drizzle(ctx.db, { schema });
+	await orm
+		.delete(schema.wikiDrafts)
+		.where(
+			and(
+				eq(schema.wikiDrafts.workspaceId, ctx.workspaceId),
+				eq(schema.wikiDrafts.userId, ctx.userId),
+				eq(schema.wikiDrafts.pageId, page.id)
+			)
+		);
+	return { ok: true };
+}
+
+// PROJ-495: app-level mirror of wiki_drafts.page_id's ON DELETE CASCADE, called from
+// services/wiki.ts#deleteWikiPage — same belt-and-braces precedent as
+// wiki-watchers.ts#deleteWikiWatchersForPages (PROJ-407: D1 doesn't guarantee FK
+// enforcement on every connection).
+export async function deleteWikiDraftsForPages(ctx: ServiceCtx, pageIds: string[]): Promise<void> {
+	if (pageIds.length === 0) return;
+	const orm = drizzle(ctx.db, { schema });
+	await inChunks(pageIds, async (chunk) => {
+		await orm
+			.delete(schema.wikiDrafts)
+			.where(
+				and(
+					eq(schema.wikiDrafts.workspaceId, ctx.workspaceId),
+					inArray(schema.wikiDrafts.pageId, chunk)
+				)
+			);
+		return [];
+	});
+}

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -26,6 +26,7 @@ import { recordActivity } from "./activity";
 import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from "./errors";
 import { inChunks } from "./sql";
 import type { ServiceCtx } from "./types";
+import { deleteWikiDraftsForPages } from "./wiki-drafts";
 import { computeFreshness } from "./wiki-freshness";
 import {
 	parseWikiFrontmatter,
@@ -1819,6 +1820,7 @@ export async function deleteWikiPage(ctx: ServiceCtx, idOrSlug: string, options?
 		await deleteWikiLinksForPages(ctx, allIds);
 		await clearIncomingLinkTargets(ctx, allIds);
 		await deleteWikiWatchersForPages(ctx, allIds);
+		await deleteWikiDraftsForPages(ctx, allIds);
 		await recordActivity(ctx, {
 			entityType: "wiki_page",
 			entityId: page.id,
@@ -1854,6 +1856,7 @@ export async function deleteWikiPage(ctx: ServiceCtx, idOrSlug: string, options?
 	await deleteWikiLinksForPages(ctx, [page.id]);
 	await clearIncomingLinkTargets(ctx, [page.id]);
 	await deleteWikiWatchersForPages(ctx, [page.id]);
+	await deleteWikiDraftsForPages(ctx, [page.id]);
 	await recordActivity(ctx, {
 		entityType: "wiki_page",
 		entityId: page.id,

--- a/apps/api/src/test/migrations.ts
+++ b/apps/api/src/test/migrations.ts
@@ -49,6 +49,7 @@ import m0045 from "../../../../packages/db/migrations/0045_wiki_frontmatter.sql?
 import m0046 from "../../../../packages/db/migrations/0046_wiki_page_templates.sql?raw";
 import m0047 from "../../../../packages/db/migrations/0047_seed_wiki_templates.sql?raw";
 import m0048 from "../../../../packages/db/migrations/0048_wiki_watchers.sql?raw";
+import m0049 from "../../../../packages/db/migrations/0049_wiki_drafts.sql?raw";
 
 export const MIGRATIONS = [
 	m0000,
@@ -100,4 +101,5 @@ export const MIGRATIONS = [
 	m0046,
 	m0047,
 	m0048,
+	m0049,
 ];

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -4493,3 +4493,235 @@ describe("Wiki watchers + list_wiki_changes (PROJ-493)", () => {
 		expect(changes.changes.some((c) => c.pageId === page.id && c.action === "created")).toBe(true);
 	});
 });
+
+describe("Wiki server-side drafts (PROJ-495)", () => {
+	let token: string;
+	let slug: string;
+	let workspaceId: string;
+
+	beforeEach(async () => {
+		const fixture = await seedFixture({ role: "admin" });
+		token = fixture.token;
+		slug = fixture.workspace.slug;
+		workspaceId = fixture.workspace.id;
+	});
+
+	async function req(url: string, opts?: RequestInit) {
+		await env.DB.prepare("DELETE FROM rate_limit").run();
+		return SELF.fetch(url, opts);
+	}
+
+	async function createPage(pageSlug: string, title: string, content = "") {
+		const res = await req("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title, content, slug: pageSlug }),
+		});
+		expect(res.status).toBe(201);
+		return (await res.json()) as { id: string; slug: string };
+	}
+
+	it("REST: no draft returns null, saving upserts, discarding clears it", async () => {
+		const page = await createPage("draft-page", "Draft Page", "original content");
+
+		const empty = await req(`http://localhost/api/wiki/${page.slug}/draft`, {
+			headers: authHeaders(token, slug),
+		});
+		expect(empty.status).toBe(200);
+		expect(await empty.json()).toBeNull();
+
+		const saveRes = await req(`http://localhost/api/wiki/${page.slug}/draft`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Draft Page", content: "draft v1", baseRevisionId: null }),
+		});
+		expect(saveRes.status).toBe(200);
+
+		let getRes = await req(`http://localhost/api/wiki/${page.slug}/draft`, {
+			headers: authHeaders(token, slug),
+		});
+		expect(await getRes.json()).toMatchObject({ title: "Draft Page", content: "draft v1" });
+
+		// Saving again upserts in place — no accumulation of draft rows.
+		await req(`http://localhost/api/wiki/${page.slug}/draft`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Draft Page", content: "draft v2", baseRevisionId: null }),
+		});
+		getRes = await req(`http://localhost/api/wiki/${page.slug}/draft`, {
+			headers: authHeaders(token, slug),
+		});
+		expect(await getRes.json()).toMatchObject({ content: "draft v2" });
+
+		const discardRes = await req(`http://localhost/api/wiki/${page.slug}/draft`, {
+			method: "DELETE",
+			headers: authHeaders(token, slug),
+		});
+		expect(discardRes.status).toBe(200);
+		getRes = await req(`http://localhost/api/wiki/${page.slug}/draft`, {
+			headers: authHeaders(token, slug),
+		});
+		expect(await getRes.json()).toBeNull();
+	});
+
+	it("drafts are per-user — one user's draft is invisible to another", async () => {
+		const page = await createPage("draft-per-user", "Draft Per User", "content");
+		const other = await seedUser(`other-${crypto.randomUUID().slice(0, 8)}@example.com`);
+		await seedMember(workspaceId, other.id, "admin");
+		const otherToken = await seedToken(workspaceId, other.id);
+
+		await req(`http://localhost/api/wiki/${page.slug}/draft`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Draft Per User", content: "mine", baseRevisionId: null }),
+		});
+
+		const otherGet = await req(`http://localhost/api/wiki/${page.slug}/draft`, {
+			headers: authHeaders(otherToken, slug),
+		});
+		expect(await otherGet.json()).toBeNull();
+	});
+
+	it("publishing the draft's content through the normal update path works, and discarding after publish clears it", async () => {
+		const page = await createPage("draft-publish", "Draft Publish", "v0");
+		const pageRes = await req(`http://localhost/api/wiki/${page.slug}`, {
+			headers: authHeaders(token, slug),
+		});
+		const pageBody = (await pageRes.json()) as { updated_at: number };
+
+		const revRes = await req(`http://localhost/api/wiki/${page.slug}/revisions`, {
+			headers: authHeaders(token, slug),
+		});
+		const revisions = (await revRes.json()) as Array<{ id: string }>;
+		const baseRevisionId = revisions[0]?.id ?? null;
+
+		await req(`http://localhost/api/wiki/${page.slug}/draft`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Draft Publish", content: "draft content", baseRevisionId }),
+		});
+
+		// Publish reuses the EXISTING conflict-checked update path — not a separate
+		// draft-publish endpoint — with the draft's own baseRevisionId.
+		const publishRes = await req(`http://localhost/api/wiki/${page.slug}`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "draft content", baseRevisionId }),
+		});
+		expect(publishRes.status).toBe(200);
+		expect(pageBody.updated_at).toBeDefined();
+
+		const discardRes = await req(`http://localhost/api/wiki/${page.slug}/draft`, {
+			method: "DELETE",
+			headers: authHeaders(token, slug),
+		});
+		expect(discardRes.status).toBe(200);
+		const getRes = await req(`http://localhost/api/wiki/${page.slug}/draft`, {
+			headers: authHeaders(token, slug),
+		});
+		expect(await getRes.json()).toBeNull();
+	});
+
+	it("a stale baseRevisionId on publish still hits the normal 409 conflict — no separate draft conflict mechanism", async () => {
+		const page = await createPage("draft-conflict", "Draft Conflict", "v0");
+
+		// Someone else's edit advances the page's latest revision past what the draft
+		// was based on.
+		await req(`http://localhost/api/wiki/${page.slug}`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "someone else's edit" }),
+		});
+
+		const publishRes = await req(`http://localhost/api/wiki/${page.slug}`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "stale draft content", baseRevisionId: null }),
+		});
+		expect(publishRes.status).toBe(409);
+	});
+
+	it("deleting a page (cascade or not) cleans up its draft rows", async () => {
+		const parent = await createPage("draft-delete-parent", "Draft Delete Parent", "content");
+		const child = (await req("http://localhost/api/wiki", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({
+				title: "Draft Delete Child",
+				content: "content",
+				slug: "draft-delete-child",
+				parentId: parent.id,
+			}),
+		}).then((r) => r.json())) as { id: string; slug: string };
+
+		await req(`http://localhost/api/wiki/${parent.slug}/draft`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({
+				title: "Draft Delete Parent",
+				content: "draft",
+				baseRevisionId: null,
+			}),
+		});
+		await req(`http://localhost/api/wiki/${child.slug}/draft`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "Draft Delete Child", content: "draft", baseRevisionId: null }),
+		});
+
+		const rows = await env.DB.prepare("SELECT page_id FROM wiki_drafts WHERE workspace_id = ?")
+			.bind(workspaceId)
+			.all();
+		expect(rows.results.length).toBe(2);
+
+		const delRes = await req(`http://localhost/api/wiki/${parent.slug}?cascade=true`, {
+			method: "DELETE",
+			headers: authHeaders(token, slug),
+		});
+		expect(delRes.status).toBe(200);
+
+		const rowsAfter = await env.DB.prepare("SELECT page_id FROM wiki_drafts WHERE workspace_id = ?")
+			.bind(workspaceId)
+			.all();
+		expect(rowsAfter.results.length).toBe(0);
+	});
+
+	it("validation: title and content are required on save", async () => {
+		const page = await createPage("draft-validation", "Draft Validation", "content");
+		const res = await req(`http://localhost/api/wiki/${page.slug}/draft`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ title: "" }),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it("MCP: save_wiki_draft / get_wiki_draft / discard_wiki_draft mirror the REST behavior", async () => {
+		async function mcp<T>(name: string, args: unknown) {
+			await env.DB.prepare("DELETE FROM rate_limit").run();
+			return mcpCall<T>(workspaceId, name, args, authHeaders(token, slug));
+		}
+		const page = await createPage("mcp-draft", "MCP Draft", "content");
+
+		const saveRes = await mcp("save_wiki_draft", {
+			slug: page.slug,
+			title: "MCP Draft",
+			content: "mcp draft content",
+			baseRevisionId: null,
+		});
+		expect(isMcpError(saveRes)).toBe(false);
+
+		const draft = mcpData<{ content: string } | null>(
+			await mcp("get_wiki_draft", { slug: page.slug })
+		);
+		expect(draft).toMatchObject({ content: "mcp draft content" });
+
+		const discardRes = await mcp("discard_wiki_draft", { slug: page.slug });
+		expect(isMcpError(discardRes)).toBe(false);
+
+		const afterDiscard = mcpData<{ content: string } | null>(
+			await mcp("get_wiki_draft", { slug: page.slug })
+		);
+		expect(afterDiscard).toBeNull();
+	});
+});

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -4625,6 +4625,31 @@ describe("Wiki server-side drafts (PROJ-495)", () => {
 	it("a stale baseRevisionId on publish still hits the normal 409 conflict — no separate draft conflict mechanism", async () => {
 		const page = await createPage("draft-conflict", "Draft Conflict", "v0");
 
+		// Establish a first revision, and capture its id the way startEdit() would —
+		// this is the baseRevisionId the draft freezes and later resubmits on publish.
+		await req(`http://localhost/api/wiki/${page.slug}`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ content: "v1" }),
+		});
+		const revRes = await req(`http://localhost/api/wiki/${page.slug}/revisions`, {
+			headers: authHeaders(token, slug),
+		});
+		const revisions = (await revRes.json()) as Array<{ id: string }>;
+		const draftBaseRevisionId = revisions[0]?.id;
+		expect(draftBaseRevisionId).toBeTruthy();
+
+		// Save a draft frozen at that revision, exactly as the client's autosave would.
+		await req(`http://localhost/api/wiki/${page.slug}/draft`, {
+			method: "PUT",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({
+				title: "Draft Conflict",
+				content: "in-progress draft edit",
+				baseRevisionId: draftBaseRevisionId,
+			}),
+		});
+
 		// Someone else's edit advances the page's latest revision past what the draft
 		// was based on.
 		await req(`http://localhost/api/wiki/${page.slug}`, {
@@ -4633,10 +4658,13 @@ describe("Wiki server-side drafts (PROJ-495)", () => {
 			body: JSON.stringify({ content: "someone else's edit" }),
 		});
 
+		// Publish resubmits the DRAFT's own (now-stale) baseRevisionId — exactly what
+		// useWikiEditing's save() sends after a restoreDraft() — and must hit the same
+		// 409 conflict path as any other stale edit.
 		const publishRes = await req(`http://localhost/api/wiki/${page.slug}`, {
 			method: "PUT",
 			headers: authHeaders(token, slug),
-			body: JSON.stringify({ content: "stale draft content", baseRevisionId: null }),
+			body: JSON.stringify({ content: "stale draft content", baseRevisionId: draftBaseRevisionId }),
 		});
 		expect(publishRes.status).toBe(409);
 	});

--- a/apps/docs/src/content/docs/agents/tool-catalog.md
+++ b/apps/docs/src/content/docs/agents/tool-catalog.md
@@ -11,7 +11,7 @@ running server.
 
 <!-- gen-mcp-catalog:start - generated block; run `pnpm --filter @projektor/api gen:catalog` to refresh -->
 
-**104 tools across 21 domains.**
+**107 tools across 21 domains.**
 
 ## Coordination
 
@@ -155,6 +155,9 @@ running server.
 | `list_wiki_notifications` | List the calling user's wiki watch notifications (newest first). Each entry records the page (denormalized slug/title, so a notification about a page that's since been deleted still shows what it was about), the action (created\|updated\|deleted), the actor, and whether it's been read. |
 | `mark_wiki_notifications_read` | Mark wiki notifications as read, by id, or all: true for every unread one. |
 | `list_wiki_changes` | Cheap delta feed of wiki page changes since a unix-seconds timestamp — for agents polling 'what changed' instead of re-fetching/re-searching the whole wiki. Backed by the existing activity log (no extra write-path cost). `since` is EXCLUSIVE; poll again using the response's `nextSince`, not a locally-computed timestamp, so changes landing on the same second as the cutoff are never missed or double-delivered. Defaults to every wiki page the caller can see (same visibility as list_wiki_pages/search_wiki) — pass watchedOnly=true to narrow to pages the caller is watching (directly or via a subtree watch). A `deleted` entry's slug/title/projectId reflect the page as it was just before deletion (the row itself is gone). |
+| `get_wiki_draft` | Get the calling user's saved server-side draft for a wiki page by id or slug (PROJ-495/R13 — replaces the old localStorage-only autosave, so a draft survives a device switch). Returns null if there is no draft. `baseRevisionId` is the page's latest revision id as of when the draft was started — pass it straight through to update_wiki_page/patch_wiki_page's own baseRevisionId when publishing, so a stale draft hits the normal conflict response instead of silently clobbering someone else's newer edit. |
+| `save_wiki_draft` | Save (upsert) the calling user's draft for a wiki page by id or slug. One draft per (page, user) — calling this again overwrites the previous draft rather than creating a new one. Not a revision and not visible to other users. Callers should debounce their own call frequency (e.g. ~1s after the last edit) — this tool does no server-side throttling. |
+| `discard_wiki_draft` | Delete the calling user's draft for a wiki page by id or slug (a no-op if there is none). Call this after a successful publish, or whenever the user explicitly discards unsaved changes. |
 
 ### Attachments
 

--- a/apps/docs/src/generated/mcp-stats.json
+++ b/apps/docs/src/generated/mcp-stats.json
@@ -1,4 +1,4 @@
 {
-	"tools": 104,
+	"tools": 107,
 	"domains": 21
 }

--- a/apps/web/src/islands/WikiPage.test.tsx
+++ b/apps/web/src/islands/WikiPage.test.tsx
@@ -298,108 +298,161 @@ describe("WikiPage — project scope control (PROJ-352)", () => {
 	});
 });
 
+interface ServerDraft {
+	title: string;
+	content: string;
+	baseRevisionId: string | null;
+	updatedAt: number;
+}
+
+// PROJ-495: mock fetch backing a fake server-side wiki_drafts row — GET/PUT/DELETE
+// .../wiki/:slug/draft, plus the usual tree/revisions/page fixtures. `draftCalls`
+// records every draft PUT body for assertions.
+function mockFetchWikiWithDraft(initialDraft: ServerDraft | null = null) {
+	let draft = initialDraft;
+	const draftPutCalls: ServerDraft[] = [];
+	const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+		const u = String(url);
+		if (u.includes("/draft")) {
+			if (init?.method === "PUT") {
+				const body = JSON.parse(init.body as string) as {
+					title: string;
+					content: string;
+					baseRevisionId: string | null;
+				};
+				draft = { ...body, updatedAt: 2_000_000 };
+				draftPutCalls.push(draft);
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) });
+			}
+			if (init?.method === "DELETE") {
+				draft = null;
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) });
+			}
+			return Promise.resolve({ ok: true, json: () => Promise.resolve(draft) });
+		}
+		if (u.includes("/revisions")) {
+			return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+		}
+		if (u.includes("/tree")) {
+			return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+		}
+		if (init?.method === "PUT") {
+			return Promise.resolve({ ok: true, json: () => Promise.resolve({ ...PAGE }) });
+		}
+		return Promise.resolve({ ok: true, json: () => Promise.resolve(PAGE) });
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	return { fetchMock, draftPutCalls };
+}
+
 async function startEditingWithTitleInput(): Promise<HTMLInputElement> {
-	mockFetchWiki(PAGE);
+	mockFetchWikiWithDraft();
 	render(<WikiPage slug="my-page" />);
 	await screen.findByText("My Page");
 	fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+	await vi.advanceTimersByTimeAsync(0);
 	return screen.getByLabelText("Page title") as HTMLInputElement;
 }
 
-async function renderWithDraftAndOpenEdit(draft: {
-	title: string;
-	content: string;
-	savedAt: number;
-}) {
-	localStorage.setItem("wiki-draft:w1", JSON.stringify(draft));
-	mockFetchWiki(PAGE);
+async function renderWithDraftAndOpenEdit(draft: ServerDraft) {
+	mockFetchWikiWithDraft(draft);
 	render(<WikiPage slug="my-page" />);
 	await screen.findByText("My Page");
 	fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+	await vi.advanceTimersByTimeAsync(0);
 }
 
-describe("draft autosave (PROJ-227)", () => {
+describe("server-side draft autosave (PROJ-495)", () => {
 	beforeEach(() => {
-		localStorage.clear();
 		vi.useFakeTimers();
 	});
 
 	afterEach(() => {
 		vi.useRealTimers();
-		localStorage.clear();
 	});
 
-	it("writes a draft to localStorage after debounce while editing", async () => {
+	it("PUTs a draft to the server after debounce while editing", async () => {
 		const titleInput = await startEditingWithTitleInput();
 		fireEvent.input(titleInput, { target: { value: "My Page Edited" } });
 
-		expect(localStorage.getItem("wiki-draft:w1")).toBeNull();
-
 		await vi.advanceTimersByTimeAsync(1000);
 
-		const raw = localStorage.getItem("wiki-draft:w1");
-		expect(raw).toBeTruthy();
-		const draft = JSON.parse(raw as string);
-		expect(draft.title).toBe("My Page Edited");
-		expect(draft.content).toBe(PAGE.content);
+		const fetchMock = vi.mocked(fetch);
+		const putCall = fetchMock.mock.calls.find(
+			([url, init]) => String(url).includes("/draft") && (init as RequestInit)?.method === "PUT"
+		);
+		expect(putCall).toBeTruthy();
+		const body = JSON.parse((putCall?.[1] as RequestInit).body as string);
+		expect(body.title).toBe("My Page Edited");
+		expect(body.content).toBe(PAGE.content);
 	});
 
-	it("clears the draft from localStorage after a successful save", async () => {
+	it("clears the server draft after a successful save", async () => {
 		const titleInput = await startEditingWithTitleInput();
 		fireEvent.input(titleInput, { target: { value: "My Page Edited" } });
 		await vi.advanceTimersByTimeAsync(1000);
-		expect(localStorage.getItem("wiki-draft:w1")).toBeTruthy();
 
 		fireEvent.click(screen.getByRole("button", { name: "Save" }));
 		await vi.advanceTimersByTimeAsync(0);
+
+		const fetchMock = vi.mocked(fetch);
 		await waitFor(() => {
-			expect(localStorage.getItem("wiki-draft:w1")).toBeNull();
+			const deleteCall = fetchMock.mock.calls.find(
+				([url, init]) =>
+					String(url).includes("/draft") && (init as RequestInit)?.method === "DELETE"
+			);
+			expect(deleteCall).toBeTruthy();
 		});
 	});
 
-	it("keeps the draft in localStorage when editing is cancelled", async () => {
+	it("does not discard the draft when editing is cancelled", async () => {
 		const titleInput = await startEditingWithTitleInput();
 		fireEvent.input(titleInput, { target: { value: "My Page Edited" } });
 		await vi.advanceTimersByTimeAsync(1000);
-		expect(localStorage.getItem("wiki-draft:w1")).toBeTruthy();
 
 		fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+		await vi.advanceTimersByTimeAsync(0);
 
-		const raw = localStorage.getItem("wiki-draft:w1");
-		expect(raw).toBeTruthy();
-		expect(JSON.parse(raw as string).title).toBe("My Page Edited");
+		const fetchMock = vi.mocked(fetch);
+		const deleteCall = fetchMock.mock.calls.find(
+			([url, init]) => String(url).includes("/draft") && (init as RequestInit)?.method === "DELETE"
+		);
+		expect(deleteCall).toBeFalsy();
 	});
 
-	it("flushes unflushed edits to the draft when leaving edit mode via navigation", async () => {
+	it("flushes unflushed edits to the server draft when leaving edit mode via navigation", async () => {
 		const titleInput = await startEditingWithTitleInput();
 		fireEvent.input(titleInput, { target: { value: "Typed just before navigating away" } });
 
 		// Navigate away (e.g. clicking a sidebar link) before the 1s debounce fires.
-		expect(localStorage.getItem("wiki-draft:w1")).toBeNull();
 		fireEvent.click(screen.getByRole("button", { name: "+ New page" }));
+		await vi.advanceTimersByTimeAsync(0);
 
-		const raw = localStorage.getItem("wiki-draft:w1");
-		expect(raw).toBeTruthy();
-		expect(JSON.parse(raw as string).title).toBe("Typed just before navigating away");
+		const fetchMock = vi.mocked(fetch);
+		const putCall = fetchMock.mock.calls.find(
+			([url, init]) => String(url).includes("/draft") && (init as RequestInit)?.method === "PUT"
+		);
+		expect(putCall).toBeTruthy();
+		const body = JSON.parse((putCall?.[1] as RequestInit).body as string);
+		expect(body.title).toBe("Typed just before navigating away");
 	});
 });
 
-describe("draft autosave (PROJ-227) — restore banner", () => {
+describe("server-side draft autosave (PROJ-495) — restore banner", () => {
 	beforeEach(() => {
-		localStorage.clear();
 		vi.useFakeTimers();
 	});
 
 	afterEach(() => {
 		vi.useRealTimers();
-		localStorage.clear();
 	});
 
 	it("shows a restore banner when a newer draft exists on startEdit", async () => {
 		await renderWithDraftAndOpenEdit({
 			title: "Draft Title",
 			content: "Draft content",
-			savedAt: 2_000_000,
+			baseRevisionId: null,
+			updatedAt: 2_000_000,
 		});
 		expect(await screen.findByText(/Restore unsaved draft from/i)).toBeTruthy();
 	});
@@ -408,7 +461,8 @@ describe("draft autosave (PROJ-227) — restore banner", () => {
 		await renderWithDraftAndOpenEdit({
 			title: "Draft Title",
 			content: "Draft content",
-			savedAt: 2_000_000,
+			baseRevisionId: null,
+			updatedAt: 2_000_000,
 		});
 		await screen.findByText(/Restore unsaved draft from/i);
 		fireEvent.click(screen.getByRole("button", { name: "Restore" }));
@@ -418,18 +472,35 @@ describe("draft autosave (PROJ-227) — restore banner", () => {
 		expect(screen.queryByText(/Restore unsaved draft from/i)).toBeNull();
 	});
 
-	it("discard removes the draft and falls through to loading from the page", async () => {
+	it("discard clears the server draft and falls through to loading from the page", async () => {
 		await renderWithDraftAndOpenEdit({
 			title: "Draft Title",
 			content: "Draft content",
-			savedAt: 2_000_000,
+			baseRevisionId: null,
+			updatedAt: 2_000_000,
 		});
 		await screen.findByText(/Restore unsaved draft from/i);
 		fireEvent.click(screen.getByRole("button", { name: "Discard" }));
+		await vi.advanceTimersByTimeAsync(0);
 
 		const titleInput = screen.getByLabelText("Page title") as HTMLInputElement;
 		expect(titleInput.value).toBe(PAGE.title);
-		expect(localStorage.getItem("wiki-draft:w1")).toBeNull();
+		const fetchMock = vi.mocked(fetch);
+		const deleteCall = fetchMock.mock.calls.find(
+			([url, init]) => String(url).includes("/draft") && (init as RequestInit)?.method === "DELETE"
+		);
+		expect(deleteCall).toBeTruthy();
+	});
+
+	it("does not offer a draft older than the page's current published content", async () => {
+		await renderWithDraftAndOpenEdit({
+			title: "Stale Draft Title",
+			content: "Stale draft content",
+			baseRevisionId: null,
+			updatedAt: PAGE.updated_at - 1,
+		});
+		await vi.advanceTimersByTimeAsync(0);
+		expect(screen.queryByText(/Restore unsaved draft from/i)).toBeNull();
 	});
 });
 

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -269,14 +269,18 @@ interface Props {
 	slug?: string;
 }
 
+// PROJ-495 (R13): shape of a saved server-side draft (services/wiki-drafts.ts#getWikiDraft).
+interface ServerDraft {
+	title: string;
+	content: string;
+	baseRevisionId: string | null;
+	updatedAt: number;
+}
+
 function formatBytes(bytes: number): string {
 	if (bytes < 1024) return `${bytes} B`;
 	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
 	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-function draftKey(pageId: string): string {
-	return `wiki-draft:${pageId}`;
 }
 
 function flattenTree(nodes: TreeNode[], parentId: string | null = null): Record<string, FlatEntry> {
@@ -1026,12 +1030,14 @@ function PageHeader({
 	);
 }
 
+// PROJ-495 (R13): the draft lives server-side now, so this can surface on any device —
+// not just after a crash on the same browser.
 function DraftRestoreBanner({
-	savedAt,
+	updatedAt,
 	onRestore,
 	onDiscard,
 }: {
-	savedAt: number;
+	updatedAt: number;
 	onRestore: () => void;
 	onDiscard: () => void;
 }) {
@@ -1041,7 +1047,7 @@ function DraftRestoreBanner({
 	].join(" ");
 	return (
 		<div class={bannerClass}>
-			<span>Restore unsaved draft from {new Date(savedAt).toLocaleString()}?</span>
+			<span>Restore unsaved draft from {new Date(updatedAt * 1000).toLocaleString()}?</span>
 			<div class="flex gap-2 shrink-0">
 				<button type="button" onClick={onRestore} class="btn btn-primary btn-sm">
 					Restore
@@ -1403,7 +1409,7 @@ interface PageArticleProps {
 	onCancelMove: () => void;
 	latestRevision: WikiRevision | null;
 	saveError: string | null;
-	draftBanner: { title: string; content: string; savedAt: number } | null;
+	draftBanner: ServerDraft | null;
 	onRestoreDraft: () => void;
 	onDiscardDraft: () => void;
 	editContent: string;
@@ -1532,7 +1538,7 @@ function PageArticleMeta(
 
 			{props.editing && props.draftBanner && (
 				<DraftRestoreBanner
-					savedAt={props.draftBanner.savedAt}
+					updatedAt={props.draftBanner.updatedAt}
 					onRestore={props.onRestoreDraft}
 					onDiscard={props.onDiscardDraft}
 				/>
@@ -2137,41 +2143,54 @@ function useWikiAttachments(workspaceSlug: string | undefined, page: WikiPageDat
 	};
 }
 
-function useDraftAutosave(
+// PROJ-495 (R13): server-side per-user draft autosave, replacing the PROJ-227
+// localStorage version so an in-progress edit survives a device switch, not just a
+// same-browser crash. Same ~1s debounce cadence as before; debouncing stays entirely
+// client-side (no server-side throttling) so this is just a plain PUT on a timer.
+function useServerDraftAutosave(
+	workspaceSlug: string | undefined,
 	editing: boolean,
 	editTitle: string,
 	editContent: string,
 	page: WikiPageData | null,
-	draftBanner: { title: string; content: string; savedAt: number } | null
+	draftBanner: ServerDraft | null,
+	baseRevisionId: string | null | undefined
 ) {
 	// Latest edit state for the flush-on-leave effect below, since its cleanup
 	// closure would otherwise only see the values from when `editing` last changed.
-	const latestDraftStateRef = useRef({ editTitle, editContent, page, draftBanner });
-	latestDraftStateRef.current = { editTitle, editContent, page, draftBanner };
+	const latestDraftStateRef = useRef({ editTitle, editContent, page, draftBanner, baseRevisionId });
+	latestDraftStateRef.current = { editTitle, editContent, page, draftBanner, baseRevisionId };
 
 	// save() clears the draft itself right before leaving edit mode; set this to
 	// suppress the flush below so it doesn't resurrect the just-cleared draft.
 	const skipLeaveFlushRef = useRef(false);
 
-	// PROJ-227: debounced draft autosave to localStorage while editing
+	function saveDraft(
+		slug: string,
+		title: string,
+		content: string,
+		base: string | null | undefined
+	) {
+		// Best-effort: a failed autosave shouldn't interrupt editing or surface an
+		// error — the explicit Save button remains the source of truth.
+		apiFetch(`/api/wiki/${encodeURIComponent(slug)}/draft`, {
+			method: "PUT",
+			workspaceSlug,
+			body: { title, content, baseRevisionId: base ?? null },
+		}).catch(() => {});
+	}
+
 	useEffect(() => {
 		if (!editing || !page || draftBanner) return;
 		const timer = setTimeout(() => {
-			try {
-				localStorage.setItem(
-					draftKey(page.id),
-					JSON.stringify({ title: editTitle, content: editContent, savedAt: Date.now() })
-				);
-			} catch {
-				// non-fatal
-			}
+			saveDraft(page.slug, editTitle, editContent, baseRevisionId);
 		}, 1000);
 		return () => clearTimeout(timer);
-	}, [editing, editTitle, editContent, page, draftBanner]);
+	}, [editing, editTitle, editContent, page, draftBanner, baseRevisionId]);
 
-	// Flush any not-yet-debounced edits to localStorage when leaving edit mode
-	// via navigation (not just Save/Cancel), so a quick click-away doesn't drop
-	// the last <1s of keystrokes from the safety-net draft.
+	// Flush any not-yet-debounced edits when leaving edit mode via navigation (not
+	// just Save/Cancel), so a quick click-away doesn't drop the last <1s of
+	// keystrokes from the safety-net draft.
 	useEffect(() => {
 		const wasEditing = editing;
 		return () => {
@@ -2185,16 +2204,10 @@ function useDraftAutosave(
 				editContent: c,
 				page: p,
 				draftBanner: db,
+				baseRevisionId: b,
 			} = latestDraftStateRef.current;
 			if (!p || db) return;
-			try {
-				localStorage.setItem(
-					draftKey(p.id),
-					JSON.stringify({ title: t, content: c, savedAt: Date.now() })
-				);
-			} catch {
-				// non-fatal
-			}
+			saveDraft(p.slug, t, c, b);
 		};
 	}, [editing]);
 
@@ -2213,11 +2226,7 @@ function useWikiEditing(
 	const [editContent, setEditContent] = useState("");
 	const [saving, setSaving] = useState(false);
 	const [saveError, setSaveError] = useState<string | null>(null);
-	const [draftBanner, setDraftBanner] = useState<{
-		title: string;
-		content: string;
-		savedAt: number;
-	} | null>(null);
+	const [draftBanner, setDraftBanner] = useState<ServerDraft | null>(null);
 	// PROJ-507: the revision id of the content the user actually started editing,
 	// frozen at startEdit() time — sent back as baseRevisionId so the server can
 	// detect a concurrent edit landing between load and save (PROJ-484's optimistic
@@ -2226,48 +2235,73 @@ function useWikiEditing(
 	// `undefined` (revisions not loaded when editing started) omits the field, which
 	// the server treats as the transitional last-write-wins path — sending `null` there
 	// would instead assert "this page has no revisions" and fail every save.
+	// PROJ-495: this same value is what the draft autosave stamps as its own
+	// baseRevisionId, and restoring a draft snaps it back to the draft's own
+	// baseRevisionId — so publishing a restored draft conflict-checks against what the
+	// draft actually started from, not whatever the page's latest revision happens to
+	// be now.
 	const [baseRevisionId, setBaseRevisionId] = useState<string | null | undefined>(undefined);
 
-	const skipLeaveFlushRef = useDraftAutosave(editing, editTitle, editContent, page, draftBanner);
+	const skipLeaveFlushRef = useServerDraftAutosave(
+		workspaceSlug,
+		editing,
+		editTitle,
+		editContent,
+		page,
+		draftBanner,
+		baseRevisionId
+	);
 
-	function startEdit() {
+	// PROJ-495: draft is fetched from the server (not just a local check) so it
+	// restores across devices, not only after a same-browser crash. Editing opens
+	// immediately with the published content; the restore banner appears once the
+	// fetch resolves, matching the R10 diff/choice pattern of offering rather than
+	// silently applying.
+	async function startEdit() {
 		if (!page) return;
 		setSaveError(null);
 		setDraftBanner(null);
 		setBaseRevisionId(latestRevisionId);
 		setEditTitle(page.title);
 		setEditContent(page.content);
+		setEditing(true);
 		try {
-			const raw = localStorage.getItem(draftKey(page.id));
-			if (raw) {
-				const draft = JSON.parse(raw);
-				if (draft && typeof draft.savedAt === "number" && draft.savedAt > page.updated_at * 1000) {
-					setDraftBanner(draft);
-				}
+			const draft = await apiFetch<ServerDraft | null>(
+				`/api/wiki/${encodeURIComponent(page.slug)}/draft`,
+				{ workspaceSlug }
+			);
+			// A draft older than the page's current published content was superseded
+			// by a publish (this user's or someone else's) since it was saved — not
+			// worth offering to restore.
+			if (draft && draft.updatedAt > page.updated_at) {
+				setDraftBanner(draft);
 			}
 		} catch {
 			// non-fatal — treat as no draft
 		}
-		setEditing(true);
 	}
 
 	function restoreDraft() {
 		if (!draftBanner) return;
 		setEditTitle(draftBanner.title);
 		setEditContent(draftBanner.content);
+		setBaseRevisionId(draftBanner.baseRevisionId);
 		setDraftBanner(null);
 	}
 
-	function discardDraft() {
+	async function discardDraft() {
 		if (!page) return;
-		try {
-			localStorage.removeItem(draftKey(page.id));
-		} catch {
-			// non-fatal
-		}
 		setEditTitle(page.title);
 		setEditContent(page.content);
 		setDraftBanner(null);
+		try {
+			await apiFetch(`/api/wiki/${encodeURIComponent(page.slug)}/draft`, {
+				method: "DELETE",
+				workspaceSlug,
+			});
+		} catch {
+			// non-fatal
+		}
 	}
 
 	function cancelEdit() {
@@ -2287,7 +2321,10 @@ function useWikiEditing(
 				body: { title: editTitle, content: editContent, baseRevisionId },
 			});
 			try {
-				localStorage.removeItem(draftKey(page.id));
+				await apiFetch(`/api/wiki/${encodeURIComponent(page.slug)}/draft`, {
+					method: "DELETE",
+					workspaceSlug,
+				});
 			} catch {
 				// non-fatal
 			}
@@ -2843,7 +2880,7 @@ function buildArticleProps(article: {
 	verifyError: string | null;
 	latestRevision: WikiRevision | null;
 	saveError: string | null;
-	draftBanner: { title: string; content: string; savedAt: number } | null;
+	draftBanner: ServerDraft | null;
 	restoreDraft: () => void;
 	discardDraft: () => void;
 	editContent: string;

--- a/packages/db/migrations/0049_wiki_drafts.sql
+++ b/packages/db/migrations/0049_wiki_drafts.sql
@@ -1,0 +1,27 @@
+-- 0049: R13 (PROJ-495) — server-side per-user wiki drafts, replacing the PROJ-227
+-- localStorage autosave so an in-progress edit survives a device switch, not just a
+-- crash on the same browser.
+--
+-- One draft row per (page, user) — saveWikiDraft upserts rather than accumulating
+-- history; a draft is scratch space, not a revision. base_revision_id is the page's
+-- latest revision id as of when the draft was started (same nullable convention as
+-- wiki_revisions/UpdatePageSchema.baseRevisionId: NULL means "the page had no
+-- revisions yet"), so publish can resubmit through update_wiki_page's EXISTING
+-- optimistic-locking check (services/wiki.ts) instead of a second conflict mechanism.
+-- page_id/user_id cascade on delete — app-level cleanup also runs explicitly from
+-- deleteWikiPage (services/wiki-drafts.ts#deleteWikiDraftsForPages), the same
+-- belt-and-braces precedent as wiki attachments/links/watchers (PROJ-407).
+CREATE TABLE `wiki_drafts` (
+	`id` text PRIMARY KEY NOT NULL,
+	`workspace_id` text NOT NULL REFERENCES `workspaces`(`id`) ON DELETE CASCADE,
+	`user_id` text NOT NULL REFERENCES `users`(`id`) ON DELETE CASCADE,
+	`page_id` text NOT NULL REFERENCES `wiki_pages`(`id`) ON DELETE CASCADE,
+	`title` text NOT NULL,
+	`content` text NOT NULL,
+	`base_revision_id` text,
+	`updated_at` integer NOT NULL
+);
+
+-- getWikiDraft/saveWikiDraft/discardWikiDraft all key off (workspace, user, page); the
+-- unique index doubles as saveWikiDraft's upsert target.
+CREATE UNIQUE INDEX `wiki_drafts_user_page_idx` ON `wiki_drafts` (`workspace_id`, `user_id`, `page_id`);

--- a/packages/db/src/schema/wiki.ts
+++ b/packages/db/src/schema/wiki.ts
@@ -191,3 +191,36 @@ export const wikiNotifications = sqliteTable(
 		userIdx: index("wiki_notifications_user_idx").on(t.workspaceId, t.userId, t.createdAt),
 	})
 );
+
+// PROJ-495 (R13): per-user scratch draft, one row per (page, user) — saveWikiDraft
+// upserts on the unique index below rather than accumulating draft history.
+// baseRevisionId is nullable (no FK to wiki_revisions — a revision can itself be
+// deleted independently) and carries the same "page had no revisions yet" convention
+// as wiki_pages/UpdatePageSchema's baseRevisionId, so publish can hand it straight to
+// updateWikiPage's existing optimistic-locking check.
+export const wikiDrafts = sqliteTable(
+	"wiki_drafts",
+	{
+		id: text("id").primaryKey(),
+		workspaceId: text("workspace_id")
+			.notNull()
+			.references(() => workspaces.id, { onDelete: "cascade" }),
+		userId: text("user_id")
+			.notNull()
+			.references(() => users.id, { onDelete: "cascade" }),
+		pageId: text("page_id")
+			.notNull()
+			.references(() => wikiPages.id, { onDelete: "cascade" }),
+		title: text("title").notNull(),
+		content: text("content").notNull(),
+		baseRevisionId: text("base_revision_id"),
+		updatedAt: integer("updated_at").notNull(),
+	},
+	(t) => ({
+		userPageUniqueIdx: uniqueIndex("wiki_drafts_user_page_idx").on(
+			t.workspaceId,
+			t.userId,
+			t.pageId
+		),
+	})
+);


### PR DESCRIPTION
## Summary

Implements PROJ-495 (R13 of the agent-first-wiki epic): server-side per-user
wiki drafts, replacing the PROJ-227 localStorage-only autosave so an
in-progress edit survives a device switch, not just a same-browser crash.

- **Migration `0049_wiki_drafts.sql`**: new `wiki_drafts` table, one row per
  `(page_id, user_id)`, upserted on `(workspace_id, user_id, page_id)`.
  Stores `title`, `content`, `base_revision_id` (nullable — the page's latest
  revision id when the draft was started), and `updated_at`.
- **`apps/api/src/services/wiki-drafts.ts`** (new domain service, mirrors
  `wiki-watchers.ts`'s pattern of duplicating page resolution/visibility
  checks rather than importing from `services/wiki.ts`, to avoid a circular
  import): `getWikiDraft`, `saveWikiDraft` (upsert), `discardWikiDraft`, and
  `deleteWikiDraftsForPages` (app-level FK-mirror cleanup, same
  belt-and-braces precedent as attachments/links/watchers on `deleteWikiPage`,
  called from both the cascade and non-cascade branches).
- **REST**: `GET/PUT/DELETE /api/wiki/:slug/draft`.
- **MCP**: `get_wiki_draft` / `save_wiki_draft` / `discard_wiki_draft`, full
  parity with REST.
- **Frontend** (`WikiPage.tsx`): the PROJ-227 localStorage autosave code is
  fully removed and replaced. Same ~1s client-side debounce cadence as
  before — debouncing stays entirely client-side, no server-side throttling
  was added.

## Design decisions

1. **Publish reuses the existing conflict-checked write path unchanged.** The
   draft's `baseRevisionId` is the *same* state (`baseRevisionId` in
   `useWikiEditing`) that both the autosave PUT and the eventual
   `update_wiki_page` publish send — frozen at `startEdit()` time, and reset
   to the draft's own `baseRevisionId` on Restore. A stale draft therefore
   hits the exact same 409 conflict response as a stale live edit; there is
   no second conflict mechanism. Covered by an integration test
   ("a stale baseRevisionId on publish still hits the normal 409 conflict").
2. **Restore-draft UX**: kept the same Restore/Discard banner UX as PROJ-227
   (consistent with R10's diff/choice pattern of *offering* rather than
   silently applying), but the draft is now fetched from the server when
   entering edit mode (`startEdit()` is now async) instead of read
   synchronously from `localStorage`. The banner only appears if the fetched
   draft's `updatedAt` is newer than the page's own `updated_at` — a draft
   superseded by any publish (this user's or someone else's) is silently
   ignored rather than offered, same filter as before just re-expressed in
   unix-seconds instead of ms-since-epoch.
3. **localStorage removal is complete**, not partial — `draftKey()`,
   `wiki-draft:<id>` reads/writes, and the whole PROJ-227 code path are
   deleted from `WikiPage.tsx`. (The unrelated `apps/web/src/utils/drafts.ts`
   localStorage helper used by `IssueDetailParts.tsx` for issue body/comment
   drafts is untouched — out of scope, different domain.)
4. **Cleanup on publish/discard is client-driven**: after a successful
   `update_wiki_page` PUT, the client issues a `DELETE .../draft` call (best
   effort, non-fatal on failure) — mirroring the old
   `localStorage.removeItem` immediately after a successful save. No
   server-side hook ties `update_wiki_page` itself to draft deletion, since a
   draft is user-scoped scratch space or­thogonal to the page write itself
   (and the same page could have other users' drafts unaffected by this
   user's publish).
5. **Draft cleanup on page delete** (`deleteWikiPage`) is unconditional
   (both cascade and non-cascade branches), matching the watchers/links/
   attachments precedent — no `is_template` special-case like watchers has,
   since a draft is never itself watch-relevant.

## Migration number

`0049_wiki_drafts.sql` (next after `0048_wiki_watchers.sql`).

## Verification

All green:
- `pnpm gen:docs` — no diff after running (the tool-catalog/README tool-count
  bump from the 3 new MCP tools is included in this PR's commit)
- `pnpm exec biome check .`
- `pnpm turbo type-check`
- `pnpm --filter @projektor/db test`
- `pnpm --filter @projektor/api test:coverage`
- `pnpm --filter @projektor/web test:coverage`
- `pnpm --filter @projektor/web build`
- `pnpm --filter @projektor/docs build`

## Follow-ups / out of scope

- No UI surfaces "you have a draft" outside of entering edit mode on the
  exact page (e.g. no cross-device "you have N unpublished drafts" list/badge
  anywhere else in the app). Could be a natural companion to R11's
  notifications list if wanted later.
- `saveWikiDraft` does no server-side rate limiting/throttling beyond the
  existing per-token rate limiter — per the ticket, debouncing is
  intentionally client-only, but a client that ignores the debounce (buggy
  or malicious) could still hammer the endpoint at whatever the shared rate
  limit allows.
- Drafts have no TTL/expiry — an abandoned draft sits in `wiki_drafts`
  forever until the page is deleted or the draft is explicitly
  discarded/published. Not addressed by this ticket; noting for a possible
  future cleanup job if the table grows unexpectedly.
- Not part of this ticket, but noticed in passing: `wiki_drafts.base_revision_id`
  has no FK to `wiki_revisions` (deliberately, per the in-code comment — a
  revision can be independently deleted), so a UI/tool that resolves a
  draft's `baseRevisionId` back to revision content for a diff view would
  need to handle "revision no longer exists" gracefully; nothing in this PR
  does that resolution today.
