### PR TITLE
PROJ-481: cofferdam triage — Design.MissingTestFile

### DIFF
--- a/apps/api/src/test/sql.test.ts
+++ b/apps/api/src/test/sql.test.ts
@@ -1,5 +1,27 @@
 import { describe, expect, it } from "vitest";
-import { inChunks } from "../services/sql";
+import { inChunks, sanitizeFtsQuery } from "../services/sql";
+
+describe("sanitizeFtsQuery (PROJ-518)", () => {
+	it("wraps each whitespace-separated token in double quotes", () => {
+		expect(sanitizeFtsQuery("hello world")).toBe('"hello" "world"');
+	});
+
+	it("neutralizes FTS5 query syntax by treating it as literal text", () => {
+		expect(sanitizeFtsQuery("foo AND bar OR NOT baz*")).toBe('"foo" "AND" "bar" "OR" "NOT" "baz*"');
+	});
+
+	it("escapes embedded double quotes so they can't break out of the phrase", () => {
+		expect(sanitizeFtsQuery('say "hi"')).toBe('"say" """hi"""');
+	});
+
+	it("drops tokens with no word characters", () => {
+		expect(sanitizeFtsQuery("--- ??? hello")).toBe('"hello"');
+	});
+
+	it("returns an empty string for blank input", () => {
+		expect(sanitizeFtsQuery("   ")).toBe("");
+	});
+});
 
 describe("inChunks", () => {
 	it("returns an empty array without calling op for an empty input", async () => {

--- a/apps/api/src/test/wiki-frontmatter.test.ts
+++ b/apps/api/src/test/wiki-frontmatter.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { ValidationError } from "../services/errors";
+import {
+	parseWikiFrontmatter,
+	stampWikiFrontmatterVerification,
+	stripTemplateFlag,
+} from "../services/wiki-frontmatter";
+
+describe("parseWikiFrontmatter (PROJ-488)", () => {
+	it("returns empty meta for content with no frontmatter block", () => {
+		expect(parseWikiFrontmatter("# Just a heading\n\nbody text")).toEqual({
+			type: null,
+			tags: [],
+			status: null,
+			verifiedAt: null,
+			verifiedBy: null,
+			owners: [],
+			verifyInterval: null,
+			isTemplate: false,
+		});
+	});
+
+	it("returns empty meta for an empty frontmatter block", () => {
+		const result = parseWikiFrontmatter("---\n---\nbody");
+		expect(result.type).toBeNull();
+		expect(result.isTemplate).toBe(false);
+	});
+
+	it("parses a full frontmatter block into meta", () => {
+		const content = [
+			"---",
+			"type: runbook",
+			"tags: [ops, oncall]",
+			"status: current",
+			"owners: [alice]",
+			"verify_interval: 30",
+			"template: true",
+			"---",
+			"body",
+		].join("\n");
+
+		expect(parseWikiFrontmatter(content)).toEqual({
+			type: "runbook",
+			tags: ["ops", "oncall"],
+			status: "current",
+			verifiedAt: null,
+			verifiedBy: null,
+			owners: ["alice"],
+			verifyInterval: 30,
+			isTemplate: true,
+		});
+	});
+
+	it("normalizes a YAML date verified_at to unix seconds", () => {
+		const content = "---\nverified_at: 2026-01-01\n---\nbody";
+		const result = parseWikiFrontmatter(content);
+		expect(result.verifiedAt).toBe(Math.floor(new Date("2026-01-01").getTime() / 1000));
+	});
+
+	it("throws ValidationError for invalid YAML", () => {
+		const content = "---\nthis: [is not: valid\n---\nbody";
+		expect(() => parseWikiFrontmatter(content)).toThrow(ValidationError);
+	});
+
+	it("throws ValidationError when frontmatter is a list, not a mapping", () => {
+		const content = "---\n- a\n- b\n---\nbody";
+		expect(() => parseWikiFrontmatter(content)).toThrow(ValidationError);
+	});
+
+	it("throws ValidationError when a field fails schema validation", () => {
+		const content = "---\nstatus: not-a-real-status\n---\nbody";
+		expect(() => parseWikiFrontmatter(content)).toThrow(ValidationError);
+	});
+
+	it("throws ValidationError for an unparseable verified_at string", () => {
+		const content = "---\nverified_at: not-a-date\n---\nbody";
+		expect(() => parseWikiFrontmatter(content)).toThrow(ValidationError);
+	});
+});
+
+describe("stripTemplateFlag (PROJ-491)", () => {
+	it("returns content unchanged when there is no frontmatter", () => {
+		expect(stripTemplateFlag("body only")).toBe("body only");
+	});
+
+	it("removes the template key but keeps other frontmatter keys", () => {
+		const content = "---\ntype: runbook\ntemplate: true\n---\nbody";
+		const result = stripTemplateFlag(content);
+		expect(result).not.toContain("template");
+		expect(result).toContain("type: runbook");
+		expect(result).toContain("body");
+	});
+
+	it("drops the frontmatter block entirely when no keys remain", () => {
+		const content = "---\ntemplate: true\n---\nbody";
+		expect(stripTemplateFlag(content)).toBe("body");
+	});
+});
+
+describe("stampWikiFrontmatterVerification (PROJ-489)", () => {
+	it("adds a frontmatter block to a page with none", () => {
+		const result = stampWikiFrontmatterVerification("body only", 1735689600, "alice");
+		expect(result).toContain("verified_by: alice");
+		expect(result).toContain("body only");
+		expect(result.startsWith("---\n")).toBe(true);
+	});
+
+	it("preserves existing frontmatter keys while stamping verification", () => {
+		const content = "---\ntype: runbook\n---\nbody";
+		const result = stampWikiFrontmatterVerification(content, 1735689600, "alice");
+		expect(result).toContain("type: runbook");
+		expect(result).toContain("verified_by: alice");
+		expect(result).toContain("body");
+	});
+
+	it("overwrites a previous verification stamp", () => {
+		const content = "---\nverified_by: bob\n---\nbody";
+		const result = stampWikiFrontmatterVerification(content, 1735689600, "alice");
+		expect(result).toContain("verified_by: alice");
+		expect(result).not.toContain("bob");
+	});
+});

--- a/apps/api/src/test/wiki-links-parse.test.ts
+++ b/apps/api/src/test/wiki-links-parse.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { parseWikiLinkTargets } from "../services/wiki-links";
+
+describe("parseWikiLinkTargets (PROJ-483)", () => {
+	it("returns no targets for content with no links", () => {
+		expect(parseWikiLinkTargets("just some body text")).toEqual([]);
+	});
+
+	it("parses a bare wikilink as a title target", () => {
+		expect(parseWikiLinkTargets("see [[Onboarding Guide]] for details")).toEqual([
+			{ kind: "title", title: "Onboarding Guide" },
+		]);
+	});
+
+	it("parses a piped wikilink using only the title, ignoring the display label", () => {
+		expect(parseWikiLinkTargets("see [[Onboarding Guide|start here]]")).toEqual([
+			{ kind: "title", title: "Onboarding Guide" },
+		]);
+	});
+
+	it("parses a same-workspace path-rooted markdown link as a slug target", () => {
+		expect(parseWikiLinkTargets("[docs](/wiki/onboarding-guide)")).toEqual([
+			{ kind: "slug", slug: "onboarding-guide" },
+		]);
+	});
+
+	it("parses a same-workspace query-string markdown link as a slug target", () => {
+		expect(parseWikiLinkTargets("[docs](/wiki?slug=onboarding-guide)")).toEqual([
+			{ kind: "slug", slug: "onboarding-guide" },
+		]);
+	});
+
+	it("ignores an absolute-URL markdown link", () => {
+		expect(parseWikiLinkTargets("[external](https://example.com/wiki/foo)")).toEqual([]);
+	});
+
+	it("ignores a protocol-relative markdown link", () => {
+		expect(parseWikiLinkTargets("[external](//example.com/wiki/foo)")).toEqual([]);
+	});
+
+	it("ignores a markdown link with no recognizable wiki path or slug param", () => {
+		expect(parseWikiLinkTargets("[label](/issues/view?id=123)")).toEqual([]);
+	});
+
+	it("decodes a percent-escaped slug in the query-param form", () => {
+		expect(parseWikiLinkTargets("[docs](/wiki?slug=caf%C3%A9-notes)")).toEqual([
+			{ kind: "slug", slug: "café-notes" },
+		]);
+	});
+
+	it("ignores a markdown link with a malformed percent-escape instead of throwing", () => {
+		expect(parseWikiLinkTargets("[docs](/wiki?slug=bad%escape)")).toEqual([]);
+	});
+
+	it("collects multiple targets across a mix of wikilinks and markdown links", () => {
+		const content = "[[Page A]] and [[Page B|alt]] plus [link](/wiki/page-c)";
+		expect(parseWikiLinkTargets(content)).toEqual([
+			{ kind: "title", title: "Page A" },
+			{ kind: "title", title: "Page B" },
+			{ kind: "slug", slug: "page-c" },
+		]);
+	});
+});

--- a/apps/web/src/islands/IssueList-helpers-date.test.ts
+++ b/apps/web/src/islands/IssueList-helpers-date.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { applyDateRangeParams } from "./IssueList-helpers";
+
+function startOfDayTs(dateStr: string): number {
+	const [y, m, d] = dateStr.split("-").map(Number);
+	return Math.floor(new Date(y, m - 1, d, 0, 0, 0).getTime() / 1000);
+}
+
+function endOfDayTs(dateStr: string): number {
+	const [y, m, d] = dateStr.split("-").map(Number);
+	return Math.floor(new Date(y, m - 1, d, 23, 59, 59).getTime() / 1000);
+}
+
+describe("applyDateRangeParams (PROJ-212)", () => {
+	it("does nothing when no date field is selected", () => {
+		const qs = new URLSearchParams();
+		applyDateRangeParams(qs, "", "2026-01-01", "2026-01-31");
+		expect([...qs.keys()]).toEqual([]);
+	});
+
+	it("does nothing when a date field is selected but no bounds are given", () => {
+		const qs = new URLSearchParams();
+		applyDateRangeParams(qs, "updated", "", "");
+		expect([...qs.keys()]).toEqual([]);
+	});
+
+	it("sets updatedAfter/updatedBefore for the 'updated' field", () => {
+		const qs = new URLSearchParams();
+		applyDateRangeParams(qs, "updated", "2026-01-01", "2026-01-31");
+		expect(qs.get("updatedAfter")).toBe(String(startOfDayTs("2026-01-01")));
+		expect(qs.get("updatedBefore")).toBe(String(endOfDayTs("2026-01-31")));
+	});
+
+	it("sets completedAfter/completedBefore for the 'completed' field", () => {
+		const qs = new URLSearchParams();
+		applyDateRangeParams(qs, "completed", "2026-01-01", "2026-01-31");
+		expect(qs.get("completedAfter")).toBe(String(startOfDayTs("2026-01-01")));
+		expect(qs.get("completedBefore")).toBe(String(endOfDayTs("2026-01-31")));
+	});
+
+	it("only sets the 'after' bound when only a from-date is given", () => {
+		const qs = new URLSearchParams();
+		applyDateRangeParams(qs, "updated", "2026-01-01", "");
+		expect(qs.get("updatedAfter")).toBe(String(startOfDayTs("2026-01-01")));
+		expect(qs.has("updatedBefore")).toBe(false);
+	});
+});

--- a/apps/web/src/islands/issue-list/derive.test.ts
+++ b/apps/web/src/islands/issue-list/derive.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import type { Issue, TaskStatus } from "../board-utils";
+import {
+	deriveProjectDescription,
+	deriveProjectOptions,
+	deriveStatusOptions,
+	deriveTypeOptions,
+} from "./derive";
+import type { ProjectMeta } from "./types";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeProject(overrides: Partial<ProjectMeta> = {}): ProjectMeta {
+	return {
+		id: "project-1",
+		key: "PROJ",
+		name: "Project",
+		description: "The main project",
+		...overrides,
+	};
+}
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+	return {
+		id: "issue-1",
+		number: 1,
+		title: "Test issue",
+		priority: "medium",
+		assignee_id: null,
+		assignee_name: null,
+		parent_id: null,
+		project_key: "PROJ",
+		project_name: "Project",
+		type_key: null,
+		type_name: null,
+		status_id: "status-1",
+		status_key: "todo",
+		status_name: "To Do",
+		status_category: "todo",
+		sprint_id: null,
+		updated_at: 1000,
+		created_at: 1000,
+		...overrides,
+	};
+}
+
+// ─── deriveProjectDescription ──────────────────────────────────────────────
+
+describe("deriveProjectDescription", () => {
+	it("returns null when no project filter is active", () => {
+		expect(deriveProjectDescription([makeProject()], "")).toBeNull();
+	});
+
+	it("returns the matching project's description", () => {
+		expect(
+			deriveProjectDescription([makeProject({ key: "PROJ", description: "desc" })], "PROJ")
+		).toBe("desc");
+	});
+
+	it("returns null when no project matches the filter key", () => {
+		expect(deriveProjectDescription([makeProject({ key: "OTHER" })], "PROJ")).toBeNull();
+	});
+});
+
+// ─── deriveStatusOptions ────────────────────────────────────────────────────
+
+describe("deriveStatusOptions", () => {
+	it("prefers the statuses endpoint result when non-empty", () => {
+		const statuses: TaskStatus[] = [
+			{ id: "s1", key: "todo", name: "To Do", category: "todo", color: null },
+		];
+		expect(deriveStatusOptions([makeIssue()], statuses)).toBe(statuses);
+	});
+
+	it("derives unique statuses from issues when the endpoint returned none", () => {
+		const issues = [
+			makeIssue({ status_id: "s1", status_key: "todo", status_name: "To Do" }),
+			makeIssue({ status_id: "s1", status_key: "todo", status_name: "To Do" }),
+			makeIssue({
+				status_id: "s2",
+				status_key: "done",
+				status_name: "Done",
+				status_category: "done",
+			}),
+		];
+		expect(deriveStatusOptions(issues, [])).toEqual([
+			{ id: "s1", key: "todo", name: "To Do", category: "todo", color: null },
+			{ id: "s2", key: "done", name: "Done", category: "done", color: null },
+		]);
+	});
+
+	it("skips issues with no status_id", () => {
+		const issues = [makeIssue({ status_id: null })];
+		expect(deriveStatusOptions(issues, [])).toEqual([]);
+	});
+});
+
+// ─── deriveProjectOptions ───────────────────────────────────────────────────
+
+describe("deriveProjectOptions", () => {
+	it("derives unique project options from issues", () => {
+		const issues = [
+			makeIssue({ project_key: "A", project_name: "Alpha" }),
+			makeIssue({ project_key: "A", project_name: "Alpha" }),
+			makeIssue({ project_key: "B", project_name: "Beta" }),
+		];
+		expect(deriveProjectOptions(issues)).toEqual([
+			{ key: "A", name: "Alpha" },
+			{ key: "B", name: "Beta" },
+		]);
+	});
+
+	it("falls back to the key as the name when project_name is missing", () => {
+		expect(deriveProjectOptions([makeIssue({ project_key: "A", project_name: null })])).toEqual([
+			{ key: "A", name: "A" },
+		]);
+	});
+
+	it("skips issues with no project_key", () => {
+		expect(deriveProjectOptions([makeIssue({ project_key: null })])).toEqual([]);
+	});
+});
+
+// ─── deriveTypeOptions ──────────────────────────────────────────────────────
+
+describe("deriveTypeOptions", () => {
+	it("derives unique type options as [key, name] entries", () => {
+		const issues = [
+			makeIssue({ type_key: "bug", type_name: "Bug" }),
+			makeIssue({ type_key: "bug", type_name: "Bug" }),
+			makeIssue({ type_key: "task", type_name: "Task" }),
+		];
+		expect(deriveTypeOptions(issues)).toEqual([
+			["bug", "Bug"],
+			["task", "Task"],
+		]);
+	});
+
+	it("falls back to the key as the name when type_name is missing", () => {
+		expect(deriveTypeOptions([makeIssue({ type_key: "bug", type_name: null })])).toEqual([
+			["bug", "bug"],
+		]);
+	});
+
+	it("skips issues with no type_key", () => {
+		expect(deriveTypeOptions([makeIssue({ type_key: null })])).toEqual([]);
+	});
+});

--- a/apps/web/src/islands/issue-list/issue-render-helpers.test.ts
+++ b/apps/web/src/islands/issue-list/issue-render-helpers.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { Issue } from "../board-utils";
+import { getStoryPoints } from "./issue-render-helpers";
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+	return {
+		id: "issue-1",
+		number: 1,
+		title: "Test issue",
+		priority: "medium",
+		assignee_id: null,
+		assignee_name: null,
+		parent_id: null,
+		project_key: "PROJ",
+		project_name: "Project",
+		type_key: null,
+		type_name: null,
+		status_id: "status-1",
+		status_key: "todo",
+		status_name: "To Do",
+		status_category: "todo",
+		sprint_id: null,
+		updated_at: 1000,
+		created_at: 1000,
+		...overrides,
+	};
+}
+
+describe("getStoryPoints", () => {
+	it("returns null when the issue has no custom fields", () => {
+		expect(getStoryPoints(makeIssue())).toBeNull();
+	});
+
+	it("returns null when no custom field has the story_points key", () => {
+		const issue = makeIssue({
+			customFields: [{ key: "team", label: "Team", type: "text", value: "Core" }],
+		});
+		expect(getStoryPoints(issue)).toBeNull();
+	});
+
+	it("returns the story_points field value when present", () => {
+		const issue = makeIssue({
+			customFields: [{ key: "story_points", label: "Story Points", type: "number", value: "5" }],
+		});
+		expect(getStoryPoints(issue)).toBe("5");
+	});
+});

--- a/apps/web/src/islands/issue-list/useFilterUrlSync.test.ts
+++ b/apps/web/src/islands/issue-list/useFilterUrlSync.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { parseDateField } from "./useFilterUrlSync";
+
+describe("parseDateField", () => {
+	it("passes through 'completed'", () => {
+		expect(parseDateField("completed")).toBe("completed");
+	});
+
+	it("passes through 'updated'", () => {
+		expect(parseDateField("updated")).toBe("updated");
+	});
+
+	it("returns an empty string for null", () => {
+		expect(parseDateField(null)).toBe("");
+	});
+
+	it("returns an empty string for an unrecognized value", () => {
+		expect(parseDateField("created")).toBe("");
+	});
+});

--- a/apps/web/src/utils/issue-prefetch.test.ts
+++ b/apps/web/src/utils/issue-prefetch.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { claimPrefetchedIssue } from "./issue-prefetch";
+
+const HANDOFF = "__projektorIssuePrefetch";
+
+function setHandoff(key: string, t: number, response: Promise<Response | null>) {
+	(window as unknown as Record<string, unknown>)[HANDOFF] = { key, t, response };
+}
+
+afterEach(() => {
+	delete (window as unknown as Record<string, unknown>)[HANDOFF];
+	vi.useRealTimers();
+});
+
+describe("claimPrefetchedIssue", () => {
+	it("returns null when there is no handoff", () => {
+		expect(claimPrefetchedIssue("PROJ-1")).toBeNull();
+	});
+
+	it("returns null when the handoff key doesn't match", () => {
+		setHandoff("PROJ-2", Date.now(), Promise.resolve(null));
+		expect(claimPrefetchedIssue("PROJ-1")).toBeNull();
+	});
+
+	it("returns null when the handoff is older than the freshness bound", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(0);
+		setHandoff("PROJ-1", 0, Promise.resolve(null));
+		vi.setSystemTime(20_000);
+		expect(claimPrefetchedIssue("PROJ-1")).toBeNull();
+	});
+
+	it("removes the handoff after a matching claim (single-use)", () => {
+		setHandoff(
+			"PROJ-1",
+			Date.now(),
+			Promise.resolve(new Response(JSON.stringify({ id: "PROJ-1" })))
+		);
+		claimPrefetchedIssue("PROJ-1");
+		expect((window as unknown as Record<string, unknown>)[HANDOFF]).toBeUndefined();
+	});
+
+	it("resolves with the parsed JSON body for a fresh, matching, ok response", async () => {
+		setHandoff(
+			"PROJ-1",
+			Date.now(),
+			Promise.resolve(new Response(JSON.stringify({ id: "PROJ-1" })))
+		);
+		const result = await claimPrefetchedIssue<{ id: string }>("PROJ-1");
+		expect(result).toEqual({ id: "PROJ-1" });
+	});
+
+	it("rejects when the prefetch response was not ok", async () => {
+		setHandoff("PROJ-1", Date.now(), Promise.resolve(new Response(null, { status: 500 })));
+		await expect(claimPrefetchedIssue("PROJ-1")).rejects.toThrow("issue prefetch missed");
+	});
+
+	it("rejects when the prefetch itself failed (null response)", async () => {
+		setHandoff("PROJ-1", Date.now(), Promise.resolve(null));
+		await expect(claimPrefetchedIssue("PROJ-1")).rejects.toThrow("issue prefetch missed");
+	});
+});

--- a/apps/web/src/utils/issue-url.test.ts
+++ b/apps/web/src/utils/issue-url.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { issueUrl } from "./issue-url";
+
+describe("issueUrl", () => {
+	it("builds the pretty project/issue URL when a project slug is given", () => {
+		expect(issueUrl("proj", 42, "Fix the Bug")).toBe("/projects/proj/issues/42/fix-the-bug");
+	});
+
+	it("falls back to the id-based URL when there is no project slug but a fallback id is given", () => {
+		expect(issueUrl(null, 42, "Fix the Bug", "abc-123")).toBe("/issues/view?id=abc-123");
+	});
+
+	it("falls back to '#' when there is neither a project slug nor a fallback id", () => {
+		expect(issueUrl(undefined, 42, "Fix the Bug")).toBe("#");
+	});
+});


### PR DESCRIPTION
## Summary

`Design.MissingTestFile` (174 findings, all "low" severity) flags any exported symbol with no colocated test file. Investigation showed the overwhelming majority are structural false positives: this codebase's convention is one behavioral/integration test file per resource in `apps/api/src/test/`, testing routes+services+schemas+mcp tools together against the mounted app — not one colocated file per source file. Confirmed via counter-example: `checkDefinitionOfReady` and `isExternallyVerifiableEvidence`, which DO have dedicated test files elsewhere in the project, were still flagged as "missing" by the same heuristic.

Added focused new unit tests for the genuinely-untested pure/testable exports found by grepping for zero existing test-file references:
- `sql.ts`: `sanitizeFtsQuery` (`inChunks` was already covered)
- `wiki-frontmatter.ts`: `parseWikiFrontmatter`, `stripTemplateFlag`, `stampWikiFrontmatterVerification`
- `wiki-links.ts`: `parseWikiLinkTargets` (pure parsing portion)
- `issue-list/derive.ts`: `deriveProjectDescription`, `deriveStatusOptions`, `deriveProjectOptions`, `deriveTypeOptions`
- `issue-render-helpers.tsx`: `getStoryPoints`
- `useFilterUrlSync.ts`: `parseDateField`
- `issue-url.ts`: `issueUrl`
- `issue-prefetch.ts`: `claimPrefetchedIssue`
- `IssueList-helpers.ts`: `applyDateRangeParams`

## Deferred

- The bulk of the 174 findings (`routes/*.ts`, `mcp/*.ts`, `schemas/*.ts`, most `services/*.ts`, `middleware/*.ts`, `packages/db/src/schema/*.ts`, and various config/tooling files) — structural false positives per the convention mismatch above, not real gaps.
- `useFetch` (`utils/use-fetch.ts`) — already marked `cofferdam-ignore: Design.OrphanExport` as intentionally-unused scaffolding (PROJ-259); writing a test for unused code contradicts simplicity.

## Test plan

- [x] `tsc --noEmit` / `astro check` clean in both apps
- [x] apps/api: 1148/1148 passing (30 new)
- [x] apps/web: 551/551 passing (34 new)
- [x] `biome check` clean
- [x] cofferdam `Design.MissingTestFile`: 174 → 169 (all 9 newly-tested files no longer appear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)