### PR TITLE
refactor(design-system): migrate FeedbackSourceSettings/EpicList/HeaderRow to Button

### DIFF
--- a/apps/web/src/islands/EpicList.tsx
+++ b/apps/web/src/islands/EpicList.tsx
@@ -14,6 +14,7 @@ import {
 import { applyDateRangeParams } from "./IssueList-helpers";
 import type { DateField } from "./issue-list/FiltersPopover";
 import FiltersPopover from "./issue-list/FiltersPopover";
+import { Button } from "./ui/Button";
 import Select from "./ui/Select";
 
 interface Props {
@@ -162,9 +163,9 @@ function EpicListHeader(props: EpicListHeaderProps) {
 				isSearchActive={false}
 			/>
 			{props.epicTypeId && (
-				<button type="button" onClick={props.onOpenCreate} class="btn btn-primary btn-sm">
+				<Button variant="primary" size="sm" onClick={props.onOpenCreate}>
 					+ New Epic
-				</button>
+				</Button>
 			)}
 		</div>
 	);
@@ -754,16 +755,16 @@ function CreateEpicModal({
 					</div>
 
 					<div class="flex gap-2">
-						<button
+						<Button
 							type="submit"
+							variant="primary"
 							disabled={submitting || !createTitle.trim() || !createProjectId}
-							class="btn btn-primary"
 						>
 							{submitting ? "Creating…" : "Create Epic"}
-						</button>
-						<button type="button" onClick={() => setShowCreate(false)} class="btn btn-outline">
+						</Button>
+						<Button variant="outline" onClick={() => setShowCreate(false)}>
 							Cancel
-						</button>
+						</Button>
 					</div>
 				</form>
 			</div>

--- a/apps/web/src/islands/FeedbackSourceSettings.tsx
+++ b/apps/web/src/islands/FeedbackSourceSettings.tsx
@@ -1,5 +1,6 @@
 import { useState } from "preact/hooks";
 import { apiFetch } from "../utils/api-client";
+import { Button } from "./ui/Button";
 
 export interface FeedbackSource {
 	id: string;
@@ -41,9 +42,9 @@ function NewTokenReveal({ token, onDismiss }: { token: string; onDismiss: () => 
 			<code class="block font-mono text-[0.8rem] px-2 py-[0.375rem] bg-bg border border-border rounded break-all">
 				{token}
 			</code>
-			<button type="button" class="btn btn-outline btn-sm mt-2" onClick={onDismiss}>
+			<Button variant="outline" size="sm" class="mt-2" onClick={onDismiss}>
 				Done
-			</button>
+			</Button>
 		</div>
 	);
 }
@@ -67,25 +68,26 @@ function DangerZone({
 			{rotating ? (
 				<span class="inline-flex gap-[0.375rem] items-center flex-wrap">
 					<span class="text-[0.8rem] text-text-muted">Rotate? Old token dies.</span>
-					<button type="button" class="btn btn-danger btn-sm" onClick={onRotateConfirm}>
+					<Button variant="danger" size="sm" onClick={onRotateConfirm}>
 						Yes
-					</button>
-					<button type="button" class="btn btn-outline btn-sm" onClick={onRotateCancel}>
+					</Button>
+					<Button variant="outline" size="sm" onClick={onRotateCancel}>
 						No
-					</button>
+					</Button>
 				</span>
 			) : (
 				<span class="inline-flex gap-[0.375rem]">
-					<button type="button" class="btn btn-outline btn-sm" onClick={onRotateStart}>
+					<Button variant="outline" size="sm" onClick={onRotateStart}>
 						Rotate token
-					</button>
-					<button
-						type="button"
-						class="btn btn-outline btn-sm text-[var(--danger-text)] border-[var(--danger-border)]"
+					</Button>
+					<Button
+						variant="outline"
+						size="sm"
+						class="text-[var(--danger-text)] border-[var(--danger-border)]"
 						onClick={onRevoke}
 					>
 						Revoke source
-					</button>
+					</Button>
 				</span>
 			)}
 		</div>
@@ -158,9 +160,9 @@ export default function FeedbackSourceSettings({
 
 			<div class="flex flex-col gap-1">
 				<span class="text-[0.8rem] font-semibold text-text-muted">Status</span>
-				<button type="button" class="btn btn-outline btn-sm w-fit" onClick={toggleActive}>
+				<Button variant="outline" size="sm" class="w-fit" onClick={toggleActive}>
 					{source.isActive ? "Active" : "Inactive"}
-				</button>
+				</Button>
 			</div>
 
 			<div class="flex flex-col gap-1">

--- a/apps/web/src/islands/issue-list/HeaderRow.tsx
+++ b/apps/web/src/islands/issue-list/HeaderRow.tsx
@@ -1,4 +1,5 @@
 import { getBacklogIssues, type Issue } from "../board-utils";
+import { Button } from "../ui/Button";
 import type { ViewMode } from "./types-view";
 import type { SearchResult } from "./useIssueSearch";
 
@@ -47,9 +48,9 @@ export default function HeaderRow({
 
 			<div class="flex gap-2 items-center max-sm:justify-between">
 				{projectsCount > 0 && (
-					<button type="button" onClick={openCreateModal} class="btn btn-primary btn-sm">
+					<Button variant="primary" size="sm" onClick={openCreateModal}>
 						+ New issue
-					</button>
+					</Button>
 				)}
 
 				{!isSearchActive && (
@@ -69,7 +70,7 @@ export default function HeaderRow({
 									border: "none",
 									borderRight: v !== "backlog" ? "1px solid var(--border)" : "none",
 									background: view === v ? "var(--accent)" : "var(--bg)",
-									color: view === v ? "#fff" : "var(--text-muted)",
+									color: view === v ? "var(--on-accent)" : "var(--text-muted)",
 									cursor: "pointer",
 									fontSize: "0.8rem",
 									fontWeight: view === v ? 600 : 400,


### PR DESCRIPTION
## Summary
- Migrate 6 `.btn`-classed elements in `FeedbackSourceSettings.tsx`, 3 in `EpicList.tsx`, and 1 in `HeaderRow.tsx` to the `Button` component.
- Fix raw hex `#fff` in `HeaderRow.tsx`'s view-mode toggle to `var(--on-accent)`.
- `FeedbackSourceSettings.tsx`'s "Revoke source" button keeps its danger-colored text/border override via the `class` passthrough — it uses `btn-outline`'s background (not `btn-danger`'s filled background), so it isn't redundant with `variant="danger"`.

Part of PROJ-527, closes PROJ-534.

## Test plan
- [x] `pnpm exec biome check --write` on the 3 changed files — clean
- [x] `pnpm exec vitest run FeedbackSourceSettings.test.tsx EpicList.test.tsx` — 17/17 pass
- [x] `pnpm --filter web test` — 572/572 pass, no new failures
- [x] `grep -rn '"btn' <3 files>` — no matches remain
- [x] `git status --short` — only the 3 target files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01548ouh4go9LE9JxnEmEyAv