### PR TITLE
chore(deps): bump @cofferdam/cofferdam to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@biomejs/biome": "^2.5.1",
     "@biomejs/cli-win32-x64": "2.5.1",
     "@cloudflare/workers-types": "^4.20250620.0",
-    "@cofferdam/cofferdam": "^0.3.13",
+    "@cofferdam/cofferdam": "^0.4.0",
     "lefthook": "^1.11.0",
     "tsx": "^4.19.0",
     "turbo": "^2.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^4.20250620.0
         version: 4.20260621.1
       '@cofferdam/cofferdam':
-        specifier: ^0.3.13
-        version: 0.3.13
+        specifier: ^0.4.0
+        version: 0.4.0
       lefthook:
         specifier: ^1.11.0
         version: 1.13.6
@@ -1154,8 +1154,8 @@ packages:
     resolution: {integrity: sha512-CsgDhJ2w8mIt6sHSnPUNsDFmkwN5DMZ4GRB19hAbeiZzetHIG9RWJsgoWz+0CfONsoTf3inrCprvT2GhzDkK4A==}
     engines: {node: '>=16'}
 
-  '@cofferdam/cofferdam@0.3.13':
-    resolution: {integrity: sha512-3phmKswhcLCY+DhTNic3KeoOqlljXSzKLiRaZHIlce5KA4WiVpurXw3C9tnihdSdk3QyAzlDNxRFwHXfgZaPYg==}
+  '@cofferdam/cofferdam@0.4.0':
+    resolution: {integrity: sha512-+VRNb4PUPblGPToChaKl7TCBBG5lHcNoY6G/Dr3ls1Pf/T60lnmC16j/nuD1YSID8Xecly46lf9nW+7DUe0YoQ==}
     engines: {node: '>=16', npm: '>=7'}
     cpu: [x64, arm64]
     os: [linux, darwin, win32]
@@ -8115,7 +8115,7 @@ snapshots:
 
   '@cofferdam/check-sdk@0.3.7': {}
 
-  '@cofferdam/cofferdam@0.3.13': {}
+  '@cofferdam/cofferdam@0.4.0': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:


### PR DESCRIPTION
## Summary
- Bumps `@cofferdam/cofferdam` devDependency from `^0.3.13` to `^0.4.0`.
- Picks up the engine performance epic (CD-165) plus three recently fixed bugs (CD-190/191/192).

## Test plan
- [x] `pnpm install` — lockfile updated cleanly
- [x] `npx cofferdam --version` reports `0.4.0`