### PR TITLE
refactor(design-system): migrate CreateIssueModal/NewSourceModal/FeedbackList to Button

### DIFF
--- a/apps/web/src/islands/FeedbackList.tsx
+++ b/apps/web/src/islands/FeedbackList.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "preact/hooks";
 import { apiFetch } from "../utils/api-client";
+import { Button } from "./ui/Button";
 import Select from "./ui/Select";
 
 interface Feedback {
@@ -101,16 +102,16 @@ function FeedbackRowActions({
 	return (
 		<div class="flex gap-2 flex-wrap">
 			{row.status === "new" && (
-				<button type="button" class="btn btn-outline btn-sm" onClick={() => onMarkReviewed(row.id)}>
+				<Button type="button" variant="outline" size="sm" onClick={() => onMarkReviewed(row.id)}>
 					Mark reviewed
-				</button>
+				</Button>
 			)}
 			{row.linkedIssueId ? (
 				<span class="text-[0.8rem] text-text-muted">Linked</span>
 			) : (
-				<button type="button" class="btn btn-outline btn-sm" onClick={() => onConvert(row.id)}>
+				<Button type="button" variant="outline" size="sm" onClick={() => onConvert(row.id)}>
 					Convert to issue
-				</button>
+				</Button>
 			)}
 		</div>
 	);
@@ -402,20 +403,22 @@ export default function FeedbackList({ workspaceSlug, projectId, sourceId }: Pro
 			{selected.size > 0 && (
 				<div class="flex gap-2 items-center mb-3 p-2 bg-surface border border-border rounded">
 					<span class="text-[0.85rem] text-text-muted">{selected.size} selected</span>
-					<button
+					<Button
 						type="button"
-						class="btn btn-outline btn-sm"
+						variant="outline"
+						size="sm"
 						onClick={() => bulkMarkReviewed(selected)}
 					>
 						Mark all reviewed
-					</button>
-					<button
+					</Button>
+					<Button
 						type="button"
-						class="btn btn-outline btn-sm"
+						variant="outline"
+						size="sm"
 						onClick={() => bulkConvertToIssue(selected)}
 					>
 						Convert all to issue
-					</button>
+					</Button>
 				</div>
 			)}
 			{loading ? (

--- a/apps/web/src/islands/NewSourceModal.tsx
+++ b/apps/web/src/islands/NewSourceModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from "preact/hooks";
 import { apiFetch } from "../utils/api-client";
+import { Button } from "./ui/Button";
 
 interface Props {
 	projectId: string;
@@ -104,12 +105,12 @@ function NewSourceForm({
 				/>
 			</div>
 			<div class="flex gap-2">
-				<button type="submit" class="btn btn-primary btn-sm" disabled={creating || !name.trim()}>
+				<Button type="submit" variant="primary" size="sm" disabled={creating || !name.trim()}>
 					{creating ? "Creating…" : "Create source"}
-				</button>
-				<button type="button" class="btn btn-outline btn-sm" onClick={onCancel} disabled={creating}>
+				</Button>
+				<Button type="button" variant="outline" size="sm" onClick={onCancel} disabled={creating}>
 					Cancel
-				</button>
+				</Button>
 			</div>
 		</form>
 	);
@@ -174,9 +175,9 @@ export default function NewSourceModal({ projectId, workspaceSlug, onClose, onCr
 						<code class="block font-mono text-[0.8rem] px-2 py-[0.375rem] bg-bg border border-border rounded break-all">
 							{newToken}
 						</code>
-						<button type="button" class="btn btn-primary btn-sm mt-3" onClick={onClose}>
+						<Button type="button" variant="primary" size="sm" class="mt-3" onClick={onClose}>
 							Done
-						</button>
+						</Button>
 					</div>
 				) : (
 					<NewSourceForm

--- a/apps/web/src/islands/issue-list/CreateIssueModal.tsx
+++ b/apps/web/src/islands/issue-list/CreateIssueModal.tsx
@@ -2,6 +2,7 @@ import type { Dispatch, StateUpdater } from "preact/hooks";
 import { PRIORITY_OPTIONS } from "../../utils/issue-utils";
 import type { TaskStatus } from "../board-utils";
 import MarkdownEditor from "../LazyMarkdownEditor";
+import { Button } from "../ui/Button";
 import Select from "../ui/Select";
 import type { ProjectMeta } from "./types";
 
@@ -190,16 +191,16 @@ export default function CreateIssueModal(props: CreateIssueModalProps) {
 					<CreateIssueModalFields {...props} />
 
 					<div class="flex gap-2">
-						<button
+						<Button
 							type="submit"
+							variant="primary"
 							disabled={submittingCreate || !createTitle.trim() || !createProjectId}
-							class="btn btn-primary"
 						>
 							{submittingCreate ? "Creating…" : "Create issue"}
-						</button>
-						<button type="button" onClick={() => setShowCreateModal(false)} class="btn btn-outline">
+						</Button>
+						<Button type="button" variant="outline" onClick={() => setShowCreateModal(false)}>
 							Cancel
-						</button>
+						</Button>
 					</div>
 				</form>
 			</div>


### PR DESCRIPTION
## Summary
- Migrates hand-rolled `.btn` CSS-class markup to the `Button` component in `CreateIssueModal.tsx` (2 sites), `NewSourceModal.tsx` (3 sites), `FeedbackList.tsx` (4 sites).
- Closes PROJ-535 (batch 2 of the design-system `.btn` migration, part of PROJ-527).

## Test plan
- [x] `pnpm exec biome check --write` on the 3 changed files
- [x] `pnpm exec vitest run` for `NewSourceModal.test.tsx` and `FeedbackList.test.tsx` — 17/17 passing (no `CreateIssueModal.test.tsx` exists)
- [x] `pnpm test` full suite from `apps/web` — 572/572 passing
- [x] `git status --short` — only the 3 target files changed
- [x] grep-verified no remaining `.btn`-class occurrences in the 3 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01548ouh4go9LE9JxnEmEyAv