### PR TITLE
PROJ-481: cofferdam triage — ReadonlyArrayParam, UnusedSuppression, ErrorHandlingIdiom

### DIFF
--- a/apps/api/src/services/wiki-links.ts
+++ b/apps/api/src/services/wiki-links.ts
@@ -51,7 +51,6 @@ function extractWikiSlugFromUrl(url: string): string | null {
 	return safeDecodeURIComponent(raw);
 }
 
-// cofferdam-ignore: Design.OrphanExport: part of the service API; used internally for parsing wiki link targets
 export function parseWikiLinkTargets(content: string): ParsedLinkTarget[] {
 	const targets: ParsedLinkTarget[] = [];
 	for (const m of content.matchAll(WIKILINK_RE)) {

--- a/apps/api/src/test/code-heatmap.test.ts
+++ b/apps/api/src/test/code-heatmap.test.ts
@@ -20,7 +20,7 @@ async function expectHeatmapOk(res: Response): Promise<CodeHeatmapResponse> {
 	return (await res.json()) as CodeHeatmapResponse;
 }
 
-function expectAppsGroup<E extends { path: string; isLeaf: boolean }>(entries: E[]): E {
+function expectAppsGroup<E extends { path: string; isLeaf: boolean }>(entries: readonly E[]): E {
 	const apps = entries.find((e) => e.path === "apps");
 	expect(apps).toBeDefined();
 	expect(apps?.isLeaf).toBe(false);

--- a/apps/web/src/islands/FeedbackList.tsx
+++ b/apps/web/src/islands/FeedbackList.tsx
@@ -277,6 +277,7 @@ function useFeedbackRows(workspaceSlug: string | undefined, projectId: string, s
 		fetchRows();
 	}, [fetchRows]);
 
+	// cofferdam-ignore: Consistency.ErrorHandlingIdiom: hook returns {data,error,loading} state, standard in this codebase
 	return { rows, status, setStatus, loading, error, setError, fetchRows };
 }
 

--- a/apps/web/src/islands/WikiPage.test.tsx
+++ b/apps/web/src/islands/WikiPage.test.tsx
@@ -46,7 +46,7 @@ function mockFetchWiki(page: WikiPageData | null, ok = true, status = 404) {
 	);
 }
 
-function mockFetchMovePage(revisions: unknown[] = []) {
+function mockFetchMovePage(revisions: readonly unknown[] = []) {
 	const otherPageNode = { id: "w2", slug: "other-page", title: "Other Page", children: [] };
 	return vi.fn().mockImplementation((url: string, init?: RequestInit) => {
 		const u = String(url);

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -2339,15 +2339,17 @@ function useServerDraftAutosave(options: UseServerDraftAutosaveOptions) {
 	return skipLeaveFlushRef;
 }
 
-async function saveWikiPageEdit(params: {
-	workspaceSlug: string | undefined;
-	page: WikiPageData;
-	editTitle: string;
-	editContent: string;
-	baseRevisionId: string | null | undefined;
-	fetchPage: (s: string) => Promise<void>;
-	fetchRevisions: (s: string) => Promise<void>;
-}): Promise<void> {
+async function saveWikiPageEdit(
+	params: Readonly<{
+		workspaceSlug: string | undefined;
+		page: WikiPageData;
+		editTitle: string;
+		editContent: string;
+		baseRevisionId: string | null | undefined;
+		fetchPage: (s: string) => Promise<void>;
+		fetchRevisions: (s: string) => Promise<void>;
+	}>
+): Promise<void> {
 	const { workspaceSlug, page, editTitle, editContent, baseRevisionId, fetchPage, fetchRevisions } =
 		params;
 	await apiFetch(`/api/wiki/${encodeURIComponent(page.slug)}`, {


### PR DESCRIPTION
## Summary

Cleans up the last three small remaining cofferdam categories on main:

- **Design.ReadonlyArrayParam** (3): array/object params never mutated by their callees. Widened to `readonly T[]` / `Readonly<T>` in `code-heatmap.test.ts`, `WikiPage.test.tsx`, and `WikiPage.tsx`'s `saveWikiPageEdit`.
- **Consistency.UnusedSuppression** (1): `wiki-links.ts` carried a stale `cofferdam-ignore: Design.OrphanExport` on `parseWikiLinkTargets` — no longer needed now that the function has its own test file (#203). Removed.
- **Consistency.ErrorHandlingIdiom** (1): `FeedbackList.tsx`'s `useFeedbackRows` returns `{rows,error,loading}` instead of throwing. This mirrors the established `{data,error,loading}` hook convention already exempted in `use-fetch.ts` — added the matching `cofferdam-ignore` rather than restructure the hook.

## Test plan

- [x] `tsc --noEmit` / `astro check` clean in both apps
- [x] apps/api: 1148/1148 passing
- [x] apps/web: 551/551 passing
- [x] `biome check` clean
- [x] cofferdam: all three targeted categories now 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)