### PR TITLE
PROJ-481: cofferdam triage — Design.DuplicateTypeShape (same-package)

### DIFF
--- a/apps/api/src/services/flow-metrics.ts
+++ b/apps/api/src/services/flow-metrics.ts
@@ -6,7 +6,7 @@ import { NotFoundError, ValidationError } from "./errors";
 import { inChunks } from "./sql";
 import type { ServiceCtx } from "./types";
 
-interface Distribution {
+export interface Distribution {
 	count: number;
 	avg: number | null;
 	p50: number | null;

--- a/apps/api/src/test/authorization.test.ts
+++ b/apps/api/src/test/authorization.test.ts
@@ -17,6 +17,8 @@ import { env, SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
 	authHeaders,
+	type JsonRpcError,
+	type JsonRpcResult,
 	seedCustomFieldDef,
 	seedFixture,
 	seedGroupGrant,
@@ -34,9 +36,6 @@ import {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-type JsonRpcResult<T = unknown> = { jsonrpc: "2.0"; id: unknown; result: T };
-type JsonRpcError = { jsonrpc: "2.0"; id: unknown; error: { code: number; message: string } };
 
 async function mcpCall(
 	workspaceId: string,

--- a/apps/api/src/test/code-heatmap.test.ts
+++ b/apps/api/src/test/code-heatmap.test.ts
@@ -1,27 +1,12 @@
 import { env, SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
+import type { CodeHeatmapEntry, ContentionHeatmapEntry } from "../services/code-heatmap";
 import { authHeaders, seedIssue, seedProjectFixture } from "./helpers";
-
-interface CodeHeatmapEntry {
-	path: string;
-	segment: string;
-	isLeaf: boolean;
-	distinctIssueCount: number;
-	claimCount: number;
-}
 
 interface CodeHeatmapResponse {
 	prefix: string;
 	totalDistinctIssues: number;
 	entries: CodeHeatmapEntry[];
-}
-
-interface ContentionHeatmapEntry {
-	path: string;
-	segment: string;
-	isLeaf: boolean;
-	distinctRejectedIssueCount: number;
-	conflictCount: number;
 }
 
 interface ContentionHeatmapResponse {

--- a/apps/api/src/test/comments.test.ts
+++ b/apps/api/src/test/comments.test.ts
@@ -2,6 +2,8 @@ import { env, SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
 	authHeaders,
+	type JsonRpcError,
+	type JsonRpcResult,
 	seedComment,
 	seedFixture,
 	seedGroupGrant,
@@ -10,9 +12,6 @@ import {
 	seedProjectFixture,
 	seedWorkspaceRoles,
 } from "./helpers";
-
-type JsonRpcResult<T = unknown> = { jsonrpc: "2.0"; id: unknown; result: T };
-type JsonRpcError = { jsonrpc: "2.0"; id: unknown; error: { code: number; message: string } };
 
 async function mcpCall<T>(
 	workspaceId: string,

--- a/apps/api/src/test/feedback.test.ts
+++ b/apps/api/src/test/feedback.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import { hashFeedbackToken } from "../services/feedback";
 import {
 	authHeaders,
+	type JsonRpcError,
+	type JsonRpcResult,
 	seedGroupGrant,
 	seedProject,
 	seedProjectFixture,
@@ -459,9 +461,6 @@ describe("Feedback triage read/patch", () => {
 		expect(res.status).toBe(400);
 	});
 });
-
-type JsonRpcResult<T = unknown> = { jsonrpc: "2.0"; id: unknown; result: T };
-type JsonRpcError = { jsonrpc: "2.0"; id: unknown; error: { code: number; message: string } };
 
 async function mcpCall<T>(
 	workspaceId: string,

--- a/apps/api/src/test/files.test.ts
+++ b/apps/api/src/test/files.test.ts
@@ -2,6 +2,8 @@ import { env, SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
 	authHeaders,
+	type JsonRpcError,
+	type JsonRpcResult,
 	seedFixture,
 	seedMember,
 	seedProject,
@@ -11,9 +13,6 @@ import {
 } from "./helpers";
 
 const ENTITY_ID = crypto.randomUUID();
-
-type JsonRpcResult<T = unknown> = { jsonrpc: "2.0"; id: unknown; result: T };
-type JsonRpcError = { jsonrpc: "2.0"; id: unknown; error: { code: number; message: string } };
 
 async function mcpCall<T>(
 	workspaceId: string,

--- a/apps/api/src/test/flow-metrics.test.ts
+++ b/apps/api/src/test/flow-metrics.test.ts
@@ -1,15 +1,14 @@
 import { env, SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
-import { authHeaders, seedComment, seedIssue, seedProjectFixture, seedTaskType } from "./helpers";
-
-type JsonRpcResult<T> = { jsonrpc: "2.0"; id: unknown; result: T };
-
-interface Distribution {
-	count: number;
-	avg: number | null;
-	p50: number | null;
-	p90: number | null;
-}
+import type { Distribution } from "../services/flow-metrics";
+import {
+	authHeaders,
+	type JsonRpcResult,
+	seedComment,
+	seedIssue,
+	seedProjectFixture,
+	seedTaskType,
+} from "./helpers";
 
 interface FlowMetrics {
 	leadTime: Distribution;

--- a/apps/api/src/test/groups.test.ts
+++ b/apps/api/src/test/groups.test.ts
@@ -1,9 +1,13 @@
 import { SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
-import { authHeaders, seedProject, seedUser, seedWorkspaceRoles } from "./helpers";
-
-type JsonRpcResult<T = unknown> = { jsonrpc: "2.0"; id: unknown; result: T };
-type JsonRpcError = { jsonrpc: "2.0"; id: unknown; error: { code: number; message: string } };
+import {
+	authHeaders,
+	type JsonRpcError,
+	type JsonRpcResult,
+	seedProject,
+	seedUser,
+	seedWorkspaceRoles,
+} from "./helpers";
 
 async function mcpCall<T>(
 	workspaceId: string,

--- a/apps/api/src/test/helpers.ts
+++ b/apps/api/src/test/helpers.ts
@@ -1,5 +1,12 @@
 import { env } from "cloudflare:test";
 
+export type JsonRpcResult<T = unknown> = { jsonrpc: "2.0"; id: unknown; result: T };
+export type JsonRpcError = {
+	jsonrpc: "2.0";
+	id: unknown;
+	error: { code: number; message: string; data?: unknown };
+};
+
 export async function hashToken(token: string): Promise<string> {
 	const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(token));
 	return Array.from(new Uint8Array(buf))

--- a/apps/api/src/test/mcp.test.ts
+++ b/apps/api/src/test/mcp.test.ts
@@ -2,6 +2,8 @@ import { SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
 	authHeaders,
+	type JsonRpcError,
+	type JsonRpcResult,
 	seedCustomFieldDef,
 	seedCustomFieldValue,
 	seedFixture,
@@ -11,13 +13,6 @@ import {
 	seedProject,
 	seedUser,
 } from "./helpers";
-
-type JsonRpcResult<T = unknown> = { jsonrpc: "2.0"; id: unknown; result: T };
-type JsonRpcError = {
-	jsonrpc: "2.0";
-	id: unknown;
-	error: { code: number; message: string; data?: unknown };
-};
 
 async function mcpFetch(
 	workspaceId: string,

--- a/apps/api/src/test/project-activity.test.ts
+++ b/apps/api/src/test/project-activity.test.ts
@@ -1,9 +1,15 @@
 import { env, SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
-import { authHeaders, seedComment, seedIssue, seedProject, seedProjectFixture } from "./helpers";
+import {
+	authHeaders,
+	type JsonRpcError,
+	type JsonRpcResult,
+	seedComment,
+	seedIssue,
+	seedProject,
+	seedProjectFixture,
+} from "./helpers";
 
-type JsonRpcResult<T = unknown> = { jsonrpc: "2.0"; id: unknown; result: T };
-type JsonRpcError = { jsonrpc: "2.0"; id: unknown; error: { code: number; message: string } };
 type McpContent = { content: Array<{ text: string }> };
 
 async function mcpCall<T>(

--- a/apps/api/src/test/projects.test.ts
+++ b/apps/api/src/test/projects.test.ts
@@ -1,9 +1,6 @@
 import { SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
-import { authHeaders, seedWorkspaceRoles } from "./helpers";
-
-type JsonRpcResult<T = unknown> = { jsonrpc: "2.0"; id: unknown; result: T };
-type JsonRpcError = { jsonrpc: "2.0"; id: unknown; error: { code: number; message: string } };
+import { authHeaders, type JsonRpcError, type JsonRpcResult, seedWorkspaceRoles } from "./helpers";
 
 async function mcpCall<T>(
 	workspaceId: string,

--- a/apps/api/src/test/scopes.test.ts
+++ b/apps/api/src/test/scopes.test.ts
@@ -16,7 +16,15 @@ import {
 	parseScopes,
 	tokenAllows,
 } from "../auth/scopes";
-import { authHeaders, seedProject, seedToken, seedUser, seedWorkspace } from "./helpers";
+import {
+	authHeaders,
+	type JsonRpcError,
+	type JsonRpcResult,
+	seedProject,
+	seedToken,
+	seedUser,
+	seedWorkspace,
+} from "./helpers";
 
 /** Seed a workspace + owner + a project in it, for scope-enforcement tests. */
 async function seedScopeFixture() {
@@ -159,9 +167,6 @@ describe("PROJ-17: REST scope enforcement", () => {
 // ---------------------------------------------------------------------------
 // MCP enforcement
 // ---------------------------------------------------------------------------
-
-type JsonRpcResult = { jsonrpc: "2.0"; id: unknown; result: unknown };
-type JsonRpcError = { jsonrpc: "2.0"; id: unknown; error: { code: number; message: string } };
 
 async function mcpCall(
 	workspaceId: string,

--- a/apps/api/src/test/wiki.test.ts
+++ b/apps/api/src/test/wiki.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { computeFreshness } from "../services/wiki-freshness";
 import {
 	authHeaders,
+	type JsonRpcError,
+	type JsonRpcResult,
 	seedFixture,
 	seedGroupGrant,
 	seedMember,
@@ -11,13 +13,6 @@ import {
 	seedUser,
 	seedWorkspaceRoles,
 } from "./helpers";
-
-type JsonRpcResult<T = unknown> = { jsonrpc: "2.0"; id: unknown; result: T };
-type JsonRpcError = {
-	jsonrpc: "2.0";
-	id: unknown;
-	error: { code: number; message: string; data?: unknown };
-};
 
 async function mcpCall<T>(
 	workspaceId: string,

--- a/apps/api/src/test/workflow.test.ts
+++ b/apps/api/src/test/workflow.test.ts
@@ -1,8 +1,6 @@
 import { SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
-import { authHeaders, seedFixture } from "./helpers";
-
-type JsonRpcResult<T> = { jsonrpc: "2.0"; id: unknown; result: T };
+import { authHeaders, type JsonRpcResult, seedFixture } from "./helpers";
 
 describe("Workflow spec", () => {
 	let token: string;

--- a/apps/api/src/test/workspaces.test.ts
+++ b/apps/api/src/test/workspaces.test.ts
@@ -2,6 +2,8 @@ import { env, SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
 	authHeaders,
+	type JsonRpcError,
+	type JsonRpcResult,
 	seedFixture,
 	seedMember,
 	seedProject,
@@ -9,9 +11,6 @@ import {
 	seedUser,
 	seedWorkspace,
 } from "./helpers";
-
-type JsonRpcResult<T = unknown> = { jsonrpc: "2.0"; id: unknown; result: T };
-type JsonRpcError = { jsonrpc: "2.0"; id: unknown; error: { code: number; message: string } };
 
 async function mcpCall<T>(
 	workspaceId: string,

--- a/apps/web/src/islands/EpicList.tsx
+++ b/apps/web/src/islands/EpicList.tsx
@@ -6,6 +6,7 @@ import { PRIORITY_OPTIONS } from "../utils/issue-utils";
 import {
 	CATEGORY_COLORS,
 	type Issue,
+	type ProjectLookup as ProjectMeta,
 	type SortKey,
 	sortIssues,
 	type TaskStatus,
@@ -17,12 +18,6 @@ import Select from "./Select";
 
 interface Props {
 	workspaceSlug?: string;
-}
-
-interface ProjectMeta {
-	id: string;
-	key: string;
-	name: string;
 }
 
 type EpicRollup = { done: number; remaining: number; total: number };

--- a/apps/web/src/islands/FeedbackSourceGrid.tsx
+++ b/apps/web/src/islands/FeedbackSourceGrid.tsx
@@ -1,32 +1,13 @@
 import { useCallback, useEffect, useState } from "preact/hooks";
 import { apiFetch } from "../utils/api-client";
+import type { FeedbackSource, FeedbackVersionSummary } from "./FeedbackSourceSettings";
 import NewSourceModal from "./NewSourceModal";
-
-interface FeedbackSource {
-	id: string;
-	name: string;
-	description: string | null;
-	isActive: boolean;
-	allowedOrigins: string[] | null;
-	tokenPreview: string;
-	createdAt: number;
-	revokedAt: number | null;
-}
-
-interface SourceVersionSummary {
-	appVersion: string | null;
-	totalCount: number;
-	withCommentCount: number;
-	thumbsUpPct: number | null;
-	avgFiveStar: number | null;
-	lastSeenAt: number;
-}
 
 interface SourceSummary {
 	sourceId: string;
 	sourceName: string | null;
 	totalCount: number;
-	versions: SourceVersionSummary[];
+	versions: FeedbackVersionSummary[];
 }
 
 interface Props {

--- a/apps/web/src/islands/FeedbackSourceSettings.tsx
+++ b/apps/web/src/islands/FeedbackSourceSettings.tsx
@@ -12,6 +12,15 @@ export interface FeedbackSource {
 	revokedAt: number | null;
 }
 
+export interface FeedbackVersionSummary {
+	appVersion: string | null;
+	totalCount: number;
+	withCommentCount: number;
+	thumbsUpPct: number | null;
+	avgFiveStar: number | null;
+	lastSeenAt: number;
+}
+
 interface Props {
 	source: FeedbackSource;
 	projectId: string;

--- a/apps/web/src/islands/FeedbackSummary.tsx
+++ b/apps/web/src/islands/FeedbackSummary.tsx
@@ -1,20 +1,12 @@
 import { useCallback, useEffect, useState } from "preact/hooks";
 import { apiFetch } from "../utils/api-client";
-
-interface VersionSummary {
-	appVersion: string | null;
-	totalCount: number;
-	withCommentCount: number;
-	thumbsUpPct: number | null;
-	avgFiveStar: number | null;
-	lastSeenAt: number;
-}
+import type { FeedbackVersionSummary } from "./FeedbackSourceSettings";
 
 interface SourceSummary {
 	sourceId: string;
 	sourceName: string | null;
 	totalCount: number;
-	versions: VersionSummary[];
+	versions: FeedbackVersionSummary[];
 }
 
 interface Props {
@@ -23,7 +15,7 @@ interface Props {
 	sourceId: string;
 }
 
-function versionMetric(v: VersionSummary): string {
+function versionMetric(v: FeedbackVersionSummary): string {
 	const parts: string[] = [];
 	if (v.thumbsUpPct !== null) parts.push(`👍 ${v.thumbsUpPct}%`);
 	if (v.avgFiveStar !== null) parts.push(`${v.avgFiveStar.toFixed(1)}★ avg`);

--- a/apps/web/src/islands/GroupManager.tsx
+++ b/apps/web/src/islands/GroupManager.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { apiFetch } from "../utils/api-client";
 import { resolveWorkspaceSlug } from "../utils/workspace";
+import type { ProjectLookup as ProjectLite } from "./board-utils";
 
 type GrantRole = "viewer" | "member" | "admin";
 
@@ -40,12 +41,6 @@ interface WsMember {
 interface MemberGroupsRow {
 	userId: string;
 	groups: Array<{ id: string; name: string }>;
-}
-
-interface ProjectLite {
-	id: string;
-	name: string;
-	key: string;
 }
 
 interface Props {

--- a/apps/web/src/islands/IssueList-helpers.ts
+++ b/apps/web/src/islands/IssueList-helpers.ts
@@ -1,4 +1,4 @@
-import type { Issue } from "./board-utils";
+import type { Issue, ProjectLookup, TaskStatus } from "./board-utils";
 
 export interface FilterQueryFilters {
 	filterStatuses: string[];
@@ -88,16 +88,17 @@ export function buildFilterQueryParams(
 	return qs;
 }
 
-export interface UrlSyncFilters {
-	filterStatuses: string[];
-	filterPriorities: string[];
-	filterEpicId: string;
-	filterSprintId: string;
-	hideEpics: boolean;
-	filterDateField: "" | "completed" | "updated";
-	filterDateFrom: string;
-	filterDateTo: string;
-}
+export type UrlSyncFilters = Pick<
+	FilterQueryFilters,
+	| "filterStatuses"
+	| "filterPriorities"
+	| "filterEpicId"
+	| "filterSprintId"
+	| "hideEpics"
+	| "filterDateField"
+	| "filterDateFrom"
+	| "filterDateTo"
+>;
 
 const URL_SYNC_KEYS = [
 	[
@@ -160,18 +161,7 @@ export function buildCreateIssuePayload(input: CreateIssueInput): Record<string,
 	};
 }
 
-interface ProjectLookup {
-	id: string;
-	key: string;
-	name: string;
-}
-
-interface StatusLookup {
-	id: string;
-	key: string;
-	name: string;
-	category: string;
-}
+type StatusLookup = Omit<TaskStatus, "color">;
 
 interface TaskTypeLookup {
 	id: string;

--- a/apps/web/src/islands/LazyMarkdownEditor.tsx
+++ b/apps/web/src/islands/LazyMarkdownEditor.tsx
@@ -1,12 +1,6 @@
 import type { ComponentType } from "preact";
 import { useEffect, useState } from "preact/hooks";
-
-interface Props {
-	value: string;
-	onChange: (value: string) => void;
-	minHeight?: string;
-	onImageFile?: (file: File) => Promise<string | null>;
-}
+import type { Props } from "./MarkdownEditor";
 
 // PROJ-431: MarkdownEditor pulls in CodeMirror — 486 KiB raw / 168 KiB gzip, 76% of
 // the JS on /issues/view and /wiki. As a static import every *reader* of an issue paid

--- a/apps/web/src/islands/MarkdownEditor.tsx
+++ b/apps/web/src/islands/MarkdownEditor.tsx
@@ -5,7 +5,7 @@ import { EditorView, keymap } from "@codemirror/view";
 import { useEffect, useRef, useState } from "preact/hooks";
 import { renderMarkdown } from "../utils/markdown";
 
-interface Props {
+export interface Props {
 	value: string;
 	onChange: (value: string) => void;
 	minHeight?: string;

--- a/apps/web/src/islands/SprintManager.test.tsx
+++ b/apps/web/src/islands/SprintManager.test.tsx
@@ -6,18 +6,7 @@
 // The pattern: set the URL, override the stub, await findBy*.
 import { fireEvent, render, screen, waitFor } from "@testing-library/preact";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import SprintManager from "./SprintManager";
-
-interface Sprint {
-	id: string;
-	name: string;
-	goal: string | null;
-	status: "planned" | "active" | "completed";
-	startDate: string | null;
-	endDate: string | null;
-	projectId: string;
-	createdAt: number;
-}
+import SprintManager, { type Sprint } from "./SprintManager";
 
 const PROJECT = { id: "p1", name: "Projektor", key: "PROJ" };
 

--- a/apps/web/src/islands/SprintManager.tsx
+++ b/apps/web/src/islands/SprintManager.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useState } from "preact/hooks";
 import { apiFetch } from "../utils/api-client";
 import { issueUrl } from "../utils/issue-url";
+import type { CustomFieldValue, ProjectLookup as Project } from "./board-utils";
 
-interface Sprint {
+export interface Sprint {
 	id: string;
 	name: string;
 	goal: string | null;
@@ -11,19 +12,6 @@ interface Sprint {
 	endDate: string | null;
 	projectId: string;
 	createdAt: number;
-}
-
-interface Project {
-	id: string;
-	name: string;
-	key: string;
-}
-
-interface CustomFieldValue {
-	key: string;
-	label: string;
-	type: string;
-	value: string;
 }
 
 interface Issue {

--- a/apps/web/src/islands/WikiPage.test.tsx
+++ b/apps/web/src/islands/WikiPage.test.tsx
@@ -8,29 +8,7 @@
 // vi.stubGlobal, then await findBy* for the async state update.
 import { fireEvent, render, screen, waitFor } from "@testing-library/preact";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import WikiPage from "./WikiPage";
-
-interface WikiFreshness {
-	state: "fresh" | "stale" | "unverified";
-	staleSince: number | null;
-}
-
-interface WikiPageData {
-	id: string;
-	slug: string;
-	title: string;
-	content: string;
-	parent_id: string | null;
-	updated_at: number;
-	type: string | null;
-	tags: string[];
-	status: string | null;
-	verified_at: number | null;
-	verified_by: string | null;
-	owners: string[];
-	verify_interval: number | null;
-	freshness: WikiFreshness | null;
-}
+import WikiPage, { type ServerDraft, type WikiPageData } from "./WikiPage";
 
 const PAGE: WikiPageData = {
 	id: "w1",
@@ -317,13 +295,6 @@ describe("WikiPage — project scope control (PROJ-352)", () => {
 		});
 	});
 });
-
-interface ServerDraft {
-	title: string;
-	content: string;
-	baseRevisionId: string | null;
-	updatedAt: number;
-}
 
 // PROJ-495: mock fetch backing a fake server-side wiki_drafts row — GET/PUT/DELETE
 // .../wiki/:slug/draft, plus the usual tree/revisions/page fixtures. `draftCalls`

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -6,14 +6,9 @@ import { useAccessGate } from "../utils/access-gate";
 import { apiFetch } from "../utils/api-client";
 import { renderMdWithWikilinks, renderMermaidDiagrams, stripFrontmatter } from "../utils/markdown";
 import AccessPending from "./AccessPending";
+import type { ProjectLookup as ProjectOption } from "./board-utils";
 import MarkdownEditor from "./LazyMarkdownEditor";
 import Select, { type SelectOption } from "./Select";
-
-interface ProjectOption {
-	id: string;
-	key: string;
-	name: string;
-}
 
 // PROJ-491 (R9): the create-form's template picker draws from list_wiki_templates.
 interface TemplateOption {
@@ -44,7 +39,7 @@ interface SearchResult {
 	freshness: WikiFreshness | null;
 }
 
-interface WikiPageData {
+export interface WikiPageData {
 	id: string;
 	slug: string;
 	title: string;
@@ -335,7 +330,7 @@ interface Props {
 }
 
 // PROJ-495 (R13): shape of a saved server-side draft (services/wiki-drafts.ts#getWikiDraft).
-interface ServerDraft {
+export interface ServerDraft {
 	title: string;
 	content: string;
 	baseRevisionId: string | null;

--- a/apps/web/src/islands/board-utils.ts
+++ b/apps/web/src/islands/board-utils.ts
@@ -13,6 +13,12 @@ export interface CustomFieldValue {
 	value: string;
 }
 
+export interface ProjectLookup {
+	id: string;
+	key: string;
+	name: string;
+}
+
 export interface Issue {
 	id: string;
 	number: number;

--- a/apps/web/src/islands/issue-detail-helpers.ts
+++ b/apps/web/src/islands/issue-detail-helpers.ts
@@ -1,17 +1,6 @@
-export interface TaskStatus {
-	id: string;
-	key: string;
-	name: string;
-	category: string;
-	color: string | null;
-}
+import type { CustomFieldValue, TaskStatus } from "./board-utils";
 
-export interface CustomFieldValue {
-	key: string;
-	label: string;
-	type: string;
-	value: string;
-}
+export type { CustomFieldValue, TaskStatus };
 
 export interface IssueLink {
 	id: string;

--- a/apps/web/src/islands/issue-list/useIssueFetching.ts
+++ b/apps/web/src/islands/issue-list/useIssueFetching.ts
@@ -1,22 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { apiFetch } from "../../utils/api-client";
 import type { Issue } from "../board-utils";
-import { buildFilterQueryParams } from "../IssueList-helpers";
+import { buildFilterQueryParams, type FilterQueryFilters } from "../IssueList-helpers";
 import type { ProjectMeta } from "./types";
 import type { ViewMode } from "./types-view";
 
-interface FilterInputs {
-	filterStatuses: string[];
-	filterPriorities: string[];
-	filterProject: string;
-	filterType: string;
-	filterEpicId: string;
-	filterSprintId: string;
-	hideEpics: boolean;
-	filterDateField: "" | "completed" | "updated";
-	filterDateFrom: string;
-	filterDateTo: string;
-}
+type FilterInputs = FilterQueryFilters;
 
 /** Owns the paginated issue set: fetching, "Load more", and loading/error state (PROJ-201/211). */
 export function useIssueFetching(

--- a/apps/web/src/islands/issue-list/useIssueListData.ts
+++ b/apps/web/src/islands/issue-list/useIssueListData.ts
@@ -1,20 +1,10 @@
+import type { FilterQueryFilters } from "../IssueList-helpers";
 import type { ViewMode } from "./types-view";
 import { useIssueFetching } from "./useIssueFetching";
 import { useIssueLookups } from "./useIssueLookups";
 import { useIssueMutations } from "./useIssueMutations";
 
-interface FilterInputs {
-	filterStatuses: string[];
-	filterPriorities: string[];
-	filterProject: string;
-	filterType: string;
-	filterEpicId: string;
-	filterSprintId: string;
-	hideEpics: boolean;
-	filterDateField: "" | "completed" | "updated";
-	filterDateFrom: string;
-	filterDateTo: string;
-}
+type FilterInputs = FilterQueryFilters;
 
 /**
  * Owns all server-backed data for the issue list: the paginated issue set,


### PR DESCRIPTION
## Summary
- Consolidates same-package `Design.DuplicateTypeShape` findings (28 -> 18) onto single exported types instead of parallel local declarations.
- JsonRpcResult/JsonRpcError shared across 13 api test files via test/helpers.ts.
- CodeHeatmapEntry/ContentionHeatmapEntry, Distribution, WikiPageData/ServerDraft, Sprint, MarkdownEditor Props, FilterQueryFilters-derived FilterInputs/UrlSyncFilters/StatusLookup, TaskStatus/CustomFieldValue, a 5-way {id,key,name} project-lookup shape, and FeedbackSource/FeedbackVersionSummary.
- Cross-package (api service DTO <-> web view-model) duplicates left alone as intentional layering — same treatment as the existing `Refactor.PreferConstOverLet`/`Design.ImportFanOutOutlier` accepted false-positive categories. A few same-package findings (Feedback Props trio, IssueDetail test IssueFixture, TaskTypeLookup/ProjectLookup) are also left: identical field shape by coincidence, not the same domain concept — sharing a type there would conflate unrelated entities.

## Test plan
- [x] `tsc --noEmit` clean for apps/api and apps/web
- [x] Full `vitest run` suite green for apps/api (1118 tests) and apps/web (517 tests)
- [x] `pnpm exec biome check .` clean
- [x] cofferdam re-scan: `Design.DuplicateTypeShape` down from 28 to 18 findings, remainder are cross-package/coincidental-shape and left by design

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJivABTizhiVgM2ziLUyNz