### PR TITLE
PROJ-481: cofferdam triage — CyclomaticComplexity

### DIFF
--- a/apps/api/src/mcp/error-adapter.ts
+++ b/apps/api/src/mcp/error-adapter.ts
@@ -63,24 +63,42 @@ function hasIssues(issues: ZodFlattenOutput): boolean {
 	);
 }
 
-export function toMcpError(err: unknown): { code: number; message: string; data?: unknown } {
-	if (err instanceof ValidationError) {
-		// PROJ-508/PROJ-523: surface the Zod issue detail (formErrors/fieldErrors) via
-		// the JSON-RPC 2.0 `error.data` member instead of dropping it. This covers
-		// ordinary schema-validation failures and hand-thrown ValidationErrors alike
-		// (e.g. patch_wiki_page's ambiguous-heading case), so an MCP agent can always
-		// read back *why* its params were rejected, not just that they were. A bounded
-		// summary is also folded into `message` — same fallback as NotFoundError/
-		// ConflictError below — for MCP hosts that don't surface `data`.
-		if (hasIssues(err.issues)) {
-			return {
-				code: -32602,
-				message: `Invalid params (${summarizeIssues(err.issues)})`,
-				data: err.issues,
-			};
-		}
+// PROJ-508/PROJ-523: surface the Zod issue detail (formErrors/fieldErrors) via the
+// JSON-RPC 2.0 `error.data` member instead of dropping it. This covers ordinary
+// schema-validation failures and hand-thrown ValidationErrors alike (e.g.
+// patch_wiki_page's ambiguous-heading case), so an MCP agent can always read back
+// *why* its params were rejected, not just that they were. A bounded summary is also
+// folded into `message` — same fallback as NotFoundError/ConflictError below — for MCP
+// hosts that don't surface `data`.
+function toMcpValidationError(err: ValidationError): {
+	code: number;
+	message: string;
+	data?: unknown;
+} {
+	if (!hasIssues(err.issues)) {
 		return { code: -32602, message: "Invalid params", data: err.issues };
 	}
+	return {
+		code: -32602,
+		message: `Invalid params (${summarizeIssues(err.issues)})`,
+		data: err.issues,
+	};
+}
+
+// PROJ-490 / PROJ-508 / PROJ-484: structured details (e.g. patch_wiki_page's
+// currentHeadings, or wiki's currentRevisionId + diff) travel in `data` — the proper
+// JSON-RPC 2.0 channel — rather than JSON-encoded into `message`. A bounded summary is
+// also folded into `message` as a fallback for MCP hosts that don't surface `data`.
+function toMcpServiceErrorWithDetails(
+	message: string,
+	details: Record<string, unknown> | undefined
+): { code: number; message: string; data?: unknown } {
+	if (!hasDetails(details)) return { code: -32000, message };
+	return { code: -32000, message: `${message} (${summarizeDetails(details)})`, data: details };
+}
+
+export function toMcpError(err: unknown): { code: number; message: string; data?: unknown } {
+	if (err instanceof ValidationError) return toMcpValidationError(err);
 	if (err instanceof ServiceError) {
 		// Only the kinds whose messages are deliberately client-facing are
 		// surfaced (audited 2026-06-30: not_found / forbidden / conflict messages
@@ -90,33 +108,17 @@ export function toMcpError(err: unknown): { code: number; message: string; data?
 		// leak its message to clients by default. (PROJ-204)
 		switch (err.kind) {
 			case "not_found":
-				// PROJ-490 / PROJ-508: structured not-found details (e.g. patch_wiki_page's
-				// currentHeadings) now travel in `data` — the proper JSON-RPC 2.0 channel —
-				// rather than JSON-encoded into `message`. A bounded summary is also folded
-				// into `message` as a fallback for MCP hosts that don't surface `data`.
-				if (err instanceof NotFoundError && hasDetails(err.details)) {
-					return {
-						code: -32000,
-						message: `${err.message} (${summarizeDetails(err.details)})`,
-						data: err.details,
-					};
-				}
-				return { code: -32000, message: err.message };
+				return toMcpServiceErrorWithDetails(
+					err.message,
+					err instanceof NotFoundError ? err.details : undefined
+				);
 			case "forbidden":
 				return { code: -32000, message: err.message };
 			case "conflict":
-				// PROJ-484 / PROJ-508: a structured conflict (e.g. wiki's currentRevisionId +
-				// diff) now travels in `data` instead of being JSON-encoded into `message`.
-				// A bounded summary is also folded into `message` as a fallback for MCP
-				// hosts that don't surface `data`.
-				if (err instanceof ConflictError && hasDetails(err.details)) {
-					return {
-						code: -32000,
-						message: `${err.message} (${summarizeDetails(err.details)})`,
-						data: err.details,
-					};
-				}
-				return { code: -32000, message: err.message };
+				return toMcpServiceErrorWithDetails(
+					err.message,
+					err instanceof ConflictError ? err.details : undefined
+				);
 			default:
 				console.error("[mcp] unhandled ServiceError kind in tools/call:", err.kind, err);
 				return { code: -32000, message: "Internal error" };

--- a/apps/api/src/services/wiki-freshness.ts
+++ b/apps/api/src/services/wiki-freshness.ts
@@ -33,16 +33,25 @@ const SECONDS_PER_DAY = 86400;
 // fabricated" convention the pre-R7 placeholder in wiki.test.ts established for the
 // `freshness` response field, which this function's return value now serializes into
 // directly (`freshness: computeFreshness(...)`).
+function computeDueAt(verifiedAt: number | null, verifyInterval: number | null): number | null {
+	if (verifyInterval === null || verifiedAt === null) return null;
+	return verifiedAt + verifyInterval * SECONDS_PER_DAY;
+}
+
+// A verify_interval/verifiedAt due date reached-or-passed, once there's no explicit
+// status override (see computeFreshness) and the page has been verified at least once.
+function computeTimeBasedFreshness(dueAt: number | null, now: number): WikiFreshness {
+	if (dueAt !== null && dueAt <= now) return { state: "stale", staleSince: dueAt };
+	return { state: "fresh", staleSince: null };
+}
+
 export function computeFreshness(input: ComputeFreshnessInput): WikiFreshness | null {
 	const { verifiedAt, verifyInterval, status } = input;
 	const hasSignal = status !== null || verifyInterval !== null;
 	if (!hasSignal) return null;
 
 	const now = input.now ?? Math.floor(Date.now() / 1000);
-	const dueAt =
-		verifyInterval !== null && verifiedAt !== null
-			? verifiedAt + verifyInterval * SECONDS_PER_DAY
-			: null;
+	const dueAt = computeDueAt(verifiedAt, verifyInterval);
 
 	// PRD R7: "status: stale/deprecated" is an independent, explicit staleness signal —
 	// it wins outright regardless of whether a verify_interval due date has technically
@@ -58,9 +67,5 @@ export function computeFreshness(input: ComputeFreshnessInput): WikiFreshness | 
 		return { state: "unverified", staleSince: null };
 	}
 
-	if (dueAt !== null && dueAt <= now) {
-		return { state: "stale", staleSince: dueAt };
-	}
-
-	return { state: "fresh", staleSince: null };
+	return computeTimeBasedFreshness(dueAt, now);
 }

--- a/apps/api/src/services/wiki-frontmatter.ts
+++ b/apps/api/src/services/wiki-frontmatter.ts
@@ -83,27 +83,21 @@ function normalizeFrontmatterRecord(raw: object): Record<string, unknown> {
 // round-tripping through create/update/revisions/diff exactly as before this feature.
 // Invalid YAML or a frontmatter value that fails schema validation throws a
 // ValidationError — this is intentionally never silently ignored or coerced.
-export function parseWikiFrontmatter(content: string): WikiFrontmatterMeta {
-	const match = FRONTMATTER_RE.exec(content);
-	if (!match) return EMPTY_WIKI_FRONTMATTER;
-
-	const raw = parseFrontmatterYaml(match[1]);
-
-	// An empty `---\n---\n` block parses to null/undefined — treat as "no frontmatter"
-	// rather than an error, since it's an easy no-op state to end up in when editing.
-	if (raw === null || raw === undefined) return EMPTY_WIKI_FRONTMATTER;
+// An empty `---\n---\n` block parses to null/undefined — treat as "no frontmatter"
+// rather than an error, since it's an easy no-op state to end up in when editing.
+// Anything else that isn't a plain mapping (a list, a scalar) is a genuine error.
+function requireFrontmatterMapping(raw: unknown): Record<string, unknown> | null {
+	if (raw === null || raw === undefined) return null;
 	if (typeof raw !== "object" || Array.isArray(raw)) {
 		throw new ValidationError({
 			formErrors: ["Frontmatter must be a YAML mapping (key: value pairs), not a list or scalar"],
 			fieldErrors: {},
 		});
 	}
+	return raw as Record<string, unknown>;
+}
 
-	const normalized = normalizeFrontmatterRecord(raw);
-	const parsed = WikiFrontmatterSchema.safeParse(normalized);
-	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
-
-	const d = parsed.data;
+function toFrontmatterMeta(d: ReturnType<typeof WikiFrontmatterSchema.parse>): WikiFrontmatterMeta {
 	return {
 		type: d.type ?? null,
 		tags: d.tags ?? [],
@@ -114,6 +108,20 @@ export function parseWikiFrontmatter(content: string): WikiFrontmatterMeta {
 		verifyInterval: d.verify_interval ?? null,
 		isTemplate: d.template ?? false,
 	};
+}
+
+export function parseWikiFrontmatter(content: string): WikiFrontmatterMeta {
+	const match = FRONTMATTER_RE.exec(content);
+	if (!match) return EMPTY_WIKI_FRONTMATTER;
+
+	const raw = requireFrontmatterMapping(parseFrontmatterYaml(match[1]));
+	if (raw === null) return EMPTY_WIKI_FRONTMATTER;
+
+	const normalized = normalizeFrontmatterRecord(raw);
+	const parsed = WikiFrontmatterSchema.safeParse(normalized);
+	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
+
+	return toFrontmatterMeta(parsed.data);
 }
 
 // PROJ-491 (R9): strips the `template: true` frontmatter key when seeding a new page's

--- a/apps/api/src/services/wiki-links.ts
+++ b/apps/api/src/services/wiki-links.ts
@@ -146,17 +146,14 @@ async function resolveSlugTarget(
 
 type ResolvedLink = { targetPageId: string | null; targetTitle: string };
 
-async function resolveLinkTargets(
+// Title-kind targets resolve in one batched query instead of one round trip per link (a
+// page with N distinct title-links previously made N sequential queries).
+async function resolveTitleLinks(
 	orm: Orm,
 	workspaceId: string,
-	targets: readonly ParsedLinkTarget[]
-): Promise<ResolvedLink[]> {
-	// Dedupe by resolved page id (or the raw unresolved key) so a page linking to the
-	// same target multiple times only gets one wiki_links row.
-	const resolved = new Map<string, ResolvedLink>();
-
-	// Title-kind targets resolve in one batched query instead of one round trip per
-	// link (a page with N distinct title-links previously made N sequential queries).
+	targets: readonly ParsedLinkTarget[],
+	resolved: Map<string, ResolvedLink>
+): Promise<void> {
 	const titleTargets = targets.filter(
 		(t): t is Extract<ParsedLinkTarget, { kind: "title" }> => t.kind === "title"
 	);
@@ -170,9 +167,16 @@ async function resolveLinkTargets(
 		const key = targetPageId ?? `title:${t.title.toLowerCase()}`;
 		if (!resolved.has(key)) resolved.set(key, { targetPageId, targetTitle: t.title });
 	}
+}
 
-	// Slug-kind targets (from same-workspace wiki URLs) each need a redirect-fallback
-	// lookup, so they stay sequential rather than batched.
+// Slug-kind targets (from same-workspace wiki URLs) each need a redirect-fallback lookup,
+// so they stay sequential rather than batched.
+async function resolveSlugLinks(
+	orm: Orm,
+	workspaceId: string,
+	targets: readonly ParsedLinkTarget[],
+	resolved: Map<string, ResolvedLink>
+): Promise<void> {
 	for (const t of targets) {
 		if (t.kind !== "slug") continue;
 		const found = await resolveSlugTarget(orm, workspaceId, t.slug);
@@ -181,6 +185,18 @@ async function resolveLinkTargets(
 			resolved.set(key, { targetPageId: found?.id ?? null, targetTitle: found?.title ?? t.slug });
 		}
 	}
+}
+
+async function resolveLinkTargets(
+	orm: Orm,
+	workspaceId: string,
+	targets: readonly ParsedLinkTarget[]
+): Promise<ResolvedLink[]> {
+	// Dedupe by resolved page id (or the raw unresolved key) so a page linking to the
+	// same target multiple times only gets one wiki_links row.
+	const resolved = new Map<string, ResolvedLink>();
+	await resolveTitleLinks(orm, workspaceId, targets, resolved);
+	await resolveSlugLinks(orm, workspaceId, targets, resolved);
 	return [...resolved.values()];
 }
 

--- a/apps/api/src/services/wiki-watchers.ts
+++ b/apps/api/src/services/wiki-watchers.ts
@@ -476,6 +476,79 @@ function extractDeletedPageInfo(diff: Record<string, unknown> | null): {
 	};
 }
 
+type WikiActivityRow = {
+	id: string;
+	action: string;
+	entityId: string;
+	actorId: string | null;
+	diff: Record<string, unknown> | null;
+	createdAt: number;
+	pageSlug: string | null;
+	pageTitle: string | null;
+	pageProjectId: string | null;
+	pageDeletedAt: number | null;
+};
+
+// PROJ-496: a "created"/"updated" event for a page that's now trashed is stale — the page
+// itself is excluded from every other read path, so the delta feed drops it too rather
+// than pointing an agent at a page get_wiki_page will 404 on. The "deleted" event for that
+// same trash action is NOT dropped: it's the one event that's supposed to report the page
+// went away.
+function eventFieldsFor(
+	action: "created" | "updated" | "deleted",
+	r: WikiActivityRow
+): {
+	slug: string | null;
+	title: string | null;
+	eventProjectId: string | null;
+	deleted: ReturnType<typeof extractDeletedPageInfo> | null;
+} {
+	const deleted = action === "deleted" ? extractDeletedPageInfo(r.diff) : null;
+	return {
+		slug: deleted ? deleted.slug : r.pageSlug,
+		title: deleted ? deleted.title : r.pageTitle,
+		eventProjectId: deleted ? deleted.projectId : r.pageProjectId,
+		deleted,
+	};
+}
+
+async function isEventVisible(
+	projectId: string | undefined,
+	eventProjectId: string | null,
+	canSeeProject: (id: string) => Promise<boolean>
+): Promise<boolean> {
+	if (projectId) return eventProjectId === projectId;
+	if (eventProjectId === null) return true;
+	return canSeeProject(eventProjectId);
+}
+
+// Resolves one activity row to an event, or null if it should be dropped (stale
+// trash-shadowed row, wrong project, or not visible to the caller).
+async function toWikiChangeEvent(
+	r: WikiActivityRow,
+	projectId: string | undefined,
+	canSeeProject: (id: string) => Promise<boolean>
+): Promise<WikiChangeEvent | null> {
+	const action = r.action as "created" | "updated" | "deleted";
+	if (action !== "deleted" && r.pageDeletedAt !== null && r.pageDeletedAt !== undefined) return null;
+
+	const { slug, title, eventProjectId, deleted } = eventFieldsFor(action, r);
+	if (!(await isEventVisible(projectId, eventProjectId, canSeeProject))) return null;
+
+	return {
+		id: r.id,
+		action,
+		pageId: r.entityId,
+		slug,
+		title,
+		projectId: eventProjectId,
+		actorId: r.actorId,
+		createdAt: r.createdAt,
+		deletedPageIds: deleted?.deletedPageIds ?? null,
+		deletedPageIdsTruncated: deleted?.deletedPageIdsTruncated ?? false,
+	};
+}
+
 // PROJ-493: resolves the (pageId -> is-watched) set for the caller, for list_wiki_changes'
 // watchedOnly filter. Mirrors notifyWikiWatchers' match rule (direct watch, or a
 // subtree watch on a proper ancestor) but walks the CURRENT tree — a page reparented out
@@ -561,6 +634,21 @@ async function watchedPageIds(
 	return matched;
 }
 
+// `since` is second-granular and exclusive, so a batch cut off mid-second by `limit` would
+// strand the rest of that second: the caller polls with nextSince = that second and `gt`
+// skips them forever. Drop the trailing partial second instead, so the next poll picks it
+// up whole. (If the WHOLE batch is one second there's nothing to trim — that needs `limit`
+// changes inside a single second, and the alternative is a poll that can never advance.)
+function trimTrailingPartialSecond<T extends { createdAt: number }>(
+	rows: readonly T[],
+	limit: number
+): readonly T[] {
+	if (rows.length !== limit || rows.length === 0) return rows;
+	const maxTs = rows[rows.length - 1].createdAt;
+	if (rows[0].createdAt === maxTs) return rows;
+	return rows.filter((r) => r.createdAt < maxTs);
+}
+
 // PROJ-493 (R11): cheap delta feed — piggybacks entirely on the `activity` table every
 // wiki_page write already populates (services/activity.ts#recordActivity, called from
 // every create/update/patch/delete path in services/wiki.ts) rather than a separate
@@ -615,17 +703,7 @@ export async function listWikiChanges(
 		.orderBy(schema.activity.createdAt)
 		.limit(limit);
 
-	// `since` is second-granular and exclusive, so a batch cut off mid-second by `limit`
-	// would strand the rest of that second: the caller polls with nextSince = that second
-	// and `gt` skips them forever. Drop the trailing partial second instead, so the next
-	// poll picks it up whole. (If the WHOLE batch is one second there's nothing to trim —
-	// that needs `limit` changes inside a single second, and the alternative is a poll
-	// that can never advance.)
-	let batch = rows;
-	if (rows.length === limit && rows.length > 0) {
-		const maxTs = rows[rows.length - 1].createdAt;
-		if (rows[0].createdAt !== maxTs) batch = rows.filter((r) => r.createdAt < maxTs);
-	}
+	const batch = trimTrailingPartialSecond(rows, limit);
 
 	// One role lookup per distinct project in the batch, not per event.
 	const roleCache = new Map<string, boolean>();
@@ -638,46 +716,11 @@ export async function listWikiChanges(
 		return visible;
 	};
 
-	// Resolves one activity row to an event, or null if it should be dropped (stale
-	// trash-shadowed row, wrong project, or not visible to the caller). Extracted from
-	// the loop below to keep listWikiChanges's own complexity/length down.
-	const toEvent = async (r: (typeof batch)[number]): Promise<WikiChangeEvent | null> => {
-		const action = r.action as "created" | "updated" | "deleted";
-		// PROJ-496: a "created"/"updated" event for a page that's now trashed is stale —
-		// the page itself is excluded from every other read path, so the delta feed drops
-		// it too rather than pointing an agent at a page get_wiki_page will 404 on. The
-		// "deleted" event for that same trash action is NOT dropped (below): it's the one
-		// event that's supposed to report the page went away.
-		if (action !== "deleted" && r.pageDeletedAt !== null && r.pageDeletedAt !== undefined)
-			return null;
-		const deleted = action === "deleted" ? extractDeletedPageInfo(r.diff) : null;
-		const slug = deleted ? deleted.slug : r.pageSlug;
-		const title = deleted ? deleted.title : r.pageTitle;
-		const eventProjectId = deleted ? deleted.projectId : r.pageProjectId;
-
-		if (projectId && eventProjectId !== projectId) return null;
-		if (!projectId && eventProjectId !== null && !(await canSeeProject(eventProjectId)))
-			return null;
-
-		return {
-			id: r.id,
-			action,
-			pageId: r.entityId,
-			slug,
-			title,
-			projectId: eventProjectId,
-			actorId: r.actorId,
-			createdAt: r.createdAt,
-			deletedPageIds: deleted?.deletedPageIds ?? null,
-			deletedPageIdsTruncated: deleted?.deletedPageIdsTruncated ?? false,
-		};
-	};
-
 	let nextSince = since;
 	const events: WikiChangeEvent[] = [];
 	for (const r of batch) {
 		if (r.createdAt > nextSince) nextSince = r.createdAt;
-		const event = await toEvent(r);
+		const event = await toWikiChangeEvent(r, projectId, canSeeProject);
 		if (event) events.push(event);
 	}
 

--- a/apps/api/src/services/wiki-watchers.ts
+++ b/apps/api/src/services/wiki-watchers.ts
@@ -530,7 +530,8 @@ async function toWikiChangeEvent(
 	canSeeProject: (id: string) => Promise<boolean>
 ): Promise<WikiChangeEvent | null> {
 	const action = r.action as "created" | "updated" | "deleted";
-	if (action !== "deleted" && r.pageDeletedAt !== null && r.pageDeletedAt !== undefined) return null;
+	if (action !== "deleted" && r.pageDeletedAt !== null && r.pageDeletedAt !== undefined)
+		return null;
 
 	const { slug, title, eventProjectId, deleted } = eventFieldsFor(action, r);
 	if (!(await isEventVisible(projectId, eventProjectId, canSeeProject))) return null;

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -388,36 +388,25 @@ function staleWikiPageCondition(now: number) {
 	)`;
 }
 
-export async function listWikiPages(ctx: ServiceCtx, input: unknown) {
-	const parsed = ListPagesInputSchema.safeParse(input);
-	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
-
-	const orm = drizzle(ctx.db, { schema });
+function buildListWikiPagesConditions(
+	ctx: ServiceCtx,
+	data: ReturnType<typeof ListPagesInputSchema.parse>
+) {
 	const conditions = [
 		eq(schema.wikiPages.workspaceId, ctx.workspaceId),
 		// PROJ-496: trashed pages never appear in the normal listing.
 		isNull(schema.wikiPages.deletedAt),
 	];
-	if (parsed.data.parentId) {
-		conditions.push(eq(schema.wikiPages.parentId, parsed.data.parentId));
-	}
-	if (parsed.data.projectId) {
-		conditions.push(eq(schema.wikiPages.projectId, parsed.data.projectId));
-	}
-	if (parsed.data.type) {
-		conditions.push(eq(schema.wikiPages.type, parsed.data.type));
-	}
-	if (parsed.data.status) {
-		conditions.push(eq(schema.wikiPages.status, parsed.data.status));
-	}
-	const tagsCond = tagsFilterCondition(parsed.data.tags ?? []);
+	if (data.parentId) conditions.push(eq(schema.wikiPages.parentId, data.parentId));
+	if (data.projectId) conditions.push(eq(schema.wikiPages.projectId, data.projectId));
+	if (data.type) conditions.push(eq(schema.wikiPages.type, data.type));
+	if (data.status) conditions.push(eq(schema.wikiPages.status, data.status));
+	const tagsCond = tagsFilterCondition(data.tags ?? []);
 	if (tagsCond) conditions.push(tagsCond);
 	// PROJ-525: matches search_wiki/listStaleWikiPages's is_template=0 exclusion — a
 	// template shouldn't leak into ordinary type/status/tags browsing (e.g. filtering by
 	// type=runbook alongside "Runbook Template").
-	if (!parsed.data.includeTemplates) {
-		conditions.push(eq(schema.wikiPages.isTemplate, false));
-	}
+	if (!data.includeTemplates) conditions.push(eq(schema.wikiPages.isTemplate, false));
 	// PROJ-311: hide project-scoped pages whose project the user isn't granted
 	// (workspace-level pages, projectId null, stay visible to everyone).
 	const visible = visibleProjectPredicate(ctx, schema.wikiPages.projectId);
@@ -425,6 +414,15 @@ export async function listWikiPages(ctx: ServiceCtx, input: unknown) {
 		const cond = or(isNull(schema.wikiPages.projectId), visible);
 		if (cond) conditions.push(cond);
 	}
+	return conditions;
+}
+
+export async function listWikiPages(ctx: ServiceCtx, input: unknown) {
+	const parsed = ListPagesInputSchema.safeParse(input);
+	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
+
+	const orm = drizzle(ctx.db, { schema });
+	const conditions = buildListWikiPagesConditions(ctx, parsed.data);
 
 	const rows = await orm
 		.select({
@@ -491,6 +489,38 @@ export async function searchWiki(ctx: ServiceCtx, input: unknown) {
 		}
 	}
 
+	const { q, params, now } = buildSearchWikiQuery(ctx, ftsQuery, {
+		projectId,
+		updatedSince,
+		type,
+		status,
+		tags,
+		limit,
+		offset,
+	});
+
+	const { results } = await ctx.db
+		.prepare(q)
+		.bind(...params)
+		.all();
+	return (results as Array<Record<string, unknown>>).map((r) => mapSearchWikiRow(r, now));
+}
+
+type SearchWikiFilters = {
+	projectId: string | undefined;
+	updatedSince: number | undefined;
+	type: string | undefined;
+	status: string | undefined;
+	tags: string[] | undefined;
+	limit: number;
+	offset: number;
+};
+
+function buildSearchWikiQuery(
+	ctx: ServiceCtx,
+	ftsQuery: string,
+	{ projectId, updatedSince, type, status, tags, limit, offset }: SearchWikiFilters
+): { q: string; params: unknown[]; now: number } {
 	let q = `SELECT p.id, p.slug, p.title, p.project_id,
               p.type, p.tags, p.status, p.verified_at, p.verified_by, p.owners, p.verify_interval,
               snippet(wiki_fts, -1, '**', '**', '…', 24) as excerpt,
@@ -553,10 +583,12 @@ export async function searchWiki(ctx: ServiceCtx, input: unknown) {
 	// maintenance queue is the right place to nag about it). The two conditions were kept
 	// in lockstep by design until this decision; any future change to one should
 	// re-examine whether the other should follow.
-	const now = Math.floor(Date.now() / 1000);
 	// PROJ-486: bm25() alone ties on equal-rank rows, which makes LIMIT/OFFSET
 	// paging non-deterministic (duplicate/skip results across pages) — break
-	// ties by page id for a stable order.
+	// ties by page id for a stable order. `now` is bound once here and reused by the
+	// caller for the freshness computed on each returned row, so the ordering and the
+	// displayed freshness state always agree.
+	const now = Math.floor(Date.now() / 1000);
 	q += ` ORDER BY (CASE WHEN (
 	              p.status IN ('stale', 'deprecated')
 	              OR (
@@ -568,16 +600,16 @@ export async function searchWiki(ctx: ServiceCtx, input: unknown) {
 	          bm25(wiki_fts, ${WIKI_FTS_BM25_WEIGHTS}), p.id LIMIT ? OFFSET ?`;
 	params.push(now, limit, offset);
 
-	const { results } = await ctx.db
-		.prepare(q)
-		.bind(...params)
-		.all();
-	return (results as Array<Record<string, unknown>>).map((r) => ({
+	return { q, params, now };
+}
+
+// PROJ-488: this is a raw D1 query, so the JSON-array columns come back as the stored
+// TEXT rather than as arrays the way drizzle's `{ mode: "json" }` decodes them for
+// listWikiPages/getWikiPage. Decode here so every wiki surface returns tags/owners with
+// the same shape.
+function mapSearchWikiRow(r: Record<string, unknown>, now: number) {
+	return {
 		...r,
-		// PROJ-488: this is a raw D1 query, so the JSON-array columns come back as the
-		// stored TEXT rather than as arrays the way drizzle's `{ mode: "json" }` decodes
-		// them for listWikiPages/getWikiPage. Decode here so every wiki surface returns
-		// tags/owners with the same shape.
 		tags: decodeJsonArrayColumn(r.tags),
 		owners: decodeJsonArrayColumn(r.owners),
 		// PROJ-489 (R7): null when the page has no verify_interval/status signal at all —
@@ -588,7 +620,7 @@ export async function searchWiki(ctx: ServiceCtx, input: unknown) {
 			status: r.status as string | null,
 			now,
 		}),
-	}));
+	};
 }
 
 const wikiPageDetailColumns = {
@@ -833,13 +865,12 @@ async function finalizeWikiPageCreate(
 export async function createWikiPage(ctx: ServiceCtx, input: unknown) {
 	const parsed = CreatePageSchema.safeParse(input);
 	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
-	const { title, parentId, projectId, slug: customSlug, templateSlug } = parsed.data;
+	const { title, projectId, slug: customSlug, templateSlug } = parsed.data;
+	const parentId = parsed.data.parentId ?? null;
+	const resolvedProjectId = projectId ?? null;
 
-	await requireWikiWrite(ctx, projectId ?? null);
-
-	if (parentId) {
-		await validateNewPageParent(ctx.db, parentId, ctx.workspaceId, projectId);
-	}
+	await requireWikiWrite(ctx, resolvedProjectId);
+	if (parentId) await validateNewPageParent(ctx.db, parentId, ctx.workspaceId, projectId);
 
 	const content = templateSlug
 		? await resolveTemplateContent(ctx, templateSlug)
@@ -852,15 +883,15 @@ export async function createWikiPage(ctx: ServiceCtx, input: unknown) {
 	const now = Math.floor(Date.now() / 1000);
 	// PROJ-488 (R6): parse+validate the optional frontmatter block up front, so an
 	// invalid frontmatter throws before any row is written (never a partial create).
-	const meta = parseWikiFrontmatter(content ?? "");
+	const meta = parseWikiFrontmatter(content);
 
 	const insertStatement = buildCreateWikiPageInsertStatement(ctx, orm, {
 		id,
-		projectId: projectId ?? null,
+		projectId: resolvedProjectId,
 		slug,
 		title,
-		content: content ?? "",
-		parentId: parentId ?? null,
+		content,
+		parentId,
 		now,
 		meta,
 	});
@@ -868,19 +899,15 @@ export async function createWikiPage(ctx: ServiceCtx, input: unknown) {
 	// PROJ-511: resolution (the async reads inside this call) happens before any of these
 	// statements exist, so by the time the batch below runs there's nothing left to throw
 	// mid-write — the content row, its FTS mirror, and its wiki_links all land atomically.
-	const linkStatements = await buildWikiLinksReindexStatements(ctx, orm, id, content ?? "");
+	const linkStatements = await buildWikiLinksReindexStatements(ctx, orm, id, content);
 
 	await writeCreateWikiPageBatch(
 		ctx,
-		[
-			insertStatement,
-			buildFtsInsertStatement(ctx, id, title, content ?? "", meta.tags),
-			...linkStatements,
-		],
+		[insertStatement, buildFtsInsertStatement(ctx, id, title, content, meta.tags), ...linkStatements],
 		slug
 	);
-	await finalizeWikiPageCreate(ctx, { id, parentId: parentId ?? null, slug, title, meta });
-	return { id, slug, projectId: projectId ?? null, url: wikiPagePath(slug), ...meta };
+	await finalizeWikiPageCreate(ctx, { id, parentId, slug, title, meta });
+	return { id, slug, projectId: resolvedProjectId, url: wikiPagePath(slug), ...meta };
 }
 
 // PROJ-484: id of the most recently created revision for a page, or null if the page

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -903,7 +903,11 @@ export async function createWikiPage(ctx: ServiceCtx, input: unknown) {
 
 	await writeCreateWikiPageBatch(
 		ctx,
-		[insertStatement, buildFtsInsertStatement(ctx, id, title, content, meta.tags), ...linkStatements],
+		[
+			insertStatement,
+			buildFtsInsertStatement(ctx, id, title, content, meta.tags),
+			...linkStatements,
+		],
 		slug
 	);
 	await finalizeWikiPageCreate(ctx, { id, parentId, slug, title, meta });

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -192,6 +192,67 @@ function TagChips({ tags }: { tags: string[] | undefined | null }) {
 // PROJ-489 (R7): the Verify button/freshness badge only render when the page has opted
 // into verification tracking (a verify_interval or a status set) — a page with neither
 // has freshness: null and nothing meaningful to verify against.
+function WikiMetadataBadges({ page }: { page: WikiPageData }) {
+	return (
+		<>
+			{page.type && (
+				<span
+					class={
+						"inline-flex items-center px-2 py-[0.1rem] rounded-full text-[0.72rem] font-semibold " +
+						"uppercase tracking-wide bg-bg border border-border text-text-muted"
+					}
+				>
+					{page.type}
+				</span>
+			)}
+			{page.status && <WikiStatusPill status={page.status} />}
+			{page.freshness && page.freshness.state !== "fresh" && (
+				<WikiFreshnessBadge state={page.freshness.state} />
+			)}
+			<TagChips tags={page.tags} />
+			{page.owners.length > 0 && <span>Owners: {page.owners.join(", ")}</span>}
+			{page.verified_at && (
+				<span>
+					Verified {new Date(page.verified_at * 1000).toLocaleDateString()}
+					{page.verified_by ? ` by ${page.verified_by}` : ""}
+				</span>
+			)}
+		</>
+	);
+}
+
+function WikiVerifyControls({
+	hasVerificationSignal,
+	onVerify,
+	verifying,
+	verifyError,
+}: {
+	hasVerificationSignal: boolean;
+	onVerify: () => void;
+	verifying: boolean;
+	verifyError: string | null;
+}) {
+	return (
+		<>
+			{hasVerificationSignal && (
+				<button
+					type="button"
+					class="btn btn-outline btn-sm"
+					onClick={onVerify}
+					disabled={verifying}
+				>
+					{verifying ? "Verifying…" : "Verify"}
+				</button>
+			)}
+			{verifyError && (
+				<span role="alert" class="text-[var(--danger-text)]">
+					{verifyError}
+				</span>
+			)}
+		</>
+	);
+}
+
 function WikiMetadataCard({
 	page,
 	onVerify,
@@ -219,43 +280,13 @@ function WikiMetadataCard({
 				"bg-surface text-[0.8rem] text-text-muted"
 			}
 		>
-			{page.type && (
-				<span
-					class={
-						"inline-flex items-center px-2 py-[0.1rem] rounded-full text-[0.72rem] font-semibold " +
-						"uppercase tracking-wide bg-bg border border-border text-text-muted"
-					}
-				>
-					{page.type}
-				</span>
-			)}
-			{page.status && <WikiStatusPill status={page.status} />}
-			{page.freshness && page.freshness.state !== "fresh" && (
-				<WikiFreshnessBadge state={page.freshness.state} />
-			)}
-			<TagChips tags={page.tags} />
-			{page.owners.length > 0 && <span>Owners: {page.owners.join(", ")}</span>}
-			{page.verified_at && (
-				<span>
-					Verified {new Date(page.verified_at * 1000).toLocaleDateString()}
-					{page.verified_by ? ` by ${page.verified_by}` : ""}
-				</span>
-			)}
-			{hasVerificationSignal && (
-				<button
-					type="button"
-					class="btn btn-outline btn-sm"
-					onClick={onVerify}
-					disabled={verifying}
-				>
-					{verifying ? "Verifying…" : "Verify"}
-				</button>
-			)}
-			{verifyError && (
-				<span role="alert" class="text-[var(--danger-text)]">
-					{verifyError}
-				</span>
-			)}
+			<WikiMetadataBadges page={page} />
+			<WikiVerifyControls
+				hasVerificationSignal={hasVerificationSignal}
+				onVerify={onVerify}
+				verifying={verifying}
+				verifyError={verifyError}
+			/>
 		</div>
 	);
 }
@@ -421,6 +452,33 @@ const SEARCH_RESULT_BUTTON_CLASS = [
 	"focus-visible:outline-accent focus-visible:outline-offset-2",
 ].join(" ");
 
+function SearchResultMetaLine({ r }: { r: SearchResult }) {
+	const isStale = r.freshness && r.freshness.state !== "fresh";
+	const show = r.type || r.status || (r.tags?.length ?? 0) > 0 || isStale;
+	if (!show) return null;
+	return (
+		<span class="block mt-[0.15rem]">
+			{r.status && <WikiStatusPill status={r.status} />}
+			{isStale && r.freshness && <WikiFreshnessBadge state={r.freshness.state} />}
+			<TagChips tags={r.tags} />
+		</span>
+	);
+}
+
+function SearchResultButton({ r, onSelect }: { r: SearchResult; onSelect: (slug: string) => void }) {
+	return (
+		<button type="button" class={SEARCH_RESULT_BUTTON_CLASS} onClick={() => onSelect(r.slug)}>
+			<span class="font-medium">{r.title}</span>
+			<SearchResultMetaLine r={r} />
+			{r.excerpt && (
+				<span class="block text-[0.75rem] text-text-muted truncate">
+					{renderHighlightedExcerpt(r.excerpt)}
+				</span>
+			)}
+		</button>
+	);
+}
+
 function SearchResultsList({
 	loading,
 	results,
@@ -436,26 +494,7 @@ function SearchResultsList({
 		<ul class="list-none m-0 p-0">
 			{results.map((r) => (
 				<li key={r.id}>
-					<button type="button" class={SEARCH_RESULT_BUTTON_CLASS} onClick={() => onSelect(r.slug)}>
-						<span class="font-medium">{r.title}</span>
-						{(r.type ||
-							r.status ||
-							(r.tags?.length ?? 0) > 0 ||
-							(r.freshness && r.freshness.state !== "fresh")) && (
-							<span class="block mt-[0.15rem]">
-								{r.status && <WikiStatusPill status={r.status} />}
-								{r.freshness && r.freshness.state !== "fresh" && (
-									<WikiFreshnessBadge state={r.freshness.state} />
-								)}
-								<TagChips tags={r.tags} />
-							</span>
-						)}
-						{r.excerpt && (
-							<span class="block text-[0.75rem] text-text-muted truncate">
-								{renderHighlightedExcerpt(r.excerpt)}
-							</span>
-						)}
-					</button>
+					<SearchResultButton r={r} onSelect={onSelect} />
 				</li>
 			))}
 		</ul>

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -465,7 +465,13 @@ function SearchResultMetaLine({ r }: { r: SearchResult }) {
 	);
 }
 
-function SearchResultButton({ r, onSelect }: { r: SearchResult; onSelect: (slug: string) => void }) {
+function SearchResultButton({
+	r,
+	onSelect,
+}: {
+	r: SearchResult;
+	onSelect: (slug: string) => void;
+}) {
 	return (
 		<button type="button" class={SEARCH_RESULT_BUTTON_CLASS} onClick={() => onSelect(r.slug)}>
 			<span class="font-medium">{r.title}</span>


### PR DESCRIPTION
## Summary
- Extracts smaller helpers out of the 11 functions that exceeded cofferdam's cyclomatic-complexity-10 limit: `mcp/error-adapter.ts#toMcpError`, `wiki-freshness.ts#computeFreshness`, `wiki-frontmatter.ts#parseWikiFrontmatter`, `wiki-links.ts#resolveLinkTargets`, `wiki-watchers.ts#listWikiChanges` (+ its inline arrow fn), `wiki.ts#listWikiPages`/`searchWiki`/`createWikiPage`, and `WikiPage.tsx`'s `WikiMetadataCard` + a search-results arrow fn.
- Purely mechanical extraction — no behavior change.
- Confirmed via re-scan: 0 `Refactor.CyclomaticComplexity` findings remain, no new findings introduced (including a `Design.ReadonlyArrayParam` self-introduced during the refactor, fixed in the same pass).

## Test plan
- [x] `tsc --noEmit` clean on both `apps/api` and `apps/web`
- [x] `apps/web` full test suite: 45 files / 517 tests passed
- [x] `apps/api` full test suite: 1117/1118 passed — the one failure (`wiki.test.ts` trash-purge timeout) is the pre-existing Windows workerd 5s-timeout flake, in code this PR doesn't touch; reproduced consistently across reruns regardless of diff scope
- [x] cofferdam re-scan: 0 CyclomaticComplexity findings, 0 new findings

Claude-Session: https://claude.ai/code/session_01RJivABTizhiVgM2ziLUyNz