### PR TITLE
refactor(design-system): migrate ProjectLanding/ProjectList/SprintBannerSection/Toolbar to Button

### DIFF
--- a/apps/web/src/islands/ProjectLanding.tsx
+++ b/apps/web/src/islands/ProjectLanding.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { statusDisplayName } from "../lib/status";
 import { apiFetch } from "../utils/api-client";
 import ProjectFlowCharts from "./ProjectFlowCharts";
+import { Button } from "./ui/Button";
 
 interface Project {
 	id: string;
@@ -224,17 +225,12 @@ function DescriptionEditForm({
 				</p>
 			)}
 			<div class="flex gap-2 mt-2">
-				<button
-					type="button"
-					onClick={onSave}
-					disabled={saving}
-					class={`btn btn-primary btn-sm${saving ? " opacity-60" : ""}`}
-				>
+				<Button type="button" variant="primary" size="sm" onClick={onSave} disabled={saving}>
 					{saving ? "Saving…" : "Save"}
-				</button>
-				<button type="button" onClick={onCancel} disabled={saving} class="btn btn-outline btn-sm">
+				</Button>
+				<Button type="button" variant="outline" size="sm" onClick={onCancel} disabled={saving}>
 					Cancel
-				</button>
+				</Button>
 			</div>
 		</div>
 	);

--- a/apps/web/src/islands/ProjectList.tsx
+++ b/apps/web/src/islands/ProjectList.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "preact/hooks";
 import { useAccessGate } from "../utils/access-gate";
 import { apiFetch } from "../utils/api-client";
 import AccessPending from "./AccessPending";
+import { Button } from "./ui/Button";
 
 interface Project {
 	id: string;
@@ -137,22 +138,12 @@ function ProjectCreateForm({
 			)}
 
 			<div class="flex gap-2 justify-end">
-				<button
-					type="button"
-					onClick={onCancel}
-					disabled={submitting}
-					class="btn btn-outline btn-sm"
-				>
+				<Button type="button" variant="outline" size="sm" onClick={onCancel} disabled={submitting}>
 					Cancel
-				</button>
-				<button
-					type="submit"
-					disabled={submitting}
-					class="btn btn-primary btn-sm"
-					style={{ opacity: submitting ? 0.6 : 1 }}
-				>
+				</Button>
+				<Button type="submit" variant="primary" size="sm" disabled={submitting}>
 					{submitting ? "Creating…" : "Create project"}
-				</button>
+				</Button>
 			</div>
 		</form>
 	);
@@ -349,9 +340,9 @@ export default function ProjectList({ workspaceSlug }: { workspaceSlug?: string 
 		<>
 			<div class="flex justify-end mb-4">
 				{!createForm.formOpen && (
-					<button type="button" onClick={createForm.open} class="btn btn-primary btn-sm">
+					<Button type="button" variant="primary" size="sm" onClick={createForm.open}>
 						+ New project
-					</button>
+					</Button>
 				)}
 			</div>
 

--- a/apps/web/src/islands/issue-list/SprintBannerSection.tsx
+++ b/apps/web/src/islands/issue-list/SprintBannerSection.tsx
@@ -2,6 +2,7 @@ import type { Dispatch, StateUpdater } from "preact/hooks";
 import { useState } from "preact/hooks";
 import { apiFetch } from "../../utils/api-client";
 import type { Issue } from "../board-utils";
+import { Button } from "../ui/Button";
 
 export interface SprintDetail {
 	id: string;
@@ -27,6 +28,8 @@ function sprintStatusStyle(status: SprintDetail["status"]): {
 	borderColor: string;
 } {
 	if (status === "active") {
+		// TODO(design-system): no --status-in-progress-bg/border token exists yet;
+		// rgba(37,99,235,*) is blue-600, distinct from --status-in-progress (#4f46e5). Flagged in PROJ-536.
 		return {
 			background: "rgba(37,99,235,0.12)",
 			color: "var(--status-in-progress)",
@@ -34,6 +37,8 @@ function sprintStatusStyle(status: SprintDetail["status"]): {
 		};
 	}
 	if (status === "completed") {
+		// TODO(design-system): no --status-done-bg/border token exists yet;
+		// rgba(22,163,74,*) matches --status-done (#16a34a) at reduced opacity. Flagged in PROJ-536.
 		return {
 			background: "rgba(22,163,74,0.12)",
 			color: "var(--status-done)",
@@ -223,20 +228,17 @@ function SprintEditForm({
 					</label>
 				</div>
 				<div class="flex gap-2">
-					<button
+					<Button
 						type="submit"
+						variant="primary"
+						size="sm"
 						disabled={sprintEditSaving || !sprintEditName.trim()}
-						class="btn btn-primary btn-sm"
 					>
 						{sprintEditSaving ? "Saving…" : "Save"}
-					</button>
-					<button
-						type="button"
-						onClick={() => setSprintEditing(false)}
-						class="btn btn-outline btn-sm"
-					>
+					</Button>
+					<Button type="button" variant="outline" size="sm" onClick={() => setSprintEditing(false)}>
 						Cancel
-					</button>
+					</Button>
 				</div>
 			</div>
 		</form>

--- a/apps/web/src/islands/issue-list/Toolbar.tsx
+++ b/apps/web/src/islands/issue-list/Toolbar.tsx
@@ -1,6 +1,7 @@
 import type { RefObject } from "preact";
 import type { Dispatch, StateUpdater } from "preact/hooks";
 import type { Issue, SortKey, TaskStatus } from "../board-utils";
+import { Button } from "../ui/Button";
 import Select from "../ui/Select";
 import type { DateField } from "./FiltersPopover";
 import FiltersPopover from "./FiltersPopover";
@@ -143,14 +144,15 @@ function SortControls({
 					{ value: "number", label: "Number" },
 				]}
 			/>
-			<button
+			<Button
 				type="button"
+				variant="outline"
+				size="sm"
 				aria-label={sortDir === "asc" ? "Sort descending" : "Sort ascending"}
 				onClick={() => setSortDir((d) => (d === "asc" ? "desc" : "asc"))}
-				class="btn btn-outline btn-sm"
 			>
 				{sortDir === "asc" ? "↑" : "↓"}
-			</button>
+			</Button>
 		</span>
 	);
 }


### PR DESCRIPTION
## Summary
- Migrates 8 hand-rolled `.btn` call sites across ProjectLanding.tsx (2), ProjectList.tsx (3), SprintBannerSection.tsx (2), Toolbar.tsx (1) to the `Button` component.
- Drops the manual `opacity-60` template-literal class in ProjectLanding.tsx and the `style={{opacity:...}}` on ProjectList.tsx's submit button — `.btn:disabled { opacity: 0.45; cursor: not-allowed; }` in Base.astro already dims disabled buttons, so both were redundant with `disabled={saving|submitting}`.
- Grep-verified no raw hex literals in the 4 target files. Found 4 raw `rgba(...)` literals in SprintBannerSection.tsx's `sprintStatusStyle` (blue/green status tints). Neither has a matching `var(--*)` alpha token in Base.astro (no `--status-in-progress-bg/border` or `--status-done-bg/border` tokens exist), so per PROJ-536 instructions these are left as-is with TODO comments flagging the gap rather than inventing new tokens.

## Test plan
- [x] `pnpm exec biome check --write <4 files>` — no fixes needed
- [x] `pnpm exec vitest run src/islands/ProjectLanding.test.tsx src/islands/ProjectList.test.tsx` — 14/14 pass
- [x] `pnpm --filter web test` — 575/575 tests pass, no new failures
- [x] `grep -n 'class=.*"btn '` on the 4 files — no matches
- [x] `git status --short` — only the 4 target files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01548ouh4go9LE9JxnEmEyAv