### PR TITLE
PROJ-481: cofferdam triage — ReadonlyArrayParam + MaxLineLength

### DIFF
--- a/.cofferdamignore
+++ b/.cofferdamignore
@@ -1,0 +1,5 @@
+# CD-69: this fixture deliberately contains IslandApiConvention violations
+# for plugins/island-api's own regression test (scripts/check-fixture.mjs),
+# which invokes cofferdam directly against this path with its own
+# cofferdam.toml — excluding it here only affects the whole-repo scan.
+plugins/island-api/fixtures/

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ dist/
 # local dev / test artifacts
 .playwright-mcp/
 dev-server.log
-.cofferdam/cache/
+**/.cofferdam/cache/
 coverage/
 
 # local agent tooling state (spawn-claude worktrees, scratch plans/research) — a nested

--- a/apps/api/src/examples/feedback-widget-submit.ts
+++ b/apps/api/src/examples/feedback-widget-submit.ts
@@ -30,7 +30,7 @@ export interface FeedbackPayload {
  * meant to be embedded in client-side code, the same trust category as a
  * Sentry DSN or a Stripe publishable key.
  */
-// cofferdam-ignore: Design.DuplicateExportName: deliberately mirrors services/feedback.ts's submitFeedback name for the docs example; never imported together
+// cofferdam-ignore: Design.DuplicateExportName: mirrors feedback.ts's submitFeedback name; never imported together
 export async function submitFeedback(
 	endpoint: string,
 	token: string,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -378,7 +378,7 @@ async function sha256hex(s: string): Promise<string> {
 // ctx — there's no authenticated user in a cron invocation, so userId is a placeholder
 // (purgeExpiredWikiPages never reads it). A failure purging one workspace is logged and
 // does not stop the sweep over the rest.
-// cofferdam-ignore: Design.OrphanExport: Cloudflare Workers cron trigger entry point — called by runtime at scheduled interval, not imported by code
+// cofferdam-ignore: Design.OrphanExport: Workers cron trigger — called by runtime, not imported
 export async function scheduled(
 	_event: ScheduledEvent,
 	env: Env,

--- a/apps/api/src/mcp/groups.ts
+++ b/apps/api/src/mcp/groups.ts
@@ -40,7 +40,7 @@ export const groupsTools: MCPTool[] = [
 		name: "list_member_groups",
 		description:
 			"List every workspace member with the access groups they belong to (owner/admin only). " +
-				"Members with no groups appear with an empty list — the pending/default-deny state.",
+			"Members with no groups appear with an empty list — the pending/default-deny state.",
 		inputSchema: { type: "object", properties: {} },
 		async handler(_input, ctx) {
 			return listMemberGroups(ctx as ServiceCtx);

--- a/apps/api/src/mcp/groups.ts
+++ b/apps/api/src/mcp/groups.ts
@@ -39,7 +39,8 @@ export const groupsTools: MCPTool[] = [
 	{
 		name: "list_member_groups",
 		description:
-			"List every workspace member with the access groups they belong to (owner/admin only). Members with no groups appear with an empty list — the pending/default-deny state.",
+			"List every workspace member with the access groups they belong to (owner/admin only). " +
+				"Members with no groups appear with an empty list — the pending/default-deny state.",
 		inputSchema: { type: "object", properties: {} },
 		async handler(_input, ctx) {
 			return listMemberGroups(ctx as ServiceCtx);

--- a/apps/api/src/mcp/issues.ts
+++ b/apps/api/src/mcp/issues.ts
@@ -87,7 +87,8 @@ export const issuesTools: MCPTool[] = [
 				needsAudit: {
 					type: "boolean",
 					description:
-						"Filter to agent-initiated done-closures flagged for human audit — true for unverifiable evidence, false for externally-checkable evidence",
+						"Filter to agent-initiated done-closures flagged for human audit — true for " +
+							"unverifiable evidence, false for externally-checkable evidence",
 				},
 				includeRollups: {
 					type: "boolean",

--- a/apps/api/src/mcp/issues.ts
+++ b/apps/api/src/mcp/issues.ts
@@ -88,7 +88,7 @@ export const issuesTools: MCPTool[] = [
 					type: "boolean",
 					description:
 						"Filter to agent-initiated done-closures flagged for human audit — true for " +
-							"unverifiable evidence, false for externally-checkable evidence",
+						"unverifiable evidence, false for externally-checkable evidence",
 				},
 				includeRollups: {
 					type: "boolean",

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -203,7 +203,7 @@ export async function authMiddleware(c: Context<HonoEnv>, next: Next) {
 type JwtHeader = { alg: string; kid?: string };
 type JwtPayload = { exp: number; aud?: string | string[]; iss?: string; email: string };
 
-function decodeJwtFields(parts: string[]): { header: JwtHeader; payload: JwtPayload } | null {
+function decodeJwtFields(parts: readonly string[]): { header: JwtHeader; payload: JwtPayload } | null {
 	try {
 		const header = JSON.parse(base64urlDecode(parts[0]));
 		const payload = JSON.parse(base64urlDecode(parts[1]));
@@ -230,7 +230,7 @@ function jwtClaimsValid(
 	return payload.iss === issuer;
 }
 
-async function verifySignatureAgainstKeys(parts: string[], keys: JsonWebKey[]): Promise<boolean> {
+async function verifySignatureAgainstKeys(parts: readonly string[], keys: readonly JsonWebKey[]): Promise<boolean> {
 	const signingInput = new TextEncoder().encode(`${parts[0]}.${parts[1]}`);
 	const sig = base64urlToUint8Array(parts[2]);
 
@@ -270,7 +270,7 @@ export async function verifyJwtPayload(
 
 // Pre-screen without keys: avoids a JWKS fetch for obviously-invalid tokens.
 // Mirrors the order of checks in verifyJwtPayload so early exits fire first.
-function preScreenCfAccessJwt(parts: string[], env: Env): boolean {
+function preScreenCfAccessJwt(parts: readonly string[], env: Env): boolean {
 	try {
 		const hdr = JSON.parse(base64urlDecode(parts[0]));
 		if (hdr.alg !== "RS256") return false;
@@ -354,7 +354,7 @@ async function getCfAccessKeysOrUnavailable(
 	}
 }
 
-async function getCfAccessKeys(env: Env, opts?: { forceRefresh?: boolean }): Promise<JsonWebKey[]> {
+async function getCfAccessKeys(env: Env, opts?: Readonly<{ forceRefresh?: boolean }>): Promise<JsonWebKey[]> {
 	if (opts?.forceRefresh) {
 		const now = Date.now();
 		if (now - lastForcedRefreshAt >= FORCE_REFRESH_COOLDOWN_MS) {

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -203,7 +203,9 @@ export async function authMiddleware(c: Context<HonoEnv>, next: Next) {
 type JwtHeader = { alg: string; kid?: string };
 type JwtPayload = { exp: number; aud?: string | string[]; iss?: string; email: string };
 
-function decodeJwtFields(parts: readonly string[]): { header: JwtHeader; payload: JwtPayload } | null {
+function decodeJwtFields(
+	parts: readonly string[]
+): { header: JwtHeader; payload: JwtPayload } | null {
 	try {
 		const header = JSON.parse(base64urlDecode(parts[0]));
 		const payload = JSON.parse(base64urlDecode(parts[1]));
@@ -230,7 +232,10 @@ function jwtClaimsValid(
 	return payload.iss === issuer;
 }
 
-async function verifySignatureAgainstKeys(parts: readonly string[], keys: readonly JsonWebKey[]): Promise<boolean> {
+async function verifySignatureAgainstKeys(
+	parts: readonly string[],
+	keys: readonly JsonWebKey[]
+): Promise<boolean> {
 	const signingInput = new TextEncoder().encode(`${parts[0]}.${parts[1]}`);
 	const sig = base64urlToUint8Array(parts[2]);
 
@@ -354,7 +359,10 @@ async function getCfAccessKeysOrUnavailable(
 	}
 }
 
-async function getCfAccessKeys(env: Env, opts?: Readonly<{ forceRefresh?: boolean }>): Promise<JsonWebKey[]> {
+async function getCfAccessKeys(
+	env: Env,
+	opts?: Readonly<{ forceRefresh?: boolean }>
+): Promise<JsonWebKey[]> {
 	if (opts?.forceRefresh) {
 		const now = Date.now();
 		if (now - lastForcedRefreshAt >= FORCE_REFRESH_COOLDOWN_MS) {

--- a/apps/api/src/middleware/etag.ts
+++ b/apps/api/src/middleware/etag.ts
@@ -31,7 +31,7 @@ export async function etagMiddleware(c: Context<HonoEnv>, next: Next): Promise<v
 	const etag = `"${await sha256Prefix(body)}"`;
 
 	if (ifNoneMatchMatches(c.req.header("If-None-Match"), etag)) {
-		// cofferdam-ignore: Refactor.MutatedParameter: setting c.res is the standard Hono middleware contract, not an accidental mutation
+		// cofferdam-ignore: Refactor.MutatedParameter: setting c.res is the standard Hono contract
 		c.res = new Response(null, {
 			status: 304,
 			headers: { ETag: etag, "Cache-Control": CACHE_CONTROL },

--- a/apps/api/src/middleware/workspace.ts
+++ b/apps/api/src/middleware/workspace.ts
@@ -54,7 +54,7 @@ function mcpWorkspaceIdFromPath(path: string): string | undefined {
 // Checked before membership so a token pointed at the wrong workspace gets the same 403
 // it always did, rather than leaking whether the caller happens to be a member there.
 function tokenConfinedToOtherWorkspace(
-	row: { id: string },
+	row: Readonly<{ id: string }>,
 	tokenWorkspaceId: string | null | undefined
 ): boolean {
 	return tokenWorkspaceId != null && row.id !== tokenWorkspaceId;

--- a/apps/api/src/routes/mcp.ts
+++ b/apps/api/src/routes/mcp.ts
@@ -202,7 +202,7 @@ function jsonRpcResult(id: unknown, result: unknown) {
 function jsonRpcError(id: unknown, code: number, message: string, data?: unknown) {
 	// `data` is the JSON-RPC 2.0 spec's optional error.data member — omitted entirely
 	// (not sent as `null`/`undefined`) when the error has no structured payload.
-	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: this returns a JSON-RPC error object per spec (jsonrpc 2.0), not a code-style error-shaped return
+	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: JSON-RPC 2.0 error object per spec, not a code-style return
 	return {
 		jsonrpc: "2.0",
 		id,

--- a/apps/api/src/services/access.ts
+++ b/apps/api/src/services/access.ts
@@ -28,7 +28,9 @@ const PROJECT_ROLE_RANK: Record<"viewer" | "member" | "admin", number> = {
 	admin: 3,
 };
 
-function strongestGrant(roles: readonly ("viewer" | "member" | "admin")[]): "viewer" | "member" | "admin" {
+function strongestGrant(
+	roles: readonly ("viewer" | "member" | "admin")[]
+): "viewer" | "member" | "admin" {
 	return roles.reduce((best, r) => (PROJECT_ROLE_RANK[r] > PROJECT_ROLE_RANK[best] ? r : best));
 }
 

--- a/apps/api/src/services/access.ts
+++ b/apps/api/src/services/access.ts
@@ -28,7 +28,7 @@ const PROJECT_ROLE_RANK: Record<"viewer" | "member" | "admin", number> = {
 	admin: 3,
 };
 
-function strongestGrant(roles: ("viewer" | "member" | "admin")[]): "viewer" | "member" | "admin" {
+function strongestGrant(roles: readonly ("viewer" | "member" | "admin")[]): "viewer" | "member" | "admin" {
 	return roles.reduce((best, r) => (PROJECT_ROLE_RANK[r] > PROJECT_ROLE_RANK[best] ? r : best));
 }
 

--- a/apps/api/src/services/activity.ts
+++ b/apps/api/src/services/activity.ts
@@ -3,12 +3,12 @@ import type { ServiceCtx } from "./types";
 
 export async function recordActivity(
 	ctx: ServiceCtx,
-	opts: {
+	opts: Readonly<{
 		entityType: "issue" | "wiki_page" | "project" | "group";
 		entityId: string;
 		action: "created" | "updated" | "deleted";
 		diff?: Record<string, unknown>;
-	}
+	}>
 ): Promise<void> {
 	const orm = drizzle(ctx.db, { schema });
 	await orm.insert(schema.activity).values({

--- a/apps/api/src/services/code-heatmap.ts
+++ b/apps/api/src/services/code-heatmap.ts
@@ -46,7 +46,7 @@ export interface ContentionHeatmapEntry {
 // directory's children" step a file explorer takes, so the caller drills down by
 // re-requesting with `prefix` set to the entry clicked.
 function groupClaimsByNextSegment(
-	claims: Array<{ path: string; issueId: string }>,
+	claims: ReadonlyArray<{ path: string; issueId: string }>,
 	prefix: string
 ): CodeHeatmapEntry[] {
 	const prefixWithSlash = prefix ? `${prefix}/` : "";
@@ -87,7 +87,7 @@ function groupClaimsByNextSegment(
 // PROJ-338: contention counterpart to groupClaimsByNextSegment — same segment-splitting
 // and isLeaf-freeze behavior, but tracks rejected-issue ids and raw conflict rows.
 function groupConflictsByNextSegment(
-	conflicts: Array<{ path: string; rejectedIssueId: string }>,
+	conflicts: ReadonlyArray<{ path: string; rejectedIssueId: string }>,
 	prefix: string
 ): ContentionHeatmapEntry[] {
 	const prefixWithSlash = prefix ? `${prefix}/` : "";

--- a/apps/api/src/services/custom-fields.ts
+++ b/apps/api/src/services/custom-fields.ts
@@ -336,7 +336,7 @@ export async function validateCustomFields(
 export async function writeCustomFieldValues(
 	db: D1Database,
 	issueId: string,
-	writes: Array<{ fieldId: string; value: string }>
+	writes: ReadonlyArray<{ fieldId: string; value: string }>
 ) {
 	const orm = drizzle(db, { schema });
 	for (const { fieldId, value } of writes) {

--- a/apps/api/src/services/errors.ts
+++ b/apps/api/src/services/errors.ts
@@ -21,9 +21,9 @@ export class NotFoundError extends ServiceError {
 	// fields (e.g. patch_wiki_page's currentHeadings list on a heading-not-found miss)
 	// beyond the plain message. Optional so every pre-existing plain-message
 	// NotFoundError is unaffected.
-	// cofferdam-ignore: Refactor.UnusedVariable: public readonly property read by error-adapter.ts
 	constructor(
 		message = "Not found",
+		// cofferdam-ignore: Refactor.UnusedVariable: public readonly property read by error-adapter.ts
 		public readonly details?: Record<string, unknown>
 	) {
 		super(message);
@@ -42,9 +42,9 @@ export class ConflictError extends ServiceError {
 	// PROJ-484: `details` carries structured, client-facing extra fields (e.g. wiki's
 	// optimistic-lock conflict: currentRevisionId + a unified diff) beyond the plain
 	// message. Optional so every pre-existing plain-message ConflictError is unaffected.
-	// cofferdam-ignore: Refactor.UnusedVariable: public readonly property read by error-adapter.ts
 	constructor(
 		message = "Conflict",
+		// cofferdam-ignore: Refactor.UnusedVariable: public readonly property read by error-adapter.ts
 		public readonly details?: Record<string, unknown>
 	) {
 		super(message);

--- a/apps/api/src/services/feedback-sources.ts
+++ b/apps/api/src/services/feedback-sources.ts
@@ -89,7 +89,8 @@ export async function createFeedbackSource(
 	await ctx.db
 		.prepare(
 			`INSERT INTO feedback_sources
-       (id, token_hash, workspace_id, project_id, name, description, is_active, allowed_origins, created_by, created_at, revoked_at)
+       (id, token_hash, workspace_id, project_id, name, description, is_active,
+        allowed_origins, created_by, created_at, revoked_at)
        VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, NULL)`
 		)
 		.bind(

--- a/apps/api/src/services/feedback.ts
+++ b/apps/api/src/services/feedback.ts
@@ -60,7 +60,8 @@ async function insertFeedbackRow(
 	await db
 		.prepare(
 			`INSERT INTO feedback
-       (id, source_id, workspace_id, project_id, rating, rating_scale, body, submitter_label, source_url, app_version, status, linked_issue_id, created_at)
+       (id, source_id, workspace_id, project_id, rating, rating_scale, body, submitter_label,
+        source_url, app_version, status, linked_issue_id, created_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'new', NULL, ?)`
 		)
 		.bind(

--- a/apps/api/src/services/feedback.ts
+++ b/apps/api/src/services/feedback.ts
@@ -401,7 +401,7 @@ interface FeedbackSummaryRow {
 
 export async function getFeedbackSummary(
 	ctx: ServiceCtx,
-	input: { projectId: string }
+	input: Readonly<{ projectId: string }>
 ): Promise<FeedbackSourceSummary[]> {
 	const { projectId } = input;
 

--- a/apps/api/src/services/file-claims.ts
+++ b/apps/api/src/services/file-claims.ts
@@ -90,7 +90,8 @@ async function assertNoConflicts(
 	}
 	if (firstConflict) {
 		throw new ConflictError(
-			`Path "${firstConflict.path}" is held by issue ${firstConflict.issueId}${firstConflict.agentId ? ` (agent ${firstConflict.agentId})` : ""}`
+			`Path "${firstConflict.path}" is held by issue ${firstConflict.issueId}` +
+				`${firstConflict.agentId ? ` (agent ${firstConflict.agentId})` : ""}`
 		);
 	}
 }

--- a/apps/api/src/services/file-claims.ts
+++ b/apps/api/src/services/file-claims.ts
@@ -58,14 +58,14 @@ async function loadActiveClaimsByPath(
 
 async function assertNoConflicts(
 	orm: ReturnType<typeof drizzle>,
-	params: {
+	params: Readonly<{
 		workspaceId: string;
 		issueId: string;
 		agentId: string | undefined;
 		paths: string[];
 		claimsByPath: Map<string, { issueId: string; agentId: string | null }>;
 		now: number;
-	}
+	}>
 ) {
 	const { workspaceId, issueId, agentId, paths, claimsByPath, now } = params;
 	// Record every contended path (rejection is all-or-nothing, but each simultaneously
@@ -98,14 +98,14 @@ async function assertNoConflicts(
 async function overrideConflictingClaims(
 	ctx: ServiceCtx,
 	orm: ReturnType<typeof drizzle>,
-	params: {
+	params: Readonly<{
 		workspaceId: string;
 		issueId: string;
 		agentId: string | undefined;
 		paths: string[];
 		claimsByPath: Map<string, typeof schema.issueFileClaims.$inferSelect>;
 		now: number;
-	}
+	}>
 ) {
 	const { workspaceId, issueId, agentId, paths, claimsByPath, now } = params;
 	const overridden: (typeof schema.issueFileClaims.$inferSelect)[] = [];
@@ -140,13 +140,13 @@ async function overrideConflictingClaims(
 
 async function insertClaims(
 	orm: ReturnType<typeof drizzle>,
-	params: {
+	params: Readonly<{
 		workspaceId: string;
 		issueId: string;
 		agentId: string | undefined;
 		paths: string[];
 		now: number;
-	}
+	}>
 ) {
 	const { workspaceId, issueId, agentId, paths, now } = params;
 	const created: (typeof schema.issueFileClaims.$inferSelect)[] = [];

--- a/apps/api/src/services/files.ts
+++ b/apps/api/src/services/files.ts
@@ -171,7 +171,7 @@ export async function createLinkAttachment(
 // back to the default for unset/invalid/non-positive values.
 const DEFAULT_STORAGE_QUOTA_BYTES = 1024 * 1024 * 1024; // 1 GiB per workspace
 
-export function storageQuotaBytes(env: { STORAGE_QUOTA_BYTES?: string }): number {
+export function storageQuotaBytes(env: Readonly<{ STORAGE_QUOTA_BYTES?: string }>): number {
 	const n = Number(env.STORAGE_QUOTA_BYTES);
 	return Number.isFinite(n) && n > 0 ? n : DEFAULT_STORAGE_QUOTA_BYTES;
 }
@@ -187,7 +187,7 @@ async function workspaceStorageUsageBytes(ctx: ServiceCtx): Promise<number> {
 /** Validates size/type/quota for a would-be upload; throws the matching typed error. */
 export async function assertUploadAllowed(
 	ctx: ServiceCtx,
-	params: { size: number; contentType: string; quotaBytes?: number }
+	params: Readonly<{ size: number; contentType: string; quotaBytes?: number }>
 ): Promise<void> {
 	if (params.size > MAX_UPLOAD_SIZE) {
 		throw new PayloadTooLargeError("File too large (max 50 MB)");

--- a/apps/api/src/services/flow-metrics.ts
+++ b/apps/api/src/services/flow-metrics.ts
@@ -13,7 +13,7 @@ interface Distribution {
 	p90: number | null;
 }
 
-function summarize(durations: number[]): Distribution {
+function summarize(durations: readonly number[]): Distribution {
 	if (durations.length === 0) return { count: 0, avg: null, p50: null, p90: null };
 	const sorted = [...durations].sort((a, b) => a - b);
 	const avg = sorted.reduce((sum, d) => sum + d, 0) / sorted.length;
@@ -49,7 +49,7 @@ type FlowIssueRow = {
 };
 
 function buildWipOverTime(
-	issues: FlowIssueRow[],
+	issues: readonly FlowIssueRow[],
 	since: number,
 	until: number
 ): Array<{ date: string; count: number }> {
@@ -74,7 +74,7 @@ function mondayAtOrBefore(t: number): number {
 }
 
 function buildThroughputOverTime(
-	issues: FlowIssueRow[],
+	issues: readonly FlowIssueRow[],
 	since: number,
 	until: number,
 	granularity: "day" | "week"
@@ -103,7 +103,7 @@ function buildThroughputOverTime(
 // as any other non-bug type. bugSharePercent is null (not 0) when a bucket completed
 // nothing, so an empty bucket reads as "no data" rather than "zero defects".
 function buildBugShareOverTime(
-	issues: FlowIssueRow[],
+	issues: readonly FlowIssueRow[],
 	since: number,
 	until: number,
 	granularity: "day" | "week"
@@ -138,7 +138,7 @@ function buildBugShareOverTime(
 // PROJ-328: review latency (in_review -> done) bucketed the same way as throughput, but
 // showing the bucket's p50 rather than a count — the "trend" the ticket asks for.
 function buildReviewLatencyOverTime(
-	issues: FlowIssueRow[],
+	issues: readonly FlowIssueRow[],
 	since: number,
 	until: number,
 	granularity: "day" | "week"
@@ -173,7 +173,7 @@ function buildReviewLatencyOverTime(
 // the net (created - completed), bucketed the same way as throughput. Answers "is the
 // backlog growing or burning?" at a glance.
 function buildArrivalVsCompletion(
-	issues: FlowIssueRow[],
+	issues: readonly FlowIssueRow[],
 	since: number,
 	until: number,
 	granularity: "day" | "week"
@@ -218,7 +218,7 @@ function classifyCfdBand(issue: FlowIssueRow, sampleAt: number): CfdBand {
 }
 
 function countCfdBands(
-	issues: FlowIssueRow[],
+	issues: readonly FlowIssueRow[],
 	sampleAt: number
 ): { backlogTodo: number; inProgress: number; inReview: number; done: number } {
 	let backlogTodo = 0;
@@ -305,7 +305,7 @@ async function fetchHumanCommentCounts(
 // still held when the issue finished counts through doneAt, not "now".
 async function fetchLeaseHeldSeconds(
 	orm: ReturnType<typeof drizzle>,
-	issues: FlowIssueRow[]
+	issues: readonly FlowIssueRow[]
 ): Promise<Map<string, number>> {
 	const doneAtById = new Map(issues.map((i) => [i.id, i.doneAt]));
 	const rows = await inChunks(
@@ -333,7 +333,7 @@ async function fetchLeaseHeldSeconds(
 // PROJ-328: human interventions per completed issue = human comments + status bounces
 // out of review. The primary "how much human attention did this take" signal.
 function computeHumanInterventions(
-	issues: FlowIssueRow[],
+	issues: readonly FlowIssueRow[],
 	humanCommentCounts: Map<string, number>,
 	inWindow: (t: number) => boolean
 ): number[] {
@@ -345,7 +345,7 @@ function computeHumanInterventions(
 // PROJ-328: autonomy ratio per completed issue = lease-held time / cycle time. Clamped
 // to [0, 1] — sequential re-leases can sum close to the full cycle but shouldn't exceed it.
 function computeAutonomyRatios(
-	issues: FlowIssueRow[],
+	issues: readonly FlowIssueRow[],
 	leaseHeldSeconds: Map<string, number>,
 	inWindow: (t: number) => boolean
 ): number[] {
@@ -367,7 +367,7 @@ function computeAutonomyRatios(
 // "waste", so it's always <= autonomyRatio for the same issue. Clamped to [0, 1] for the
 // same reason as autonomyRatio (sequential re-leases can sum close to the full lead time).
 function computeFlowEfficiencies(
-	issues: FlowIssueRow[],
+	issues: readonly FlowIssueRow[],
 	leaseHeldSeconds: Map<string, number>,
 	inWindow: (t: number) => boolean
 ): number[] {
@@ -389,7 +389,7 @@ function computeFlowEfficiencies(
 // reflects the shared date-range controls. Surfaces items stuck long enough to be worth
 // investigating before they finish and pollute the cycle-time percentiles.
 function buildAgingWip(
-	issues: FlowIssueRow[],
+	issues: readonly FlowIssueRow[],
 	now: number
 ): Array<{ id: string; status: "in_progress" | "in_review"; ageSeconds: number }> {
 	return issues

--- a/apps/api/src/services/groups.ts
+++ b/apps/api/src/services/groups.ts
@@ -34,8 +34,10 @@ async function loadGroup(orm: ReturnType<typeof drizzle>, ctx: ServiceCtx, group
  */
 export async function listGroups(ctx: ServiceCtx) {
 	const orm = drizzle(ctx.db, { schema });
-	const memberCount = sql<number>`(SELECT count(*) FROM user_group_members m WHERE m.group_id = ${schema.userGroups.id})`;
-	const grantCount = sql<number>`(SELECT count(*) FROM group_project_grants g WHERE g.group_id = ${schema.userGroups.id})`;
+	const memberCount = sql<number>`(SELECT count(*) FROM user_group_members m
+		WHERE m.group_id = ${schema.userGroups.id})`;
+	const grantCount = sql<number>`(SELECT count(*) FROM group_project_grants g
+		WHERE g.group_id = ${schema.userGroups.id})`;
 	const cols = {
 		id: schema.userGroups.id,
 		name: schema.userGroups.name,

--- a/apps/api/src/services/issue-leases.ts
+++ b/apps/api/src/services/issue-leases.ts
@@ -201,7 +201,8 @@ export async function claimIssue(ctx: ServiceCtx, raw: unknown) {
 		// so the factory-health tile has fault data instead of nothing tracked.
 		await ctx.db
 			.prepare(
-				"INSERT INTO wip_cap_denials (id, workspace_id, project_id, issue_id, agent_session_id, occurred_at) VALUES (?, ?, ?, ?, ?, ?)"
+				"INSERT INTO wip_cap_denials (id, workspace_id, project_id, issue_id, agent_session_id, " +
+					"occurred_at) VALUES (?, ?, ?, ?, ?, ?)"
 			)
 			.bind(crypto.randomUUID(), ctx.workspaceId, projectId, issueId, agentId, now)
 			.run();

--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -1084,11 +1084,13 @@ function now(): number {
 	return Math.floor(Date.now() / 1000);
 }
 
-function formatCompletionReportComment(report: Readonly<{
-	summary: string;
-	verification: string;
-	prLink?: string;
-}>): string {
+function formatCompletionReportComment(
+	report: Readonly<{
+		summary: string;
+		verification: string;
+		prLink?: string;
+	}>
+): string {
 	const lines = [
 		"**Completion report**",
 		"",

--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -496,7 +496,7 @@ async function fetchIssueByRef(orm: ReturnType<typeof drizzle>, ctx: ServiceCtx,
 	);
 }
 
-function computeChildRollup(childRows: Array<{ status: string; count: number }>) {
+function computeChildRollup(childRows: ReadonlyArray<{ status: string; count: number }>) {
 	const byStatus: Record<string, number> = {};
 	let total = 0;
 	for (const r of childRows) {
@@ -658,7 +658,7 @@ type CreateIssueData = z.infer<typeof CreateIssueSchema>;
 async function insertIssueRow(
 	ctx: ServiceCtx,
 	orm: ReturnType<typeof drizzle>,
-	params: {
+	params: Readonly<{
 		id: string;
 		projectId: string;
 		title: string;
@@ -671,7 +671,7 @@ async function insertIssueRow(
 		parentId: string | null;
 		resolvedTypeId: string | null;
 		now: number;
-	}
+	}>
 ): Promise<void> {
 	// Atomic number allocation: the subquery for MAX(number) and the INSERT run as
 	// a single SQLite statement, eliminating the read-then-write race that existed
@@ -922,12 +922,12 @@ function applyFlowTimestampTransitions(
 function applyReviewTransitions(
 	setValues: SetValues,
 	existing: ExistingIssue,
-	transition: {
+	transition: Readonly<{
 		resolvedStatusKey: string;
 		newStatusCategory: string | undefined;
 		enteringInReview: boolean;
 		enteringDone: boolean;
-	}
+	}>
 ): boolean {
 	const { resolvedStatusKey, newStatusCategory, enteringInReview, enteringDone } = transition;
 	if (enteringInReview && existing.inReviewAt == null) setValues.inReviewAt = now();
@@ -990,7 +990,7 @@ async function assertReviewGate(
 	ctx: ServiceCtx,
 	data: UpdateIssueData,
 	existing: ExistingIssue,
-	transition: { enteringInReview: boolean; enteringDone: boolean }
+	transition: Readonly<{ enteringInReview: boolean; enteringDone: boolean }>
 ): Promise<void> {
 	const { enteringInReview, enteringDone } = transition;
 	if (!enteringInReview && !enteringDone) return;
@@ -1084,11 +1084,11 @@ function now(): number {
 	return Math.floor(Date.now() / 1000);
 }
 
-function formatCompletionReportComment(report: {
+function formatCompletionReportComment(report: Readonly<{
 	summary: string;
 	verification: string;
 	prLink?: string;
-}): string {
+}>): string {
 	const lines = [
 		"**Completion report**",
 		"",
@@ -1435,7 +1435,7 @@ async function computeStoryPoints(
 }
 
 function scoreOpenIssues(
-	openIssues: OpenIssue[],
+	openIssues: readonly OpenIssue[],
 	inDegree: Record<string, number>,
 	storyPoints: Record<string, number>
 ) {

--- a/apps/api/src/services/provisioning.ts
+++ b/apps/api/src/services/provisioning.ts
@@ -131,7 +131,7 @@ async function grantOwner(
 async function provisionAdmin(
 	orm: ReturnType<typeof drizzle>,
 	env: Env,
-	user: { id: string; email: string },
+	user: Readonly<{ id: string; email: string }>,
 	slug: string,
 	name: string
 ): Promise<void> {
@@ -341,7 +341,7 @@ async function runProvisioning(env: Env, user: { id: string; email: string }): P
  * on this is the hot path for every anonymous request. There is exactly one public-viewer
  * identity, so the marker is shared by all of them.
  */
-export async function provisionPublicViewer(env: Env, user: { id: string }): Promise<void> {
+export async function provisionPublicViewer(env: Env, user: Readonly<{ id: string }>): Promise<void> {
 	if (await alreadyProvisioned(env, user.id)) return;
 
 	const slug = env.DEFAULT_WORKSPACE_SLUG?.trim() || "projektor";

--- a/apps/api/src/services/provisioning.ts
+++ b/apps/api/src/services/provisioning.ts
@@ -341,7 +341,10 @@ async function runProvisioning(env: Env, user: { id: string; email: string }): P
  * on this is the hot path for every anonymous request. There is exactly one public-viewer
  * identity, so the marker is shared by all of them.
  */
-export async function provisionPublicViewer(env: Env, user: Readonly<{ id: string }>): Promise<void> {
+export async function provisionPublicViewer(
+	env: Env,
+	user: Readonly<{ id: string }>
+): Promise<void> {
 	if (await alreadyProvisioned(env, user.id)) return;
 
 	const slug = env.DEFAULT_WORKSPACE_SLUG?.trim() || "projektor";

--- a/apps/api/src/services/sql.ts
+++ b/apps/api/src/services/sql.ts
@@ -38,7 +38,7 @@ export async function inChunks<I, O>(
 ): Promise<O[]> {
 	if (items.length === 0) return [];
 	const out: O[] = [];
-	// cofferdam-ignore: Refactor.PreferArrayMethodOverLoop: sequential `await` per chunk is intentional (avoids firing all chunk queries concurrently); .map() would parallelize
+	// cofferdam-ignore: Refactor.PreferArrayMethodOverLoop: sequential await per chunk; .map() would parallelize
 	for (let i = 0; i < items.length; i += CHUNK_SIZE) {
 		out.push(...(await op(items.slice(i, i + CHUNK_SIZE) as I[])));
 	}

--- a/apps/api/src/services/wiki-export.ts
+++ b/apps/api/src/services/wiki-export.ts
@@ -204,7 +204,7 @@ async function collectAttachments(
 }
 
 function safeZipPathSegment(value: string): string {
-	// biome-ignore lint/suspicious/noControlCharactersInRegex: intentionally stripping NUL/control chars from zip entry names
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping control chars from zip names
 	const stripped = value.replace(/[\\/]/g, "_").replace(/[\x00-\x1f]/g, "");
 	return /^\.+$/.test(stripped) ? "_" : stripped;
 }

--- a/apps/api/src/services/wiki-export.ts
+++ b/apps/api/src/services/wiki-export.ts
@@ -166,7 +166,7 @@ function ensureFrontmatter(page: ExportedPage): string {
 // pointer attachments have an empty r2_key and nothing to zip).
 async function collectAttachments(
 	ctx: ServiceCtx,
-	pages: ExportedPage[]
+	pages: readonly ExportedPage[]
 ): Promise<Array<{ pageSlug: string; filename: string; r2Key: string; size: number }>> {
 	if (pages.length === 0) return [];
 	const orm = drizzle(ctx.db, { schema });

--- a/apps/api/src/services/wiki-links.ts
+++ b/apps/api/src/services/wiki-links.ts
@@ -74,7 +74,7 @@ export function parseWikiLinkTargets(content: string): ParsedLinkTarget[] {
 async function resolveTitleTargets(
 	orm: Orm,
 	workspaceId: string,
-	titles: string[]
+	titles: readonly string[]
 ): Promise<Map<string, string>> {
 	const byLower = new Map<string, string>();
 	if (titles.length === 0) return byLower;
@@ -149,7 +149,7 @@ type ResolvedLink = { targetPageId: string | null; targetTitle: string };
 async function resolveLinkTargets(
 	orm: Orm,
 	workspaceId: string,
-	targets: ParsedLinkTarget[]
+	targets: readonly ParsedLinkTarget[]
 ): Promise<ResolvedLink[]> {
 	// Dedupe by resolved page id (or the raw unresolved key) so a page linking to the
 	// same target multiple times only gets one wiki_links row.
@@ -387,7 +387,7 @@ export interface WikiBacklink {
  */
 export async function backlinksForResolvedPage(
 	ctx: ServiceCtx,
-	page: { id: string }
+	page: Readonly<{ id: string }>
 ): Promise<WikiBacklink[]> {
 	const orm = drizzle(ctx.db, { schema });
 	const rows = await orm
@@ -436,7 +436,7 @@ export async function backlinksForResolvedPage(
 // Resolves which of `rows` (all project-scoped) the caller has an effective grant on.
 async function visibleSourcePageIds(
 	ctx: ServiceCtx,
-	rows: Array<{ pageId: string; projectId: string | null }>
+	rows: ReadonlyArray<{ pageId: string; projectId: string | null }>
 ): Promise<string[]> {
 	if (rows.length === 0) return [];
 	const uniqueProjectIds = [

--- a/apps/api/src/services/wiki-links.ts
+++ b/apps/api/src/services/wiki-links.ts
@@ -237,7 +237,8 @@ export async function buildWikiLinksReindexStatements(
 		statements.push(
 			ctx.db
 				.prepare(
-					`INSERT INTO wiki_links (id, workspace_id, source_page_id, target_page_id, target_title, created_at) VALUES ${placeholders}`
+					`INSERT INTO wiki_links (id, workspace_id, source_page_id, target_page_id, target_title,
+						created_at) VALUES ${placeholders}`
 				)
 				.bind(...params)
 		);
@@ -256,7 +257,7 @@ export async function buildWikiLinksReindexStatements(
  * patchWikiPage call buildWikiLinksReindexStatements directly instead, to include these
  * statements in the same batch as the content write/revision/FTS reindex (PROJ-511).
  */
-// cofferdam-ignore: Design.OrphanExport: re-indexing function available for direct use; prefer buildWikiLinksReindexStatements for batch operations
+// cofferdam-ignore: Design.OrphanExport: available for direct use; prefer buildWikiLinksReindexStatements for batches
 export async function reindexWikiLinks(
 	ctx: ServiceCtx,
 	orm: Orm,
@@ -478,7 +479,8 @@ export async function listBrokenWikiLinks(
 		// silently stop being reported as broken.
 		or(
 			isNull(schema.wikiLinks.targetPageId),
-			sql`EXISTS (SELECT 1 FROM wiki_pages tp WHERE tp.id = ${schema.wikiLinks.targetPageId} AND tp.deleted_at IS NOT NULL)`
+			sql`EXISTS (SELECT 1 FROM wiki_pages tp WHERE tp.id = ${schema.wikiLinks.targetPageId}
+				AND tp.deleted_at IS NOT NULL)`
 		),
 		// PROJ-496: a trashed source page's broken links aren't a maintenance concern
 		// anymore — they'll be purged along with the page.

--- a/apps/api/src/services/wiki-watchers.ts
+++ b/apps/api/src/services/wiki-watchers.ts
@@ -620,28 +620,26 @@ export async function listWikiChanges(
 		return visible;
 	};
 
-	let nextSince = since;
-	const events: WikiChangeEvent[] = [];
-	for (const r of batch) {
-		if (r.createdAt > nextSince) nextSince = r.createdAt;
+	// Resolves one activity row to an event, or null if it should be dropped (stale
+	// trash-shadowed row, wrong project, or not visible to the caller). Extracted from
+	// the loop below to keep listWikiChanges's own complexity/length down.
+	const toEvent = async (r: (typeof batch)[number]): Promise<WikiChangeEvent | null> => {
 		const action = r.action as "created" | "updated" | "deleted";
 		// PROJ-496: a "created"/"updated" event for a page that's now trashed is stale —
 		// the page itself is excluded from every other read path, so the delta feed drops
 		// it too rather than pointing an agent at a page get_wiki_page will 404 on. The
 		// "deleted" event for that same trash action is NOT dropped (below): it's the one
 		// event that's supposed to report the page went away.
-		if (action !== "deleted" && r.pageDeletedAt !== null && r.pageDeletedAt !== undefined) continue;
+		if (action !== "deleted" && r.pageDeletedAt !== null && r.pageDeletedAt !== undefined) return null;
 		const deleted = action === "deleted" ? extractDeletedPageInfo(r.diff) : null;
 		const slug = deleted ? deleted.slug : r.pageSlug;
 		const title = deleted ? deleted.title : r.pageTitle;
 		const eventProjectId = deleted ? deleted.projectId : r.pageProjectId;
 
-		if (projectId && eventProjectId !== projectId) continue;
-		if (!projectId && eventProjectId !== null && !(await canSeeProject(eventProjectId))) {
-			continue;
-		}
+		if (projectId && eventProjectId !== projectId) return null;
+		if (!projectId && eventProjectId !== null && !(await canSeeProject(eventProjectId))) return null;
 
-		events.push({
+		return {
 			id: r.id,
 			action,
 			pageId: r.entityId,
@@ -652,7 +650,15 @@ export async function listWikiChanges(
 			createdAt: r.createdAt,
 			deletedPageIds: deleted?.deletedPageIds ?? null,
 			deletedPageIdsTruncated: deleted?.deletedPageIdsTruncated ?? false,
-		});
+		};
+	};
+
+	let nextSince = since;
+	const events: WikiChangeEvent[] = [];
+	for (const r of batch) {
+		if (r.createdAt > nextSince) nextSince = r.createdAt;
+		const event = await toEvent(r);
+		if (event) events.push(event);
 	}
 
 	if (watchedOnly) {

--- a/apps/api/src/services/wiki-watchers.ts
+++ b/apps/api/src/services/wiki-watchers.ts
@@ -210,13 +210,13 @@ const ACTION_LABEL: Record<"created" | "updated" | "deleted", string> = {
 // their own change.
 export async function notifyWikiWatchers(
 	ctx: ServiceCtx,
-	opts: {
+	opts: Readonly<{
 		pageId: string;
 		parentId: string | null;
 		slug: string;
 		title: string;
 		action: "created" | "updated" | "deleted";
-	}
+	}>
 ): Promise<void> {
 	const ancestorIds = await resolveAncestorChain(
 		ctx.db,
@@ -255,7 +255,7 @@ export async function notifyWikiWatchers(
 async function insertNotifications(
 	ctx: ServiceCtx,
 	orm: Orm,
-	entries: {
+	entries: readonly {
 		userId: string;
 		pageId: string;
 		slug: string;
@@ -301,7 +301,7 @@ async function insertNotifications(
 // side — otherwise they'd get a "deleted" event with no matching "restored" one.
 export async function notifyCascadeDescendantWatchers(
 	ctx: ServiceCtx,
-	descendants: { id: string; slug: string; title: string; isTemplate: boolean }[],
+	descendants: readonly { id: string; slug: string; title: string; isTemplate: boolean }[],
 	action: "created" | "updated" | "deleted" = "deleted"
 ): Promise<void> {
 	const pages = descendants.filter((p) => !p.isTemplate);
@@ -630,14 +630,16 @@ export async function listWikiChanges(
 		// it too rather than pointing an agent at a page get_wiki_page will 404 on. The
 		// "deleted" event for that same trash action is NOT dropped (below): it's the one
 		// event that's supposed to report the page went away.
-		if (action !== "deleted" && r.pageDeletedAt !== null && r.pageDeletedAt !== undefined) return null;
+		if (action !== "deleted" && r.pageDeletedAt !== null && r.pageDeletedAt !== undefined)
+			return null;
 		const deleted = action === "deleted" ? extractDeletedPageInfo(r.diff) : null;
 		const slug = deleted ? deleted.slug : r.pageSlug;
 		const title = deleted ? deleted.title : r.pageTitle;
 		const eventProjectId = deleted ? deleted.projectId : r.pageProjectId;
 
 		if (projectId && eventProjectId !== projectId) return null;
-		if (!projectId && eventProjectId !== null && !(await canSeeProject(eventProjectId))) return null;
+		if (!projectId && eventProjectId !== null && !(await canSeeProject(eventProjectId)))
+			return null;
 
 		return {
 			id: r.id,

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -1117,6 +1117,96 @@ async function deleteWikiFtsEntries(ctx: ServiceCtx, pageIds: string[]): Promise
 	});
 }
 
+// Builds the batch of statements for a single updateWikiPage call — content revision
+// snapshot, the page row update itself, FTS/link reindex, and the redirect upsert on
+// rename. Extracted from updateWikiPage to keep that function's own complexity/length
+// down; behavior (including the PROJ-511 atomicity guarantee — all of this lands in one
+// ctx.db.batch() call in the caller) is unchanged.
+function buildUpdateWikiPageStatements(
+	ctx: ServiceCtx,
+	orm: ReturnType<typeof drizzle>,
+	page: Awaited<ReturnType<typeof resolvePageByIdOrSlug>>,
+	now: number,
+	isRename: boolean,
+	meta: ReturnType<typeof parseWikiFrontmatter> | undefined,
+	fields: {
+		title?: string;
+		content?: string;
+		parentId?: string | null;
+		slug?: string;
+		summary?: string;
+	}
+): D1PreparedStatement[] {
+	const { title, content, parentId, slug, summary } = fields;
+	const statements: D1PreparedStatement[] = [];
+
+	if (content !== undefined) {
+		// PROJ-484: title snapshot is the page's title as of THIS revision (i.e. before
+		// this update applies any new title) — consistent with content, which snapshots
+		// the pre-edit value too. summary is this edit's optional changelog note.
+		statements.push(
+			toD1Statement(
+				ctx,
+				orm
+					.insert(schema.wikiRevisions)
+					.values({
+						id: crypto.randomUUID(),
+						pageId: page.id,
+						content: page.content,
+						title: page.title,
+						summary: summary ?? null,
+						authorId: ctx.userId,
+						createdAt: now,
+					})
+					.toSQL()
+			)
+		);
+	}
+
+	const setData = buildWikiPageUpdateSet(now, ctx.userId, { title, content, parentId, slug, meta });
+	statements.push(
+		toD1Statement(
+			ctx,
+			orm
+				.update(schema.wikiPages)
+				// biome-ignore lint/suspicious/noExplicitAny: Drizzle set() requires typed columns; setData is safe
+				.set(setData as any)
+				.where(eq(schema.wikiPages.id, page.id))
+				.toSQL()
+		)
+	);
+
+	// FTS and link-graph reindex statements are built separately by the caller (both need
+	// an async lookup — current tags / link-target resolution — before their statements
+	// exist) and concatenated onto this array; see updateWikiPage.
+
+	if (isRename) {
+		// Upsert: the old slug may already carry a stale redirect from an earlier rename
+		// of some other page — this rename takes ownership of it.
+		statements.push(
+			toD1Statement(
+				ctx,
+				orm
+					.insert(schema.wikiRedirects)
+					.values({
+						id: crypto.randomUUID(),
+						workspaceId: ctx.workspaceId,
+						oldSlug: page.slug,
+						pageId: page.id,
+						createdAt: now,
+					})
+					.onConflictDoUpdate({
+						target: [schema.wikiRedirects.workspaceId, schema.wikiRedirects.oldSlug],
+						set: { pageId: page.id, createdAt: now },
+					})
+					.toSQL()
+			)
+		);
+	}
+
+	return statements;
+}
+
 export async function updateWikiPage(ctx: ServiceCtx, idOrSlug: string, input: unknown) {
 	const parsed = UpdatePageSchema.safeParse(input);
 	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
@@ -1180,43 +1270,13 @@ export async function updateWikiPage(ctx: ServiceCtx, idOrSlug: string, input: u
 	// resolution work above (frontmatter parse, link-target resolution inside
 	// buildWikiLinksReindexStatements) happens before any of these exist, so it can no
 	// longer leave the page updated with a stale/wiped links or FTS row.
-	const statements: D1PreparedStatement[] = [];
-
-	if (content !== undefined) {
-		// PROJ-484: title snapshot is the page's title as of THIS revision (i.e. before
-		// this update applies any new title) — consistent with content, which snapshots
-		// the pre-edit value too. summary is this edit's optional changelog note.
-		statements.push(
-			toD1Statement(
-				ctx,
-				orm
-					.insert(schema.wikiRevisions)
-					.values({
-						id: crypto.randomUUID(),
-						pageId: page.id,
-						content: page.content,
-						title: page.title,
-						summary: summary ?? null,
-						authorId: ctx.userId,
-						createdAt: now,
-					})
-					.toSQL()
-			)
-		);
-	}
-
-	const setData = buildWikiPageUpdateSet(now, ctx.userId, { title, content, parentId, slug, meta });
-	statements.push(
-		toD1Statement(
-			ctx,
-			orm
-				.update(schema.wikiPages)
-				// biome-ignore lint/suspicious/noExplicitAny: Drizzle set() requires typed columns; setData is safe
-				.set(setData as any)
-				.where(eq(schema.wikiPages.id, page.id))
-				.toSQL()
-		)
-	);
+	const statements = buildUpdateWikiPageStatements(ctx, orm, page, now, isRename, meta, {
+		title,
+		content,
+		parentId,
+		slug,
+		summary,
+	});
 
 	// PROJ-486/PROJ-520: only reindexed when title or content actually changed — a
 	// parentId/slug-only update leaves the FTS mirror row untouched, matching the old
@@ -1231,30 +1291,6 @@ export async function updateWikiPage(ctx: ServiceCtx, idOrSlug: string, input: u
 	// update leaves them unchanged, so only reindex when content actually changed.
 	if (content !== undefined) {
 		statements.push(...(await buildWikiLinksReindexStatements(ctx, orm, page.id, content)));
-	}
-
-	if (isRename) {
-		// Upsert: the old slug may already carry a stale redirect from an earlier rename
-		// of some other page — this rename takes ownership of it.
-		statements.push(
-			toD1Statement(
-				ctx,
-				orm
-					.insert(schema.wikiRedirects)
-					.values({
-						id: crypto.randomUUID(),
-						workspaceId: ctx.workspaceId,
-						oldSlug: page.slug,
-						pageId: page.id,
-						createdAt: now,
-					})
-					.onConflictDoUpdate({
-						target: [schema.wikiRedirects.workspaceId, schema.wikiRedirects.oldSlug],
-						set: { pageId: page.id, createdAt: now },
-					})
-					.toSQL()
-			)
-		);
 	}
 
 	try {

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -278,7 +278,7 @@ async function validateUpdatedPageParent(
 	db: D1Database,
 	parentId: string,
 	workspaceId: string,
-	page: { id: string; projectId: string | null }
+	page: Readonly<{ id: string; projectId: string | null }>
 ): Promise<void> {
 	const orm = drizzle(db, { schema });
 	const parentPage = await orm
@@ -311,13 +311,13 @@ async function validateUpdatedPageParent(
 function buildWikiPageUpdateSet(
 	now: number,
 	updatedById: string,
-	fields: {
+	fields: Readonly<{
 		title?: string;
 		content?: string;
 		parentId?: string | null;
 		slug?: string;
 		meta?: WikiFrontmatterMeta;
-	}
+	}>
 ): Record<string, unknown> {
 	const setData: Record<string, unknown> = { updatedAt: now, updatedById };
 	if (fields.title !== undefined) setData.title = fields.title;
@@ -339,10 +339,12 @@ function buildWikiPageUpdateSet(
 	return setData;
 }
 
-function buildWikiPageUpdateDiff(fields: {
-	title?: string;
-	content?: string;
-}): Record<string, unknown> {
+function buildWikiPageUpdateDiff(
+	fields: Readonly<{
+		title?: string;
+		content?: string;
+	}>
+): Record<string, unknown> {
 	const diff: Record<string, unknown> = {};
 	if (fields.title !== undefined) diff.title = fields.title;
 	if (fields.content !== undefined) diff.content = fields.content;
@@ -354,7 +356,7 @@ function buildWikiPageUpdateDiff(fields: {
 // way to query into a JSON array column without denormalizing it into its own table;
 // `tags` has no direct index (see 0045_wiki_frontmatter.sql), so this is a per-row
 // scan, acceptable at current wiki sizes — revisit with a join table if it becomes hot.
-function tagsFilterCondition(tags: string[]) {
+function tagsFilterCondition(tags: readonly string[]) {
 	if (tags.length === 0) return undefined;
 	return sql`EXISTS (SELECT 1 FROM json_each(${schema.wikiPages.tags}) WHERE value IN (${sql.join(
 		tags.map((t) => sql`${t}`),
@@ -936,7 +938,7 @@ const MAX_DIFF_CELLS = 1_000_000;
 
 type DiffOp = { type: "equal" | "add" | "remove"; line: string };
 
-function computeLineDiff(oldLines: string[], newLines: string[]): DiffOp[] {
+function computeLineDiff(oldLines: readonly string[], newLines: readonly string[]): DiffOp[] {
 	const n = oldLines.length;
 	const m = newLines.length;
 	if (n * m > MAX_DIFF_CELLS) {
@@ -1041,7 +1043,7 @@ export function buildUnifiedDiff(baseContent: string, currentContent: string): s
 // D1PreparedStatement, not drizzle's own query builders.
 function toD1Statement(
 	ctx: ServiceCtx,
-	query: { sql: string; params: unknown[] }
+	query: Readonly<{ sql: string; params: unknown[] }>
 ): D1PreparedStatement {
 	return ctx.db.prepare(query.sql).bind(...query.params);
 }
@@ -1055,7 +1057,7 @@ function buildFtsInsertStatement(
 	id: string,
 	title: string,
 	content: string,
-	tags: string[]
+	tags: readonly string[]
 ): D1PreparedStatement {
 	// PROJ-488: tags is space-joined — wiki_fts's default unicode61 tokenizer splits on
 	// non-alphanumeric, so a comma join would tokenize identically, but space matches how
@@ -1129,13 +1131,13 @@ function buildUpdateWikiPageStatements(
 	now: number,
 	isRename: boolean,
 	meta: ReturnType<typeof parseWikiFrontmatter> | undefined,
-	fields: {
+	fields: Readonly<{
 		title?: string;
 		content?: string;
 		parentId?: string | null;
 		slug?: string;
 		summary?: string;
-	}
+	}>
 ): D1PreparedStatement[] {
 	const { title, content, parentId, slug, summary } = fields;
 	const statements: D1PreparedStatement[] = [];
@@ -1507,7 +1509,7 @@ function parseHeadingSections(content: string): HeadingSection[] {
 	}));
 }
 
-function findSections(sections: HeadingSection[], heading: string): HeadingSection[] {
+function findSections(sections: readonly HeadingSection[], heading: string): HeadingSection[] {
 	const target = heading.trim();
 	return sections.filter((s) => s.heading === target);
 }
@@ -1516,13 +1518,13 @@ function extractSectionText(content: string, section: HeadingSection): string {
 	return content.split("\n").slice(section.startLine, section.endLine).join("\n");
 }
 
-function trimTrailingBlankLines(lines: string[]): string[] {
+function trimTrailingBlankLines(lines: readonly string[]): string[] {
 	const out = [...lines];
 	while (out.length > 0 && out[out.length - 1].trim() === "") out.pop();
 	return out;
 }
 
-function trimLeadingBlankLines(lines: string[]): string[] {
+function trimLeadingBlankLines(lines: readonly string[]): string[] {
 	const out = [...lines];
 	while (out.length > 0 && out[0].trim() === "") out.shift();
 	return out;

--- a/apps/api/src/services/workspaces.ts
+++ b/apps/api/src/services/workspaces.ts
@@ -70,7 +70,7 @@ export async function createWorkspace(db: D1Database, userId: string, input: unk
 
 export async function getWorkspaceWithMembers(
 	ctx: ServiceCtx,
-	workspace: { id: string; name: string; slug: string }
+	workspace: Readonly<{ id: string; name: string; slug: string }>
 ) {
 	const orm = drizzle(ctx.db, { schema });
 	const members = await orm
@@ -310,7 +310,7 @@ export async function deleteWorkspace(
 
 export async function getWorkspaceMcpInfo(
 	_ctx: ServiceCtx,
-	workspace: { id: string; slug: string },
+	workspace: Readonly<{ id: string; slug: string }>,
 	origin: string
 ): Promise<{
 	mcpUrl: string;

--- a/apps/api/src/test/auth.test.ts
+++ b/apps/api/src/test/auth.test.ts
@@ -364,7 +364,7 @@ describe("PROJ-354: CF Access auth caches are isolate-local", () => {
 // ---------------------------------------------------------------------------
 
 describe("PROJ-358: JWKS force-refresh on signature verification failure", () => {
-	it("token signed by an uncached key authenticates via forced refresh; a further bad signature within the cooldown does not refetch again", async () => {
+	it("uncached-key token authenticates via forced refresh; bad sig within cooldown doesn't refetch again", async () => {
 		const genKeyPair = () =>
 			crypto.subtle.generateKey(
 				{

--- a/apps/api/src/test/code-heatmap.test.ts
+++ b/apps/api/src/test/code-heatmap.test.ts
@@ -48,7 +48,8 @@ describe("Code heatmap (PROJ-332)", () => {
 	// distinct.
 	async function seedClaim(issueId: string, path: string, claimedAt: number, releasedAt?: number) {
 		await env.DB.prepare(
-			"INSERT INTO issue_file_claims (id, workspace_id, issue_id, agent_id, path, claimed_at, released_at) VALUES (?, ?, ?, NULL, ?, ?, ?)"
+			"INSERT INTO issue_file_claims (id, workspace_id, issue_id, agent_id, path, claimed_at, " +
+				"released_at) VALUES (?, ?, ?, NULL, ?, ?, ?)"
 		)
 			.bind(crypto.randomUUID(), workspaceId, issueId, path, claimedAt, releasedAt ?? null)
 			.run();
@@ -62,7 +63,8 @@ describe("Code heatmap (PROJ-332)", () => {
 		forced = 0
 	) {
 		await env.DB.prepare(
-			"INSERT INTO claim_conflicts (id, workspace_id, path, rejected_issue_id, rejected_agent_id, holding_issue_id, holding_agent_id, forced, occurred_at) VALUES (?, ?, ?, ?, NULL, ?, NULL, ?, ?)"
+			"INSERT INTO claim_conflicts (id, workspace_id, path, rejected_issue_id, rejected_agent_id, " +
+				"holding_issue_id, holding_agent_id, forced, occurred_at) VALUES (?, ?, ?, ?, NULL, ?, NULL, ?, ?)"
 		)
 			.bind(
 				crypto.randomUUID(),

--- a/apps/api/src/test/feedback-bulk.test.ts
+++ b/apps/api/src/test/feedback-bulk.test.ts
@@ -29,7 +29,8 @@ async function seedFeedbackRow(
 	const id = crypto.randomUUID();
 	await env.DB.prepare(
 		`INSERT INTO feedback
-       (id, source_id, workspace_id, project_id, rating, rating_scale, body, submitter_label, status, linked_issue_id, created_at)
+       (id, source_id, workspace_id, project_id, rating, rating_scale, body, submitter_label,
+        status, linked_issue_id, created_at)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	)
 		.bind(

--- a/apps/api/src/test/feedback-bulk.test.ts
+++ b/apps/api/src/test/feedback-bulk.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { authHeaders, seedIssue, seedProjectFixture } from "./helpers";
 
 async function mintSource(
-	f: { projectId: string; token: string; slug: string },
+	f: Readonly<{ projectId: string; token: string; slug: string }>,
 	body: Record<string, unknown> = { name: "Widget" }
 ): Promise<void> {
 	await SELF.fetch(`http://localhost/api/projects/${f.projectId}/feedback-sources`, {
@@ -17,14 +17,14 @@ async function seedFeedbackRow(
 	sourceId: string,
 	workspaceId: string,
 	projectId: string,
-	opts: {
+	opts: Readonly<{
 		rating?: number;
 		ratingScale?: string;
 		body?: string;
 		submitterLabel?: string;
 		status?: string;
 		linkedIssueId?: string;
-	} = {}
+	}> = {}
 ): Promise<string> {
 	const id = crypto.randomUUID();
 	await env.DB.prepare(

--- a/apps/api/src/test/feedback-summary.test.ts
+++ b/apps/api/src/test/feedback-summary.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { authHeaders, seedProjectFixture } from "./helpers";
 
 async function mintSource(
-	f: { projectId: string; token: string; slug: string },
+	f: Readonly<{ projectId: string; token: string; slug: string }>,
 	body: Record<string, unknown> = { name: "Widget" }
 ): Promise<string> {
 	const res = await SELF.fetch(`http://localhost/api/projects/${f.projectId}/feedback-sources`, {
@@ -18,13 +18,13 @@ async function seedFeedbackRow(
 	sourceId: string,
 	workspaceId: string,
 	projectId: string,
-	opts: {
+	opts: Readonly<{
 		rating?: number;
 		ratingScale?: string;
 		body?: string;
 		appVersion?: string;
 		createdAt?: number;
-	} = {}
+	}> = {}
 ): Promise<string> {
 	const id = crypto.randomUUID();
 	const now = opts.createdAt ?? Math.floor(Date.now() / 1000);

--- a/apps/api/src/test/feedback.test.ts
+++ b/apps/api/src/test/feedback.test.ts
@@ -859,7 +859,9 @@ describe("PROJ-390: cross-project feedback source mutation is rejected", () => {
 });
 
 describe("PROJ-390: mutating a revoked feedback source", () => {
-	async function seedRevokedSource(f: Readonly<{ projectId: string; token: string; slug: string }>) {
+	async function seedRevokedSource(
+		f: Readonly<{ projectId: string; token: string; slug: string }>
+	) {
 		const created = await SELF.fetch(
 			`http://localhost/api/projects/${f.projectId}/feedback-sources`,
 			{

--- a/apps/api/src/test/feedback.test.ts
+++ b/apps/api/src/test/feedback.test.ts
@@ -132,7 +132,7 @@ describe("Feedback sources REST", () => {
 });
 
 async function mintSource(
-	f: { projectId: string; token: string; slug: string },
+	f: Readonly<{ projectId: string; token: string; slug: string }>,
 	body: Record<string, unknown> = { name: "Widget" }
 ): Promise<string> {
 	const res = await SELF.fetch(`http://localhost/api/projects/${f.projectId}/feedback-sources`, {
@@ -322,7 +322,7 @@ async function seedFeedbackRow(
 	sourceId: string,
 	workspaceId: string,
 	projectId: string,
-	opts: { body?: string; status?: string } = {}
+	opts: Readonly<{ body?: string; status?: string }> = {}
 ): Promise<string> {
 	const id = crypto.randomUUID();
 	const now = Math.floor(Date.now() / 1000);
@@ -859,7 +859,7 @@ describe("PROJ-390: cross-project feedback source mutation is rejected", () => {
 });
 
 describe("PROJ-390: mutating a revoked feedback source", () => {
-	async function seedRevokedSource(f: { projectId: string; token: string; slug: string }) {
+	async function seedRevokedSource(f: Readonly<{ projectId: string; token: string; slug: string }>) {
 		const created = await SELF.fetch(
 			`http://localhost/api/projects/${f.projectId}/feedback-sources`,
 			{

--- a/apps/api/src/test/flow-metrics.test.ts
+++ b/apps/api/src/test/flow-metrics.test.ts
@@ -870,7 +870,8 @@ describe("Factory health tiles (PROJ-334)", () => {
 	) {
 		const now = Math.floor(Date.now() / 1000);
 		await env.DB.prepare(
-			"INSERT INTO issue_file_claims (id, workspace_id, issue_id, agent_id, path, claimed_at, released_at, release_reason) VALUES (?, ?, ?, NULL, ?, ?, ?, ?)"
+			"INSERT INTO issue_file_claims (id, workspace_id, issue_id, agent_id, path, claimed_at, " +
+				"released_at, release_reason) VALUES (?, ?, ?, NULL, ?, ?, ?, ?)"
 		)
 			.bind(
 				crypto.randomUUID(),
@@ -894,7 +895,8 @@ describe("Factory health tiles (PROJ-334)", () => {
 
 	async function seedWipCapDenial(project: string, issueId: string, occurredAt: number) {
 		await env.DB.prepare(
-			"INSERT INTO wip_cap_denials (id, workspace_id, project_id, issue_id, agent_session_id, occurred_at) VALUES (?, ?, ?, ?, NULL, ?)"
+			"INSERT INTO wip_cap_denials (id, workspace_id, project_id, issue_id, agent_session_id, " +
+				"occurred_at) VALUES (?, ?, ?, ?, NULL, ?)"
 		)
 			.bind(crypto.randomUUID(), workspaceId, project, issueId, occurredAt)
 			.run();

--- a/apps/api/src/test/helpers.ts
+++ b/apps/api/src/test/helpers.ts
@@ -37,7 +37,7 @@ export async function seedMember(workspaceId: string, userId: string, role = "me
 export async function seedToken(
 	workspaceId: string,
 	userId: string,
-	opts?: { scopes?: string[]; expiresAt?: number }
+	opts?: Readonly<{ scopes?: string[]; expiresAt?: number }>
 ): Promise<string> {
 	const raw = `tok_${crypto.randomUUID().replace(/-/g, "")}`;
 	const hash = await hashToken(raw);
@@ -63,7 +63,7 @@ export async function seedToken(
 /** Seed a user-scoped token (NULL workspace_id — valid across all the user's workspaces). */
 export async function seedUserToken(
 	userId: string,
-	opts?: { scopes?: string[]; expiresAt?: number }
+	opts?: Readonly<{ scopes?: string[]; expiresAt?: number }>
 ): Promise<string> {
 	const raw = `tok_${crypto.randomUUID().replace(/-/g, "")}`;
 	const hash = await hashToken(raw);
@@ -155,7 +155,7 @@ export async function seedComment(
 
 export async function seedTaskType(
 	workspaceId: string,
-	opts?: { id?: string; key?: string; name?: string; isDefault?: boolean; position?: number }
+	opts?: Readonly<{ id?: string; key?: string; name?: string; isDefault?: boolean; position?: number }>
 ) {
 	const id = opts?.id ?? crypto.randomUUID();
 	const key = opts?.key ?? `type-${id.slice(0, 8)}`;
@@ -170,7 +170,7 @@ export async function seedTaskType(
 
 export async function seedTaskStatus(
 	workspaceId: string,
-	opts?: { key?: string; name?: string; category?: string; isDefault?: boolean; position?: number }
+	opts?: Readonly<{ key?: string; name?: string; category?: string; isDefault?: boolean; position?: number }>
 ) {
 	const id = crypto.randomUUID();
 	const key = opts?.key ?? `status-${id.slice(0, 8)}`;
@@ -195,7 +195,7 @@ export async function seedIssue(
 	workspaceId: string,
 	projectId: string,
 	createdById: string,
-	opts?: {
+	opts?: Readonly<{
 		title?: string;
 		status?: string;
 		statusId?: string;
@@ -204,7 +204,7 @@ export async function seedIssue(
 		parentId?: string;
 		typeId?: string;
 		createdAt?: number;
-	}
+	}>
 ) {
 	const id = crypto.randomUUID();
 	const now = opts?.createdAt ?? Math.floor(Date.now() / 1000);
@@ -244,13 +244,13 @@ export async function seedIssue(
 
 export async function seedCustomFieldDef(
 	workspaceId: string,
-	opts: {
+	opts: Readonly<{
 		key: string;
 		label?: string;
 		type?: string;
 		options?: string[];
 		projectId?: string | null;
-	}
+	}>
 ) {
 	const id = crypto.randomUUID();
 	const now = Math.floor(Date.now() / 1000);
@@ -290,7 +290,7 @@ export async function seedCustomFieldValue(issueId: string, fieldId: string, val
 export async function seedAgentLease(
 	workspaceId: string,
 	issueId: string,
-	opts?: { kind?: "agent" | "human"; live?: boolean; name?: string }
+	opts?: Readonly<{ kind?: "agent" | "human"; live?: boolean; name?: string }>
 ): Promise<{ agentSessionId: string; leaseId: string }> {
 	const now = Math.floor(Date.now() / 1000);
 	const live = opts?.live ?? true;
@@ -331,7 +331,7 @@ export async function seedAgentLease(
 }
 
 /** Seed a complete workspace + user + member + token in one call */
-export async function seedFixture(opts?: { slug?: string; email?: string; role?: string }) {
+export async function seedFixture(opts?: Readonly<{ slug?: string; email?: string; role?: string }>) {
 	const workspace = await seedWorkspace(opts?.slug ?? `ws-${crypto.randomUUID().slice(0, 8)}`);
 	const user = await seedUser(opts?.email ?? `u-${crypto.randomUUID().slice(0, 8)}@example.com`);
 	await seedMember(workspace.id, user.id, opts?.role ?? "member");
@@ -340,7 +340,7 @@ export async function seedFixture(opts?: { slug?: string; email?: string; role?:
 }
 
 /** Seed a workspace fixture plus a project in it — the common `beforeEach` shape across API tests. */
-export async function seedProjectFixture(opts?: { role?: string }) {
+export async function seedProjectFixture(opts?: Readonly<{ role?: string }>) {
 	const fixture = await seedFixture({ role: opts?.role });
 	const project = await seedProject(fixture.workspace.id);
 	// PROJ-311: access is default-deny, so a non-admin fixture would otherwise see
@@ -360,7 +360,7 @@ export async function seedProjectFixture(opts?: { role?: string }) {
 }
 
 /** Seed a project fixture plus an issue in it. */
-export async function seedIssueFixture(opts?: { role?: string; issueTitle?: string }) {
+export async function seedIssueFixture(opts?: Readonly<{ role?: string; issueTitle?: string }>) {
 	const base = await seedProjectFixture({ role: opts?.role });
 	const issue = await seedIssue(base.workspaceId, base.projectId, base.userId, {
 		title: opts?.issueTitle ?? "Test Issue",

--- a/apps/api/src/test/helpers.ts
+++ b/apps/api/src/test/helpers.ts
@@ -146,7 +146,8 @@ export async function seedComment(
 	const id = crypto.randomUUID();
 	const now = Math.floor(Date.now() / 1000);
 	await env.DB.prepare(
-		"INSERT INTO issue_comments (id, issue_id, author_id, body, created_at, updated_at, author_kind) VALUES (?, ?, ?, ?, ?, ?, ?)"
+		"INSERT INTO issue_comments (id, issue_id, author_id, body, created_at, updated_at, " +
+			"author_kind) VALUES (?, ?, ?, ?, ?, ?, ?)"
 	)
 		.bind(id, issueId, authorId, body, now, now, authorKind ?? null)
 		.run();
@@ -155,7 +156,13 @@ export async function seedComment(
 
 export async function seedTaskType(
 	workspaceId: string,
-	opts?: Readonly<{ id?: string; key?: string; name?: string; isDefault?: boolean; position?: number }>
+	opts?: Readonly<{
+		id?: string;
+		key?: string;
+		name?: string;
+		isDefault?: boolean;
+		position?: number;
+	}>
 ) {
 	const id = opts?.id ?? crypto.randomUUID();
 	const key = opts?.key ?? `type-${id.slice(0, 8)}`;
@@ -170,7 +177,13 @@ export async function seedTaskType(
 
 export async function seedTaskStatus(
 	workspaceId: string,
-	opts?: Readonly<{ key?: string; name?: string; category?: string; isDefault?: boolean; position?: number }>
+	opts?: Readonly<{
+		key?: string;
+		name?: string;
+		category?: string;
+		isDefault?: boolean;
+		position?: number;
+	}>
 ) {
 	const id = crypto.randomUUID();
 	const key = opts?.key ?? `status-${id.slice(0, 8)}`;
@@ -331,7 +344,9 @@ export async function seedAgentLease(
 }
 
 /** Seed a complete workspace + user + member + token in one call */
-export async function seedFixture(opts?: Readonly<{ slug?: string; email?: string; role?: string }>) {
+export async function seedFixture(
+	opts?: Readonly<{ slug?: string; email?: string; role?: string }>
+) {
 	const workspace = await seedWorkspace(opts?.slug ?? `ws-${crypto.randomUUID().slice(0, 8)}`);
 	const user = await seedUser(opts?.email ?? `u-${crypto.randomUUID().slice(0, 8)}@example.com`);
 	await seedMember(workspace.id, user.id, opts?.role ?? "member");

--- a/apps/api/src/test/migration-0050.test.ts
+++ b/apps/api/src/test/migration-0050.test.ts
@@ -26,7 +26,8 @@ async function runMigration0050() {
 async function insertPage(workspaceId: string, userId: string, slug: string, createdAt: number) {
 	const id = crypto.randomUUID();
 	await env.DB.prepare(
-		`INSERT INTO wiki_pages (id, workspace_id, project_id, slug, title, content, parent_id, created_by_id, updated_by_id, created_at, updated_at)
+		`INSERT INTO wiki_pages (id, workspace_id, project_id, slug, title, content,
+		 parent_id, created_by_id, updated_by_id, created_at, updated_at)
 		 VALUES (?, ?, NULL, ?, ?, ?, NULL, ?, ?, ?, ?)`
 	)
 		.bind(id, workspaceId, slug, slug, "content", userId, userId, createdAt, createdAt)
@@ -113,7 +114,7 @@ describe("0050 wiki slug slash backfill", () => {
 		expect(redirect?.page_id).toBe(pageId);
 	});
 
-	it("truncates an oversized rewritten candidate before appending the id suffix so it never exceeds 200 chars", async () => {
+	it("truncates an oversized rewritten candidate before appending the id suffix, staying under 200 chars", async () => {
 		const now = Math.floor(Date.now() / 1000);
 		const candidate = `${"b".repeat(120)}-${"c".repeat(120)}`; // 241 chars
 		const slashy = `${"b".repeat(120)}/${"c".repeat(120)}`; // same length, collides once rewritten

--- a/apps/api/src/test/project-activity.test.ts
+++ b/apps/api/src/test/project-activity.test.ts
@@ -36,7 +36,7 @@ function parseEvents(res: JsonRpcResult<McpContent> | JsonRpcError): unknown[] {
 async function seedSprint(
 	workspaceId: string,
 	projectId: string,
-	opts: { name?: string; status?: string; startDate?: number; endDate?: number } = {}
+	opts: Readonly<{ name?: string; status?: string; startDate?: number; endDate?: number }> = {}
 ) {
 	const id = crypto.randomUUID();
 	const now = Math.floor(Date.now() / 1000);
@@ -63,7 +63,7 @@ async function seedWikiPage(
 	workspaceId: string,
 	projectId: string,
 	authorId: string,
-	opts: { title?: string; slug?: string; updatedAt?: number; deletedAt?: number } = {}
+	opts: Readonly<{ title?: string; slug?: string; updatedAt?: number; deletedAt?: number }> = {}
 ) {
 	const id = crypto.randomUUID();
 	const now = Math.floor(Date.now() / 1000);

--- a/apps/api/src/test/share.test.ts
+++ b/apps/api/src/test/share.test.ts
@@ -142,13 +142,14 @@ describe("Share tokens", () => {
 		expect(res.status).toBe(403);
 	});
 
-	it("PROJ-241: excludes internal custom fields and includes non-internal ones from the public share payload", async () => {
+	it("PROJ-241: public share payload excludes internal custom fields, includes non-internal ones", async () => {
 		const { env } = await import("cloudflare:test");
 		const now = Math.floor(Date.now() / 1000);
 
 		const internalFieldId = crypto.randomUUID();
 		await env.DB.prepare(
-			"INSERT INTO custom_field_definitions (id, workspace_id, project_id, key, label, type, options, created_at, is_internal) VALUES (?, ?, NULL, ?, ?, 'text', NULL, ?, 1)"
+			"INSERT INTO custom_field_definitions (id, workspace_id, project_id, key, label, type, " +
+				"options, created_at, is_internal) VALUES (?, ?, NULL, ?, ?, 'text', NULL, ?, 1)"
 		)
 			.bind(internalFieldId, workspaceId, "secret_notes", "Secret Notes", now)
 			.run();
@@ -160,7 +161,8 @@ describe("Share tokens", () => {
 
 		const publicFieldId = crypto.randomUUID();
 		await env.DB.prepare(
-			"INSERT INTO custom_field_definitions (id, workspace_id, project_id, key, label, type, options, created_at, is_internal) VALUES (?, ?, NULL, ?, ?, 'text', NULL, ?, 0)"
+			"INSERT INTO custom_field_definitions (id, workspace_id, project_id, key, label, type, " +
+				"options, created_at, is_internal) VALUES (?, ?, NULL, ?, ?, 'text', NULL, ?, 0)"
 		)
 			.bind(publicFieldId, workspaceId, "public_note", "Public Note", now)
 			.run();

--- a/apps/api/src/test/sprints.test.ts
+++ b/apps/api/src/test/sprints.test.ts
@@ -364,7 +364,7 @@ describe("Sprints role guards", () => {
 		expect(completeRes.status).toBe(403);
 	});
 
-	it("PROJ-357: a member with write access only on the sprint's project cannot move an issue from a project they have no grant on", async () => {
+	it("PROJ-357: write access only on the sprint's project can't move an issue from an ungranted one", async () => {
 		const roles = await seedWorkspaceRoles();
 		const projectA = await seedProject(roles.workspace.id, "PJA");
 		const projectB = await seedProject(roles.workspace.id, "PJB");

--- a/apps/api/src/test/wiki-export.test.ts
+++ b/apps/api/src/test/wiki-export.test.ts
@@ -22,7 +22,8 @@ async function seedManyPages(
 	const now = Math.floor(Date.now() / 1000);
 	const statements = Array.from({ length: count }, (_, i) =>
 		env.DB.prepare(
-			`INSERT INTO wiki_pages (id, workspace_id, project_id, slug, title, content, parent_id, created_by_id, updated_by_id, created_at, updated_at)
+			`INSERT INTO wiki_pages (id, workspace_id, project_id, slug, title, content,
+			 parent_id, created_by_id, updated_by_id, created_at, updated_at)
 			 VALUES (?, ?, ?, ?, ?, '', NULL, ?, ?, ?, ?)`
 		).bind(
 			crypto.randomUUID(),
@@ -258,8 +259,10 @@ describe("Wiki export (PROJ-497)", () => {
 		// child's projectId from diverging from its parent's — writing directly via SQL
 		// simulates a regression of that write-time invariant.
 		await env.DB.prepare(
-			`INSERT INTO wiki_pages (id, workspace_id, project_id, slug, title, content, parent_id, created_by_id, updated_by_id, created_at, updated_at)
-			 VALUES (?, ?, NULL, ?, ?, ?, ?, (SELECT created_by_id FROM wiki_pages WHERE id = ?), (SELECT updated_by_id FROM wiki_pages WHERE id = ?), ?, ?)`
+			`INSERT INTO wiki_pages (id, workspace_id, project_id, slug, title, content,
+			 parent_id, created_by_id, updated_by_id, created_at, updated_at)
+			 VALUES (?, ?, NULL, ?, ?, ?, ?, (SELECT created_by_id FROM wiki_pages WHERE id = ?),
+				 (SELECT updated_by_id FROM wiki_pages WHERE id = ?), ?, ?)`
 		)
 			.bind(
 				mismatchedId,
@@ -299,7 +302,8 @@ describe("Wiki export (PROJ-497)", () => {
 		const now = Math.floor(Date.now() / 1000);
 		const statements = Array.from({ length: MAX_EXPORT_PAGES + 1 }, (_, i) =>
 			env.DB.prepare(
-				`INSERT INTO wiki_pages (id, workspace_id, project_id, slug, title, content, parent_id, created_by_id, updated_by_id, created_at, updated_at)
+				`INSERT INTO wiki_pages (id, workspace_id, project_id, slug, title, content,
+				 parent_id, created_by_id, updated_by_id, created_at, updated_at)
 				 VALUES (?, ?, NULL, ?, ?, '', ?, ?, ?, ?, ?)`
 			).bind(
 				crypto.randomUUID(),

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -5328,7 +5328,7 @@ describe("Wiki trash (PROJ-496)", () => {
 			headers: authHeaders(token, slug),
 		});
 		type TreeNode = { id: string; children: TreeNode[] };
-		const flatten = (nodes: TreeNode[]): string[] =>
+		const flatten = (nodes: readonly TreeNode[]): string[] =>
 			nodes.flatMap((n) => [n.id, ...flatten(n.children ?? [])]);
 		expect(flatten((await treeRes.json()) as TreeNode[])).not.toContain(page.id);
 

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -118,7 +118,7 @@ describe("Wiki API", () => {
 			expect(tree.find((p) => p.slug === "weekly-updates")?.url).toBe("/wiki/weekly-updates");
 		});
 
-		it("does not include projectId in the url when the page is scoped to a project (slugs are workspace-unique, PROJ-483)", async () => {
+		it("omits projectId from the url for a project-scoped page (slugs are workspace-unique, PROJ-483)", async () => {
 			const project = await seedProject(workspaceId);
 			await seedGroupGrant(workspaceId, userId, project.id);
 			const createRes = await SELF.fetch("http://localhost/api/wiki", {
@@ -877,7 +877,7 @@ describe("Wiki API", () => {
 		return { attachmentId: id, r2Key: row!.r2_key };
 	}
 
-	it("DELETE /api/wiki/:slug (default) trashes the page but leaves its R2 attachment in place until purge (PROJ-426/PROJ-496)", async () => {
+	it("DELETE :slug trashes the page, leaving its R2 attachment until purge (PROJ-426/496)", async () => {
 		const owner = await seedFixture({ role: "owner" });
 		const ownerHeaders = authHeaders(owner.token, owner.workspace.slug);
 
@@ -910,7 +910,7 @@ describe("Wiki API", () => {
 		expect(row).not.toBeNull();
 	});
 
-	it("DELETE /api/wiki/:slug?cascade=true trashes the subtree but leaves R2 attachments in place until purge (PROJ-426/PROJ-496)", async () => {
+	it("DELETE ?cascade=true trashes the subtree, leaving R2 attachments until purge (PROJ-426/496)", async () => {
 		const owner = await seedFixture({ role: "owner" });
 		const ownerHeaders = authHeaders(owner.token, owner.workspace.slug);
 
@@ -1126,7 +1126,7 @@ describe("Wiki slug uniqueness and redirects (PROJ-483)", () => {
 		expect(res.status).toBe(400);
 	});
 
-	it("POST /api/wiki falls back to an opaque slug for a symbol-only/non-Latin title whose derived slug would be empty (PROJ-517/512 finding 5)", async () => {
+	it("POST /api/wiki uses an opaque slug for a non-Latin title (empty derived slug, PROJ-517 #5)", async () => {
 		const res = await SELF.fetch("http://localhost/api/wiki", {
 			method: "POST",
 			headers: authHeaders(token, slug),
@@ -1143,7 +1143,7 @@ describe("Wiki slug uniqueness and redirects (PROJ-483)", () => {
 		expect(fetched.title).toBe("測試");
 	});
 
-	it("POST /api/wiki falls back to an opaque slug for a title whose derived slug would exceed SlugSchema's 200-char max (PROJ-517/512 finding 5)", async () => {
+	it("POST /api/wiki uses an opaque slug when derived slug exceeds SlugSchema's 200-char max (PROJ-517)", async () => {
 		const res = await SELF.fetch("http://localhost/api/wiki", {
 			method: "POST",
 			headers: authHeaders(token, slug),
@@ -1184,13 +1184,14 @@ describe("Wiki slug uniqueness and redirects (PROJ-483)", () => {
 		expect(isMcpError(res)).toBe(true);
 	});
 
-	it("a slashy slug rewritten by the PROJ-517 backfill migration still resolves, and the old slug redirects (finding 1)", async () => {
+	it("a slashy slug rewritten by the PROJ-517 backfill still resolves, and the old slug redirects (#1)", async () => {
 		// Simulate a pre-PROJ-517 row that predates SlugSchema's no-slash rule by
 		// inserting directly (SlugSchema would now reject this via the service layer).
 		const pageId = crypto.randomUUID();
 		const now = Math.floor(Date.now() / 1000);
 		await env.DB.prepare(
-			`INSERT INTO wiki_pages (id, workspace_id, project_id, slug, title, content, parent_id, created_by_id, updated_by_id, created_at, updated_at)
+			`INSERT INTO wiki_pages (id, workspace_id, project_id, slug, title, content,
+				parent_id, created_by_id, updated_by_id, created_at, updated_at)
 			 VALUES (?, ?, NULL, ?, ?, ?, NULL, ?, ?, ?, ?)`
 		)
 			.bind(
@@ -2289,7 +2290,7 @@ describe("Wiki optimistic locking (PROJ-484)", () => {
 		expect(res.status).toBe(400);
 	});
 
-	it("MCP: update_wiki_page parity — matching baseRevisionId succeeds, stale is rejected with a structured conflict", async () => {
+	it("MCP: update_wiki_page — matching baseRevisionId succeeds, stale is rejected with a conflict", async () => {
 		const created = mcpData<{ slug: string }>(
 			await mcp("create_wiki_page", { title: "MCP Locked Doc", content: "v1" })
 		);
@@ -2494,7 +2495,7 @@ describe("Wiki revision diff (PROJ-492)", () => {
 		expect(result.diff).toContain("+beta");
 	});
 
-	it("restore is a plain update_wiki_page call with the old revision's content — creates a new revision, never rewrites history", async () => {
+	it("restore is a plain update_wiki_page call with old content — new revision, never rewrites history", async () => {
 		await req("http://localhost/api/wiki", {
 			method: "POST",
 			headers: authHeaders(token, slug),
@@ -2539,7 +2540,7 @@ describe("Wiki revision diff (PROJ-492)", () => {
 		expect(revisions.map((r) => r.id)).toContain(latest.id);
 	});
 
-	it("restore with a baseRevisionId that went stale while history was open is a 409, not a silent overwrite", async () => {
+	it("restore with a baseRevisionId stale from open history is a 409, not a silent overwrite", async () => {
 		await req("http://localhost/api/wiki", {
 			method: "POST",
 			headers: authHeaders(token, slug),
@@ -2790,7 +2791,7 @@ describe("Wiki patch operations (PROJ-490)", () => {
 		expect(body.currentHeadings).toEqual(["Alpha", "Beta"]);
 	});
 
-	it("REST: disjoint-section writes never conflict — two agents patching different sections against a stale baseRevisionId both succeed", async () => {
+	it("REST: disjoint-section writes never conflict — two patches vs. a stale baseRevisionId both succeed", async () => {
 		await createPage("patch-disjoint", "Patch Disjoint", TWO_SECTIONS);
 		const revRes = await req("http://localhost/api/wiki/patch-disjoint/revisions", {
 			headers: authHeaders(token, slug),
@@ -2973,7 +2974,7 @@ describe("Wiki patch operations (PROJ-490)", () => {
 		expect(res.status).toBe(400);
 	});
 
-	it("REST: append_to_page accepts a baseRevisionId that DOES belong to the page, even though it's stale (staleness isn't rejected for this op)", async () => {
+	it("REST: append_to_page accepts a stale baseRevisionId belonging to the page (staleness ignored here)", async () => {
 		await createPage("patch-append-stale-base", "Patch Append Stale Base", TWO_SECTIONS);
 		const firstRes = await req("http://localhost/api/wiki/patch-append-stale-base", {
 			method: "PATCH",
@@ -3371,7 +3372,7 @@ describe("Wiki link graph and backlinks (PROJ-485)", () => {
 		expect(backlinks).toEqual([]);
 	});
 
-	it("PROJ-510: a malformed %-escape in a markdown link URL doesn't crash the write, and other links on the page still index", async () => {
+	it("PROJ-510: a malformed %-escape in a link URL doesn't crash the write; other links still index", async () => {
 		const runbook = await createPage("Runbook Eta", "how to page");
 		const res = await SELF.fetch("http://localhost/api/wiki", {
 			method: "POST",
@@ -3607,13 +3608,15 @@ describe("Wiki link graph and backlinks (PROJ-485)", () => {
 		// pre-PROJ-485 content that predates the link graph.
 		const now = Math.floor(Date.now() / 1000);
 		await env.DB.prepare(
-			"INSERT INTO wiki_pages (id, workspace_id, slug, title, content, created_by_id, updated_by_id, created_at, updated_at) " +
+			"INSERT INTO wiki_pages (id, workspace_id, slug, title, content, created_by_id, " +
+				"updated_by_id, created_at, updated_at) " +
 				"VALUES ('legacy-target', ?, 'legacy-target', 'Legacy Target', 'x', ?, ?, ?, ?)"
 		)
 			.bind(owner.workspace.id, owner.user.id, owner.user.id, now, now)
 			.run();
 		await env.DB.prepare(
-			"INSERT INTO wiki_pages (id, workspace_id, slug, title, content, created_by_id, updated_by_id, created_at, updated_at) " +
+			"INSERT INTO wiki_pages (id, workspace_id, slug, title, content, created_by_id, " +
+				"updated_by_id, created_at, updated_at) " +
 				"VALUES ('legacy-source', ?, 'legacy-source', 'Legacy Source', '[[Legacy Target]]', ?, ?, ?, ?)"
 		)
 			.bind(owner.workspace.id, owner.user.id, owner.user.id, now, now)
@@ -4041,7 +4044,7 @@ describe("Wiki freshness model (PROJ-489)", () => {
 	// verified) in search ranking — only in list_stale_pages (the maintenance queue).
 	// A freshly authored page that opts into verification tracking shouldn't rank worse
 	// than a legacy page with no frontmatter at all just for declaring an interval.
-	it("GET /api/wiki/search does NOT demote an unverified page below a lower-relevance page with no freshness signal", async () => {
+	it("GET /api/wiki/search does NOT demote an unverified page below a page with no freshness signal", async () => {
 		// If "unverified" were still in the demotion tier, this page would sort AFTER
 		// "No Signal" below regardless of relevance, the same way a stale/deprecated page
 		// is forced below a fresh one in the tests above. Giving it the stronger (title)
@@ -4077,7 +4080,7 @@ describe("Wiki freshness model (PROJ-489)", () => {
 		expect(results[0].freshness?.state).toBe("unverified");
 	});
 
-	it("GET /api/wiki/stale-pages lists computed-stale, unverified, and explicitly stale/deprecated pages, excluding fresh ones", async () => {
+	it("GET /api/wiki/stale-pages lists computed-stale, unverified, deprecated pages, excluding fresh", async () => {
 		await SELF.fetch("http://localhost/api/wiki", {
 			method: "POST",
 			headers: authHeaders(token, slug),
@@ -4654,7 +4657,7 @@ describe("Wiki watchers + list_wiki_changes (PROJ-493)", () => {
 		expect(await notifications(watcher.token)).toEqual([]);
 	});
 
-	it("a cascade delete generates a single 'deleted' notification for the root page, not one per descendant", async () => {
+	it("a cascade delete generates a single 'deleted' notification for the root, not one per descendant", async () => {
 		const parent = await createPage("cascade-parent", "Cascade Parent", "content");
 		await createChildPage("cascade-child", "Cascade Child", "child", parent.id);
 		const watcher = await seedWatcher();
@@ -4711,7 +4714,7 @@ describe("Wiki watchers + list_wiki_changes (PROJ-493)", () => {
 		expect(stillThere?.c).toBe(1);
 	});
 
-	it("a cascade undelete notifies someone watching a DESCENDANT directly (PROJ-496 follow-up: symmetric with cascade delete)", async () => {
+	it("a cascade undelete notifies someone watching a DESCENDANT (PROJ-496: symmetric with cascade delete)", async () => {
 		const parent = await createPage("cascade-restore-root", "Cascade Restore Root", "content");
 		const child = await createChildPage(
 			"cascade-restore-kid",
@@ -4814,7 +4817,7 @@ describe("Wiki watchers + list_wiki_changes (PROJ-493)", () => {
 		expect((await notifications(watcher.token, "?unreadOnly=true")).length).toBe(0);
 	});
 
-	it("list_wiki_changes: since is exclusive, nextSince advances, default scope isn't limited to watched pages", async () => {
+	it("list_wiki_changes: since is exclusive, nextSince advances, default scope isn't watched-only", async () => {
 		const t0 = Math.floor(Date.now() / 1000) - 1;
 		const page = await createPage("delta-doc", "Delta Doc", "content");
 
@@ -5075,7 +5078,7 @@ describe("Wiki server-side drafts (PROJ-495)", () => {
 		expect(await otherGet.json()).toBeNull();
 	});
 
-	it("publishing the draft's content through the normal update path works, and discarding after publish clears it", async () => {
+	it("publishing the draft's content via the normal update path works; discarding after publish clears it", async () => {
 		const page = await createPage("draft-publish", "Draft Publish", "v0");
 		const pageRes = await req(`http://localhost/api/wiki/${page.slug}`, {
 			headers: authHeaders(token, slug),
@@ -5115,7 +5118,7 @@ describe("Wiki server-side drafts (PROJ-495)", () => {
 		expect(await getRes.json()).toBeNull();
 	});
 
-	it("a stale baseRevisionId on publish still hits the normal 409 conflict — no separate draft conflict mechanism", async () => {
+	it("a stale baseRevisionId on publish still hits the normal 409 — no separate draft conflict mechanism", async () => {
 		const page = await createPage("draft-conflict", "Draft Conflict", "v0");
 
 		// Establish a first revision, and capture its id the way startEdit() would —
@@ -5513,7 +5516,7 @@ describe("Wiki trash (PROJ-496)", () => {
 		expect(res.status).toBe(403);
 	});
 
-	it("purge permanently removes only pages trashed more than 30 days ago, and cleans up every dependent table + R2", async () => {
+	it("purge removes only pages trashed >30 days ago, cleaning up every dependent table + R2", async () => {
 		const oldPage = await createPage("Trash Purge Old", "purge-old-searchterm");
 		await createPage("Trash Purge Old Target", "content");
 		await req(`http://localhost/api/wiki/${oldPage.slug}`, {
@@ -5747,7 +5750,7 @@ describe("Wiki trash (PROJ-496)", () => {
 		}
 	});
 
-	it("undeleting a cascade-trashed root 409s when a descendant's slug was reclaimed while trashed, instead of a raw 500", async () => {
+	it("undeleting a cascade-trashed root 409s (not a raw 500) when a descendant's slug was reclaimed", async () => {
 		const parent = await createPage("Cascade Undelete Conflict Parent", "content");
 		const child = await createPage("Cascade Undelete Conflict Child", "content", {
 			parentId: parent.id,
@@ -5778,7 +5781,7 @@ describe("Wiki trash (PROJ-496)", () => {
 		expect(parentRow?.deleted_at).not.toBeNull();
 	});
 
-	it("undeleting a cascade-trashed root does NOT restore a descendant that was independently trashed in the same batch-collision window", async () => {
+	it("undeleting a cascade-trashed root does NOT restore a descendant trashed separately, same window", async () => {
 		// Regression test for the trash_batch_id disambiguation (PROJ-496 follow-up):
 		// trashing the child alone and then cascade-trashing the parent right after, with
 		// no artificial time offset, used to be indistinguishable from "trashed in one
@@ -5805,7 +5808,7 @@ describe("Wiki trash (PROJ-496)", () => {
 		expect(childRow?.deleted_at).not.toBeNull();
 	});
 
-	it("non-cascade trash leaves an already-trashed child's parent_id untouched, and undelete restores it under the original parent", async () => {
+	it("non-cascade trash leaves a trashed child's parent_id untouched; undelete restores original parent", async () => {
 		const parent = await createPage("Noncascade Reparent Parent", "content");
 		const child = await createPage("Noncascade Reparent Child", "content", {
 			parentId: parent.id,

--- a/apps/api/vitest.config.mts
+++ b/apps/api/vitest.config.mts
@@ -62,7 +62,7 @@ export default defineConfig({
     // These are expected — every failing test asserts the resulting JSON-RPC
     // error and passes. Suppress only our discriminated ServiceError kinds;
     // any other unhandled error still fails the run.
-    onUnhandledError(error: { kind?: string }) {
+    onUnhandledError(error: Readonly<{ kind?: string }>) {
       const KNOWN = ['validation', 'not_found', 'forbidden', 'conflict']
       if (error?.kind && KNOWN.includes(error.kind)) return false
     },

--- a/apps/docs/src/content/docs/contributing/conventions.md
+++ b/apps/docs/src/content/docs/contributing/conventions.md
@@ -4,7 +4,9 @@ description: "Architecture contract and conventions for working on the Projektor
 sidebar:
   order: 1
 ---
-> **Note:** this page is generated from [`AGENTS.md`](https://github.com/TAJD/projektor/blob/main/AGENTS.md) in the repo root by `scripts/gen-conventions-page.ts`. Edit that file, not this page - it is overwritten on every generate.
+> **Note:** this page is generated from [`AGENTS.md`](https://github.com/TAJD/projektor/blob/main/AGENTS.md)
+> in the repo root by `scripts/gen-conventions-page.ts`. Edit that file, not this page - it is
+> overwritten on every generate.
 
 Guidance for AI agents (and humans) working **on** the projektor codebase.
 Read this before making changes - it captures conventions that aren't obvious from the code alone.

--- a/apps/docs/src/content/docs/guides/feedback-widget-integration.md
+++ b/apps/docs/src/content/docs/guides/feedback-widget-integration.md
@@ -69,8 +69,7 @@ export interface FeedbackPayload {
  * meant to be embedded in client-side code, the same trust category as a
  * Sentry DSN or a Stripe publishable key.
  */
-// cofferdam-ignore: Design.DuplicateExportName: mirrors services/feedback.ts's submitFeedback
-// name for the docs example; never imported together
+// cofferdam-ignore: Design.DuplicateExportName: mirrors feedback.ts's submitFeedback name; never imported together
 export async function submitFeedback(
 	endpoint: string,
 	token: string,

--- a/apps/docs/src/content/docs/guides/feedback-widget-integration.md
+++ b/apps/docs/src/content/docs/guides/feedback-widget-integration.md
@@ -4,7 +4,13 @@ description: "Collect end-user feedback from your own site and route it into a p
 sidebar:
   order: 4
 ---
-> **Note:** the code below is generated from [`apps/api/src/examples/feedback-widget-submit.ts`](https://github.com/TAJD/projektor/blob/main/apps/api/src/examples/feedback-widget-submit.ts) by `scripts/gen-feedback-example-page.ts`, and is executed against a live projektor instance in [`apps/api/src/test/feedback-example.test.ts`](https://github.com/TAJD/projektor/blob/main/apps/api/src/test/feedback-example.test.ts) - edit that source file, not this page, and run `pnpm gen:docs`.
+> **Note:** the code below is generated from [`apps/api/src/examples/feedback-widget-submit.ts`][src]
+> by `scripts/gen-feedback-example-page.ts`, and is executed against a live projektor instance in
+> [`apps/api/src/test/feedback-example.test.ts`][test] - edit that source file, not this page, and
+> run `pnpm gen:docs`.
+
+[src]: https://github.com/TAJD/projektor/blob/main/apps/api/src/examples/feedback-widget-submit.ts
+[test]: https://github.com/TAJD/projektor/blob/main/apps/api/src/test/feedback-example.test.ts
 
 A **feedback source** is a named, independently-credentialed collection point (e.g.
 "Onboarding survey", "In-app rating widget") that a project owner or admin creates once.
@@ -63,7 +69,8 @@ export interface FeedbackPayload {
  * meant to be embedded in client-side code, the same trust category as a
  * Sentry DSN or a Stripe publishable key.
  */
-// cofferdam-ignore: Design.DuplicateExportName: deliberately mirrors services/feedback.ts's submitFeedback name for the docs example; never imported together
+// cofferdam-ignore: Design.DuplicateExportName: mirrors services/feedback.ts's submitFeedback
+// name for the docs example; never imported together
 export async function submitFeedback(
 	endpoint: string,
 	token: string,

--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -117,7 +117,8 @@ export default async function globalSetup(): Promise<void> {
 	const inProgressStatus = seededStatuses.find((s) => s.key === "in_progress");
 	if (!todoStatus || !inProgressStatus) {
 		throw new Error(
-			`Expected default 'todo' and 'in_progress' task statuses to be seeded for workspace ${slug}, got keys: ${seededStatuses.map((s) => s.key).join(", ")}`
+			`Expected default 'todo' and 'in_progress' task statuses to be seeded for workspace ${slug}, ` +
+				`got keys: ${seededStatuses.map((s) => s.key).join(", ")}`
 		);
 	}
 

--- a/apps/web/src/islands/AccessPending.tsx
+++ b/apps/web/src/islands/AccessPending.tsx
@@ -9,7 +9,10 @@ export default function AccessPending() {
 		>
 			<div
 				aria-hidden="true"
-				class="flex items-center justify-center w-12 h-12 rounded-full bg-[var(--surface)] border border-[var(--border)] text-2xl"
+				class={
+					"flex items-center justify-center w-12 h-12 rounded-full bg-[var(--surface)] " +
+					"border border-[var(--border)] text-2xl"
+				}
 			>
 				🔒
 			</div>

--- a/apps/web/src/islands/AccountMenu.tsx
+++ b/apps/web/src/islands/AccountMenu.tsx
@@ -13,7 +13,8 @@ interface MeResponse {
 }
 
 const POPOVER_MARGIN = 8;
-const PUBLIC_VIEWER_EMAIL = "public-viewer@projektor.local"; // PROJ-373 anonymous fallback — apps/api/src/middleware/auth.ts
+// PROJ-373 anonymous fallback — apps/api/src/middleware/auth.ts
+const PUBLIC_VIEWER_EMAIL = "public-viewer@projektor.local";
 
 function initials(name: string, email: string): string {
 	const source = name.trim() || email;

--- a/apps/web/src/islands/EpicList.test.tsx
+++ b/apps/web/src/islands/EpicList.test.tsx
@@ -79,7 +79,7 @@ const LOW_EPIC: Issue = {
 	created_at: 1000,
 };
 
-function mockFetchEpics(issues: Issue[] = [EPIC_ISSUE]) {
+function mockFetchEpics(issues: readonly Issue[] = [EPIC_ISSUE]) {
 	vi.stubGlobal(
 		"fetch",
 		vi.fn().mockImplementation((url: string) => {

--- a/apps/web/src/islands/EpicList.tsx
+++ b/apps/web/src/islands/EpicList.tsx
@@ -82,22 +82,22 @@ function persistResolvedProjectId(resolved: string) {
 function resolveProjectId(
 	prev: string | null,
 	stored: string | null,
-	projects: ProjectMeta[]
+	projects: readonly ProjectMeta[]
 ): string | null {
 	if (prev) return prev;
 	const validated = stored && projects.some((p) => p.id === stored) ? stored : null;
 	return validated ?? projects[0]?.id ?? null;
 }
 
-function defaultCreateProjectId(projectId: string | null, projects: ProjectMeta[]): string {
+function defaultCreateProjectId(projectId: string | null, projects: readonly ProjectMeta[]): string {
 	if (projectId) return projects.find((p) => p.id === projectId)?.id ?? projects[0]?.id ?? "";
 	return projects[0]?.id ?? "";
 }
 
 function computeFilteredEpics(
-	epics: Issue[],
-	filterStatuses: string[],
-	filterPriorities: string[]
+	epics: readonly Issue[],
+	filterStatuses: readonly string[],
+	filterPriorities: readonly string[]
 ): Issue[] {
 	return epics.filter((ep) => {
 		if (filterStatuses.length > 0 && (!ep.status_id || !filterStatuses.includes(ep.status_id)))
@@ -107,7 +107,7 @@ function computeFilteredEpics(
 	});
 }
 
-function computeDerivedStatuses(epics: Issue[]): TaskStatus[] {
+function computeDerivedStatuses(epics: readonly Issue[]): TaskStatus[] {
 	const derived: TaskStatus[] = [];
 	const seen = new Set<string>();
 	for (const ep of epics) {
@@ -363,7 +363,7 @@ function useEpicsData({
 function useCreateEpicForm(
 	workspaceSlug: string | undefined,
 	projectId: string | null,
-	projects: ProjectMeta[],
+	projects: readonly ProjectMeta[],
 	epicTypeId: string | null,
 	fetchEpics: () => Promise<void>
 ) {

--- a/apps/web/src/islands/EpicList.tsx
+++ b/apps/web/src/islands/EpicList.tsx
@@ -89,7 +89,10 @@ function resolveProjectId(
 	return validated ?? projects[0]?.id ?? null;
 }
 
-function defaultCreateProjectId(projectId: string | null, projects: readonly ProjectMeta[]): string {
+function defaultCreateProjectId(
+	projectId: string | null,
+	projects: readonly ProjectMeta[]
+): string {
 	if (projectId) return projects.find((p) => p.id === projectId)?.id ?? projects[0]?.id ?? "";
 	return projects[0]?.id ?? "";
 }
@@ -356,7 +359,7 @@ function useEpicsData({
 		if (projectIdReady) fetchEpics();
 	}, [fetchEpics, projectIdReady]);
 
-	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data, error, loading} state so components can render error UI declaratively — standard pattern in this codebase's data hooks
+	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data,error,loading} state, standard in this codebase
 	return { epics, loading, error, fetchEpics };
 }
 

--- a/apps/web/src/islands/FeedbackList.test.tsx
+++ b/apps/web/src/islands/FeedbackList.test.tsx
@@ -33,7 +33,7 @@ const ROW_2 = {
 	createdAt: 1001,
 };
 
-function stubFetch(rows: unknown[] = [ROW, ROW_2], bulkConvertStatus = 201) {
+function stubFetch(rows: readonly unknown[] = [ROW, ROW_2], bulkConvertStatus = 201) {
 	const fetchMock = vi.fn().mockImplementation((url: string, _init?: RequestInit) => {
 		const u = String(url);
 		if (u.includes("/bulk-convert-to-issue")) {

--- a/apps/web/src/islands/FeedbackSourceGrid.tsx
+++ b/apps/web/src/islands/FeedbackSourceGrid.tsx
@@ -101,7 +101,7 @@ export default function FeedbackSourceGrid({ workspaceSlug, projectId: projectId
 	const [showCreate, setShowCreate] = useState(false);
 
 	const fetchAll = useCallback(
-		async (opts?: { background?: boolean }) => {
+		async (opts?: Readonly<{ background?: boolean }>) => {
 			if (!projectId) return;
 			if (!opts?.background) setLoading(true);
 			setError(null);

--- a/apps/web/src/islands/GroupManager.test.tsx
+++ b/apps/web/src/islands/GroupManager.test.tsx
@@ -98,7 +98,7 @@ describe("GroupManager rename", () => {
 // Groups so the flows above stay reachable without switching tabs first.
 const REGULAR_MEMBER = { id: "u2", email: "mo@example.com", name: "Mo Member", role: "member" };
 
-function mockFetchForTabs(opts: { role: string }) {
+function mockFetchForTabs(opts: Readonly<{ role: string }>) {
 	vi.stubGlobal(
 		"fetch",
 		vi.fn().mockImplementation((url: string) => {

--- a/apps/web/src/islands/GroupManager.tsx
+++ b/apps/web/src/islands/GroupManager.tsx
@@ -61,8 +61,8 @@ const BTN_SECONDARY =
 	"px-3 py-[0.4rem] rounded text-[0.8rem] font-semibold bg-bg text-text-base border border-border " +
 	"cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed";
 const BTN_DANGER =
-	"px-2 py-[0.3rem] rounded text-[0.75rem] font-semibold bg-transparent text-[var(--danger-text)] border border-border " +
-	"cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed";
+	"px-2 py-[0.3rem] rounded text-[0.75rem] font-semibold bg-transparent text-[var(--danger-text)] " +
+	"border border-border cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed";
 const INPUT =
 	"px-[0.625rem] py-[0.4rem] border border-border rounded text-[0.85rem] bg-bg text-text-base " +
 	"font-[inherit] focus:outline-[2px] focus:outline-accent focus:outline-offset-1";
@@ -160,7 +160,7 @@ function useGroupManagerData(slug: string) {
 		void refetch();
 	}, [refetch]);
 
-	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: React hooks conventionally return {data, loading, error} state objects, not throw errors
+	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data,error,loading} state, standard in this codebase
 	return { data, loading, error, setError, forbidden, refetch };
 }
 
@@ -253,10 +253,12 @@ function RoleBanner(props: Readonly<{ role: string; isAdmin: boolean }>) {
 // Members overview — group chips + pending badge
 // ---------------------------------------------------------------------------
 
-function MemberGroupsCell(props: Readonly<{
-	member: WsMember;
-	groups: Array<{ id: string; name: string }>;
-}>) {
+function MemberGroupsCell(
+	props: Readonly<{
+		member: WsMember;
+		groups: Array<{ id: string; name: string }>;
+	}>
+) {
 	const isAdmin = props.member.role === "owner" || props.member.role === "admin";
 	if (isAdmin) {
 		return <span class="text-[0.78rem] text-text-muted">All projects (bypasses groups)</span>;
@@ -273,10 +275,12 @@ function MemberGroupsCell(props: Readonly<{
 	);
 }
 
-function MembersMobileCards(props: Readonly<{
-	members: WsMember[];
-	groupsByUser: Map<string, Array<{ id: string; name: string }>>;
-}>) {
+function MembersMobileCards(
+	props: Readonly<{
+		members: WsMember[];
+		groupsByUser: Map<string, Array<{ id: string; name: string }>>;
+	}>
+) {
 	return (
 		<div class="hidden max-sm:flex max-sm:flex-col max-sm:gap-3">
 			{props.members.map((m) => (
@@ -293,7 +297,9 @@ function MembersMobileCards(props: Readonly<{
 	);
 }
 
-function MembersOverview(props: Readonly<{ members: WsMember[]; memberGroups: MemberGroupsRow[] }>) {
+function MembersOverview(
+	props: Readonly<{ members: WsMember[]; memberGroups: MemberGroupsRow[] }>
+) {
 	const groupsByUser = new Map(props.memberGroups.map((r) => [r.userId, r.groups]));
 	return (
 		<section class={CARD}>

--- a/apps/web/src/islands/GroupManager.tsx
+++ b/apps/web/src/islands/GroupManager.tsx
@@ -215,7 +215,7 @@ function useGroupActions(
 
 // WAI-ARIA tabs pattern: arrow keys move focus AND activate (automatic
 // activation), Home/End jump to the first/last tab.
-function nextTabId(tabs: TabId[], activeTab: TabId, key: string): TabId | null {
+function nextTabId(tabs: readonly TabId[], activeTab: TabId, key: string): TabId | null {
 	const idx = tabs.indexOf(activeTab);
 	if (key === "ArrowRight") return tabs[(idx + 1) % tabs.length];
 	if (key === "ArrowLeft") return tabs[(idx - 1 + tabs.length) % tabs.length];
@@ -236,7 +236,7 @@ function useTabRefs() {
 // Role indicator — tells the caller what they can do here
 // ---------------------------------------------------------------------------
 
-function RoleBanner(props: { role: string; isAdmin: boolean }) {
+function RoleBanner(props: Readonly<{ role: string; isAdmin: boolean }>) {
 	return (
 		<div class={INFO}>
 			<span class={ROLE_TAG}>{props.role}</span>
@@ -253,10 +253,10 @@ function RoleBanner(props: { role: string; isAdmin: boolean }) {
 // Members overview — group chips + pending badge
 // ---------------------------------------------------------------------------
 
-function MemberGroupsCell(props: {
+function MemberGroupsCell(props: Readonly<{
 	member: WsMember;
 	groups: Array<{ id: string; name: string }>;
-}) {
+}>) {
 	const isAdmin = props.member.role === "owner" || props.member.role === "admin";
 	if (isAdmin) {
 		return <span class="text-[0.78rem] text-text-muted">All projects (bypasses groups)</span>;
@@ -273,10 +273,10 @@ function MemberGroupsCell(props: {
 	);
 }
 
-function MembersMobileCards(props: {
+function MembersMobileCards(props: Readonly<{
 	members: WsMember[];
 	groupsByUser: Map<string, Array<{ id: string; name: string }>>;
-}) {
+}>) {
 	return (
 		<div class="hidden max-sm:flex max-sm:flex-col max-sm:gap-3">
 			{props.members.map((m) => (
@@ -293,7 +293,7 @@ function MembersMobileCards(props: {
 	);
 }
 
-function MembersOverview(props: { members: WsMember[]; memberGroups: MemberGroupsRow[] }) {
+function MembersOverview(props: Readonly<{ members: WsMember[]; memberGroups: MemberGroupsRow[] }>) {
 	const groupsByUser = new Map(props.memberGroups.map((r) => [r.userId, r.groups]));
 	return (
 		<section class={CARD}>

--- a/apps/web/src/islands/IssueDetail.tsx
+++ b/apps/web/src/islands/IssueDetail.tsx
@@ -352,7 +352,7 @@ function useIssueCore({
 	};
 }
 
-function useIssueMutations(args: {
+function useIssueMutations(args: Readonly<{
 	issue: IssueData | null;
 	setIssue: (updater: (prev: IssueData | null) => IssueData | null) => void;
 	issueId: string;
@@ -360,7 +360,7 @@ function useIssueMutations(args: {
 	statuses: TaskStatus[];
 	members: Member[];
 	fetchIssue: () => Promise<void>;
-}) {
+}>) {
 	const { issue, setIssue, issueId, workspaceSlug, statuses, members, fetchIssue } = args;
 	const [updatingStatus, setUpdatingStatus] = useState(false);
 	const [updatingPriority, setUpdatingPriority] = useState(false);
@@ -473,7 +473,7 @@ function IssueBreadcrumb({ issue, backHref }: { issue: IssueData; backHref: stri
 	);
 }
 
-function IssueDetailView(props: {
+function IssueDetailView(props: Readonly<{
 	issue: IssueData;
 	issueId: string;
 	workspaceSlug?: string;
@@ -500,7 +500,7 @@ function IssueDetailView(props: {
 	changePriority: (priority: string) => void;
 	changeAssignee: (assigneeId: string) => void;
 	fetchIssue: () => Promise<void>;
-}) {
+}>) {
 	const { issue, issueId, workspaceSlug } = props;
 	return (
 		<article class="max-w-[900px] mx-auto">

--- a/apps/web/src/islands/IssueDetail.tsx
+++ b/apps/web/src/islands/IssueDetail.tsx
@@ -337,7 +337,7 @@ function useIssueCore({
 		return () => clearTimeout(t);
 	}, [fetchAttachments, issueId]);
 
-	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data, error, loading} state so components can render error UI declaratively — standard pattern in this codebase's data hooks
+	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data,error,loading} state, standard in this codebase
 	return {
 		issue,
 		setIssue,
@@ -352,15 +352,17 @@ function useIssueCore({
 	};
 }
 
-function useIssueMutations(args: Readonly<{
-	issue: IssueData | null;
-	setIssue: (updater: (prev: IssueData | null) => IssueData | null) => void;
-	issueId: string;
-	workspaceSlug: string | undefined;
-	statuses: TaskStatus[];
-	members: Member[];
-	fetchIssue: () => Promise<void>;
-}>) {
+function useIssueMutations(
+	args: Readonly<{
+		issue: IssueData | null;
+		setIssue: (updater: (prev: IssueData | null) => IssueData | null) => void;
+		issueId: string;
+		workspaceSlug: string | undefined;
+		statuses: TaskStatus[];
+		members: Member[];
+		fetchIssue: () => Promise<void>;
+	}>
+) {
 	const { issue, setIssue, issueId, workspaceSlug, statuses, members, fetchIssue } = args;
 	const [updatingStatus, setUpdatingStatus] = useState(false);
 	const [updatingPriority, setUpdatingPriority] = useState(false);
@@ -473,34 +475,36 @@ function IssueBreadcrumb({ issue, backHref }: { issue: IssueData; backHref: stri
 	);
 }
 
-function IssueDetailView(props: Readonly<{
-	issue: IssueData;
-	issueId: string;
-	workspaceSlug?: string;
-	backHref: string | null;
-	issueRef: string;
-	copyUrl: string;
-	blockedByLinks: IssueLink[];
-	parentEpic: IssueData | null;
-	childIssues: IssueData[];
-	links: IssueLink[];
-	fetchingLinks: boolean;
-	fetchLinks: () => Promise<void>;
-	attachments: Attachment[];
-	fetchAttachments: () => Promise<void>;
-	comments: Comment[];
-	currentUserId: string | null;
-	fetchComments: () => Promise<void>;
-	statuses: TaskStatus[];
-	members: Member[];
-	updatingStatus: boolean;
-	updatingPriority: boolean;
-	updatingAssignee: boolean;
-	changeStatus: (statusId: string) => void;
-	changePriority: (priority: string) => void;
-	changeAssignee: (assigneeId: string) => void;
-	fetchIssue: () => Promise<void>;
-}>) {
+function IssueDetailView(
+	props: Readonly<{
+		issue: IssueData;
+		issueId: string;
+		workspaceSlug?: string;
+		backHref: string | null;
+		issueRef: string;
+		copyUrl: string;
+		blockedByLinks: IssueLink[];
+		parentEpic: IssueData | null;
+		childIssues: IssueData[];
+		links: IssueLink[];
+		fetchingLinks: boolean;
+		fetchLinks: () => Promise<void>;
+		attachments: Attachment[];
+		fetchAttachments: () => Promise<void>;
+		comments: Comment[];
+		currentUserId: string | null;
+		fetchComments: () => Promise<void>;
+		statuses: TaskStatus[];
+		members: Member[];
+		updatingStatus: boolean;
+		updatingPriority: boolean;
+		updatingAssignee: boolean;
+		changeStatus: (statusId: string) => void;
+		changePriority: (priority: string) => void;
+		changeAssignee: (assigneeId: string) => void;
+		fetchIssue: () => Promise<void>;
+	}>
+) {
 	const { issue, issueId, workspaceSlug } = props;
 	return (
 		<article class="max-w-[900px] mx-auto">

--- a/apps/web/src/islands/IssueDetailParts.tsx
+++ b/apps/web/src/islands/IssueDetailParts.tsx
@@ -1643,7 +1643,10 @@ export function CommentsSection({
 					rows={4}
 					// text-base (16px) on phones: below 16px iOS Safari zooms the viewport
 					// when the field takes focus. sm:text-sm keeps desktop as it was.
-					class="w-full px-3 py-2 border border-border rounded text-base sm:text-sm resize-y box-border mb-2 bg-bg text-text-base"
+					class={
+						"w-full px-3 py-2 border border-border rounded text-base sm:text-sm " +
+						"resize-y box-border mb-2 bg-bg text-text-base"
+					}
 				/>
 				<button
 					type="submit"

--- a/apps/web/src/islands/IssueList-helpers.ts
+++ b/apps/web/src/islands/IssueList-helpers.ts
@@ -182,7 +182,11 @@ interface TaskTypeLookup {
 export function buildOptimisticIssue(
 	created: Readonly<{ id: string; number: number }>,
 	input: CreateIssueInput,
-	lookups: Readonly<{ projects: ProjectLookup[]; statuses: StatusLookup[]; taskTypes: TaskTypeLookup[] }>
+	lookups: Readonly<{
+		projects: ProjectLookup[];
+		statuses: StatusLookup[];
+		taskTypes: TaskTypeLookup[];
+	}>
 ): Issue {
 	const proj = lookups.projects.find((p) => p.id === input.createProjectId);
 	const chosenStatus = lookups.statuses.find((s) => s.id === input.createStatusId);

--- a/apps/web/src/islands/IssueList-helpers.ts
+++ b/apps/web/src/islands/IssueList-helpers.ts
@@ -30,7 +30,7 @@ function applyEpicParams(
 	qs: URLSearchParams,
 	filterEpicId: string,
 	hideEpics: boolean,
-	taskTypes: KeyedById[]
+	taskTypes: readonly KeyedById[]
 ): void {
 	if (filterEpicId && filterEpicId !== "none") qs.set("parentId", filterEpicId);
 	if (filterEpicId === "none") qs.set("noParent", "true");
@@ -60,7 +60,7 @@ export function applyDateRangeParams(
 // (everything except limit/cursor, which the callers set).
 export function buildFilterQueryParams(
 	filters: FilterQueryFilters,
-	projects: KeyedById[],
+	projects: readonly KeyedById[],
 	taskTypes: KeyedById[]
 ): URLSearchParams {
 	const {
@@ -180,9 +180,9 @@ interface TaskTypeLookup {
 }
 
 export function buildOptimisticIssue(
-	created: { id: string; number: number },
+	created: Readonly<{ id: string; number: number }>,
 	input: CreateIssueInput,
-	lookups: { projects: ProjectLookup[]; statuses: StatusLookup[]; taskTypes: TaskTypeLookup[] }
+	lookups: Readonly<{ projects: ProjectLookup[]; statuses: StatusLookup[]; taskTypes: TaskTypeLookup[] }>
 ): Issue {
 	const proj = lookups.projects.find((p) => p.id === input.createProjectId);
 	const chosenStatus = lookups.statuses.find((s) => s.id === input.createStatusId);

--- a/apps/web/src/islands/MarkdownEditor.tsx
+++ b/apps/web/src/islands/MarkdownEditor.tsx
@@ -44,7 +44,7 @@ function imageFilesFromDrop(data: DataTransfer | null): File[] {
 // positions. A file whose upload fails (onImageFile resolves null) is silently skipped.
 async function insertUploadedImages(
 	view: EditorView,
-	files: File[],
+	files: readonly File[],
 	pos: number,
 	onImageFile: (file: File) => Promise<string | null>
 ): Promise<void> {
@@ -353,7 +353,7 @@ function useMarkdownEditorView(
 	return { containerRef, viewRef };
 }
 
-function useMarkdownCommands(viewRef: { current: EditorView | null }) {
+function useMarkdownCommands(viewRef: Readonly<{ current: EditorView | null }>) {
 	function bold() {
 		if (viewRef.current) wrapSelection(viewRef.current, "**", "**");
 	}

--- a/apps/web/src/islands/MetricsDashboard.tsx
+++ b/apps/web/src/islands/MetricsDashboard.tsx
@@ -774,9 +774,9 @@ export default function MetricsDashboard({ workspaceSlug }: Props) {
 							<SectionHeading
 								metricId="aging-wip"
 								caption={
-								"Age since claim for every currently open issue, against this window's cycle-time " +
-								"p50/p90 — stuck items show up before they finish and skew the percentiles"
-							}
+									"Age since claim for every currently open issue, against this window's cycle-time " +
+									"p50/p90 — stuck items show up before they finish and skew the percentiles"
+								}
 							/>
 							<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto">
 								<AgingWipScatter

--- a/apps/web/src/islands/MetricsDashboard.tsx
+++ b/apps/web/src/islands/MetricsDashboard.tsx
@@ -189,7 +189,7 @@ function useFlowMetrics(workspaceSlug: string | undefined, range: RangeState) {
 			.finally(() => setLoading(false));
 	}, [projectId, workspaceSlug, range.since, range.until, range.granularity]);
 
-	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data, error, loading} state so components can render error UI declaratively — standard pattern in this codebase's data hooks
+	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data,error,loading} state, standard in this codebase
 	return { projectId, metrics, loading, error };
 }
 
@@ -324,7 +324,12 @@ function HealthTile({ metricId, value }: { metricId: MetricId; value: number }) 
 					: undefined
 			}
 		>
-			<p class="m-0 mb-1 text-[0.72rem] font-semibold text-text-muted uppercase tracking-[0.04em] inline-flex items-center gap-1">
+			<p
+				class={
+					"m-0 mb-1 text-[0.72rem] font-semibold text-text-muted uppercase " +
+					"tracking-[0.04em] inline-flex items-center gap-1"
+				}
+			>
 				{def.label}
 				<MetricHelp id={metricId} />
 			</p>
@@ -378,7 +383,7 @@ function BugShareChart({
 							const maxTicks = Math.max(2, Math.floor(u.width / 70));
 							const stride = Math.max(1, Math.ceil(n / maxTicks));
 							const idxs: number[] = [];
-							// cofferdam-ignore: Refactor.PreferArrayMethodOverLoop: variable stride, not a 1:1 map over a fixed-length source
+							// cofferdam-ignore: Refactor.PreferArrayMethodOverLoop: variable stride, not a 1:1 map
 							for (let i = 0; i < n; i += stride) idxs.push(i);
 							if (idxs[idxs.length - 1] !== n - 1) idxs.push(n - 1);
 							return idxs;
@@ -446,7 +451,7 @@ function ReviewLatencyChart({ data }: { data: FlowMetrics["reviewLatencyOverTime
 							const maxTicks = Math.max(2, Math.floor(u.width / 70));
 							const stride = Math.max(1, Math.ceil(n / maxTicks));
 							const idxs: number[] = [];
-							// cofferdam-ignore: Refactor.PreferArrayMethodOverLoop: variable stride, not a 1:1 map over a fixed-length source
+							// cofferdam-ignore: Refactor.PreferArrayMethodOverLoop: variable stride, not a 1:1 map
 							for (let i = 0; i < n; i += stride) idxs.push(i);
 							if (idxs[idxs.length - 1] !== n - 1) idxs.push(n - 1);
 							return idxs;
@@ -575,7 +580,7 @@ function ArrivalVsCompletionChart({ data }: { data: FlowMetrics["arrivalVsComple
 							const maxTicks = Math.max(2, Math.floor(u.width / 70));
 							const stride = Math.max(1, Math.ceil(n / maxTicks));
 							const idxs: number[] = [];
-							// cofferdam-ignore: Refactor.PreferArrayMethodOverLoop: variable stride, not a 1:1 map over a fixed-length source
+							// cofferdam-ignore: Refactor.PreferArrayMethodOverLoop: variable stride, not a 1:1 map
 							for (let i = 0; i < n; i += stride) idxs.push(i);
 							if (idxs[idxs.length - 1] !== n - 1) idxs.push(n - 1);
 							return idxs;
@@ -768,7 +773,10 @@ export default function MetricsDashboard({ workspaceSlug }: Props) {
 						<div class="mb-8">
 							<SectionHeading
 								metricId="aging-wip"
-								caption="Age since claim for every currently open issue, against this window's cycle-time p50/p90 — stuck items show up before they finish and skew the percentiles"
+								caption={
+								"Age since claim for every currently open issue, against this window's cycle-time " +
+								"p50/p90 — stuck items show up before they finish and skew the percentiles"
+							}
 							/>
 							<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto">
 								<AgingWipScatter

--- a/apps/web/src/islands/MyIssues.test.tsx
+++ b/apps/web/src/islands/MyIssues.test.tsx
@@ -75,7 +75,7 @@ const OPEN_ISSUE_PROJ_B: Issue = {
 	created_at: 1000,
 };
 
-function setupFetch(issues: Issue[] = [OPEN_ISSUE_PROJ_A, DONE_ISSUE_PROJ_A, OPEN_ISSUE_PROJ_B]) {
+function setupFetch(issues: readonly Issue[] = [OPEN_ISSUE_PROJ_A, DONE_ISSUE_PROJ_A, OPEN_ISSUE_PROJ_B]) {
 	return vi.fn().mockImplementation((url: string) => {
 		const u = String(url);
 		if (u.includes("/api/issues")) {

--- a/apps/web/src/islands/MyIssues.test.tsx
+++ b/apps/web/src/islands/MyIssues.test.tsx
@@ -75,7 +75,9 @@ const OPEN_ISSUE_PROJ_B: Issue = {
 	created_at: 1000,
 };
 
-function setupFetch(issues: readonly Issue[] = [OPEN_ISSUE_PROJ_A, DONE_ISSUE_PROJ_A, OPEN_ISSUE_PROJ_B]) {
+function setupFetch(
+	issues: readonly Issue[] = [OPEN_ISSUE_PROJ_A, DONE_ISSUE_PROJ_A, OPEN_ISSUE_PROJ_B]
+) {
 	return vi.fn().mockImplementation((url: string) => {
 		const u = String(url);
 		if (u.includes("/api/issues")) {

--- a/apps/web/src/islands/MyIssues.tsx
+++ b/apps/web/src/islands/MyIssues.tsx
@@ -58,7 +58,7 @@ interface ProjectGroup {
 	issues: Issue[];
 }
 
-function groupIssuesByProject(visible: Issue[]): {
+function groupIssuesByProject(visible: readonly Issue[]): {
 	order: string[];
 	byProject: Map<string, ProjectGroup>;
 } {

--- a/apps/web/src/islands/ProjectFlowCharts.tsx
+++ b/apps/web/src/islands/ProjectFlowCharts.tsx
@@ -66,7 +66,7 @@ function useProjectFlowCharts(workspaceSlug: string | undefined, projectId: stri
 			.finally(() => setLoading(false));
 	}, [projectId, workspaceSlug]);
 
-	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data, error, loading} state so components can render error UI declaratively — standard pattern in this codebase's data hooks
+	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data,error,loading} state, standard in this codebase
 	return { metrics, loading, error };
 }
 

--- a/apps/web/src/islands/ProjectLanding.test.tsx
+++ b/apps/web/src/islands/ProjectLanding.test.tsx
@@ -38,8 +38,8 @@ const WIKI_PAGE = {
 };
 
 function mockFetchProject(
-	issues: (typeof ISSUE)[] = [ISSUE],
-	wiki: unknown[] = [],
+	issues: readonly (typeof ISSUE)[] = [ISSUE],
+	wiki: readonly unknown[] = [],
 	flowMetrics: unknown = { throughputOverTime: [], cfdOverTime: [] }
 ) {
 	vi.stubGlobal(

--- a/apps/web/src/islands/ProjectLanding.tsx
+++ b/apps/web/src/islands/ProjectLanding.tsx
@@ -318,7 +318,10 @@ function RecentWikiSection({ pages, projectId }: { pages: RecentWikiPage[]; proj
 						<div key={page.id} class="py-2 border-b border-border last:border-b-0">
 							<div class="flex justify-between items-baseline gap-2">
 								<a
-									href={`/wiki/${encodeURIComponent(page.slug)}${projectId ? `?projectId=${encodeURIComponent(projectId)}` : ""}`}
+									href={
+										`/wiki/${encodeURIComponent(page.slug)}` +
+										`${projectId ? `?projectId=${encodeURIComponent(projectId)}` : ""}`
+									}
 									class="text-text-base no-underline text-sm hover:underline focus:underline"
 								>
 									{page.title}

--- a/apps/web/src/islands/ProjectLanding.tsx
+++ b/apps/web/src/islands/ProjectLanding.tsx
@@ -68,11 +68,11 @@ function sortByRecency<T extends { updated_at: number }>(items: unknown, limit: 
 async function loadProjectData(
 	idOrSlug: string,
 	workspaceSlug: string | undefined,
-	setters: {
+	setters: Readonly<{
 		setProject: (p: Project) => void;
 		setRecentIssues: (v: RecentIssue[]) => void;
 		setRecentWiki: (v: RecentWikiPage[]) => void;
-	}
+	}>
 ) {
 	// /api/projects/:id resolves either a UUID or a slug, but the issues/wiki
 	// endpoints below filter on the real project UUID — resolve the project first.

--- a/apps/web/src/islands/Select.tsx
+++ b/apps/web/src/islands/Select.tsx
@@ -13,7 +13,7 @@ const OPEN_TRIGGER_KEYS = new Set(["ArrowDown", "Enter", " "]);
 function useCloseOnOutside(
 	open: boolean,
 	close: () => void,
-	rootRef: { current: HTMLDivElement | null }
+	rootRef: Readonly<{ current: HTMLDivElement | null }>
 ) {
 	useEffect(() => {
 		if (!open) return;

--- a/apps/web/src/islands/SprintManager.test.tsx
+++ b/apps/web/src/islands/SprintManager.test.tsx
@@ -32,7 +32,7 @@ const SPRINT: Sprint = {
 	createdAt: 1000,
 };
 
-function mockFetchSprints(sprints: Sprint[] = [SPRINT]) {
+function mockFetchSprints(sprints: readonly Sprint[] = [SPRINT]) {
 	vi.stubGlobal(
 		"fetch",
 		vi.fn().mockImplementation((url: string) => {

--- a/apps/web/src/islands/SprintManager.tsx
+++ b/apps/web/src/islands/SprintManager.tsx
@@ -321,7 +321,7 @@ function useSprintData(workspaceSlug: string | undefined) {
 		if (projectId) fetchSprints(projectId);
 	}, [projectId, fetchSprints]);
 
-	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data, error, loading} state so components can render error UI declaratively — standard pattern in this codebase's data hooks
+	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data,error,loading} state, standard in this codebase
 	return { projectId, project, sprints, loading, error, fetchSprints };
 }
 

--- a/apps/web/src/islands/SprintManager.tsx
+++ b/apps/web/src/islands/SprintManager.tsx
@@ -90,7 +90,7 @@ async function fetchSprintIssues(
 	return data.items;
 }
 
-function computeVelocity(sprint: Sprint, issues: Issue[]): SprintVelocity {
+function computeVelocity(sprint: Sprint, issues: readonly Issue[]): SprintVelocity {
 	return {
 		sprint,
 		pointsCompleted: issues
@@ -100,11 +100,11 @@ function computeVelocity(sprint: Sprint, issues: Issue[]): SprintVelocity {
 	};
 }
 
-function activeCountOf(sprints: Sprint[]): number {
+function activeCountOf(sprints: readonly Sprint[]): number {
 	return sprints.filter((s) => s.status === "active").length;
 }
 
-function completedSprintsOf(sprints: Sprint[]): Sprint[] {
+function completedSprintsOf(sprints: readonly Sprint[]): Sprint[] {
 	return sprints.filter((s) => s.status === "completed");
 }
 
@@ -325,7 +325,7 @@ function useSprintData(workspaceSlug: string | undefined) {
 	return { projectId, project, sprints, loading, error, fetchSprints };
 }
 
-function useSprintVelocity(sprints: Sprint[], workspaceSlug: string | undefined) {
+function useSprintVelocity(sprints: readonly Sprint[], workspaceSlug: string | undefined) {
 	const [velocityData, setVelocityData] = useState<SprintVelocity[]>([]);
 	const [velocityLoading, setVelocityLoading] = useState(false);
 
@@ -429,7 +429,7 @@ function useSprintCreateForm(
 
 function useSprintComplete(
 	projectId: string | null,
-	sprints: Sprint[],
+	sprints: readonly Sprint[],
 	workspaceSlug: string | undefined,
 	refetch: (pid: string) => Promise<void>
 ) {

--- a/apps/web/src/islands/TokenManager.test.tsx
+++ b/apps/web/src/islands/TokenManager.test.tsx
@@ -17,7 +17,7 @@ const TOKEN = {
 	createdAt: 1000,
 };
 
-function mockFetchTokens(tokens: (typeof TOKEN)[] = [TOKEN]) {
+function mockFetchTokens(tokens: readonly (typeof TOKEN)[] = [TOKEN]) {
 	vi.stubGlobal(
 		"fetch",
 		vi.fn().mockImplementation((url: string) => {

--- a/apps/web/src/islands/WikiPage.test.tsx
+++ b/apps/web/src/islands/WikiPage.test.tsx
@@ -524,7 +524,7 @@ describe("server-side draft autosave (PROJ-495) — restore banner", () => {
 describe("optimistic locking (PROJ-507)", () => {
 	const REVISION = { id: "rev-1", author_id: "u1", author_name: "Ann", created_at: 500 };
 
-	function mockFetchWikiWithRevision(putResponse: { ok: boolean; status?: number }) {
+	function mockFetchWikiWithRevision(putResponse: Readonly<{ ok: boolean; status?: number }>) {
 		return vi.fn().mockImplementation((url: string, init?: RequestInit) => {
 			const u = String(url);
 			if (u.includes("/revisions")) {
@@ -1123,11 +1123,11 @@ describe("revision history: diff view + restore (PROJ-492)", () => {
 		summary: "Fixed a typo",
 	};
 
-	function mockFetchWithRevision(opts: {
+	function mockFetchWithRevision(opts: Readonly<{
 		diff?: { from: string; to: string; diff: string };
 		oldRevisionContent?: string;
 		putResponse?: { ok: boolean; status?: number };
-	}) {
+	}>) {
 		return vi.fn().mockImplementation((url: string, init?: RequestInit) => {
 			const u = String(url);
 			if (u.includes("/diff")) {

--- a/apps/web/src/islands/WikiPage.test.tsx
+++ b/apps/web/src/islands/WikiPage.test.tsx
@@ -231,7 +231,7 @@ describe("WikiPage — path-based routing (PROJ-487)", () => {
 		});
 	});
 
-	it("redirects straight to the current canonical slug, not the requested one (avoids a redirect chain, PROJ-483)", async () => {
+	it("redirects to the current canonical slug, not the requested one (no redirect chain, PROJ-483)", async () => {
 		// The old/renamed slug was requested (e.g. via a stale bookmark that hit the
 		// Worker's pretty-URL fallback), but the API's live-then-redirect lookup
 		// resolved it to the page's current slug.
@@ -1123,11 +1123,13 @@ describe("revision history: diff view + restore (PROJ-492)", () => {
 		summary: "Fixed a typo",
 	};
 
-	function mockFetchWithRevision(opts: Readonly<{
-		diff?: { from: string; to: string; diff: string };
-		oldRevisionContent?: string;
-		putResponse?: { ok: boolean; status?: number };
-	}>) {
+	function mockFetchWithRevision(
+		opts: Readonly<{
+			diff?: { from: string; to: string; diff: string };
+			oldRevisionContent?: string;
+			putResponse?: { ok: boolean; status?: number };
+		}>
+	) {
 		return vi.fn().mockImplementation((url: string, init?: RequestInit) => {
 			const u = String(url);
 			if (u.includes("/diff")) {

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -99,7 +99,7 @@ const WIKI_WELL_KNOWN_TYPES = new Set(WIKI_TYPE_FILTER_OPTIONS.map((o) => o.valu
 // case-insensitively (frontmatter `type` is never case-normalized) so e.g. `Runbook`
 // doesn't produce a second, visually-indistinguishable entry alongside the well-known
 // lowercase `runbook`.
-function buildTypeFilterOptions(discoveredTypes: string[]): SelectOption[] {
+function buildTypeFilterOptions(discoveredTypes: readonly string[]): SelectOption[] {
 	const seen = new Set(Array.from(WIKI_WELL_KNOWN_TYPES).map((t) => t.toLowerCase()));
 	const extras: string[] = [];
 	for (const t of discoveredTypes) {
@@ -309,7 +309,7 @@ function formatBytes(bytes: number): string {
 
 // PROJ-514: walks the tree already fetched by useWikiTree to discover distinct `type`
 // values for the sidebar filter dropdown, instead of issuing a second unfiltered fetch.
-function collectTreeTypes(nodes: TreeNode[]): string[] {
+function collectTreeTypes(nodes: readonly TreeNode[]): string[] {
 	const types: string[] = [];
 	for (const node of nodes) {
 		if (node.type) types.push(node.type);
@@ -318,7 +318,7 @@ function collectTreeTypes(nodes: TreeNode[]): string[] {
 	return types;
 }
 
-function flattenTree(nodes: TreeNode[], parentId: string | null = null): Record<string, FlatEntry> {
+function flattenTree(nodes: readonly TreeNode[], parentId: string | null = null): Record<string, FlatEntry> {
 	const map: Record<string, FlatEntry> = {};
 	for (const node of nodes) {
 		map[node.id] = { id: node.id, slug: node.slug, title: node.title, parentId };
@@ -1678,7 +1678,7 @@ interface CreateFormProps {
 	onCancel: () => void;
 }
 
-function WikiMainContent(props: {
+function WikiMainContent(props: Readonly<{
 	creating: boolean;
 	createProps: CreateFormProps;
 	slug: string;
@@ -1686,7 +1686,7 @@ function WikiMainContent(props: {
 	error: string | null;
 	page: WikiPageData | null;
 	articleProps: Omit<PageArticleProps, "page">;
-}) {
+}>) {
 	if (props.creating) return <CreatePageForm {...props.createProps} />;
 	if (!props.slug) {
 		return <p class="text-text-muted">Select a page from the sidebar or create a new one.</p>;
@@ -1824,7 +1824,7 @@ function useWikiStalePages(workspaceSlug: string | undefined, projectId: string)
 function useWikiFilters(
 	workspaceSlug: string | undefined,
 	projectId: string,
-	pageTree: TreeNode[]
+	pageTree: readonly TreeNode[]
 ) {
 	const [filterType, setFilterType] = useState("");
 	const [filterStatus, setFilterStatus] = useState("");
@@ -1880,7 +1880,7 @@ function useWikiFilters(
 function useWikiSearch(
 	workspaceSlug: string | undefined,
 	projectId: string,
-	filters: { filterType: string; filterStatus: string; filterTags: string }
+	filters: Readonly<{ filterType: string; filterStatus: string; filterTags: string }>
 ) {
 	const [searchQuery, setSearchQuery] = useState("");
 	const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
@@ -2684,7 +2684,7 @@ function useCreatePageForm(
 	};
 }
 
-function createWikiActions(args: {
+function createWikiActions(args: Readonly<{
 	workspaceSlug: string | undefined;
 	page: WikiPageData | null;
 	fetchTree: () => Promise<void>;
@@ -2697,7 +2697,7 @@ function createWikiActions(args: {
 	rawStartCreate: (parentId: string | null) => void;
 	rawSubmitCreate: () => Promise<string | undefined>;
 	cancelMove: () => void;
-}) {
+}>) {
 	const {
 		workspaceSlug,
 		page,
@@ -2794,7 +2794,7 @@ const WIKI_PAGE_STYLES = `
 	}
 `;
 
-function WikiPageShell(props: {
+function WikiPageShell(props: Readonly<{
 	workspaceSlug: string | undefined;
 	projectId: string;
 	searchQuery: string;
@@ -2817,7 +2817,7 @@ function WikiPageShell(props: {
 		page: WikiPageData | null;
 		articleProps: Omit<PageArticleProps, "page">;
 	};
-}) {
+}>) {
 	return (
 		<div class="flex min-h-screen max-sm:flex-col">
 			<style>{WIKI_PAGE_STYLES}</style>
@@ -2861,7 +2861,7 @@ function deriveWikiPageState(
 	pageMap: Record<string, FlatEntry>,
 	editState: ReturnType<typeof useWikiEditing>,
 	createForm: ReturnType<typeof useCreatePageForm>,
-	toc: TocItem[]
+	toc: readonly TocItem[]
 ) {
 	const latestRevision = pageData.revisions[0] ?? null;
 	// Breadcrumbs for current page (PROJ-114)
@@ -2881,7 +2881,7 @@ function deriveWikiPageState(
 	return { latestRevision, breadcrumbs, showToc, createParentTitle, wikiPages, moveOptions };
 }
 
-function buildCreateFormProps(create: {
+function buildCreateFormProps(create: Readonly<{
 	createParentTitle: string | null;
 	createTitle: string;
 	createSlug: string;
@@ -2896,7 +2896,7 @@ function buildCreateFormProps(create: {
 	onCreateTemplateChange: (v: string) => void;
 	submitCreate: () => void;
 	cancelCreate: () => void;
-}): CreateFormProps {
+}>): CreateFormProps {
 	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data, error, loading} state so components can render error UI declaratively — standard pattern in this codebase's data hooks
 	return {
 		parentTitle: create.createParentTitle,
@@ -2916,7 +2916,7 @@ function buildCreateFormProps(create: {
 	};
 }
 
-function buildArticleProps(article: {
+function buildArticleProps(article: Readonly<{
 	breadcrumbs: FlatEntry[];
 	navigateTo: (slug: string) => void;
 	showToc: boolean;
@@ -2952,7 +2952,7 @@ function buildArticleProps(article: {
 	workspaceSlug: string | undefined;
 	move: ReturnType<typeof useMovePage>;
 	moveOptions: SelectOption[];
-}): Omit<PageArticleProps, "page"> {
+}>): Omit<PageArticleProps, "page"> {
 	return {
 		breadcrumbs: article.breadcrumbs,
 		onNavigate: article.navigateTo,

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -213,9 +213,19 @@ function WikiMetadataCard({
 	if (!hasMetadata && !hasVerificationSignal) return null;
 
 	return (
-		<div class="flex flex-wrap items-center gap-2 mb-4 p-3 border border-border rounded-lg bg-surface text-[0.8rem] text-text-muted">
+		<div
+			class={
+				"flex flex-wrap items-center gap-2 mb-4 p-3 border border-border rounded-lg " +
+				"bg-surface text-[0.8rem] text-text-muted"
+			}
+		>
 			{page.type && (
-				<span class="inline-flex items-center px-2 py-[0.1rem] rounded-full text-[0.72rem] font-semibold uppercase tracking-wide bg-bg border border-border text-text-muted">
+				<span
+					class={
+						"inline-flex items-center px-2 py-[0.1rem] rounded-full text-[0.72rem] font-semibold " +
+						"uppercase tracking-wide bg-bg border border-border text-text-muted"
+					}
+				>
 					{page.type}
 				</span>
 			)}
@@ -318,7 +328,10 @@ function collectTreeTypes(nodes: readonly TreeNode[]): string[] {
 	return types;
 }
 
-function flattenTree(nodes: readonly TreeNode[], parentId: string | null = null): Record<string, FlatEntry> {
+function flattenTree(
+	nodes: readonly TreeNode[],
+	parentId: string | null = null
+): Record<string, FlatEntry> {
 	const map: Record<string, FlatEntry> = {};
 	for (const node of nodes) {
 		map[node.id] = { id: node.id, slug: node.slug, title: node.title, parentId };
@@ -1108,7 +1121,12 @@ function RevisionDiffView({ diff }: { diff: string }) {
 		return <p class="mt-2 mb-1 text-[0.75rem] text-text-muted italic">No changes.</p>;
 	}
 	return (
-		<pre class="mt-2 mb-1 p-2 bg-surface border border-border rounded-md text-[0.75rem] overflow-x-auto leading-snug whitespace-pre-wrap">
+		<pre
+			class={
+				"mt-2 mb-1 p-2 bg-surface border border-border rounded-md text-[0.75rem] " +
+				"overflow-x-auto leading-snug whitespace-pre-wrap"
+			}
+		>
 			{diff.split("\n").map((line, i) => {
 				const cls = line.startsWith("+")
 					? "text-green-600"
@@ -1678,15 +1696,17 @@ interface CreateFormProps {
 	onCancel: () => void;
 }
 
-function WikiMainContent(props: Readonly<{
-	creating: boolean;
-	createProps: CreateFormProps;
-	slug: string;
-	loading: boolean;
-	error: string | null;
-	page: WikiPageData | null;
-	articleProps: Omit<PageArticleProps, "page">;
-}>) {
+function WikiMainContent(
+	props: Readonly<{
+		creating: boolean;
+		createProps: CreateFormProps;
+		slug: string;
+		loading: boolean;
+		error: string | null;
+		page: WikiPageData | null;
+		articleProps: Omit<PageArticleProps, "page">;
+	}>
+) {
 	if (props.creating) return <CreatePageForm {...props.createProps} />;
 	if (!props.slug) {
 		return <p class="text-text-muted">Select a page from the sidebar or create a new one.</p>;
@@ -1976,7 +1996,7 @@ function useWikiPageData(workspaceSlug: string | undefined, slug: string) {
 		}
 	}, [slug, fetchPage, fetchRevisions]);
 
-	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data, error, loading} state so components can render error UI declaratively — standard pattern in this codebase's data hooks
+	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data,error,loading} state, standard in this codebase
 	return {
 		page,
 		setPage,
@@ -2044,7 +2064,7 @@ function useTableOfContents(page: WikiPageData | null, contentRef: RefObject<HTM
 		const headings = Array.from(container.querySelectorAll("h1, h2, h3")) as HTMLElement[];
 		headings.forEach((h) => {
 			if (!h.id) {
-				// cofferdam-ignore: Refactor.MutatedParameter: setting a live DOM element's id is the point (anchor IDs for the ToC), not a code smell
+				// cofferdam-ignore: Refactor.MutatedParameter: setting a live DOM element's id is the point (anchor IDs)
 				h.id = (h.textContent ?? "")
 					.toLowerCase()
 					.replace(/[^a-z0-9]+/g, "-")
@@ -2397,7 +2417,8 @@ function useWikiEditing(
 			// part of it, and slugs like "proj-409-notes" would otherwise read as conflicts.
 			if (String(e).endsWith("failed: 409")) {
 				setSaveError(
-					"This page was changed by someone else since you loaded it. Reload the page before saving to avoid overwriting their changes."
+					"This page was changed by someone else since you loaded it. Reload the page before " +
+						"saving to avoid overwriting their changes."
 				);
 			} else {
 				setSaveError(`Save failed: ${String(e)}`);
@@ -2684,20 +2705,22 @@ function useCreatePageForm(
 	};
 }
 
-function createWikiActions(args: Readonly<{
-	workspaceSlug: string | undefined;
-	page: WikiPageData | null;
-	fetchTree: () => Promise<void>;
-	setSlug: (s: string) => void;
-	setCreating: (v: boolean) => void;
-	setEditing: (v: boolean) => void;
-	setPage: (p: WikiPageData | null) => void;
-	setError: (e: string | null) => void;
-	setToc: (t: TocItem[]) => void;
-	rawStartCreate: (parentId: string | null) => void;
-	rawSubmitCreate: () => Promise<string | undefined>;
-	cancelMove: () => void;
-}>) {
+function createWikiActions(
+	args: Readonly<{
+		workspaceSlug: string | undefined;
+		page: WikiPageData | null;
+		fetchTree: () => Promise<void>;
+		setSlug: (s: string) => void;
+		setCreating: (v: boolean) => void;
+		setEditing: (v: boolean) => void;
+		setPage: (p: WikiPageData | null) => void;
+		setError: (e: string | null) => void;
+		setToc: (t: TocItem[]) => void;
+		rawStartCreate: (parentId: string | null) => void;
+		rawSubmitCreate: () => Promise<string | undefined>;
+		cancelMove: () => void;
+	}>
+) {
 	const {
 		workspaceSlug,
 		page,
@@ -2794,30 +2817,32 @@ const WIKI_PAGE_STYLES = `
 	}
 `;
 
-function WikiPageShell(props: Readonly<{
-	workspaceSlug: string | undefined;
-	projectId: string;
-	searchQuery: string;
-	onSearchQueryChange: (v: string) => void;
-	searchResults: SearchResult[];
-	searchLoading: boolean;
-	treeLoading: boolean;
-	pageTree: TreeNode[];
-	slug: string;
-	onNavigate: (slug: string) => void;
-	onCreate: () => void;
-	filters: ReturnType<typeof useWikiFilters>;
-	stale: ReturnType<typeof useWikiStalePages>;
-	mainContentProps: {
-		creating: boolean;
-		createProps: CreateFormProps;
+function WikiPageShell(
+	props: Readonly<{
+		workspaceSlug: string | undefined;
+		projectId: string;
+		searchQuery: string;
+		onSearchQueryChange: (v: string) => void;
+		searchResults: SearchResult[];
+		searchLoading: boolean;
+		treeLoading: boolean;
+		pageTree: TreeNode[];
 		slug: string;
-		loading: boolean;
-		error: string | null;
-		page: WikiPageData | null;
-		articleProps: Omit<PageArticleProps, "page">;
-	};
-}>) {
+		onNavigate: (slug: string) => void;
+		onCreate: () => void;
+		filters: ReturnType<typeof useWikiFilters>;
+		stale: ReturnType<typeof useWikiStalePages>;
+		mainContentProps: {
+			creating: boolean;
+			createProps: CreateFormProps;
+			slug: string;
+			loading: boolean;
+			error: string | null;
+			page: WikiPageData | null;
+			articleProps: Omit<PageArticleProps, "page">;
+		};
+	}>
+) {
 	return (
 		<div class="flex min-h-screen max-sm:flex-col">
 			<style>{WIKI_PAGE_STYLES}</style>
@@ -2881,23 +2906,25 @@ function deriveWikiPageState(
 	return { latestRevision, breadcrumbs, showToc, createParentTitle, wikiPages, moveOptions };
 }
 
-function buildCreateFormProps(create: Readonly<{
-	createParentTitle: string | null;
-	createTitle: string;
-	createSlug: string;
-	createContent: string;
-	createError: string | null;
-	createSaving: boolean;
-	templates: TemplateOption[];
-	createTemplateSlug: string;
-	onCreateTitleChange: (v: string) => void;
-	onCreateSlugChange: (v: string) => void;
-	setCreateContent: (v: string) => void;
-	onCreateTemplateChange: (v: string) => void;
-	submitCreate: () => void;
-	cancelCreate: () => void;
-}>): CreateFormProps {
-	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data, error, loading} state so components can render error UI declaratively — standard pattern in this codebase's data hooks
+function buildCreateFormProps(
+	create: Readonly<{
+		createParentTitle: string | null;
+		createTitle: string;
+		createSlug: string;
+		createContent: string;
+		createError: string | null;
+		createSaving: boolean;
+		templates: TemplateOption[];
+		createTemplateSlug: string;
+		onCreateTitleChange: (v: string) => void;
+		onCreateSlugChange: (v: string) => void;
+		setCreateContent: (v: string) => void;
+		onCreateTemplateChange: (v: string) => void;
+		submitCreate: () => void;
+		cancelCreate: () => void;
+	}>
+): CreateFormProps {
+	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data,error,loading} state, standard in this codebase
 	return {
 		parentTitle: create.createParentTitle,
 		title: create.createTitle,
@@ -2916,43 +2943,45 @@ function buildCreateFormProps(create: Readonly<{
 	};
 }
 
-function buildArticleProps(article: Readonly<{
-	breadcrumbs: FlatEntry[];
-	navigateTo: (slug: string) => void;
-	showToc: boolean;
-	toc: TocItem[];
-	activeHeadingId: string;
-	contentRef: RefObject<HTMLDivElement>;
-	editing: boolean;
-	editTitle: string;
-	setEditTitle: (v: string) => void;
-	saving: boolean;
-	save: () => void;
-	cancelEdit: () => void;
-	startEdit: () => void;
-	startCreate: (parentId: string | null) => void;
-	deletePage: () => void;
-	onVerify: () => void;
-	verifying: boolean;
-	verifyError: string | null;
-	latestRevision: WikiRevision | null;
-	saveError: string | null;
-	draftBanner: ServerDraft | null;
-	restoreDraft: () => void;
-	discardDraft: () => void;
-	editContent: string;
-	setEditContent: (v: string) => void;
-	wikiPages: FlatEntry[];
-	revisions: WikiRevision[];
-	showHistory: boolean;
-	setShowHistory: (updater: (h: boolean) => boolean) => void;
-	onRestoreRevision: (revision: WikiRevision) => void;
-	restoringRevisionId: string | null;
-	attach: ReturnType<typeof useWikiAttachments>;
-	workspaceSlug: string | undefined;
-	move: ReturnType<typeof useMovePage>;
-	moveOptions: SelectOption[];
-}>): Omit<PageArticleProps, "page"> {
+function buildArticleProps(
+	article: Readonly<{
+		breadcrumbs: FlatEntry[];
+		navigateTo: (slug: string) => void;
+		showToc: boolean;
+		toc: TocItem[];
+		activeHeadingId: string;
+		contentRef: RefObject<HTMLDivElement>;
+		editing: boolean;
+		editTitle: string;
+		setEditTitle: (v: string) => void;
+		saving: boolean;
+		save: () => void;
+		cancelEdit: () => void;
+		startEdit: () => void;
+		startCreate: (parentId: string | null) => void;
+		deletePage: () => void;
+		onVerify: () => void;
+		verifying: boolean;
+		verifyError: string | null;
+		latestRevision: WikiRevision | null;
+		saveError: string | null;
+		draftBanner: ServerDraft | null;
+		restoreDraft: () => void;
+		discardDraft: () => void;
+		editContent: string;
+		setEditContent: (v: string) => void;
+		wikiPages: FlatEntry[];
+		revisions: WikiRevision[];
+		showHistory: boolean;
+		setShowHistory: (updater: (h: boolean) => boolean) => void;
+		onRestoreRevision: (revision: WikiRevision) => void;
+		restoringRevisionId: string | null;
+		attach: ReturnType<typeof useWikiAttachments>;
+		workspaceSlug: string | undefined;
+		move: ReturnType<typeof useMovePage>;
+		moveOptions: SelectOption[];
+	}>
+): Omit<PageArticleProps, "page"> {
 	return {
 		breadcrumbs: article.breadcrumbs,
 		onNavigate: article.navigateTo,

--- a/apps/web/src/islands/board-utils.ts
+++ b/apps/web/src/islands/board-utils.ts
@@ -155,7 +155,11 @@ const SORT_COMPARATORS: Record<SortKey, (a: Issue, b: Issue) => number> = {
 };
 
 /** Sorts a copy of an issue list by the given SortKey. */
-export function sortIssues(issues: readonly Issue[], sortBy: SortKey, sortDir: "asc" | "desc"): Issue[] {
+export function sortIssues(
+	issues: readonly Issue[],
+	sortBy: SortKey,
+	sortDir: "asc" | "desc"
+): Issue[] {
 	const compare = SORT_COMPARATORS[sortBy];
 	return [...issues].sort((a, b) => {
 		const diff = compare ? compare(a, b) : 0;

--- a/apps/web/src/islands/board-utils.ts
+++ b/apps/web/src/islands/board-utils.ts
@@ -92,7 +92,7 @@ export function assigneeInitials(name: string): string {
  * For other categories: returns the first status in that category.
  */
 export function getFirstStatusForCategory(
-	statuses: TaskStatus[],
+	statuses: readonly TaskStatus[],
 	category: string
 ): TaskStatus | undefined {
 	if (category === "todo") {
@@ -108,22 +108,22 @@ export function getFirstStatusForCategory(
  * Returns issues to display in a board column.
  * Todo column excludes backlog issues (those belong to the Backlog view).
  */
-export function getBoardColumnIssues(issues: Issue[], category: string): Issue[] {
+export function getBoardColumnIssues(issues: readonly Issue[], category: string): Issue[] {
 	return issues.filter(
 		(i) => i.status_category === category && (category !== "todo" || i.status_key !== "backlog")
 	);
 }
 
 /** Returns issues for the Backlog view: todo category with backlog key. */
-export function getBacklogIssues(issues: Issue[]): Issue[] {
+export function getBacklogIssues(issues: readonly Issue[]): Issue[] {
 	return issues.filter((i) => i.status_category === "todo" && i.status_key === "backlog");
 }
 
 /** Applies multi-predicate filtering to an issue list (all predicates are AND-ed). */
 export function filterIssues(
-	issues: Issue[],
-	filterStatuses: string[],
-	filterPriorities: string[],
+	issues: readonly Issue[],
+	filterStatuses: readonly string[],
+	filterPriorities: readonly string[],
 	filterProject: string,
 	filterType: string
 ): Issue[] {
@@ -155,7 +155,7 @@ const SORT_COMPARATORS: Record<SortKey, (a: Issue, b: Issue) => number> = {
 };
 
 /** Sorts a copy of an issue list by the given SortKey. */
-export function sortIssues(issues: Issue[], sortBy: SortKey, sortDir: "asc" | "desc"): Issue[] {
+export function sortIssues(issues: readonly Issue[], sortBy: SortKey, sortDir: "asc" | "desc"): Issue[] {
 	const compare = SORT_COMPARATORS[sortBy];
 	return [...issues].sort((a, b) => {
 		const diff = compare ? compare(a, b) : 0;

--- a/apps/web/src/islands/charts/CodeHeatmap.tsx
+++ b/apps/web/src/islands/charts/CodeHeatmap.tsx
@@ -66,7 +66,7 @@ function useCodeHeatmap(
 			.finally(() => setLoading(false));
 	}, [workspaceSlug, projectId, since, until, prefix, mode]);
 
-	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data, error, loading} state so components can render error UI declaratively — standard pattern in this codebase's data hooks
+	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data,error,loading} state, standard in this codebase
 	return { mode, setMode, prefix, setPrefix, data, loading, error };
 }
 

--- a/apps/web/src/islands/charts/UplotChart.tsx
+++ b/apps/web/src/islands/charts/UplotChart.tsx
@@ -22,7 +22,7 @@ export default function UplotChart({ data, buildOptions, height = 220 }: Props) 
 
 		function create(el: HTMLDivElement) {
 			chartRef.current?.destroy();
-			// cofferdam-ignore: Refactor.PreferNullishCoalescing: clientWidth is legitimately 0 before layout — that's the case this falls back on, so ?? (which keeps 0) would be wrong here
+			// cofferdam-ignore: Refactor.PreferNullishCoalescing: clientWidth is legitimately 0 pre-layout; ?? would keep it
 			const width = el.clientWidth || 600;
 			chartRef.current = new uPlot(buildOptions(width, height), data, el);
 		}

--- a/apps/web/src/islands/issue-list/BacklogView.tsx
+++ b/apps/web/src/islands/issue-list/BacklogView.tsx
@@ -11,7 +11,7 @@ import {
 	statusBadge,
 } from "./issue-render-helpers";
 
-function applyBacklogOrder(issues: Issue[], backlogOrder: string[]): Issue[] {
+function applyBacklogOrder(issues: readonly Issue[], backlogOrder: string[]): readonly Issue[] {
 	if (backlogOrder.length === 0) return issues;
 	const inOrder = backlogOrder.flatMap((id) => {
 		const issue = issues.find((i) => i.id === id);
@@ -175,7 +175,7 @@ function BacklogMobileCards({
 	updatingPriorityId,
 	changePriority,
 }: {
-	issues: Issue[];
+	issues: readonly Issue[];
 	updatingPriorityId: string | null;
 	changePriority: (issueId: string, priority: string) => void;
 }) {

--- a/apps/web/src/islands/issue-list/FiltersPopover.tsx
+++ b/apps/web/src/islands/issue-list/FiltersPopover.tsx
@@ -16,7 +16,7 @@ function StatusPills({
 	filterStatuses,
 	setFilterStatuses,
 }: {
-	derivedStatuses: TaskStatus[];
+	derivedStatuses: readonly TaskStatus[];
 	filterStatuses: string[];
 	setFilterStatuses: Dispatch<StateUpdater<string[]>>;
 }) {
@@ -153,7 +153,7 @@ function DateRangeFilter({
 }
 
 interface FiltersPopoverProps {
-	derivedStatuses: TaskStatus[];
+	derivedStatuses: readonly TaskStatus[];
 	filterStatuses: string[];
 	setFilterStatuses: Dispatch<StateUpdater<string[]>>;
 	filterPriorities: string[];

--- a/apps/web/src/islands/issue-list/HeaderRow.tsx
+++ b/apps/web/src/islands/issue-list/HeaderRow.tsx
@@ -9,7 +9,7 @@ function countLabel(view: ViewMode, filtered: Issue[], totalIssues: number): str
 	return `${listCount} issue${listCount !== 1 ? "s" : ""}${suffix}`;
 }
 
-function searchCountLabel(results: SearchResult[], query: string): string {
+function searchCountLabel(results: readonly SearchResult[], query: string): string {
 	return `${results.length} result${results.length !== 1 ? "s" : ""} for «${query.trim()}»`;
 }
 

--- a/apps/web/src/islands/issue-list/SearchBox.tsx
+++ b/apps/web/src/islands/issue-list/SearchBox.tsx
@@ -20,9 +20,8 @@ export default function SearchBox({
 				onInput={(e) => setSearchQuery((e.target as HTMLInputElement).value)}
 				placeholder="Search…"
 				aria-label="Search issues"
-				class={`py-1 px-[0.625rem] border border-border rounded bg-bg text-text-base text-[0.8rem] outline-none max-sm:w-full ${
-					isSearchActive ? "w-48" : "w-28"
-				}`}
+				class={`py-1 px-[0.625rem] border border-border rounded bg-bg text-text-base text-[0.8rem]
+					outline-none max-sm:w-full ${isSearchActive ? "w-48" : "w-28"}`}
 				style={{ transition: "width 0.2s" }}
 			/>
 			{isSearchActive && (

--- a/apps/web/src/islands/issue-list/Toolbar.tsx
+++ b/apps/web/src/islands/issue-list/Toolbar.tsx
@@ -161,7 +161,7 @@ interface ToolbarProps extends FilterSelectsProps {
 	isSearchActive: boolean;
 	searchInputRef: RefObject<HTMLInputElement>;
 
-	derivedStatuses: TaskStatus[];
+	derivedStatuses: readonly TaskStatus[];
 	filterStatuses: string[];
 	setFilterStatuses: Dispatch<StateUpdater<string[]>>;
 	filterPriorities: string[];

--- a/apps/web/src/islands/issue-list/derive.ts
+++ b/apps/web/src/islands/issue-list/derive.ts
@@ -11,7 +11,10 @@ export function deriveProjectDescription(
 }
 
 /** Status filter options: prefer the statuses endpoint, else derive from loaded issues. */
-export function deriveStatusOptions(issues: readonly Issue[], statuses: readonly TaskStatus[]): readonly TaskStatus[] {
+export function deriveStatusOptions(
+	issues: readonly Issue[],
+	statuses: readonly TaskStatus[]
+): readonly TaskStatus[] {
 	if (statuses.length > 0) return statuses;
 	return [
 		...new Map(
@@ -33,7 +36,9 @@ export function deriveStatusOptions(issues: readonly Issue[], statuses: readonly
 	];
 }
 
-export function deriveProjectOptions(issues: readonly Issue[]): Array<{ key: string; name: string }> {
+export function deriveProjectOptions(
+	issues: readonly Issue[]
+): Array<{ key: string; name: string }> {
 	return [
 		...new Map(
 			issues

--- a/apps/web/src/islands/issue-list/derive.ts
+++ b/apps/web/src/islands/issue-list/derive.ts
@@ -3,7 +3,7 @@ import type { ProjectMeta } from "./types";
 
 /** Description of the active project filter, for the banner under the toolbar. */
 export function deriveProjectDescription(
-	projects: ProjectMeta[],
+	projects: readonly ProjectMeta[],
 	filterProject: string
 ): string | null {
 	if (!filterProject) return null;
@@ -11,7 +11,7 @@ export function deriveProjectDescription(
 }
 
 /** Status filter options: prefer the statuses endpoint, else derive from loaded issues. */
-export function deriveStatusOptions(issues: Issue[], statuses: TaskStatus[]): TaskStatus[] {
+export function deriveStatusOptions(issues: readonly Issue[], statuses: readonly TaskStatus[]): readonly TaskStatus[] {
 	if (statuses.length > 0) return statuses;
 	return [
 		...new Map(
@@ -33,7 +33,7 @@ export function deriveStatusOptions(issues: Issue[], statuses: TaskStatus[]): Ta
 	];
 }
 
-export function deriveProjectOptions(issues: Issue[]): Array<{ key: string; name: string }> {
+export function deriveProjectOptions(issues: readonly Issue[]): Array<{ key: string; name: string }> {
 	return [
 		...new Map(
 			issues
@@ -48,7 +48,7 @@ export function deriveProjectOptions(issues: Issue[]): Array<{ key: string; name
 	];
 }
 
-export function deriveTypeOptions(issues: Issue[]): Array<[string, string]> {
+export function deriveTypeOptions(issues: readonly Issue[]): Array<[string, string]> {
 	return [
 		...new Map(
 			issues

--- a/apps/web/src/islands/issue-list/useIssueFetching.ts
+++ b/apps/web/src/islands/issue-list/useIssueFetching.ts
@@ -108,7 +108,7 @@ export function useIssueFetching(
 		fetchIssues();
 	}, [fetchIssues]);
 
-	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data, error, loading} state so components can render error UI declaratively — standard pattern in this codebase's data hooks
+	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data,error,loading} state, standard in this codebase
 	return {
 		issues,
 		setIssues,

--- a/apps/web/src/islands/issue-list/useIssueMutations.ts
+++ b/apps/web/src/islands/issue-list/useIssueMutations.ts
@@ -6,7 +6,7 @@ import type { Issue, TaskStatus } from "../board-utils";
 /** Owns the status/priority PATCH flows shared by the board, backlog, and list views. */
 export function useIssueMutations(
 	workspaceSlug: string | undefined,
-	statuses: TaskStatus[],
+	statuses: readonly TaskStatus[],
 	setIssues: Dispatch<StateUpdater<Issue[]>>,
 	fetchIssues: () => Promise<void>
 ) {

--- a/apps/web/src/islands/metric-definitions.ts
+++ b/apps/web/src/islands/metric-definitions.ts
@@ -58,7 +58,7 @@ export const METRIC_DEFINITIONS: Record<MetricId, MetricDefinition> = {
 		definition: "What fraction of completed work each bucket was bug fixes, not new work.",
 		computation:
 			"Bug share = bug-typed issues completed ÷ all issues completed, per bucket; buckets with " +
-				"no completions are gapped, not zero.",
+			"no completions are gapped, not zero.",
 	},
 	"review-latency": {
 		label: "Review latency",
@@ -106,10 +106,10 @@ export const METRIC_DEFINITIONS: Record<MetricId, MetricDefinition> = {
 		label: "Aging WIP",
 		definition:
 			"How long issues that are still open have already been in progress or review — stuck " +
-				"work shows up here before it finishes.",
+			"work shows up here before it finishes.",
 		computation:
 			"Age since claim for every currently open in_progress/in_review issue, plotted against " +
-				"this window's cycle-time p50/p90.",
+			"this window's cycle-time p50/p90.",
 	},
 	"lease-expiries": {
 		label: "Lease expiries",
@@ -148,6 +148,6 @@ export const METRIC_DEFINITIONS: Record<MetricId, MetricDefinition> = {
 			"Which parts of the codebase cause agents to collide over file claims, blocking parallelism.",
 		computation:
 			"Directories/paths sized by distinct issues whose claim_files attempt was rejected or " +
-				"overridden there, in the window.",
+			"overridden there, in the window.",
 	},
 };

--- a/apps/web/src/islands/metric-definitions.ts
+++ b/apps/web/src/islands/metric-definitions.ts
@@ -57,7 +57,8 @@ export const METRIC_DEFINITIONS: Record<MetricId, MetricDefinition> = {
 		label: "Bug share",
 		definition: "What fraction of completed work each bucket was bug fixes, not new work.",
 		computation:
-			"Bug share = bug-typed issues completed ÷ all issues completed, per bucket; buckets with no completions are gapped, not zero.",
+			"Bug share = bug-typed issues completed ÷ all issues completed, per bucket; buckets with " +
+				"no completions are gapped, not zero.",
 	},
 	"review-latency": {
 		label: "Review latency",
@@ -104,9 +105,11 @@ export const METRIC_DEFINITIONS: Record<MetricId, MetricDefinition> = {
 	"aging-wip": {
 		label: "Aging WIP",
 		definition:
-			"How long issues that are still open have already been in progress or review — stuck work shows up here before it finishes.",
+			"How long issues that are still open have already been in progress or review — stuck " +
+				"work shows up here before it finishes.",
 		computation:
-			"Age since claim for every currently open in_progress/in_review issue, plotted against this window's cycle-time p50/p90.",
+			"Age since claim for every currently open in_progress/in_review issue, plotted against " +
+				"this window's cycle-time p50/p90.",
 	},
 	"lease-expiries": {
 		label: "Lease expiries",
@@ -144,6 +147,7 @@ export const METRIC_DEFINITIONS: Record<MetricId, MetricDefinition> = {
 		definition:
 			"Which parts of the codebase cause agents to collide over file claims, blocking parallelism.",
 		computation:
-			"Directories/paths sized by distinct issues whose claim_files attempt was rejected or overridden there, in the window.",
+			"Directories/paths sized by distinct issues whose claim_files attempt was rejected or " +
+				"overridden there, in the window.",
 	},
 };

--- a/apps/web/src/islands/metrics/flow-charts.tsx
+++ b/apps/web/src/islands/metrics/flow-charts.tsx
@@ -64,7 +64,7 @@ export function EmptyChartState({ message }: { message: string }) {
 	);
 }
 
-function tickIndices(width: number, labels: string[]): number[] {
+function tickIndices(width: number, labels: readonly string[]): number[] {
 	const n = labels.length;
 	const maxTicks = Math.max(2, Math.floor(width / 70));
 	const stride = Math.max(1, Math.ceil(n / maxTicks));

--- a/apps/web/src/islands/saved-views.ts
+++ b/apps/web/src/islands/saved-views.ts
@@ -88,16 +88,16 @@ export function parseSavedViews(raw: string | null): SavedView[] {
 }
 
 /** Insert or replace a view by name (names are unique within a bucket). */
-export function upsertView(views: SavedView[], view: SavedView): SavedView[] {
+export function upsertView(views: readonly SavedView[], view: SavedView): SavedView[] {
 	return [...views.filter((v) => v.name !== view.name), view];
 }
 
-export function removeView(views: SavedView[], name: string): SavedView[] {
+export function removeView(views: readonly SavedView[], name: string): SavedView[] {
 	return views.filter((v) => v.name !== name);
 }
 
 /** Order-insensitive equality for the two list-valued filters. */
-function sameSet(a: string[], b: string[]): boolean {
+function sameSet(a: readonly string[], b: readonly string[]): boolean {
 	return JSON.stringify([...a].sort()) === JSON.stringify([...b].sort());
 }
 

--- a/apps/web/src/test/viewport.ts
+++ b/apps/web/src/test/viewport.ts
@@ -7,7 +7,7 @@
 import { afterEach } from "vitest";
 
 export const MOBILE_WIDTH = 375;
-// cofferdam-ignore: Design.OrphanExport: exported alongside MOBILE_WIDTH for symmetry; used internally for the afterEach reset today
+// cofferdam-ignore: Design.OrphanExport: exported alongside MOBILE_WIDTH for symmetry; used internally today
 export const DESKTOP_WIDTH = 1024;
 
 export function setViewportWidth(width: number): void {

--- a/apps/web/src/utils/api-client.ts
+++ b/apps/web/src/utils/api-client.ts
@@ -7,7 +7,10 @@ function buildHeaders(
 	return h;
 }
 
-/** Thrown when `apiFetch`'s underlying `fetch` call rejects (network failure/offline), as opposed to a completed HTTP error response. */
+/**
+ * Thrown when `apiFetch`'s underlying `fetch` call rejects (network failure/offline), as opposed
+ * to a completed HTTP error response.
+ */
 export class ApiOfflineError extends Error {
 	constructor(path: string, method: string) {
 		super(`API ${method} ${path} failed: network unavailable`);

--- a/apps/web/src/utils/use-fetch.ts
+++ b/apps/web/src/utils/use-fetch.ts
@@ -35,6 +35,6 @@ export function useFetch<T>(url: string | null, headers: Record<string, string>)
 		};
 	}, [url]);
 
-	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data, error, loading} state so components can render error UI declaratively — standard pattern in this codebase's data hooks
+	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data,error,loading} state, standard in this codebase
 	return { data, loading, error };
 }

--- a/plugins/island-api/expected.json
+++ b/plugins/island-api/expected.json
@@ -45,10 +45,10 @@
       "priority": 15,
       "severity": "high",
       "file": "fixtures/apps/web/src/islands/fixture.ts",
-      "line": 33,
+      "line": 35,
       "column": 19,
-      "start_byte": 1372,
-      "end_byte": 1398,
+      "start_byte": 1587,
+      "end_byte": 1613,
       "message": "Raw \"fetch()\" call — use apiFetch from utils/api-client.ts instead.",
       "baselined": false
     },
@@ -58,10 +58,10 @@
       "priority": 15,
       "severity": "high",
       "file": "fixtures/apps/web/src/islands/fixture.ts",
-      "line": 34,
+      "line": 36,
       "column": 19,
-      "start_byte": 1439,
-      "end_byte": 1472,
+      "start_byte": 1654,
+      "end_byte": 1687,
       "message": "Raw \"window.fetch()\" call — use apiFetch from utils/api-client.ts instead.",
       "baselined": false
     }

--- a/plugins/island-api/src/index.ts
+++ b/plugins/island-api/src/index.ts
@@ -32,7 +32,7 @@ import { Category, defineCheck, Severity, type AstNode } from "@cofferdam/check-
 const BUILD_HEADERS_PATTERN = /\b(function|const)\s+buildHeaders\b/;
 const GLOBAL_FETCH_OBJECTS = new Set(["window", "globalThis", "self"]);
 
-// cofferdam-ignore: Design.OrphanExport: loaded dynamically via cofferdam.toml's `plugins = ["./plugins/island-api"]`, not a static import
+// cofferdam-ignore: Design.OrphanExport: loaded dynamically via cofferdam.toml's plugins list
 export default defineCheck({
   id: "IslandApiConvention",
   category: Category.Warning,

--- a/scripts/gen-conventions-page.ts
+++ b/scripts/gen-conventions-page.ts
@@ -32,7 +32,9 @@ description: "Architecture contract and conventions for working on the Projektor
 sidebar:
   order: 1
 ---
-> **Note:** this page is generated from [\`AGENTS.md\`](https://github.com/TAJD/projektor/blob/main/AGENTS.md) in the repo root by \`scripts/gen-conventions-page.ts\`. Edit that file, not this page - it is overwritten on every generate.
+> **Note:** this page is generated from [\`AGENTS.md\`](https://github.com/TAJD/projektor/blob/main/AGENTS.md)
+> in the repo root by \`scripts/gen-conventions-page.ts\`. Edit that file, not this page - it is
+> overwritten on every generate.
 
 `;
 

--- a/scripts/gen-feedback-example-page.ts
+++ b/scripts/gen-feedback-example-page.ts
@@ -43,7 +43,13 @@ description: "Collect end-user feedback from your own site and route it into a p
 sidebar:
   order: 4
 ---
-> **Note:** the code below is generated from [\`apps/api/src/examples/feedback-widget-submit.ts\`](https://github.com/TAJD/projektor/blob/main/apps/api/src/examples/feedback-widget-submit.ts) by \`scripts/gen-feedback-example-page.ts\`, and is executed against a live projektor instance in [\`apps/api/src/test/feedback-example.test.ts\`](https://github.com/TAJD/projektor/blob/main/apps/api/src/test/feedback-example.test.ts) - edit that source file, not this page, and run \`pnpm gen:docs\`.
+> **Note:** the code below is generated from [\`apps/api/src/examples/feedback-widget-submit.ts\`][src]
+> by \`scripts/gen-feedback-example-page.ts\`, and is executed against a live projektor instance in
+> [\`apps/api/src/test/feedback-example.test.ts\`][test] - edit that source file, not this page, and
+> run \`pnpm gen:docs\`.
+
+[src]: https://github.com/TAJD/projektor/blob/main/apps/api/src/examples/feedback-widget-submit.ts
+[test]: https://github.com/TAJD/projektor/blob/main/apps/api/src/test/feedback-example.test.ts
 
 A **feedback source** is a named, independently-credentialed collection point (e.g.
 "Onboarding survey", "In-app rating widget") that a project owner or admin creates once.


### PR DESCRIPTION
## Summary
- Fix all 150 `Design.ReadonlyArrayParam` findings — annotate never-mutated array params as `readonly T[]`/`ReadonlyArray<T>`/`Readonly<T>`, propagating through downstream signatures where needed.
- Fix all 99 `Readability.MaxLineLength` findings across apps/api, apps/web, plugins/island-api, and scripts/ — using per-content-type strategies (SQL literal newlines, string concatenation for user-facing text, JSX class-attribute reformatting, shortened test descriptions, markdown reference-style links) chosen to avoid changing runtime behavior or visible text.
- Fix a self-introduced regression: several `cofferdam-ignore`/`biome-ignore` suppression comments got wrapped onto two lines during the MaxLineLength pass, which broke the suppression match and caused 6 previously-resolved categories to reappear (ErrorHandlingIdiom, OrphanExport, MutatedParameter, PreferArrayMethodOverLoop, PreferNullishCoalescing, DuplicateExportName) alongside stale UnusedSuppression findings. All reverted to single-line, shortened comments.

## Test plan
- [x] `tsc --noEmit` clean for both `apps/api` and `apps/web`
- [x] Full apps/api vitest suite: 1118/1118 passing
- [x] Full apps/web vitest suite: 517/517 passing
- [x] `cofferdam check --no-baseline` confirms 0 findings for ReadonlyArrayParam, MaxLineLength, and all 6 regressed categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJivABTizhiVgM2ziLUyNz