### PR TITLE
fix(design-system): restore SavedViewsControl popover scroll bound and fix listbox a11y (PROJ-553)

### DIFF
--- a/apps/web/src/islands/issue-list/SavedViewsControl.tsx
+++ b/apps/web/src/islands/issue-list/SavedViewsControl.tsx
@@ -108,7 +108,6 @@ function ViewsMenu({ saved }: { saved: Saved }) {
 					as="ul"
 					strategy="fixed-inline"
 					class="popover-select-menu"
-					role="listbox"
 					ariaLabel="Saved views"
 					elementRef={viewsMenuRef}
 					position={viewsMenuPos.current}

--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -604,6 +604,8 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
       .popover-select-menu {
         border-radius: 6px;
         padding: 0.25rem;
+        max-height: 16rem;
+        overflow-y: auto;
       }
       .metric-help-popover {
         position: absolute;


### PR DESCRIPTION
## Summary
- `.popover-select-menu` (Base.astro) was missing `max-height: 16rem; overflow-y: auto;` that `.select-menu` had — the saved-views dropdown (position: fixed) could grow past the viewport with no scrollbar once there were enough saved views.
- `SavedViewsControl.tsx`'s `Popover` had `role="listbox"` but its `<li>` items each nest two independently-focusable buttons (apply view + delete), which doesn't fit ARIA `option` semantics (an option shouldn't contain multiple focusable children). Dropped `role="listbox"`, keeping `ariaLabel="Saved views"` — matching pre-PROJ-533 behavior.

## Test plan
- [x] `pnpm exec biome check --write` on changed files — clean
- [x] `pnpm --filter web test` — 572/572 passed (matches baseline)
- [x] `git status --short` confirms only `Base.astro` and `SavedViewsControl.tsx` changed

Fixes PROJ-553.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01548ouh4go9LE9JxnEmEyAv