### PR TITLE
fix(design-system): add ref forwarding, aria-modal, and title support to Popover/Button

### DIFF
--- a/apps/web/src/islands/ui/Button.test.tsx
+++ b/apps/web/src/islands/ui/Button.test.tsx
@@ -56,4 +56,10 @@ describe("Button", () => {
 
 		expect(() => render(<Button as="a">No href</Button>)).toThrow();
 	});
+
+	it("passes title through to the rendered element", () => {
+		render(<Button title="Copy link">Copy</Button>);
+		const button = screen.getByRole("button", { name: "Copy" });
+		expect(button.getAttribute("title")).toBe("Copy link");
+	});
 });

--- a/apps/web/src/islands/ui/Button.tsx
+++ b/apps/web/src/islands/ui/Button.tsx
@@ -9,6 +9,7 @@ export interface ButtonProps {
 	style?: JSX.CSSProperties;
 	type?: "button" | "submit";
 	disabled?: boolean;
+	title?: string;
 	onClick?: (e: MouseEvent) => void;
 	children: ComponentChildren;
 	[key: `aria-${string}`]: string | boolean | undefined;
@@ -33,6 +34,7 @@ export function Button({
 	style,
 	type = "button",
 	disabled,
+	title,
 	onClick,
 	children,
 	...rest
@@ -43,7 +45,7 @@ export function Button({
 
 	if (as === "span") {
 		return (
-			<span class={classes} style={style} {...rest}>
+			<span class={classes} style={style} title={title} {...rest}>
 				{children}
 			</span>
 		);
@@ -52,7 +54,7 @@ export function Button({
 	if (as === "a") {
 		if (!href) throw new Error("Button: `href` is required when as='a'");
 		return (
-			<a href={href} class={classes} style={style} {...rest}>
+			<a href={href} class={classes} style={style} title={title} {...rest}>
 				{children}
 			</a>
 		);
@@ -64,6 +66,7 @@ export function Button({
 			class={classes}
 			style={style}
 			disabled={disabled}
+			title={title}
 			onClick={onClick}
 			{...rest}
 		>

--- a/apps/web/src/islands/ui/Popover.test.tsx
+++ b/apps/web/src/islands/ui/Popover.test.tsx
@@ -56,4 +56,60 @@ describe("Popover", () => {
 		expect(() => render(<Popover strategy="portal-fixed">No position</Popover>)).toThrow();
 		expect(() => render(<Popover strategy="fixed-inline">No position</Popover>)).toThrow();
 	});
+
+	it("resolves elementRef to the rendered DOM element when anchored", () => {
+		const elementRef = { current: null as HTMLElement | null };
+		render(
+			<Popover strategy="anchored" elementRef={elementRef}>
+				<span>Ref content</span>
+			</Popover>
+		);
+		const el = screen.getByText("Ref content").parentElement as HTMLElement;
+		expect(elementRef.current).toBe(el);
+	});
+
+	it("resolves elementRef to the portaled DOM node under document.body when portal-fixed", () => {
+		const elementRef = { current: null as HTMLElement | null };
+		render(
+			<Popover strategy="portal-fixed" position={{ top: 10 }} elementRef={elementRef}>
+				<span>Portal ref content</span>
+			</Popover>
+		);
+		const el = screen.getByText("Portal ref content").parentElement as HTMLElement;
+		expect(document.body.contains(el)).toBe(true);
+		expect(elementRef.current).toBe(el);
+	});
+
+	it('round-trips aria-modal="false" when ariaModal={false} and role are both passed', () => {
+		render(
+			<Popover strategy="anchored" role="dialog" ariaModal={false}>
+				<span>Dialog content</span>
+			</Popover>
+		);
+		const el = screen.getByText("Dialog content").parentElement as HTMLElement;
+		expect(el.getAttribute("aria-modal")).toBe("false");
+		expect(el.getAttribute("role")).toBe("dialog");
+	});
+
+	it("renders ariaLabel even when role is omitted", () => {
+		render(
+			<Popover strategy="anchored" ariaLabel="Definition">
+				<span>Label-only content</span>
+			</Popover>
+		);
+		const el = screen.getByText("Label-only content").parentElement as HTMLElement;
+		expect(el.getAttribute("aria-label")).toBe("Definition");
+		expect(el.hasAttribute("role")).toBe(false);
+	});
+
+	it("renders role even when ariaLabel is omitted", () => {
+		render(
+			<Popover strategy="anchored" role="menu">
+				<span>Role-only content</span>
+			</Popover>
+		);
+		const el = screen.getByText("Role-only content").parentElement as HTMLElement;
+		expect(el.getAttribute("role")).toBe("menu");
+		expect(el.hasAttribute("aria-label")).toBe(false);
+	});
 });

--- a/apps/web/src/islands/ui/Popover.tsx
+++ b/apps/web/src/islands/ui/Popover.tsx
@@ -1,4 +1,4 @@
-import type { ComponentChildren } from "preact";
+import type { ComponentChildren, Ref } from "preact";
 import { createPortal } from "preact/compat";
 
 export interface PopoverProps {
@@ -14,6 +14,15 @@ export interface PopoverProps {
 	 * landmark with the same accessible name. */
 	role?: "dialog" | "menu" | "listbox";
 	ariaLabel?: string;
+	/** Only emitted when defined, independently of `role`/`ariaLabel` — needed
+	 * by the non-modal toggletip contract (MetricHelp/GlossaryHelp render
+	 * `role="dialog" aria-modal="false"`). */
+	ariaModal?: boolean;
+	/** Forwarded as `ref` on the rendered root element, in every strategy
+	 * branch — needed by callers (AccountMenu, GlossaryHelp) that use it for
+	 * outside-click-dismissal logic (a click inside the popover's own
+	 * content must not count as "outside"). */
+	elementRef?: Ref<HTMLElement>;
 	/** Extra class(es) carrying usage-specific radius/padding/font-size/
 	 * position — `.popover` alone only sets the properties genuinely
 	 * shared across every current popover (background, border, shadow,
@@ -48,6 +57,8 @@ export function Popover({
 	as = "div",
 	role,
 	ariaLabel,
+	ariaModal,
+	elementRef,
 	class: extraClass,
 	strategy,
 	position,
@@ -55,11 +66,19 @@ export function Popover({
 }: PopoverProps) {
 	const classes = extraClass ? `popover ${extraClass}` : "popover";
 	const Tag = as;
-	const a11yProps = role ? { role, "aria-label": ariaLabel } : {};
+	const a11yProps = {
+		...(role !== undefined ? { role } : {}),
+		...(ariaLabel !== undefined ? { "aria-label": ariaLabel } : {}),
+		...(ariaModal !== undefined
+			? { "aria-modal": (ariaModal ? "true" : "false") as "true" | "false" }
+			: {}),
+	};
+	// biome-ignore lint/suspicious/noExplicitAny: dynamic `Tag = as` ("div" | "ul") makes JSX infer an unsatisfiable intersection ref type across both element kinds.
+	const refProp = { ref: elementRef as any };
 
 	if (strategy === "anchored") {
 		return (
-			<Tag id={id} class={classes} {...a11yProps}>
+			<Tag id={id} class={classes} {...a11yProps} {...refProp}>
 				{children}
 			</Tag>
 		);
@@ -77,7 +96,7 @@ export function Popover({
 	};
 
 	const el = (
-		<Tag id={id} class={classes} style={style} {...a11yProps}>
+		<Tag id={id} class={classes} style={style} {...a11yProps} {...refProp}>
 			{children}
 		</Tag>
 	);


### PR DESCRIPTION
Fixes PROJ-551 — Popover/Button lacked API surface (ref forwarding, aria-modal, decoupled ariaLabel, Button title) that upcoming migration tasks (MetricHelp/GlossaryHelp/AccountMenu/IssueDetailParts) require. No call sites migrated in this PR, component-API-only.