### PR TITLE
chore: bump version to v0.4.17 for release

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@projektor/web",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "private": true,
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
## Summary
- Bumps `apps/web/package.json` version to `0.4.17`, ahead of tagging `v0.4.17` to trigger the release/deploy pipeline for the just-merged PROJ-482 epic work (PRs #184, #186, #187, #188, #189, #190, #191).

## Test plan
- [x] `pnpm turbo type-check` passes (pre-commit hook)
- [ ] CI green