### PR TITLE
PROJ-481: cofferdam triage — Readability.MaxFunctionLength

### DIFF
--- a/apps/api/src/services/flow-metrics.ts
+++ b/apps/api/src/services/flow-metrics.ts
@@ -330,6 +330,36 @@ async function fetchLeaseHeldSeconds(
 	return held;
 }
 
+function computeCoreDistributions(
+	issues: readonly FlowIssueRow[],
+	inWindow: (t: number) => boolean
+): {
+	leadTimes: number[];
+	cycleTimes: number[];
+	reviewLatencies: number[];
+	timeInProgress: number[];
+} {
+	const leadTimes = issues
+		.filter((i) => i.readyAt !== null && i.doneAt !== null && inWindow(i.doneAt))
+		// biome-ignore lint/style/noNonNullAssertion: filtered above
+		.map((i) => i.doneAt! - i.readyAt!);
+	const cycleTimes = issues
+		.filter((i) => i.claimedAt !== null && i.doneAt !== null && inWindow(i.doneAt))
+		// biome-ignore lint/style/noNonNullAssertion: filtered above
+		.map((i) => i.doneAt! - i.claimedAt!);
+	const reviewLatencies = issues
+		.filter((i) => i.inReviewAt !== null && i.doneAt !== null && inWindow(i.doneAt))
+		// biome-ignore lint/style/noNonNullAssertion: filtered above
+		.map((i) => i.doneAt! - i.inReviewAt!);
+	// PROJ-329: time in in_progress = claimed -> the issue's next recorded stage
+	// (entering review, or done directly for issues that skipped review).
+	const timeInProgress = issues
+		.filter((i) => i.claimedAt !== null && i.doneAt !== null && inWindow(i.doneAt))
+		// biome-ignore lint/style/noNonNullAssertion: filtered above
+		.map((i) => (i.inReviewAt ?? i.doneAt!) - i.claimedAt!);
+	return { leadTimes, cycleTimes, reviewLatencies, timeInProgress };
+}
+
 // PROJ-328: human interventions per completed issue = human comments + status bounces
 // out of review. The primary "how much human attention did this take" signal.
 function computeHumanInterventions(
@@ -519,24 +549,10 @@ export async function getFlowMetrics(ctx: ServiceCtx, raw: unknown) {
 	const inWindow = (t: number) =>
 		(since === undefined || t >= since) && (until === undefined || t <= until);
 
-	const leadTimes = issues
-		.filter((i) => i.readyAt !== null && i.doneAt !== null && inWindow(i.doneAt))
-		// biome-ignore lint/style/noNonNullAssertion: filtered above
-		.map((i) => i.doneAt! - i.readyAt!);
-	const cycleTimes = issues
-		.filter((i) => i.claimedAt !== null && i.doneAt !== null && inWindow(i.doneAt))
-		// biome-ignore lint/style/noNonNullAssertion: filtered above
-		.map((i) => i.doneAt! - i.claimedAt!);
-	const reviewLatencies = issues
-		.filter((i) => i.inReviewAt !== null && i.doneAt !== null && inWindow(i.doneAt))
-		// biome-ignore lint/style/noNonNullAssertion: filtered above
-		.map((i) => i.doneAt! - i.inReviewAt!);
-	// PROJ-329: time in in_progress = claimed -> the issue's next recorded stage
-	// (entering review, or done directly for issues that skipped review).
-	const timeInProgress = issues
-		.filter((i) => i.claimedAt !== null && i.doneAt !== null && inWindow(i.doneAt))
-		// biome-ignore lint/style/noNonNullAssertion: filtered above
-		.map((i) => (i.inReviewAt ?? i.doneAt!) - i.claimedAt!);
+	const { leadTimes, cycleTimes, reviewLatencies, timeInProgress } = computeCoreDistributions(
+		issues,
+		inWindow
+	);
 
 	const issueIds = issues.map((i) => i.id);
 

--- a/apps/api/src/services/wiki.ts
+++ b/apps/api/src/services/wiki.ts
@@ -1959,6 +1959,74 @@ export async function listWikiTemplates(ctx: ServiceCtx, input: unknown) {
 	return rows.map((r) => ({ ...r, url: wikiPagePath(r.slug) }));
 }
 
+const DEFAULT_WIKI_TEMPLATES: Array<{ slug: string; title: string; type: string; body: string }> = [
+	{
+		slug: "templates-runbook",
+		title: "Runbook Template",
+		type: "runbook",
+		body: [
+			"# Runbook: [Title]",
+			"",
+			"## Purpose",
+			"",
+			"What this runbook is for and when to use it.",
+			"",
+			"## Preconditions",
+			"",
+			"-",
+			"",
+			"## Steps",
+			"",
+			"1.",
+			"2.",
+			"3.",
+			"",
+			"## Rollback",
+			"",
+			"## Verification",
+			"",
+		].join("\n"),
+	},
+	{
+		slug: "templates-adr",
+		title: "ADR Template",
+		type: "adr",
+		body: [
+			"# ADR NNNN: [Title]",
+			"",
+			"## Status",
+			"",
+			"Proposed",
+			"",
+			"## Context",
+			"",
+			"## Decision",
+			"",
+			"## Consequences",
+			"",
+		].join("\n"),
+	},
+	{
+		slug: "templates-spec",
+		title: "Spec Template",
+		type: "spec",
+		body: [
+			"# [Feature] Spec",
+			"",
+			"## Problem",
+			"",
+			"## Goals",
+			"",
+			"## Non-goals",
+			"",
+			"## Design",
+			"",
+			"## Open questions",
+			"",
+		].join("\n"),
+	},
+];
+
 // PROJ-491 (R9): seeds the built-in templates (runbook, adr, spec) for a newly created
 // workspace, under a "Templates" parent page (slugged "page-templates" — see
 // RESERVED_WIKI_SLUGS) — same content the 0047 migration backfills
@@ -1997,75 +2065,7 @@ export async function seedDefaultWikiTemplates(
 		.bind(parentId, workspaceId, "Templates", "", "")
 		.run();
 
-	const templates: Array<{ slug: string; title: string; type: string; body: string }> = [
-		{
-			slug: "templates-runbook",
-			title: "Runbook Template",
-			type: "runbook",
-			body: [
-				"# Runbook: [Title]",
-				"",
-				"## Purpose",
-				"",
-				"What this runbook is for and when to use it.",
-				"",
-				"## Preconditions",
-				"",
-				"-",
-				"",
-				"## Steps",
-				"",
-				"1.",
-				"2.",
-				"3.",
-				"",
-				"## Rollback",
-				"",
-				"## Verification",
-				"",
-			].join("\n"),
-		},
-		{
-			slug: "templates-adr",
-			title: "ADR Template",
-			type: "adr",
-			body: [
-				"# ADR NNNN: [Title]",
-				"",
-				"## Status",
-				"",
-				"Proposed",
-				"",
-				"## Context",
-				"",
-				"## Decision",
-				"",
-				"## Consequences",
-				"",
-			].join("\n"),
-		},
-		{
-			slug: "templates-spec",
-			title: "Spec Template",
-			type: "spec",
-			body: [
-				"# [Feature] Spec",
-				"",
-				"## Problem",
-				"",
-				"## Goals",
-				"",
-				"## Non-goals",
-				"",
-				"## Design",
-				"",
-				"## Open questions",
-				"",
-			].join("\n"),
-		},
-	];
-
-	for (const t of templates) {
+	for (const t of DEFAULT_WIKI_TEMPLATES) {
 		const content = `---\ntype: ${t.type}\nstatus: draft\ntemplate: true\n---\n${t.body}`;
 		await orm.insert(schema.wikiPages).values({
 			id: crypto.randomUUID(),

--- a/apps/api/src/test/issues.test.ts
+++ b/apps/api/src/test/issues.test.ts
@@ -1446,7 +1446,6 @@ describe("Issues API — includeRollups/includeBody/assignee=me (perf sweep)", (
 	});
 });
 
-// cofferdam-ignore: Readability.MaxFunctionLength: full integration test suite in one describe block, normal test style
 describe("Issues MCP — typeId", () => {
 	let token: string;
 	let slug: string;

--- a/apps/web/src/islands/AccountMenu.tsx
+++ b/apps/web/src/islands/AccountMenu.tsx
@@ -23,19 +23,56 @@ function initials(name: string, email: string): string {
 	return source.slice(0, 2).toUpperCase();
 }
 
-// PROJ-428: replaces the old unlabeled Log in/Log out emoji links. The app is
-// entirely behind Cloudflare Access, so there's no true logged-out state to
-// render here — "Refresh session" and "Log out" are manual escape hatches for
-// re-challenging or ending the CF Access session (see apps/api/src/routes/auth.ts).
-export function AccountMenu({ workspaceSlug }: Props) {
+function AccountMenuPopover({
+	menuId,
+	popoverRef,
+	pos,
+	user,
+	redirectTarget,
+}: {
+	menuId: string;
+	popoverRef: { current: HTMLDivElement | null };
+	pos: { top: number; right: number };
+	user: { email: string; name: string };
+	redirectTarget: string;
+}) {
+	return createPortal(
+		<div
+			id={menuId}
+			ref={popoverRef}
+			class="account-menu-popover"
+			style={{ position: "fixed", top: `${pos.top}px`, right: `${pos.right}px` }}
+		>
+			<div class="account-menu-identity">
+				<div class="account-menu-identity-name">{user.name}</div>
+				<div class="account-menu-identity-email">{user.email}</div>
+			</div>
+			<div role="menu" aria-label="Account">
+				<a
+					role="menuitem"
+					class="account-menu-item"
+					href={`/auth/login?redirect_url=${encodeURIComponent(redirectTarget)}`}
+				>
+					Refresh session
+				</a>
+				<a
+					role="menuitem"
+					class="account-menu-item"
+					href="/cdn-cgi/access/logout"
+					// PROJ-431: don't leave one user's unsent drafts on a shared device.
+					onClick={() => clearAllDrafts()}
+				>
+					Log out
+				</a>
+			</div>
+		</div>,
+		document.body
+	);
+}
+
+function useAccountUser(workspaceSlug: string | undefined) {
 	const [user, setUser] = useState<{ email: string; name: string } | null>(null);
 	const [failed, setFailed] = useState(false);
-	const [open, setOpen] = useState(false);
-	const [popoverPos, setPopoverPos] = useState<{ top: number; right: number } | null>(null);
-	const rootRef = useRef<HTMLDivElement>(null);
-	const triggerRef = useRef<HTMLButtonElement>(null);
-	const popoverRef = useRef<HTMLDivElement>(null);
-	const menuId = useId();
 
 	useEffect(() => {
 		let cancelled = false;
@@ -59,6 +96,50 @@ export function AccountMenu({ workspaceSlug }: Props) {
 		};
 	}, [workspaceSlug]);
 
+	return { user, failed };
+}
+
+// PROJ-419-style portal: the top bar this menu lives in gets a CSS
+// `transform` when hidden on scroll (see Base.astro's .topbar-hidden),
+// which would otherwise become the containing block for a `position:
+// fixed` popover and break its positioning. Portalling to document.body
+// sidesteps that, same as GlossaryHelp's popover.
+function useCloseOnOutsideOrEscape(
+	open: boolean,
+	isInside: (node: Node) => boolean,
+	onOutsideClick: () => void,
+	onEscape: () => void
+) {
+	useEffect(() => {
+		if (!open) return;
+		function onPointerDown(e: MouseEvent) {
+			if (!(e.target instanceof Node) || !isInside(e.target)) onOutsideClick();
+		}
+		function onKeyDown(e: KeyboardEvent) {
+			if (e.key === "Escape") onEscape();
+		}
+		document.addEventListener("mousedown", onPointerDown);
+		document.addEventListener("keydown", onKeyDown);
+		return () => {
+			document.removeEventListener("mousedown", onPointerDown);
+			document.removeEventListener("keydown", onKeyDown);
+		};
+	}, [open]);
+}
+
+// PROJ-428: replaces the old unlabeled Log in/Log out emoji links. The app is
+// entirely behind Cloudflare Access, so there's no true logged-out state to
+// render here — "Refresh session" and "Log out" are manual escape hatches for
+// re-challenging or ending the CF Access session (see apps/api/src/routes/auth.ts).
+export function AccountMenu({ workspaceSlug }: Props) {
+	const { user, failed } = useAccountUser(workspaceSlug);
+	const [open, setOpen] = useState(false);
+	const [popoverPos, setPopoverPos] = useState<{ top: number; right: number } | null>(null);
+	const rootRef = useRef<HTMLDivElement>(null);
+	const triggerRef = useRef<HTMLButtonElement>(null);
+	const popoverRef = useRef<HTMLDivElement>(null);
+	const menuId = useId();
+
 	function isInside(node: Node) {
 		return !!(rootRef.current?.contains(node) || popoverRef.current?.contains(node));
 	}
@@ -74,29 +155,15 @@ export function AccountMenu({ workspaceSlug }: Props) {
 		setOpen(true);
 	}
 
-	// PROJ-419-style portal: the top bar this menu lives in gets a CSS
-	// `transform` when hidden on scroll (see Base.astro's .topbar-hidden),
-	// which would otherwise become the containing block for a `position:
-	// fixed` popover and break its positioning. Portalling to document.body
-	// sidesteps that, same as GlossaryHelp's popover.
-	useEffect(() => {
-		if (!open) return;
-		function onPointerDown(e: MouseEvent) {
-			if (!(e.target instanceof Node) || !isInside(e.target)) setOpen(false);
+	useCloseOnOutsideOrEscape(
+		open,
+		isInside,
+		() => setOpen(false),
+		() => {
+			setOpen(false);
+			triggerRef.current?.focus();
 		}
-		function onKeyDown(e: KeyboardEvent) {
-			if (e.key === "Escape") {
-				setOpen(false);
-				triggerRef.current?.focus();
-			}
-		}
-		document.addEventListener("mousedown", onPointerDown);
-		document.addEventListener("keydown", onKeyDown);
-		return () => {
-			document.removeEventListener("mousedown", onPointerDown);
-			document.removeEventListener("keydown", onKeyDown);
-		};
-	}, [open]);
+	);
 
 	if (failed) {
 		return (
@@ -138,44 +205,15 @@ export function AccountMenu({ workspaceSlug }: Props) {
 					▾
 				</span>
 			</button>
-			{open &&
-				popoverPos &&
-				createPortal(
-					<div
-						id={menuId}
-						ref={popoverRef}
-						class="account-menu-popover"
-						style={{
-							position: "fixed",
-							top: `${popoverPos.top}px`,
-							right: `${popoverPos.right}px`,
-						}}
-					>
-						<div class="account-menu-identity">
-							<div class="account-menu-identity-name">{user.name}</div>
-							<div class="account-menu-identity-email">{user.email}</div>
-						</div>
-						<div role="menu" aria-label="Account">
-							<a
-								role="menuitem"
-								class="account-menu-item"
-								href={`/auth/login?redirect_url=${encodeURIComponent(redirectTarget)}`}
-							>
-								Refresh session
-							</a>
-							<a
-								role="menuitem"
-								class="account-menu-item"
-								href="/cdn-cgi/access/logout"
-								// PROJ-431: don't leave one user's unsent drafts on a shared device.
-								onClick={() => clearAllDrafts()}
-							>
-								Log out
-							</a>
-						</div>
-					</div>,
-					document.body
-				)}
+			{open && popoverPos && (
+				<AccountMenuPopover
+					menuId={menuId}
+					popoverRef={popoverRef}
+					pos={popoverPos}
+					user={user}
+					redirectTarget={redirectTarget}
+				/>
+			)}
 		</div>
 	);
 }

--- a/apps/web/src/islands/FeedbackList.tsx
+++ b/apps/web/src/islands/FeedbackList.tsx
@@ -171,13 +171,88 @@ function FeedbackMobileCards({
 	);
 }
 
-export default function FeedbackList({ workspaceSlug, projectId, sourceId }: Props) {
+interface FeedbackTableProps {
+	rows: Feedback[];
+	selected: Set<string>;
+	expanded: Set<string>;
+	onToggleSelectAll: () => void;
+	onToggleRow: (id: string) => void;
+	onToggleExpanded: (id: string) => void;
+	onMarkReviewed: (id: string) => void;
+	onConvert: (id: string) => void;
+}
+
+function FeedbackTable({
+	rows,
+	selected,
+	expanded,
+	onToggleSelectAll,
+	onToggleRow,
+	onToggleExpanded,
+	onMarkReviewed,
+	onConvert,
+}: FeedbackTableProps) {
+	return (
+		<div class="overflow-x-auto max-sm:hidden">
+			<table class="w-full border-collapse text-[0.9rem]">
+				<thead>
+					<tr>
+						<th class={TH}>
+							<input
+								type="checkbox"
+								aria-label="select all"
+								checked={rows.length > 0 && selected.size === rows.length}
+								onChange={onToggleSelectAll}
+							/>
+						</th>
+						<th class={TH}>Rating</th>
+						<th class={TH}>Feedback</th>
+						<th class={TH}>Status</th>
+						<th class={TH}>Received</th>
+						<th class={TH}></th>
+					</tr>
+				</thead>
+				<tbody>
+					{rows.map((r) => (
+						<tr key={r.id}>
+							<td class={TD}>
+								<input
+									type="checkbox"
+									aria-label={`select row ${r.id}`}
+									checked={selected.has(r.id)}
+									onChange={() => onToggleRow(r.id)}
+								/>
+							</td>
+							<td class={TD}>{ratingDisplay(r.rating, r.ratingScale)}</td>
+							<td class={`${TD} text-text-base`}>
+								<div>{r.body ?? "—"}</div>
+								{r.submitterLabel && (
+									<div class="text-[0.75rem] text-text-muted mt-1">{r.submitterLabel}</div>
+								)}
+								<FeedbackContext
+									row={r}
+									expanded={expanded.has(r.id)}
+									onToggle={() => onToggleExpanded(r.id)}
+								/>
+							</td>
+							<td class={`${TD} text-text-muted`}>{r.status}</td>
+							<td class={`${TD} text-text-muted`}>{formatDate(r.createdAt)}</td>
+							<td class={`${TD} whitespace-nowrap`}>
+								<FeedbackRowActions row={r} onMarkReviewed={onMarkReviewed} onConvert={onConvert} />
+							</td>
+						</tr>
+					))}
+				</tbody>
+			</table>
+		</div>
+	);
+}
+
+function useFeedbackRows(workspaceSlug: string | undefined, projectId: string, sourceId: string) {
 	const [rows, setRows] = useState<Feedback[]>([]);
 	const [status, setStatus] = useState("");
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
-	const [selected, setSelected] = useState<Set<string>>(new Set());
-	const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
 	const fetchRows = useCallback(async () => {
 		if (!projectId || !sourceId) return;
@@ -202,6 +277,16 @@ export default function FeedbackList({ workspaceSlug, projectId, sourceId }: Pro
 		fetchRows();
 	}, [fetchRows]);
 
+	return { rows, status, setStatus, loading, error, setError, fetchRows };
+}
+
+function useFeedbackActions(
+	workspaceSlug: string | undefined,
+	projectId: string,
+	setError: (e: string | null) => void,
+	fetchRows: () => Promise<void>,
+	setSelected: (s: Set<string>) => void
+) {
 	async function convert(id: string) {
 		try {
 			await apiFetch(`/api/projects/${projectId}/feedback/${id}/convert-to-issue`, {
@@ -227,7 +312,7 @@ export default function FeedbackList({ workspaceSlug, projectId, sourceId }: Pro
 		}
 	}
 
-	async function bulkMarkReviewed() {
+	async function bulkMarkReviewed(selected: Set<string>) {
 		try {
 			await apiFetch(`/api/projects/${projectId}/feedback/bulk-mark-reviewed`, {
 				method: "POST",
@@ -241,7 +326,7 @@ export default function FeedbackList({ workspaceSlug, projectId, sourceId }: Pro
 		}
 	}
 
-	async function bulkConvertToIssue() {
+	async function bulkConvertToIssue(selected: Set<string>) {
 		try {
 			await apiFetch(`/api/projects/${projectId}/feedback/bulk-convert-to-issue`, {
 				method: "POST",
@@ -255,26 +340,40 @@ export default function FeedbackList({ workspaceSlug, projectId, sourceId }: Pro
 		}
 	}
 
+	return { convert, markReviewed, bulkMarkReviewed, bulkConvertToIssue };
+}
+
+function useToggleSet() {
+	const [set, setSet] = useState<Set<string>>(new Set());
+	function toggle(id: string) {
+		setSet((prev) => {
+			const next = new Set(prev);
+			if (next.has(id)) next.delete(id);
+			else next.add(id);
+			return next;
+		});
+	}
+	return [set, toggle, setSet] as const;
+}
+
+export default function FeedbackList({ workspaceSlug, projectId, sourceId }: Props) {
+	const { rows, status, setStatus, loading, error, setError, fetchRows } = useFeedbackRows(
+		workspaceSlug,
+		projectId,
+		sourceId
+	);
+	const [selected, toggleRow, setSelected] = useToggleSet();
+	const [expanded, toggleExpanded] = useToggleSet();
+	const { convert, markReviewed, bulkMarkReviewed, bulkConvertToIssue } = useFeedbackActions(
+		workspaceSlug,
+		projectId,
+		setError,
+		fetchRows,
+		setSelected
+	);
+
 	function toggleSelectAll() {
 		setSelected((prev) => (prev.size === rows.length ? new Set() : new Set(rows.map((r) => r.id))));
-	}
-
-	function toggleRow(id: string) {
-		setSelected((prev) => {
-			const next = new Set(prev);
-			if (next.has(id)) next.delete(id);
-			else next.add(id);
-			return next;
-		});
-	}
-
-	function toggleExpanded(id: string) {
-		setExpanded((prev) => {
-			const next = new Set(prev);
-			if (next.has(id)) next.delete(id);
-			else next.add(id);
-			return next;
-		});
 	}
 
 	return (
@@ -302,10 +401,18 @@ export default function FeedbackList({ workspaceSlug, projectId, sourceId }: Pro
 			{selected.size > 0 && (
 				<div class="flex gap-2 items-center mb-3 p-2 bg-surface border border-border rounded">
 					<span class="text-[0.85rem] text-text-muted">{selected.size} selected</span>
-					<button type="button" class="btn btn-outline btn-sm" onClick={bulkMarkReviewed}>
+					<button
+						type="button"
+						class="btn btn-outline btn-sm"
+						onClick={() => bulkMarkReviewed(selected)}
+					>
 						Mark all reviewed
 					</button>
-					<button type="button" class="btn btn-outline btn-sm" onClick={bulkConvertToIssue}>
+					<button
+						type="button"
+						class="btn btn-outline btn-sm"
+						onClick={() => bulkConvertToIssue(selected)}
+					>
 						Convert all to issue
 					</button>
 				</div>
@@ -318,62 +425,16 @@ export default function FeedbackList({ workspaceSlug, projectId, sourceId }: Pro
 				</div>
 			) : (
 				<>
-					<div class="overflow-x-auto max-sm:hidden">
-						<table class="w-full border-collapse text-[0.9rem]">
-							<thead>
-								<tr>
-									<th class={TH}>
-										<input
-											type="checkbox"
-											aria-label="select all"
-											checked={rows.length > 0 && selected.size === rows.length}
-											onChange={toggleSelectAll}
-										/>
-									</th>
-									<th class={TH}>Rating</th>
-									<th class={TH}>Feedback</th>
-									<th class={TH}>Status</th>
-									<th class={TH}>Received</th>
-									<th class={TH}></th>
-								</tr>
-							</thead>
-							<tbody>
-								{rows.map((r) => (
-									<tr key={r.id}>
-										<td class={TD}>
-											<input
-												type="checkbox"
-												aria-label={`select row ${r.id}`}
-												checked={selected.has(r.id)}
-												onChange={() => toggleRow(r.id)}
-											/>
-										</td>
-										<td class={TD}>{ratingDisplay(r.rating, r.ratingScale)}</td>
-										<td class={`${TD} text-text-base`}>
-											<div>{r.body ?? "—"}</div>
-											{r.submitterLabel && (
-												<div class="text-[0.75rem] text-text-muted mt-1">{r.submitterLabel}</div>
-											)}
-											<FeedbackContext
-												row={r}
-												expanded={expanded.has(r.id)}
-												onToggle={() => toggleExpanded(r.id)}
-											/>
-										</td>
-										<td class={`${TD} text-text-muted`}>{r.status}</td>
-										<td class={`${TD} text-text-muted`}>{formatDate(r.createdAt)}</td>
-										<td class={`${TD} whitespace-nowrap`}>
-											<FeedbackRowActions
-												row={r}
-												onMarkReviewed={markReviewed}
-												onConvert={convert}
-											/>
-										</td>
-									</tr>
-								))}
-							</tbody>
-						</table>
-					</div>
+					<FeedbackTable
+						rows={rows}
+						selected={selected}
+						expanded={expanded}
+						onToggleSelectAll={toggleSelectAll}
+						onToggleRow={toggleRow}
+						onToggleExpanded={toggleExpanded}
+						onMarkReviewed={markReviewed}
+						onConvert={convert}
+					/>
 					<FeedbackMobileCards
 						rows={rows}
 						selected={selected}

--- a/apps/web/src/islands/FeedbackSourceDetail.tsx
+++ b/apps/web/src/islands/FeedbackSourceDetail.tsx
@@ -32,6 +32,119 @@ function statusLabel(s: FeedbackSource): string {
 	return s.isActive ? "Active" : "Inactive";
 }
 
+function FeedbackSourceHeader({
+	source,
+	sources,
+	projectId,
+}: {
+	source: FeedbackSource;
+	sources: FeedbackSource[];
+	projectId: string;
+}) {
+	return (
+		<div class="flex flex-wrap items-center justify-between gap-3 mb-4">
+			<div class="flex items-center gap-2">
+				<h1 class="text-xl font-bold text-text-base m-0">{source.name}</h1>
+				<span class="text-[0.7rem] font-medium px-1.5 py-0.5 rounded bg-surface border border-border text-text-muted">
+					{statusLabel(source)}
+				</span>
+			</div>
+			{sources.length > 1 && (
+				<Select
+					ariaLabel="Switch feedback source"
+					value={source.id}
+					onChange={(id) => {
+						window.location.href = `/feedback/${id}${projectId ? `?projectId=${projectId}` : ""}`;
+					}}
+					options={sources.map((s) => ({ value: s.id, label: s.name }))}
+				/>
+			)}
+		</div>
+	);
+}
+
+function FeedbackTabPanels({
+	tab,
+	workspaceSlug,
+	projectId,
+	source,
+	onSettingsChanged,
+}: {
+	tab: TabId;
+	workspaceSlug?: string;
+	projectId: string;
+	source: FeedbackSource;
+	onSettingsChanged: () => void;
+}) {
+	return (
+		<>
+			{tab === "items" && (
+				<div role="tabpanel" id="feedback-tabpanel-items" aria-labelledby="feedback-tab-items">
+					<FeedbackList workspaceSlug={workspaceSlug} projectId={projectId} sourceId={source.id} />
+				</div>
+			)}
+			{tab === "summary" && (
+				<div role="tabpanel" id="feedback-tabpanel-summary" aria-labelledby="feedback-tab-summary">
+					<FeedbackSummary
+						workspaceSlug={workspaceSlug}
+						projectId={projectId}
+						sourceId={source.id}
+					/>
+				</div>
+			)}
+			{tab === "settings" && (
+				<div
+					role="tabpanel"
+					id="feedback-tabpanel-settings"
+					aria-labelledby="feedback-tab-settings"
+				>
+					<FeedbackSourceSettings
+						source={source}
+						projectId={projectId}
+						workspaceSlug={workspaceSlug}
+						onChanged={onSettingsChanged}
+					/>
+				</div>
+			)}
+		</>
+	);
+}
+
+function FeedbackTabBar({
+	tab,
+	tabRefs,
+	onTabKeyDown,
+	onTabClick,
+}: {
+	tab: TabId;
+	tabRefs: { current: Partial<Record<TabId, HTMLButtonElement | null>> };
+	onTabKeyDown: (e: KeyboardEvent) => void;
+	onTabClick: (id: TabId) => void;
+}) {
+	return (
+		<div role="tablist" aria-label="Feedback source" class={TAB_LIST} onKeyDown={onTabKeyDown}>
+			{TABS.map((id) => (
+				<button
+					key={id}
+					ref={(el) => {
+						tabRefs.current[id] = el;
+					}}
+					type="button"
+					role="tab"
+					id={`feedback-tab-${id}`}
+					aria-selected={tab === id}
+					aria-controls={`feedback-tabpanel-${id}`}
+					tabIndex={tab === id ? 0 : -1}
+					class={tabBtnClass(tab === id)}
+					onClick={() => onTabClick(id)}
+				>
+					{TAB_LABELS[id]}
+				</button>
+			))}
+		</div>
+	);
+}
+
 export default function FeedbackSourceDetail({
 	workspaceSlug,
 	projectId: projectIdProp,
@@ -127,74 +240,17 @@ export default function FeedbackSourceDetail({
 
 	return (
 		<div>
-			<div class="flex flex-wrap items-center justify-between gap-3 mb-4">
-				<div class="flex items-center gap-2">
-					<h1 class="text-xl font-bold text-text-base m-0">{source.name}</h1>
-					<span class="text-[0.7rem] font-medium px-1.5 py-0.5 rounded bg-surface border border-border text-text-muted">
-						{statusLabel(source)}
-					</span>
-				</div>
-				{sources.length > 1 && (
-					<Select
-						ariaLabel="Switch feedback source"
-						value={source.id}
-						onChange={(id) => {
-							window.location.href = `/feedback/${id}${projectId ? `?projectId=${projectId}` : ""}`;
-						}}
-						options={sources.map((s) => ({ value: s.id, label: s.name }))}
-					/>
-				)}
-			</div>
+			<FeedbackSourceHeader source={source} sources={sources} projectId={projectId} />
 
-			<div role="tablist" aria-label="Feedback source" class={TAB_LIST} onKeyDown={onTabKeyDown}>
-				{TABS.map((id) => (
-					<button
-						key={id}
-						ref={(el) => {
-							tabRefs.current[id] = el;
-						}}
-						type="button"
-						role="tab"
-						id={`feedback-tab-${id}`}
-						aria-selected={tab === id}
-						aria-controls={`feedback-tabpanel-${id}`}
-						tabIndex={tab === id ? 0 : -1}
-						class={tabBtnClass(tab === id)}
-						onClick={() => setTab(id)}
-					>
-						{TAB_LABELS[id]}
-					</button>
-				))}
-			</div>
+			<FeedbackTabBar tab={tab} tabRefs={tabRefs} onTabKeyDown={onTabKeyDown} onTabClick={setTab} />
 
-			{tab === "items" && (
-				<div role="tabpanel" id="feedback-tabpanel-items" aria-labelledby="feedback-tab-items">
-					<FeedbackList workspaceSlug={workspaceSlug} projectId={projectId} sourceId={source.id} />
-				</div>
-			)}
-			{tab === "summary" && (
-				<div role="tabpanel" id="feedback-tabpanel-summary" aria-labelledby="feedback-tab-summary">
-					<FeedbackSummary
-						workspaceSlug={workspaceSlug}
-						projectId={projectId}
-						sourceId={source.id}
-					/>
-				</div>
-			)}
-			{tab === "settings" && (
-				<div
-					role="tabpanel"
-					id="feedback-tabpanel-settings"
-					aria-labelledby="feedback-tab-settings"
-				>
-					<FeedbackSourceSettings
-						source={source}
-						projectId={projectId}
-						workspaceSlug={workspaceSlug}
-						onChanged={fetchSources}
-					/>
-				</div>
-			)}
+			<FeedbackTabPanels
+				tab={tab}
+				workspaceSlug={workspaceSlug}
+				projectId={projectId}
+				source={source}
+				onSettingsChanged={fetchSources}
+			/>
 		</div>
 	);
 }

--- a/apps/web/src/islands/FeedbackSourceSettings.tsx
+++ b/apps/web/src/islands/FeedbackSourceSettings.tsx
@@ -32,6 +32,66 @@ function formatDate(ts: number): string {
 	return new Date(ts * 1000).toLocaleDateString();
 }
 
+function NewTokenReveal({ token, onDismiss }: { token: string; onDismiss: () => void }) {
+	return (
+		<div class="bg-surface border border-border rounded-md p-4">
+			<p class="text-[var(--danger-text)] text-[0.8rem] my-1">
+				⚠ Copy this token now — you won't be able to see it again.
+			</p>
+			<code class="block font-mono text-[0.8rem] px-2 py-[0.375rem] bg-bg border border-border rounded break-all">
+				{token}
+			</code>
+			<button type="button" class="btn btn-outline btn-sm mt-2" onClick={onDismiss}>
+				Done
+			</button>
+		</div>
+	);
+}
+
+function DangerZone({
+	rotating,
+	onRotateStart,
+	onRotateCancel,
+	onRotateConfirm,
+	onRevoke,
+}: {
+	rotating: boolean;
+	onRotateStart: () => void;
+	onRotateCancel: () => void;
+	onRotateConfirm: () => void;
+	onRevoke: () => void;
+}) {
+	return (
+		<div class="flex flex-col gap-2">
+			<span class="text-[0.8rem] font-semibold text-text-muted">Danger zone</span>
+			{rotating ? (
+				<span class="inline-flex gap-[0.375rem] items-center flex-wrap">
+					<span class="text-[0.8rem] text-text-muted">Rotate? Old token dies.</span>
+					<button type="button" class="btn btn-danger btn-sm" onClick={onRotateConfirm}>
+						Yes
+					</button>
+					<button type="button" class="btn btn-outline btn-sm" onClick={onRotateCancel}>
+						No
+					</button>
+				</span>
+			) : (
+				<span class="inline-flex gap-[0.375rem]">
+					<button type="button" class="btn btn-outline btn-sm" onClick={onRotateStart}>
+						Rotate token
+					</button>
+					<button
+						type="button"
+						class="btn btn-outline btn-sm text-[var(--danger-text)] border-[var(--danger-border)]"
+						onClick={onRevoke}
+					>
+						Revoke source
+					</button>
+				</span>
+			)}
+		</div>
+	);
+}
+
 export default function FeedbackSourceSettings({
 	source,
 	projectId,
@@ -89,23 +149,7 @@ export default function FeedbackSourceSettings({
 				</p>
 			)}
 
-			{newToken && (
-				<div class="bg-surface border border-border rounded-md p-4">
-					<p class="text-[var(--danger-text)] text-[0.8rem] my-1">
-						⚠ Copy this token now — you won't be able to see it again.
-					</p>
-					<code class="block font-mono text-[0.8rem] px-2 py-[0.375rem] bg-bg border border-border rounded break-all">
-						{newToken}
-					</code>
-					<button
-						type="button"
-						class="btn btn-outline btn-sm mt-2"
-						onClick={() => setNewToken(null)}
-					>
-						Done
-					</button>
-				</div>
-			)}
+			{newToken && <NewTokenReveal token={newToken} onDismiss={() => setNewToken(null)} />}
 
 			<div class="flex flex-col gap-1">
 				<span class="text-[0.8rem] font-semibold text-text-muted">Token</span>
@@ -124,33 +168,13 @@ export default function FeedbackSourceSettings({
 				<span class="text-[0.875rem] text-text-base">{formatDate(source.createdAt)}</span>
 			</div>
 
-			<div class="flex flex-col gap-2">
-				<span class="text-[0.8rem] font-semibold text-text-muted">Danger zone</span>
-				{rotating ? (
-					<span class="inline-flex gap-[0.375rem] items-center flex-wrap">
-						<span class="text-[0.8rem] text-text-muted">Rotate? Old token dies.</span>
-						<button type="button" class="btn btn-danger btn-sm" onClick={confirmRotate}>
-							Yes
-						</button>
-						<button type="button" class="btn btn-outline btn-sm" onClick={() => setRotating(false)}>
-							No
-						</button>
-					</span>
-				) : (
-					<span class="inline-flex gap-[0.375rem]">
-						<button type="button" class="btn btn-outline btn-sm" onClick={() => setRotating(true)}>
-							Rotate token
-						</button>
-						<button
-							type="button"
-							class="btn btn-outline btn-sm text-[var(--danger-text)] border-[var(--danger-border)]"
-							onClick={revoke}
-						>
-							Revoke source
-						</button>
-					</span>
-				)}
-			</div>
+			<DangerZone
+				rotating={rotating}
+				onRotateStart={() => setRotating(true)}
+				onRotateCancel={() => setRotating(false)}
+				onRotateConfirm={confirmRotate}
+				onRevoke={revoke}
+			/>
 		</section>
 	);
 }

--- a/apps/web/src/islands/GroupManager.tsx
+++ b/apps/web/src/islands/GroupManager.tsx
@@ -342,97 +342,27 @@ interface DetailProps {
 	onClose: () => void;
 }
 
-function GroupDetailEditor(props: DetailProps) {
-	const { slug, groupId } = props;
-	const [detail, setDetail] = useState<GroupDetail | null>(null);
-	const [err, setErr] = useState<string | null>(null);
-	const [busy, setBusy] = useState(false);
-	const [nameDraft, setNameDraft] = useState("");
-	const [addUserId, setAddUserId] = useState("");
-	const [grantProjectId, setGrantProjectId] = useState("");
-	const [grantRole, setGrantRole] = useState<GrantRole>("member");
-
-	const refetch = useCallback(async () => {
-		try {
-			const d = await apiFetch<GroupDetail>(`/api/workspaces/${slug}/groups/${groupId}`, {
-				workspaceSlug: slug,
-			});
-			setDetail(d);
-			setNameDraft(d.name);
-		} catch (e) {
-			setErr(String(e));
-		}
-	}, [slug, groupId]);
-
-	useEffect(() => {
-		void refetch();
-	}, [refetch]);
-
-	async function run(fn: () => Promise<void>) {
-		setBusy(true);
-		setErr(null);
-		try {
-			await fn();
-			await refetch();
-			await props.onChanged();
-		} catch (e) {
-			setErr(String(e));
-		} finally {
-			setBusy(false);
-		}
-	}
-
-	if (!detail) {
-		return (
-			<div class={CARD}>
-				{err ? <span class="text-[var(--danger-text)]">{err}</span> : "Loading…"}
-			</div>
-		);
-	}
-
-	const memberIds = new Set(detail.members.map((m) => m.userId));
-	const addable = props.members.filter(
-		(m) => !memberIds.has(m.id) && m.role !== "owner" && m.role !== "admin"
-	);
-	const grantedIds = new Set(detail.grants.map((g) => g.projectId));
-	const grantable = props.projects.filter((p) => !grantedIds.has(p.id));
-	const trimmedName = nameDraft.trim();
-
+function GroupMembersSection({
+	slug,
+	groupId,
+	detail,
+	busy,
+	addUserId,
+	setAddUserId,
+	addable,
+	run,
+}: {
+	slug: string;
+	groupId: string;
+	detail: GroupDetail;
+	busy: boolean;
+	addUserId: string;
+	setAddUserId: (id: string) => void;
+	addable: WsMember[];
+	run: (fn: () => Promise<void>) => Promise<void>;
+}) {
 	return (
-		<section class={CARD}>
-			<div class="flex items-center gap-2 mb-3">
-				<label class="sr-only" for="group-name">
-					Group name
-				</label>
-				<input
-					id="group-name"
-					class={`${INPUT} flex-1 font-semibold`}
-					value={nameDraft}
-					disabled={busy}
-					onInput={(e) => setNameDraft((e.target as HTMLInputElement).value)}
-				/>
-				<button
-					type="button"
-					class={BTN_PRIMARY}
-					disabled={busy || trimmedName === "" || trimmedName === detail.name}
-					onClick={() =>
-						run(async () => {
-							await apiFetch(`/api/workspaces/${slug}/groups/${groupId}`, {
-								method: "PATCH",
-								workspaceSlug: slug,
-								body: { name: trimmedName },
-							});
-						})
-					}
-				>
-					Rename
-				</button>
-				<button type="button" class={BTN_SECONDARY} onClick={props.onClose}>
-					Close
-				</button>
-			</div>
-			{err && <div class="text-[var(--danger-text)] text-[0.8rem] mb-2">{err}</div>}
-
+		<>
 			<h3 class="text-[0.85rem] font-semibold text-text-base mb-2">Members</h3>
 			<div class="mb-2">
 				{detail.members.length === 0 && (
@@ -492,7 +422,149 @@ function GroupDetailEditor(props: DetailProps) {
 					Add
 				</button>
 			</div>
+		</>
+	);
+}
 
+function GroupGrantListItem({
+	slug,
+	groupId,
+	grant,
+	busy,
+	run,
+}: {
+	slug: string;
+	groupId: string;
+	grant: GroupGrantRow;
+	busy: boolean;
+	run: (fn: () => Promise<void>) => Promise<void>;
+}) {
+	return (
+		<div class="flex items-center gap-2 mb-1">
+			<span class="text-[0.82rem] text-text-base min-w-[9rem]">
+				{grant.projectName} <span class="text-text-muted">({grant.projectKey})</span>
+			</span>
+			<select
+				class={INPUT}
+				value={grant.role}
+				disabled={busy}
+				onChange={(e) =>
+					run(async () => {
+						await apiFetch(`/api/workspaces/${slug}/groups/${groupId}/grants`, {
+							method: "PUT",
+							workspaceSlug: slug,
+							body: { projectId: grant.projectId, role: (e.target as HTMLSelectElement).value },
+						});
+					})
+				}
+			>
+				{GRANT_ROLES.map((r) => (
+					<option key={r} value={r}>
+						{r}
+					</option>
+				))}
+			</select>
+			<button
+				type="button"
+				class={BTN_DANGER}
+				disabled={busy}
+				onClick={() =>
+					run(async () => {
+						await apiFetch(`/api/workspaces/${slug}/groups/${groupId}/grants/${grant.projectId}`, {
+							method: "DELETE",
+							workspaceSlug: slug,
+						});
+					})
+				}
+			>
+				Remove
+			</button>
+		</div>
+	);
+}
+
+function GroupGrantForm({
+	groupId,
+	grantProjectId,
+	setGrantProjectId,
+	grantRole,
+	setGrantRole,
+	grantable,
+	busy,
+	onGrant,
+}: {
+	groupId: string;
+	grantProjectId: string;
+	setGrantProjectId: (id: string) => void;
+	grantRole: GrantRole;
+	setGrantRole: (role: GrantRole) => void;
+	grantable: ProjectLite[];
+	busy: boolean;
+	onGrant: () => void;
+}) {
+	return (
+		<div class="flex items-center gap-2">
+			<select
+				id={`group-grant-project-${groupId}`}
+				class={INPUT}
+				value={grantProjectId}
+				onChange={(e) => setGrantProjectId((e.target as HTMLSelectElement).value)}
+			>
+				<option value="">Grant a project…</option>
+				{grantable.map((p) => (
+					<option key={p.id} value={p.id}>
+						{p.name} ({p.key})
+					</option>
+				))}
+			</select>
+			<select
+				class={INPUT}
+				value={grantRole}
+				onChange={(e) => setGrantRole((e.target as HTMLSelectElement).value as GrantRole)}
+			>
+				{GRANT_ROLES.map((r) => (
+					<option key={r} value={r}>
+						{r}
+					</option>
+				))}
+			</select>
+			<button
+				type="button"
+				class={BTN_PRIMARY}
+				disabled={busy || !grantProjectId}
+				onClick={onGrant}
+			>
+				Grant
+			</button>
+		</div>
+	);
+}
+
+function GroupGrantsSection({
+	slug,
+	groupId,
+	detail,
+	busy,
+	grantProjectId,
+	setGrantProjectId,
+	grantRole,
+	setGrantRole,
+	grantable,
+	run,
+}: {
+	slug: string;
+	groupId: string;
+	detail: GroupDetail;
+	busy: boolean;
+	grantProjectId: string;
+	setGrantProjectId: (id: string) => void;
+	grantRole: GrantRole;
+	setGrantRole: (role: GrantRole) => void;
+	grantable: ProjectLite[];
+	run: (fn: () => Promise<void>) => Promise<void>;
+}) {
+	return (
+		<>
 			<h3 class="text-[0.85rem] font-semibold text-text-base mb-2">Project grants</h3>
 			<div class="mb-2">
 				{detail.grants.length === 0 && (
@@ -501,91 +573,196 @@ function GroupDetailEditor(props: DetailProps) {
 					</div>
 				)}
 				{detail.grants.map((g) => (
-					<div key={g.projectId} class="flex items-center gap-2 mb-1">
-						<span class="text-[0.82rem] text-text-base min-w-[9rem]">
-							{g.projectName} <span class="text-text-muted">({g.projectKey})</span>
-						</span>
-						<select
-							class={INPUT}
-							value={g.role}
-							disabled={busy}
-							onChange={(e) =>
-								run(async () => {
-									await apiFetch(`/api/workspaces/${slug}/groups/${groupId}/grants`, {
-										method: "PUT",
-										workspaceSlug: slug,
-										body: { projectId: g.projectId, role: (e.target as HTMLSelectElement).value },
-									});
-								})
-							}
-						>
-							{GRANT_ROLES.map((r) => (
-								<option key={r} value={r}>
-									{r}
-								</option>
-							))}
-						</select>
-						<button
-							type="button"
-							class={BTN_DANGER}
-							disabled={busy}
-							onClick={() =>
-								run(async () => {
-									await apiFetch(
-										`/api/workspaces/${slug}/groups/${groupId}/grants/${g.projectId}`,
-										{ method: "DELETE", workspaceSlug: slug }
-									);
-								})
-							}
-						>
-							Remove
-						</button>
-					</div>
+					<GroupGrantListItem
+						key={g.projectId}
+						slug={slug}
+						groupId={groupId}
+						grant={g}
+						busy={busy}
+						run={run}
+					/>
 				))}
 			</div>
-			<div class="flex items-center gap-2">
-				<select
-					class={INPUT}
-					value={grantProjectId}
-					onChange={(e) => setGrantProjectId((e.target as HTMLSelectElement).value)}
-				>
-					<option value="">Grant a project…</option>
-					{grantable.map((p) => (
-						<option key={p.id} value={p.id}>
-							{p.name} ({p.key})
-						</option>
-					))}
-				</select>
-				<select
-					class={INPUT}
-					value={grantRole}
-					onChange={(e) => setGrantRole((e.target as HTMLSelectElement).value as GrantRole)}
-				>
-					{GRANT_ROLES.map((r) => (
-						<option key={r} value={r}>
-							{r}
-						</option>
-					))}
-				</select>
-				<button
-					type="button"
-					class={BTN_PRIMARY}
-					disabled={busy || !grantProjectId}
-					onClick={() =>
-						run(async () => {
-							await apiFetch(`/api/workspaces/${slug}/groups/${groupId}/grants`, {
-								method: "PUT",
-								workspaceSlug: slug,
-								body: { projectId: grantProjectId, role: grantRole },
-							});
-							setGrantProjectId("");
-							setGrantRole("member");
-						})
-					}
-				>
-					Grant
-				</button>
+			<GroupGrantForm
+				groupId={groupId}
+				grantProjectId={grantProjectId}
+				setGrantProjectId={setGrantProjectId}
+				grantRole={grantRole}
+				setGrantRole={setGrantRole}
+				grantable={grantable}
+				busy={busy}
+				onGrant={() =>
+					run(async () => {
+						await apiFetch(`/api/workspaces/${slug}/groups/${groupId}/grants`, {
+							method: "PUT",
+							workspaceSlug: slug,
+							body: { projectId: grantProjectId, role: grantRole },
+						});
+						setGrantProjectId("");
+						setGrantRole("member");
+					})
+				}
+			/>
+		</>
+	);
+}
+
+function useGroupDetail(slug: string, groupId: string, onChanged: () => Promise<void>) {
+	const [detail, setDetail] = useState<GroupDetail | null>(null);
+	const [err, setErr] = useState<string | null>(null);
+	const [busy, setBusy] = useState(false);
+	const [nameDraft, setNameDraft] = useState("");
+
+	const refetch = useCallback(async () => {
+		try {
+			const d = await apiFetch<GroupDetail>(`/api/workspaces/${slug}/groups/${groupId}`, {
+				workspaceSlug: slug,
+			});
+			setDetail(d);
+			setNameDraft(d.name);
+		} catch (e) {
+			setErr(String(e));
+		}
+	}, [slug, groupId]);
+
+	useEffect(() => {
+		void refetch();
+	}, [refetch]);
+
+	async function run(fn: () => Promise<void>) {
+		setBusy(true);
+		setErr(null);
+		try {
+			await fn();
+			await refetch();
+			await onChanged();
+		} catch (e) {
+			setErr(String(e));
+		} finally {
+			setBusy(false);
+		}
+	}
+
+	return { detail, err, busy, nameDraft, setNameDraft, run };
+}
+
+function GroupNameHeader({
+	slug,
+	groupId,
+	detail,
+	busy,
+	nameDraft,
+	setNameDraft,
+	run,
+	onClose,
+}: {
+	slug: string;
+	groupId: string;
+	detail: GroupDetail;
+	busy: boolean;
+	nameDraft: string;
+	setNameDraft: (name: string) => void;
+	run: (fn: () => Promise<void>) => Promise<void>;
+	onClose: () => void;
+}) {
+	const trimmedName = nameDraft.trim();
+	return (
+		<div class="flex items-center gap-2 mb-3">
+			<label class="sr-only" for="group-name">
+				Group name
+			</label>
+			<input
+				id="group-name"
+				class={`${INPUT} flex-1 font-semibold`}
+				value={nameDraft}
+				disabled={busy}
+				onInput={(e) => setNameDraft((e.target as HTMLInputElement).value)}
+			/>
+			<button
+				type="button"
+				class={BTN_PRIMARY}
+				disabled={busy || trimmedName === "" || trimmedName === detail.name}
+				onClick={() =>
+					run(async () => {
+						await apiFetch(`/api/workspaces/${slug}/groups/${groupId}`, {
+							method: "PATCH",
+							workspaceSlug: slug,
+							body: { name: trimmedName },
+						});
+					})
+				}
+			>
+				Rename
+			</button>
+			<button type="button" class={BTN_SECONDARY} onClick={onClose}>
+				Close
+			</button>
+		</div>
+	);
+}
+
+function GroupDetailEditor(props: DetailProps) {
+	const { slug, groupId } = props;
+	const { detail, err, busy, nameDraft, setNameDraft, run } = useGroupDetail(
+		slug,
+		groupId,
+		props.onChanged
+	);
+	const [addUserId, setAddUserId] = useState("");
+	const [grantProjectId, setGrantProjectId] = useState("");
+	const [grantRole, setGrantRole] = useState<GrantRole>("member");
+
+	if (!detail) {
+		return (
+			<div class={CARD}>
+				{err ? <span class="text-[var(--danger-text)]">{err}</span> : "Loading…"}
 			</div>
+		);
+	}
+
+	const memberIds = new Set(detail.members.map((m) => m.userId));
+	const addable = props.members.filter(
+		(m) => !memberIds.has(m.id) && m.role !== "owner" && m.role !== "admin"
+	);
+	const grantedIds = new Set(detail.grants.map((g) => g.projectId));
+	const grantable = props.projects.filter((p) => !grantedIds.has(p.id));
+	return (
+		<section class={CARD}>
+			<GroupNameHeader
+				slug={slug}
+				groupId={groupId}
+				detail={detail}
+				busy={busy}
+				nameDraft={nameDraft}
+				setNameDraft={setNameDraft}
+				run={run}
+				onClose={props.onClose}
+			/>
+			{err && <div class="text-[var(--danger-text)] text-[0.8rem] mb-2">{err}</div>}
+
+			<GroupMembersSection
+				slug={slug}
+				groupId={groupId}
+				detail={detail}
+				busy={busy}
+				addUserId={addUserId}
+				setAddUserId={setAddUserId}
+				addable={addable}
+				run={run}
+			/>
+
+			<GroupGrantsSection
+				slug={slug}
+				groupId={groupId}
+				detail={detail}
+				busy={busy}
+				grantProjectId={grantProjectId}
+				setGrantProjectId={setGrantProjectId}
+				grantRole={grantRole}
+				setGrantRole={setGrantRole}
+				grantable={grantable}
+				run={run}
+			/>
 		</section>
 	);
 }

--- a/apps/web/src/islands/IssueDetailParts.tsx
+++ b/apps/web/src/islands/IssueDetailParts.tsx
@@ -349,17 +349,12 @@ export function TitleSection({
 	);
 }
 
-export function BodySection({
-	issue,
-	issueId,
-	workspaceSlug,
-	fetchIssue,
-}: {
-	issue: IssueData;
-	issueId: string;
-	workspaceSlug?: string;
-	fetchIssue: () => Promise<void>;
-}) {
+function useBodyEditor(
+	issue: IssueData,
+	issueId: string,
+	workspaceSlug: string | undefined,
+	fetchIssue: () => Promise<void>
+) {
 	const [editingBody, setEditingBody] = useState(false);
 	const [editBody, setEditBody] = useState("");
 	const [savingBody, setSavingBody] = useState(false);
@@ -426,6 +421,79 @@ export function BodySection({
 		}
 	}
 
+	return {
+		editingBody,
+		editBody,
+		savingBody,
+		saveBodyError,
+		hasDraft,
+		bodyRef,
+		startEditBody,
+		updateBody,
+		cancelEditBody,
+		saveBody,
+	};
+}
+
+function BodyEditForm({
+	editBody,
+	updateBody,
+	saveBody,
+	cancelEditBody,
+	savingBody,
+}: {
+	editBody: string;
+	updateBody: (value: string) => void;
+	saveBody: () => void;
+	cancelEditBody: () => void;
+	savingBody: boolean;
+}) {
+	return (
+		<div>
+			<div class="mb-2">
+				<MarkdownEditor value={editBody} onChange={updateBody} minHeight="240px" />
+			</div>
+			<div class="flex gap-2">
+				<button type="button" onClick={saveBody} disabled={savingBody} class="btn btn-primary">
+					{savingBody ? "Saving…" : "Save"}
+				</button>
+				<button
+					type="button"
+					onClick={cancelEditBody}
+					disabled={savingBody}
+					class="btn btn-outline"
+				>
+					Cancel
+				</button>
+			</div>
+		</div>
+	);
+}
+
+export function BodySection({
+	issue,
+	issueId,
+	workspaceSlug,
+	fetchIssue,
+}: {
+	issue: IssueData;
+	issueId: string;
+	workspaceSlug?: string;
+	fetchIssue: () => Promise<void>;
+}) {
+	const {
+		editingBody,
+		editBody,
+		savingBody,
+		saveBodyError,
+		hasDraft,
+		bodyRef,
+		startEditBody,
+		updateBody,
+		cancelEditBody,
+		saveBody,
+	} = useBodyEditor(issue, issueId, workspaceSlug, fetchIssue);
+
 	return (
 		<section class="mb-8">
 			<div class="flex items-center gap-3 mb-4">
@@ -465,24 +533,13 @@ export function BodySection({
 			)}
 
 			{editingBody ? (
-				<div>
-					<div class="mb-2">
-						<MarkdownEditor value={editBody} onChange={updateBody} minHeight="240px" />
-					</div>
-					<div class="flex gap-2">
-						<button type="button" onClick={saveBody} disabled={savingBody} class="btn btn-primary">
-							{savingBody ? "Saving…" : "Save"}
-						</button>
-						<button
-							type="button"
-							onClick={cancelEditBody}
-							disabled={savingBody}
-							class="btn btn-outline"
-						>
-							Cancel
-						</button>
-					</div>
-				</div>
+				<BodyEditForm
+					editBody={editBody}
+					updateBody={updateBody}
+					saveBody={saveBody}
+					cancelEditBody={cancelEditBody}
+					savingBody={savingBody}
+				/>
 			) : issue.body ? (
 				<div
 					ref={bodyRef}
@@ -1178,35 +1235,19 @@ function UrlLinkForm({
 
 type AttachMode = "none" | "file" | "wiki" | "url";
 
-export function AttachmentsSection({
-	issueId,
-	workspaceSlug,
-	attachments,
-	fetchAttachments,
-}: {
-	issueId: string;
-	workspaceSlug?: string;
-	attachments: Attachment[];
-	fetchAttachments: () => Promise<void>;
-}) {
-	const [mode, setMode] = useState<AttachMode>("none");
-
+function useAttachmentUpload(
+	issueId: string,
+	workspaceSlug: string | undefined,
+	onDone: () => void,
+	fetchAttachments: () => Promise<void>
+) {
 	const [uploadFile, setUploadFile] = useState<File | null>(null);
 	const [uploading, setUploading] = useState(false);
 	const [uploadError, setUploadError] = useState<string | null>(null);
 
-	const [linking, setLinking] = useState(false);
-	const [linkError, setLinkError] = useState<string | null>(null);
-	const [urlValue, setUrlValue] = useState("");
-	const [labelValue, setLabelValue] = useState("");
-
-	function resetForms() {
-		setMode("none");
+	function reset() {
 		setUploadFile(null);
 		setUploadError(null);
-		setLinkError(null);
-		setUrlValue("");
-		setLabelValue("");
 	}
 
 	async function uploadAttachment() {
@@ -1219,13 +1260,41 @@ export function AttachmentsSection({
 			form.append("entityType", "issue");
 			form.append("entityId", issueId);
 			await apiFetch("/api/files", { workspaceSlug, method: "POST", body: form });
-			resetForms();
+			onDone();
 			await fetchAttachments();
 		} catch (e) {
 			setUploadError(String(e));
 		} finally {
 			setUploading(false);
 		}
+	}
+
+	return {
+		uploadFile,
+		setUploadFile,
+		uploading,
+		uploadError,
+		setUploadError,
+		uploadAttachment,
+		reset,
+	};
+}
+
+function useAttachmentLinks(
+	issueId: string,
+	workspaceSlug: string | undefined,
+	onDone: () => void,
+	fetchAttachments: () => Promise<void>
+) {
+	const [linking, setLinking] = useState(false);
+	const [linkError, setLinkError] = useState<string | null>(null);
+	const [urlValue, setUrlValue] = useState("");
+	const [labelValue, setLabelValue] = useState("");
+
+	function reset() {
+		setLinkError(null);
+		setUrlValue("");
+		setLabelValue("");
 	}
 
 	async function linkWikiPage(wikiPageId: string) {
@@ -1237,7 +1306,7 @@ export function AttachmentsSection({
 				method: "POST",
 				body: { kind: "wiki_ref", entityType: "issue", entityId: issueId, wikiPageId },
 			});
-			resetForms();
+			onDone();
 			await fetchAttachments();
 		} catch (e) {
 			setLinkError(String(e));
@@ -1262,7 +1331,7 @@ export function AttachmentsSection({
 					label: labelValue.trim() || undefined,
 				},
 			});
-			resetForms();
+			onDone();
 			await fetchAttachments();
 		} catch (e) {
 			setLinkError(String(e));
@@ -1270,6 +1339,36 @@ export function AttachmentsSection({
 			setLinking(false);
 		}
 	}
+
+	return {
+		linking,
+		linkError,
+		setLinkError,
+		urlValue,
+		setUrlValue,
+		labelValue,
+		setLabelValue,
+		linkWikiPage,
+		addUrl,
+		reset,
+	};
+}
+
+function useAttachmentForms(
+	issueId: string,
+	workspaceSlug: string | undefined,
+	fetchAttachments: () => Promise<void>
+) {
+	const [mode, setMode] = useState<AttachMode>("none");
+
+	function resetForms() {
+		setMode("none");
+		upload.reset();
+		links.reset();
+	}
+
+	const upload = useAttachmentUpload(issueId, workspaceSlug, resetForms, fetchAttachments);
+	const links = useAttachmentLinks(issueId, workspaceSlug, resetForms, fetchAttachments);
 
 	async function deleteAttachment(attachmentId: string) {
 		try {
@@ -1279,6 +1378,26 @@ export function AttachmentsSection({
 			// non-fatal
 		}
 	}
+
+	return { mode, setMode, upload, links, resetForms, deleteAttachment };
+}
+
+export function AttachmentsSection({
+	issueId,
+	workspaceSlug,
+	attachments,
+	fetchAttachments,
+}: {
+	issueId: string;
+	workspaceSlug?: string;
+	attachments: Attachment[];
+	fetchAttachments: () => Promise<void>;
+}) {
+	const { mode, setMode, upload, links, resetForms, deleteAttachment } = useAttachmentForms(
+		issueId,
+		workspaceSlug,
+		fetchAttachments
+	);
 
 	return (
 		<section class="mb-8">
@@ -1301,35 +1420,35 @@ export function AttachmentsSection({
 
 			{mode === "file" && (
 				<AttachmentUploadForm
-					uploadFile={uploadFile}
-					setUploadFile={setUploadFile}
-					uploadError={uploadError}
-					setUploadError={setUploadError}
-					uploading={uploading}
-					onUpload={uploadAttachment}
+					uploadFile={upload.uploadFile}
+					setUploadFile={upload.setUploadFile}
+					uploadError={upload.uploadError}
+					setUploadError={upload.setUploadError}
+					uploading={upload.uploading}
+					onUpload={upload.uploadAttachment}
 					onCancel={resetForms}
 				/>
 			)}
 			{mode === "wiki" && (
 				<WikiPageLinkForm
 					workspaceSlug={workspaceSlug}
-					linking={linking}
-					linkError={linkError}
-					setLinkError={setLinkError}
-					onLink={linkWikiPage}
+					linking={links.linking}
+					linkError={links.linkError}
+					setLinkError={links.setLinkError}
+					onLink={links.linkWikiPage}
 					onCancel={resetForms}
 				/>
 			)}
 			{mode === "url" && (
 				<UrlLinkForm
-					urlValue={urlValue}
-					setUrlValue={setUrlValue}
-					labelValue={labelValue}
-					setLabelValue={setLabelValue}
-					linkError={linkError}
-					setLinkError={setLinkError}
-					linking={linking}
-					onAdd={addUrl}
+					urlValue={links.urlValue}
+					setUrlValue={links.setUrlValue}
+					labelValue={links.labelValue}
+					setLabelValue={links.setLabelValue}
+					linkError={links.linkError}
+					setLinkError={links.setLinkError}
+					linking={links.linking}
+					onAdd={links.addUrl}
 					onCancel={resetForms}
 				/>
 			)}

--- a/apps/web/src/islands/MetricsDashboard.tsx
+++ b/apps/web/src/islands/MetricsDashboard.tsx
@@ -691,6 +691,143 @@ function SectionBand({ title, children }: { title?: string; children: ComponentC
 	);
 }
 
+function FlowBand({ metrics }: { metrics: FlowMetrics }) {
+	return (
+		<SectionBand title="Flow">
+			<DistributionTiles metricId="lead-time" dist={metrics.leadTime} />
+			<DistributionTiles metricId="cycle-time" dist={metrics.cycleTime} />
+
+			<div class="mb-8">
+				<SectionHeading metricId="throughput" />
+				<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto">
+					<ThroughputChart data={metrics.throughputOverTime} />
+				</div>
+			</div>
+
+			<div class="mb-8">
+				<SectionHeading
+					metricId="bug-share"
+					caption="Bugs as a share of completed throughput — a rising trend is a quality signal, not just a volume one"
+				/>
+				<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto">
+					<BugShareChart data={metrics.bugShareOverTime} bugTypeTracked={metrics.bugTypeTracked} />
+				</div>
+			</div>
+
+			<div class="mb-8">
+				<SectionHeading metricId="wip" />
+				<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto">
+					<WipChart data={metrics.wipOverTime} />
+				</div>
+			</div>
+
+			<div class="mb-8">
+				<SectionHeading
+					metricId="aging-wip"
+					caption={
+						"Age since claim for every currently open issue, against this window's cycle-time " +
+						"p50/p90 — stuck items show up before they finish and skew the percentiles"
+					}
+				/>
+				<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto">
+					<AgingWipScatter
+						data={metrics.agingWip}
+						p50={metrics.cycleTime.p50}
+						p90={metrics.cycleTime.p90}
+					/>
+				</div>
+			</div>
+
+			<div class="mb-8">
+				<SectionHeading
+					metricId="cumulative-flow"
+					caption="Issue counts per status category over time — a widening band is where the factory is choking"
+				/>
+				<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto mb-3">
+					<CfdChart data={metrics.cfdOverTime} />
+				</div>
+				{/* PROJ-392: Review latency isn't a second 4-tile group — pairing a dense
+				    4-tile card with a near-empty one in a two-column grid read as a
+				    visual bug (implying parity where there isn't any). Time-in-progress
+				    now takes the full row; the caption below points to the canonical
+				    Review-latency breakdown instead. */}
+				<DistributionTiles
+					metricId="time-in-progress"
+					caption="Review latency has its own breakdown in Efficiency & collaboration, below"
+					dist={metrics.timeInProgress}
+				/>
+			</div>
+
+			<div class="mb-8">
+				<SectionHeading
+					metricId="arrival-vs-completion"
+					caption="Issues created vs completed per bucket, with the net — is the backlog growing or burning?"
+				/>
+				<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto">
+					<ArrivalVsCompletionChart data={metrics.arrivalVsCompletionOverTime} />
+				</div>
+			</div>
+		</SectionBand>
+	);
+}
+
+function EfficiencyBand({ metrics }: { metrics: FlowMetrics }) {
+	return (
+		<SectionBand title="Efficiency & collaboration">
+			<DistributionTiles
+				metricId="flow-efficiency"
+				caption="Lease-held time ÷ lead time — how much of the wait, not just the work, was agent-driven"
+				dist={metrics.flowEfficiency}
+				format={formatPercent}
+			/>
+
+			<DistributionTiles
+				metricId="autonomy-ratio"
+				dist={metrics.autonomyRatio}
+				format={formatPercent}
+			/>
+
+			<div class="mb-8">
+				<SectionHeading metricId="review-latency" />
+				<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto mb-3">
+					<ReviewLatencyChart data={metrics.reviewLatencyOverTime} />
+				</div>
+				<DistributionTiles
+					metricId="review-latency"
+					dist={metrics.reviewLatency}
+					showHeading={false}
+				/>
+			</div>
+
+			<DistributionTiles
+				metricId="human-interventions"
+				title="Human interventions per issue"
+				dist={metrics.humanInterventions}
+				format={formatCount}
+			/>
+		</SectionBand>
+	);
+}
+
+function FactoryHealthBand({ factoryHealth }: { factoryHealth: FlowMetrics["factoryHealth"] }) {
+	return (
+		<SectionBand title="Factory health">
+			<div class="mb-8">
+				<p class="m-0 mb-3 text-[0.72rem] text-text-muted">
+					Fault signals for the factory itself, for the selected window — a low background rate is
+					normal; watch the trend, not any single nonzero tile
+				</p>
+				<div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+					<HealthTile metricId="lease-expiries" value={factoryHealth.leaseExpiries} />
+					<HealthTile metricId="abandoned-claims" value={factoryHealth.abandonedClaims} />
+					<HealthTile metricId="gate-rejections" value={factoryHealth.gateRejections} />
+					<HealthTile metricId="wip-cap-pressure" value={factoryHealth.wipCapPressure} />
+				</div>
+			</div>
+		</SectionBand>
+	);
+}
+
 export default function MetricsDashboard({ workspaceSlug }: Props) {
 	const [range, setRange] = useRangeUrlSync();
 	const { projectId, metrics, loading, error } = useFlowMetrics(workspaceSlug, range);
@@ -713,118 +850,8 @@ export default function MetricsDashboard({ workspaceSlug }: Props) {
 			)}
 			{!loading && !error && metrics && (
 				<>
-					<SectionBand title="Flow">
-						<DistributionTiles metricId="lead-time" dist={metrics.leadTime} />
-						<DistributionTiles metricId="cycle-time" dist={metrics.cycleTime} />
-
-						<div class="mb-8">
-							<SectionHeading metricId="throughput" />
-							<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto">
-								<ThroughputChart data={metrics.throughputOverTime} />
-							</div>
-						</div>
-
-						<div class="mb-8">
-							<SectionHeading
-								metricId="bug-share"
-								caption="Bugs as a share of completed throughput — a rising trend is a quality signal, not just a volume one"
-							/>
-							<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto">
-								<BugShareChart
-									data={metrics.bugShareOverTime}
-									bugTypeTracked={metrics.bugTypeTracked}
-								/>
-							</div>
-						</div>
-
-						<div class="mb-8">
-							<SectionHeading metricId="wip" />
-							<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto">
-								<WipChart data={metrics.wipOverTime} />
-							</div>
-						</div>
-
-						<div class="mb-8">
-							<SectionHeading
-								metricId="aging-wip"
-								caption={
-									"Age since claim for every currently open issue, against this window's cycle-time " +
-									"p50/p90 — stuck items show up before they finish and skew the percentiles"
-								}
-							/>
-							<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto">
-								<AgingWipScatter
-									data={metrics.agingWip}
-									p50={metrics.cycleTime.p50}
-									p90={metrics.cycleTime.p90}
-								/>
-							</div>
-						</div>
-
-						<div class="mb-8">
-							<SectionHeading
-								metricId="cumulative-flow"
-								caption="Issue counts per status category over time — a widening band is where the factory is choking"
-							/>
-							<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto mb-3">
-								<CfdChart data={metrics.cfdOverTime} />
-							</div>
-							{/* PROJ-392: Review latency isn't a second 4-tile group — pairing a dense
-							    4-tile card with a near-empty one in a two-column grid read as a
-							    visual bug (implying parity where there isn't any). Time-in-progress
-							    now takes the full row; the caption below points to the canonical
-							    Review-latency breakdown instead. */}
-							<DistributionTiles
-								metricId="time-in-progress"
-								caption="Review latency has its own breakdown in Efficiency & collaboration, below"
-								dist={metrics.timeInProgress}
-							/>
-						</div>
-
-						<div class="mb-8">
-							<SectionHeading
-								metricId="arrival-vs-completion"
-								caption="Issues created vs completed per bucket, with the net — is the backlog growing or burning?"
-							/>
-							<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto">
-								<ArrivalVsCompletionChart data={metrics.arrivalVsCompletionOverTime} />
-							</div>
-						</div>
-					</SectionBand>
-
-					<SectionBand title="Efficiency & collaboration">
-						<DistributionTiles
-							metricId="flow-efficiency"
-							caption="Lease-held time ÷ lead time — how much of the wait, not just the work, was agent-driven"
-							dist={metrics.flowEfficiency}
-							format={formatPercent}
-						/>
-
-						<DistributionTiles
-							metricId="autonomy-ratio"
-							dist={metrics.autonomyRatio}
-							format={formatPercent}
-						/>
-
-						<div class="mb-8">
-							<SectionHeading metricId="review-latency" />
-							<div class="p-4 bg-surface border border-border rounded-lg overflow-x-auto mb-3">
-								<ReviewLatencyChart data={metrics.reviewLatencyOverTime} />
-							</div>
-							<DistributionTiles
-								metricId="review-latency"
-								dist={metrics.reviewLatency}
-								showHeading={false}
-							/>
-						</div>
-
-						<DistributionTiles
-							metricId="human-interventions"
-							title="Human interventions per issue"
-							dist={metrics.humanInterventions}
-							format={formatCount}
-						/>
-					</SectionBand>
+					<FlowBand metrics={metrics} />
+					<EfficiencyBand metrics={metrics} />
 
 					<SectionBand>
 						{projectId && (
@@ -837,29 +864,7 @@ export default function MetricsDashboard({ workspaceSlug }: Props) {
 						)}
 					</SectionBand>
 
-					<SectionBand title="Factory health">
-						<div class="mb-8">
-							<p class="m-0 mb-3 text-[0.72rem] text-text-muted">
-								Fault signals for the factory itself, for the selected window — a low background
-								rate is normal; watch the trend, not any single nonzero tile
-							</p>
-							<div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
-								<HealthTile metricId="lease-expiries" value={metrics.factoryHealth.leaseExpiries} />
-								<HealthTile
-									metricId="abandoned-claims"
-									value={metrics.factoryHealth.abandonedClaims}
-								/>
-								<HealthTile
-									metricId="gate-rejections"
-									value={metrics.factoryHealth.gateRejections}
-								/>
-								<HealthTile
-									metricId="wip-cap-pressure"
-									value={metrics.factoryHealth.wipCapPressure}
-								/>
-							</div>
-						</div>
-					</SectionBand>
+					<FactoryHealthBand factoryHealth={metrics.factoryHealth} />
 				</>
 			)}
 		</div>

--- a/apps/web/src/islands/NewSourceModal.tsx
+++ b/apps/web/src/islands/NewSourceModal.tsx
@@ -25,6 +25,96 @@ const INPUT_CLASS =
 	"w-full px-[0.625rem] py-[0.4rem] border border-border rounded text-[0.875rem] bg-bg text-text-base " +
 	"font-[inherit] focus:outline-[2px] focus:outline-accent focus:outline-offset-1";
 
+function NewSourceForm({
+	name,
+	setName,
+	description,
+	setDescription,
+	origins,
+	setOrigins,
+	creating,
+	error,
+	onSubmit,
+	onCancel,
+}: {
+	name: string;
+	setName: (v: string) => void;
+	description: string;
+	setDescription: (v: string) => void;
+	origins: string;
+	setOrigins: (v: string) => void;
+	creating: boolean;
+	error: string | null;
+	onSubmit: (e: Event) => void;
+	onCancel: () => void;
+}) {
+	return (
+		<form onSubmit={onSubmit}>
+			{error && (
+				<p role="alert" class="text-[var(--danger-text)] mb-3 text-sm">
+					{error}
+				</p>
+			)}
+			<div class="mb-[0.875rem]">
+				<label
+					class="block text-[0.78rem] font-semibold text-text-muted mb-[0.3rem] uppercase tracking-[0.04em]"
+					for="fs-name"
+				>
+					Name *
+				</label>
+				<input
+					id="fs-name"
+					class={INPUT_CLASS}
+					value={name}
+					onInput={(e) => setName((e.target as HTMLInputElement).value)}
+					required
+					maxLength={100}
+					// biome-ignore lint/a11y/noAutofocus: intentional — modal opens on user action
+					autoFocus
+				/>
+			</div>
+			<div class="mb-[0.875rem]">
+				<label
+					class="block text-[0.78rem] font-semibold text-text-muted mb-[0.3rem] uppercase tracking-[0.04em]"
+					for="fs-desc"
+				>
+					Description
+				</label>
+				<input
+					id="fs-desc"
+					class={INPUT_CLASS}
+					value={description}
+					onInput={(e) => setDescription((e.target as HTMLInputElement).value)}
+					maxLength={500}
+				/>
+			</div>
+			<div class="mb-[0.875rem]">
+				<label
+					class="block text-[0.78rem] font-semibold text-text-muted mb-[0.3rem] uppercase tracking-[0.04em]"
+					for="fs-origins"
+				>
+					Allowed origins (one per line, optional)
+				</label>
+				<textarea
+					id="fs-origins"
+					class={INPUT_CLASS}
+					rows={2}
+					value={origins}
+					onInput={(e) => setOrigins((e.target as HTMLTextAreaElement).value)}
+				/>
+			</div>
+			<div class="flex gap-2">
+				<button type="submit" class="btn btn-primary btn-sm" disabled={creating || !name.trim()}>
+					{creating ? "Creating…" : "Create source"}
+				</button>
+				<button type="button" class="btn btn-outline btn-sm" onClick={onCancel} disabled={creating}>
+					Cancel
+				</button>
+			</div>
+		</form>
+	);
+}
+
 export default function NewSourceModal({ projectId, workspaceSlug, onClose, onCreated }: Props) {
 	const [name, setName] = useState("");
 	const [description, setDescription] = useState("");
@@ -89,78 +179,18 @@ export default function NewSourceModal({ projectId, workspaceSlug, onClose, onCr
 						</button>
 					</div>
 				) : (
-					<form onSubmit={handleCreate}>
-						{error && (
-							<p role="alert" class="text-[var(--danger-text)] mb-3 text-sm">
-								{error}
-							</p>
-						)}
-						<div class="mb-[0.875rem]">
-							<label
-								class="block text-[0.78rem] font-semibold text-text-muted mb-[0.3rem] uppercase tracking-[0.04em]"
-								for="fs-name"
-							>
-								Name *
-							</label>
-							<input
-								id="fs-name"
-								class={INPUT_CLASS}
-								value={name}
-								onInput={(e) => setName((e.target as HTMLInputElement).value)}
-								required
-								maxLength={100}
-								// biome-ignore lint/a11y/noAutofocus: intentional — modal opens on user action
-								autoFocus
-							/>
-						</div>
-						<div class="mb-[0.875rem]">
-							<label
-								class="block text-[0.78rem] font-semibold text-text-muted mb-[0.3rem] uppercase tracking-[0.04em]"
-								for="fs-desc"
-							>
-								Description
-							</label>
-							<input
-								id="fs-desc"
-								class={INPUT_CLASS}
-								value={description}
-								onInput={(e) => setDescription((e.target as HTMLInputElement).value)}
-								maxLength={500}
-							/>
-						</div>
-						<div class="mb-[0.875rem]">
-							<label
-								class="block text-[0.78rem] font-semibold text-text-muted mb-[0.3rem] uppercase tracking-[0.04em]"
-								for="fs-origins"
-							>
-								Allowed origins (one per line, optional)
-							</label>
-							<textarea
-								id="fs-origins"
-								class={INPUT_CLASS}
-								rows={2}
-								value={origins}
-								onInput={(e) => setOrigins((e.target as HTMLTextAreaElement).value)}
-							/>
-						</div>
-						<div class="flex gap-2">
-							<button
-								type="submit"
-								class="btn btn-primary btn-sm"
-								disabled={creating || !name.trim()}
-							>
-								{creating ? "Creating…" : "Create source"}
-							</button>
-							<button
-								type="button"
-								class="btn btn-outline btn-sm"
-								onClick={onClose}
-								disabled={creating}
-							>
-								Cancel
-							</button>
-						</div>
-					</form>
+					<NewSourceForm
+						name={name}
+						setName={setName}
+						description={description}
+						setDescription={setDescription}
+						origins={origins}
+						setOrigins={setOrigins}
+						creating={creating}
+						error={error}
+						onSubmit={handleCreate}
+						onCancel={onClose}
+					/>
 				)}
 			</div>
 		</div>

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -2339,6 +2339,49 @@ function useServerDraftAutosave(options: UseServerDraftAutosaveOptions) {
 	return skipLeaveFlushRef;
 }
 
+async function saveWikiPageEdit(params: {
+	workspaceSlug: string | undefined;
+	page: WikiPageData;
+	editTitle: string;
+	editContent: string;
+	baseRevisionId: string | null | undefined;
+	fetchPage: (s: string) => Promise<void>;
+	fetchRevisions: (s: string) => Promise<void>;
+}): Promise<void> {
+	const { workspaceSlug, page, editTitle, editContent, baseRevisionId, fetchPage, fetchRevisions } =
+		params;
+	await apiFetch(`/api/wiki/${encodeURIComponent(page.slug)}`, {
+		method: "PUT",
+		workspaceSlug,
+		body: { title: editTitle, content: editContent, baseRevisionId },
+	});
+	try {
+		await apiFetch(`/api/wiki/${encodeURIComponent(page.slug)}/draft`, {
+			method: "DELETE",
+			workspaceSlug,
+		});
+	} catch {
+		// non-fatal
+	}
+	await fetchPage(page.slug);
+	await fetchRevisions(page.slug);
+}
+
+// PROJ-507: a 409 means someone else saved this page after we loaded it (PROJ-484's
+// optimistic lock rejected our stale baseRevisionId) — surface that distinctly rather
+// than the generic failure message, so the user knows to reload instead of retrying the
+// same save. Match the tail of apiFetch's message, not a bare "409" — the request path is
+// part of it, and slugs like "proj-409-notes" would otherwise read as conflicts.
+function wikiSaveErrorMessage(e: unknown): string {
+	if (String(e).endsWith("failed: 409")) {
+		return (
+			"This page was changed by someone else since you loaded it. Reload the page before " +
+			"saving to avoid overwriting their changes."
+		);
+	}
+	return `Save failed: ${String(e)}`;
+}
+
 function useWikiEditing(
 	workspaceSlug: string | undefined,
 	page: WikiPageData | null,
@@ -2440,38 +2483,19 @@ function useWikiEditing(
 		setSaving(true);
 		setSaveError(null);
 		try {
-			await apiFetch(`/api/wiki/${encodeURIComponent(page.slug)}`, {
-				method: "PUT",
+			await saveWikiPageEdit({
 				workspaceSlug,
-				body: { title: editTitle, content: editContent, baseRevisionId },
+				page,
+				editTitle,
+				editContent,
+				baseRevisionId,
+				fetchPage,
+				fetchRevisions,
 			});
-			try {
-				await apiFetch(`/api/wiki/${encodeURIComponent(page.slug)}/draft`, {
-					method: "DELETE",
-					workspaceSlug,
-				});
-			} catch {
-				// non-fatal
-			}
-			await fetchPage(page.slug);
-			await fetchRevisions(page.slug);
 			skipLeaveFlushRef.current = true;
 			setEditing(false);
 		} catch (e) {
-			// PROJ-507: a 409 means someone else saved this page after we loaded it
-			// (PROJ-484's optimistic lock rejected our stale baseRevisionId) — surface
-			// that distinctly rather than the generic failure message, so the user
-			// knows to reload instead of retrying the same save.
-			// Match the tail of apiFetch's message, not a bare "409" — the request path is
-			// part of it, and slugs like "proj-409-notes" would otherwise read as conflicts.
-			if (String(e).endsWith("failed: 409")) {
-				setSaveError(
-					"This page was changed by someone else since you loaded it. Reload the page before " +
-						"saving to avoid overwriting their changes."
-				);
-			} else {
-				setSaveError(`Save failed: ${String(e)}`);
-			}
+			setSaveError(wikiSaveErrorMessage(e));
 		} finally {
 			setSaving(false);
 		}
@@ -3087,11 +3111,11 @@ function buildArticleProps(
 	};
 }
 
-export default function WikiPage({
-	workspaceSlug,
-	projectId: projectIdProp,
-	slug: slugProp,
-}: Props) {
+function useWikiPageState(
+	workspaceSlug: string | undefined,
+	projectIdProp: string | undefined,
+	slugProp: string | undefined
+) {
 	const gate = useAccessGate(workspaceSlug);
 	const { slug, setSlug, projectId } = useWikiUrlState(projectIdProp, slugProp);
 	const { pageTree, pageMap, treeLoading, fetchTree } = useWikiTree(workspaceSlug, projectId);
@@ -3130,6 +3154,53 @@ export default function WikiPage({
 		pageData.fetchPage,
 		pageData.fetchRevisions
 	);
+
+	return {
+		gate,
+		slug,
+		setSlug,
+		projectId,
+		pageTree,
+		pageMap,
+		treeLoading,
+		fetchTree,
+		filters,
+		stale,
+		searchQuery,
+		setSearchQuery,
+		searchResults,
+		searchLoading,
+		pageData,
+		toc,
+		setToc,
+		activeHeadingId,
+		attach,
+		editState,
+		createForm,
+		wikiTemplates,
+		move,
+		verify,
+		restoreState,
+	};
+}
+
+function assembleWikiPageProps(state: ReturnType<typeof useWikiPageState>, workspaceSlug?: string) {
+	const {
+		setSlug,
+		pageMap,
+		fetchTree,
+		pageData,
+		toc,
+		setToc,
+		activeHeadingId,
+		attach,
+		editState,
+		createForm,
+		wikiTemplates,
+		move,
+		verify,
+		restoreState,
+	} = state;
 
 	const { navigateTo, startCreate, submitCreate, deletePage } = createWikiActions({
 		workspaceSlug,
@@ -3208,6 +3279,35 @@ export default function WikiPage({
 		move,
 		moveOptions,
 	});
+
+	return { navigateTo, startCreate, createProps, articleProps };
+}
+
+export default function WikiPage({
+	workspaceSlug,
+	projectId: projectIdProp,
+	slug: slugProp,
+}: Props) {
+	const state = useWikiPageState(workspaceSlug, projectIdProp, slugProp);
+	const {
+		gate,
+		slug,
+		projectId,
+		pageTree,
+		treeLoading,
+		filters,
+		stale,
+		searchQuery,
+		setSearchQuery,
+		searchResults,
+		searchLoading,
+		pageData,
+		createForm,
+	} = state;
+	const { navigateTo, startCreate, createProps, articleProps } = assembleWikiPageProps(
+		state,
+		workspaceSlug
+	);
 
 	if (gate.pending) return <AccessPending />;
 


### PR DESCRIPTION
## Summary
- Extracts sub-components/custom hooks from functions exceeding cofferdam's 100-line MaxFunctionLength limit: `flow-metrics.ts`/`wiki.ts` service helpers, and UI islands (FeedbackSourceSettings, NewSourceModal, AccountMenu, FeedbackSourceDetail, FeedbackList, GroupManager, IssueDetailParts, MetricsDashboard, WikiPage).
- Removes one stale `cofferdam-ignore` suppression directive left over from an already-fixed finding.
- All extractions are behavior-preserving (props/closures passed through unchanged, no logic changes) — verified against the existing test suite.

## Deferred (not fixed in this PR)
The ~35 remaining `Readability.MaxFunctionLength` findings are all in large sequential integration test files (`wiki.test.ts`, `feedback.test.ts`, `files.test.ts`, etc. — some `it()` bodies run 500+ lines). Splitting these carries real regression risk for negligible readability gain, consistent with this session's triage of other low-value/high-risk cofferdam categories (e.g. `Refactor.PreferConstOverLet`, cross-package `Design.DuplicateTypeShape`). Left as-is.

## Test plan
- [x] `tsc --noEmit` clean (apps/api, apps/web)
- [x] apps/api vitest: 1118/1118 passed
- [x] apps/web vitest: 517/517 passed
- [x] `biome check .`: clean
- [x] cofferdam `Readability.MaxFunctionLength`: 49 → 35 (all remaining are test files); 1 stale suppression removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJivABTizhiVgM2ziLUyNz