### PR TITLE
refactor(design-system): migrate ShareView/SprintManager to Button/Badge

### DIFF
--- a/apps/web/src/islands/ShareView.tsx
+++ b/apps/web/src/islands/ShareView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "preact/hooks";
 import { apiFetch } from "../utils/api-client";
 import { renderMd, renderMermaidDiagrams } from "../utils/markdown";
+import { Badge } from "./ui/Badge";
 
 interface SharedIssue {
 	title: string;
@@ -98,13 +99,12 @@ function IssueHeader({ issue }: { issue: SharedIssue }) {
 				}}
 			>
 				{/* Priority badge */}
-				<span class="badge" style={{ background: priorityStyle.bg, color: priorityStyle.text }}>
+				<Badge style={{ background: priorityStyle.bg, color: priorityStyle.text }}>
 					{PRIORITY_LABELS[issue.priority] ?? issue.priority}
-				</span>
+				</Badge>
 				{/* Status badge */}
 				{issue.status_name && (
-					<span
-						class="badge"
+					<Badge
 						style={{
 							background: "var(--surface)",
 							color: "var(--text-muted)",
@@ -112,7 +112,7 @@ function IssueHeader({ issue }: { issue: SharedIssue }) {
 						}}
 					>
 						{issue.status_name}
-					</span>
+					</Badge>
 				)}
 				{/* Project */}
 				{issue.project_name && (

--- a/apps/web/src/islands/SprintManager.tsx
+++ b/apps/web/src/islands/SprintManager.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useState } from "preact/hooks";
 import { apiFetch } from "../utils/api-client";
 import { issueUrl } from "../utils/issue-url";
 import type { CustomFieldValue, ProjectLookup as Project } from "./board-utils";
+import { Badge } from "./ui/Badge";
+import { Button } from "./ui/Button";
 
 export interface Sprint {
 	id: string;
@@ -48,17 +50,17 @@ function getStoryPoints(issue: Issue): number {
 function statusBadge(status: Sprint["status"]) {
 	const styles: Record<Sprint["status"], { bg: string; color: string }> = {
 		planned: { bg: "var(--surface)", color: "var(--text-muted)" },
-		active: { bg: "rgba(37,99,235,0.12)", color: "var(--status-in-progress)" },
-		completed: { bg: "rgba(22,163,74,0.12)", color: "var(--status-done)" },
+		active: { bg: "var(--sprint-active-bg)", color: "var(--status-in-progress)" },
+		completed: { bg: "var(--sprint-completed-bg)", color: "var(--status-done)" },
 	};
 	const s = styles[status] ?? styles.planned;
 	return (
-		<span
-			class="badge border border-current font-semibold capitalize"
+		<Badge
+			class="border border-current font-semibold capitalize"
 			style={{ background: s.bg, color: s.color }}
 		>
 			{status}
-		</span>
+		</Badge>
 	);
 }
 
@@ -521,9 +523,9 @@ function SprintManagerContent({
 			<div class="flex justify-between items-center mb-4">
 				<p class="m-0 text-sm text-text-muted">{sprintCountLabel(sprints.length)}</p>
 				{!createForm.showCreate && (
-					<button type="button" class="btn btn-primary btn-sm" onClick={createForm.open}>
+					<Button variant="primary" size="sm" onClick={createForm.open}>
 						+ New sprint
-					</button>
+					</Button>
 				)}
 			</div>
 
@@ -772,21 +774,24 @@ function CreateSprintForm({
 				)}
 
 				<div class="flex gap-2 max-sm:flex-col">
-					<button
+					<Button
 						type="submit"
-						class="btn btn-primary btn-sm max-sm:w-full"
+						variant="primary"
+						size="sm"
+						class="max-sm:w-full"
 						disabled={creating || !createName.trim()}
 					>
 						{creating ? "Creating…" : "Create sprint"}
-					</button>
-					<button
-						type="button"
-						class="btn btn-outline btn-sm max-sm:w-full"
+					</Button>
+					<Button
+						variant="outline"
+						size="sm"
+						class="max-sm:w-full"
 						onClick={onCancel}
 						disabled={creating}
 					>
 						Cancel
-					</button>
+					</Button>
 				</div>
 			</form>
 		</div>
@@ -814,25 +819,20 @@ function SprintCompleteControls({
 }: SprintCompleteControlsProps) {
 	if (!active) {
 		return (
-			<button type="button" class="btn btn-outline btn-sm" onClick={() => onStart(sprintId)}>
+			<Button variant="outline" size="sm" onClick={() => onStart(sprintId)}>
 				Complete sprint
-			</button>
+			</Button>
 		);
 	}
 	return (
 		<span class="inline-flex gap-[0.375rem] items-center">
 			<span class="text-[0.8rem] text-text-muted">Mark complete?</span>
-			<button
-				type="button"
-				class="btn btn-danger btn-sm"
-				disabled={completing}
-				onClick={() => onConfirm(sprintId)}
-			>
+			<Button variant="danger" size="sm" disabled={completing} onClick={() => onConfirm(sprintId)}>
 				{completing ? "…" : "Yes, complete"}
-			</button>
-			<button type="button" class="btn btn-outline btn-sm" disabled={completing} onClick={onCancel}>
+			</Button>
+			<Button variant="outline" size="sm" disabled={completing} onClick={onCancel}>
 				Cancel
-			</button>
+			</Button>
 			{completeError && <span class="text-[var(--danger-text)] text-xs">{completeError}</span>}
 		</span>
 	);
@@ -873,12 +873,14 @@ function SprintRow({
 				</span>
 			</div>
 			<div class="flex gap-2 items-center flex-wrap">
-				<a
+				<Button
+					as="a"
 					href={`/issues?sprintId=${encodeURIComponent(sprint.id)}`}
-					class="btn btn-outline btn-sm"
+					variant="outline"
+					size="sm"
 				>
 					View issues →
-				</a>
+				</Button>
 
 				{sprint.status === "active" && (
 					<SprintCompleteControls

--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -118,6 +118,9 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
         --status-in-review: #7c3aed;
         --status-done: #16a34a;
         --status-cancelled: #dc2626;
+        /* Sprint status badge tokens (light) */
+        --sprint-active-bg: rgba(37, 99, 235, 0.12);
+        --sprint-completed-bg: rgba(22, 163, 74, 0.12);
         /* Danger action tokens (light) */
         --danger-text: #dc2626;
         --danger-bg: rgba(220, 38, 38, 0.10);
@@ -164,6 +167,9 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
           --status-in-review: #c4b5fd;
           --status-done: #4ade80;
           --status-cancelled: #f87171;
+          /* Sprint status badge tokens (dark) */
+          --sprint-active-bg: rgba(37, 99, 235, 0.12);
+          --sprint-completed-bg: rgba(22, 163, 74, 0.12);
           /* Danger action tokens (dark) - brighter red stays readable on near-black */
           --danger-text: #f87171;
           --danger-bg: rgba(248, 113, 113, 0.12);
@@ -205,6 +211,8 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
         --status-in-review: #c4b5fd;
         --status-done: #4ade80;
         --status-cancelled: #f87171;
+        --sprint-active-bg: rgba(37, 99, 235, 0.12);
+        --sprint-completed-bg: rgba(22, 163, 74, 0.12);
         --danger-text: #f87171;
         --danger-bg: rgba(248, 113, 113, 0.12);
         --danger-border: rgba(248, 113, 113, 0.32);
@@ -242,6 +250,8 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
         --status-in-review: #7c3aed;
         --status-done: #16a34a;
         --status-cancelled: #dc2626;
+        --sprint-active-bg: rgba(37, 99, 235, 0.12);
+        --sprint-completed-bg: rgba(22, 163, 74, 0.12);
         --danger-text: #dc2626;
         --danger-bg: rgba(220, 38, 38, 0.10);
         --danger-border: rgba(220, 38, 38, 0.30);


### PR DESCRIPTION
## Summary
- Migrates ShareView.tsx's two priority/status badges to the `Badge` component (import from `./ui/Badge`), preserving the existing `PRIORITY_COLORS` token-based style passthrough.
- Migrates SprintManager.tsx's 6 `.btn` call sites to `Button` (named import from `./ui/Button`), mapping `btn-primary`→`variant="primary"`, `btn-outline`→`variant="outline"`, `btn-danger`→`variant="danger"`, `btn-sm`→`size="sm"`, and the `<a class="btn btn-outline btn-sm">` to `<Button as="a" ...>`. Utility classes like `max-sm:w-full` are preserved via `class` passthrough.
- Migrates SprintManager.tsx's `statusBadge()` span to `Badge`. Replaces its raw `rgba(37,99,235,0.12)` / `rgba(22,163,74,0.12)` literals with new CSS custom properties `--sprint-active-bg` / `--sprint-completed-bg`, added to all four theme blocks in `Base.astro` (`:root`, `@media (prefers-color-scheme: dark)`, `[data-theme='dark']`, `[data-theme='light']`) — same rgba value in both themes since these are already semi-transparent overlays.

All 3 badge sites migrated to `Badge` (its `style` prop cleanly supports per-instance colors, confirmed via `Badge.tsx`/`Badge.test.tsx`).

## Test plan
- [x] `pnpm exec biome check --write` on changed files — no issues
- [x] `pnpm exec vitest run src/islands/ShareView.test.tsx src/islands/SprintManager.test.tsx` — 21 passed (no test changes needed; existing tests already use role/text queries)
- [x] `pnpm --filter web test` — 575 passed, 54 files, no new failures
- [x] Grep-verified no remaining `.btn`/`.badge` classes in either target file
- [x] `git status --short` — only `ShareView.tsx`, `SprintManager.tsx`, `Base.astro` changed

Refs PROJ-537.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01548ouh4go9LE9JxnEmEyAv