### PR TITLE
refactor(design-system): migrate MetricHelp and AccountMenu popovers to islands/ui/Popover

### DIFF
--- a/apps/web/src/islands/AccountMenu.tsx
+++ b/apps/web/src/islands/AccountMenu.tsx
@@ -1,8 +1,8 @@
-import { createPortal } from "preact/compat";
 import { useEffect, useId, useRef, useState } from "preact/hooks";
 import { apiFetch } from "../utils/api-client";
 import { clearAllDrafts } from "../utils/drafts";
 import { resolveWorkspaceSlug } from "../utils/workspace";
+import { Popover } from "./ui/Popover";
 
 interface Props {
 	workspaceSlug?: string;
@@ -36,12 +36,13 @@ function AccountMenuPopover({
 	user: { email: string; name: string };
 	redirectTarget: string;
 }) {
-	return createPortal(
-		<div
+	return (
+		<Popover
 			id={menuId}
-			ref={popoverRef}
-			class="account-menu-popover"
-			style={{ position: "fixed", top: `${pos.top}px`, right: `${pos.right}px` }}
+			strategy="portal-fixed"
+			class="popover-account-menu"
+			elementRef={popoverRef}
+			position={pos}
 		>
 			<div class="account-menu-identity">
 				<div class="account-menu-identity-name">{user.name}</div>
@@ -65,8 +66,7 @@ function AccountMenuPopover({
 					Log out
 				</a>
 			</div>
-		</div>,
-		document.body
+		</Popover>
 	);
 }
 

--- a/apps/web/src/islands/MetricHelp.tsx
+++ b/apps/web/src/islands/MetricHelp.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useRef, useState } from "preact/hooks";
 import { METRIC_DEFINITIONS, type MetricId } from "./metric-definitions";
+import { Popover } from "./ui/Popover";
 
 // PROJ-335: shared help affordance for every stat/chart, backed by metric-definitions.ts.
 // A toggletip, not a native <dialog>/alert: a button that toggles a popover, dismissed via
@@ -41,16 +42,17 @@ export function MetricHelp({ id }: { id: MetricId }) {
 				<span aria-hidden="true">ⓘ</span>
 			</button>
 			{open && (
-				<div
+				<Popover
 					id={popoverId}
+					strategy="anchored"
+					class="popover-metric-help"
 					role="dialog"
-					aria-modal="false"
-					aria-label={`${def.label} definition`}
-					class="metric-help-popover"
+					ariaModal={false}
+					ariaLabel={`${def.label} definition`}
 				>
 					<p class="m-0 mb-1 text-[0.8rem] text-text-base">{def.definition}</p>
 					<p class="m-0 text-[0.72rem] text-text-muted">{def.computation}</p>
-				</div>
+				</Popover>
 			)}
 		</span>
 	);


### PR DESCRIPTION
## Summary
- MetricHelp.tsx: replaces the hand-rolled `role="dialog" aria-modal="false"` popover div with `<Popover strategy="anchored" class="popover-metric-help" role="dialog" ariaModal={false} ariaLabel={...}>`, same children unchanged. No `elementRef` needed — MetricHelp dismisses via its own `rootRef`-based outside-click/Escape listeners on the wrapping `<span>`, not on the popover element itself.
- AccountMenu.tsx: replaces the `createPortal(...)` call with `<Popover strategy="portal-fixed" class="popover-account-menu" elementRef={popoverRef} position={popoverPos}>`, still gated on `open && popoverPos` in AccountMenu. Deliberately passes no `role`/`ariaLabel` to Popover — the accessible `role="menu" aria-label="Account"` landmark stays on the inner div, unchanged, avoiding a duplicate ARIA landmark. Dropped the now-unused `createPortal` import from `preact/compat`.

Refs PROJ-532.

## Test plan
- [x] `pnpm --filter web exec vitest run` for `AccountMenu.test.tsx` (MetricHelp has no test file) — 8/8 passed
- [x] `grep -n "createPortal\|metric-help-popover\|account-menu-popover"` on both files — no matches
- [x] `pnpm exec biome check .` — clean
- [x] `astro check` — 0 errors, 0 warnings (9 pre-existing hints unrelated to these files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01548ouh4go9LE9JxnEmEyAv