### PR TITLE
fix(design-system): replace raw hex/rgb literals with tokens in remaining files

### DIFF
--- a/apps/web/src/islands/ApiHealth.tsx
+++ b/apps/web/src/islands/ApiHealth.tsx
@@ -11,5 +11,5 @@ export default function ApiHealth() {
 			.then(setStatus);
 	}, []);
 
-	return <p style={{ fontSize: "0.9rem", color: "#666" }}>API status: {status}</p>;
+	return <p style={{ fontSize: "0.9rem", color: "var(--text-muted)" }}>API status: {status}</p>;
 }

--- a/apps/web/src/islands/IssueDetail.tsx
+++ b/apps/web/src/islands/IssueDetail.tsx
@@ -514,7 +514,7 @@ function IssueDetailView(
 			{props.blockedByLinks.length > 0 && (
 				<div
 					role="alert"
-					class="mb-4 px-[0.875rem] py-2 bg-[rgba(251,191,36,0.12)] border border-[rgba(251,191,36,0.5)]
+					class="mb-4 px-[0.875rem] py-2 bg-[var(--warning-bg)] border border-[var(--warning-border)]
 						rounded-md text-sm text-text-base flex items-center gap-2"
 				>
 					<span>⚠</span>

--- a/apps/web/src/islands/SprintManager.tsx
+++ b/apps/web/src/islands/SprintManager.tsx
@@ -137,7 +137,7 @@ function CompletionSummaryPanel({
 	const doneSP = doneIssues.reduce((sum, i) => sum + getStoryPoints(i), 0);
 
 	return (
-		<div class="mb-6 px-5 py-4 bg-[rgba(22,163,74,0.06)] border border-[rgba(22,163,74,0.3)] rounded-lg">
+		<div class="mb-6 px-5 py-4 bg-[var(--success-bg)] border border-[var(--success-border)] rounded-lg">
 			<div class="flex justify-between items-start mb-3">
 				<h3 class="m-0 text-base font-semibold text-text-base">Sprint complete: {sprint.name}</h3>
 				<button
@@ -226,7 +226,7 @@ function VelocityChart({ data, loading }: { data: SprintVelocity[]; loading: boo
 										class="relative w-full rounded-t"
 										style={{
 											height: `${Math.max(totalH, 2)}px`,
-											background: "rgba(37,99,235,0.15)",
+											background: "var(--velocity-bar-bg)",
 										}}
 									>
 										{doneH > 0 && (
@@ -258,7 +258,7 @@ function VelocityChart({ data, loading }: { data: SprintVelocity[]; loading: boo
 						<span class="inline-flex items-center gap-1">
 							<span
 								class="inline-block w-3 h-2 rounded-sm"
-								style={{ background: "rgba(37,99,235,0.15)" }}
+								style={{ background: "var(--velocity-bar-bg)" }}
 							/>
 							Total SP
 						</span>
@@ -615,8 +615,8 @@ function SprintBreadcrumb({ project }: { project: Project | null }) {
 }
 
 const ACTIVE_SPRINT_NOTICE_CLASS =
-	"mb-4 px-[0.875rem] py-[0.625rem] bg-[rgba(37,99,235,0.08)] " +
-	"border border-[rgba(37,99,235,0.25)] rounded-md text-sm text-[var(--status-in-progress)]";
+	"mb-4 px-[0.875rem] py-[0.625rem] bg-[var(--sprint-notice-bg)] " +
+	"border border-[var(--sprint-notice-border)] rounded-md text-sm text-[var(--status-in-progress)]";
 
 function ActiveSprintNotice({ sprints }: { sprints: Sprint[] }) {
 	const active = sprints.find((s) => s.status === "active");

--- a/apps/web/src/islands/issue-list/BoardView.tsx
+++ b/apps/web/src/islands/issue-list/BoardView.tsx
@@ -151,7 +151,7 @@ export default function BoardView({
 							].join(" ")}
 							style={{
 								border: `1px solid ${isOver ? "var(--accent)" : "var(--border)"}`,
-								background: isOver ? "rgba(37,99,235,0.04)" : "var(--bg)",
+								background: isOver ? "var(--dropzone-bg)" : "var(--bg)",
 							}}
 						>
 							{colIssues.length === 0 ? (

--- a/apps/web/src/islands/issue-list/FiltersPopover.tsx
+++ b/apps/web/src/islands/issue-list/FiltersPopover.tsx
@@ -5,10 +5,10 @@ import { categoryColor, type TaskStatus } from "../board-utils";
 export type DateField = "" | "completed" | "updated";
 
 const PILL_COLORS: Record<string, { bg: string; text: string }> = {
-	urgent: { bg: "#dc2626", text: "#fff" },
-	high: { bg: "#d97706", text: "#fff" },
-	medium: { bg: "#2563eb", text: "#fff" },
-	low: { bg: "#6b7280", text: "#fff" },
+	urgent: { bg: "var(--priority-urgent-solid)", text: "var(--on-accent)" },
+	high: { bg: "var(--priority-high-solid)", text: "var(--on-accent)" },
+	medium: { bg: "var(--priority-medium-solid)", text: "var(--on-accent)" },
+	low: { bg: "var(--priority-low-solid)", text: "var(--on-accent)" },
 };
 
 function StatusPills({
@@ -39,7 +39,7 @@ function StatusPills({
 							borderRadius: "9999px",
 							border: active ? "none" : "1px solid var(--border)",
 							background: active ? categoryColor(s.category) : "var(--bg)",
-							color: active ? "#fff" : "var(--text)",
+							color: active ? "var(--on-accent)" : "var(--text)",
 							cursor: "pointer",
 							fontSize: "0.8rem",
 							fontWeight: active ? 600 : 400,
@@ -180,7 +180,7 @@ function FiltersToggleButton({
 }) {
 	const activeStyle =
 		activeFilterCount > 0
-			? { border: "none", background: "var(--accent)", color: "#fff", fontWeight: 600 }
+			? { border: "none", background: "var(--accent)", color: "var(--on-accent)", fontWeight: 600 }
 			: {
 					border: "1px solid var(--border)",
 					background: "var(--bg)",

--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -105,6 +105,11 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
         --priority-low-bg: rgba(107, 114, 128, 0.12);
         --priority-none-text: var(--priority-low-text);
         --priority-none-bg: var(--priority-low-bg);
+        /* Priority solid pill tokens (light) - filled swatches (e.g. filter pills), not text-on-surface */
+        --priority-urgent-solid: #dc2626;
+        --priority-high-solid: #d97706;
+        --priority-medium-solid: #2563eb;
+        --priority-low-solid: #6b7280;
         /* Code tokens (light) - dark text on clearly-distinct slate-200 bg */
         --code-color: #1e293b;
         --code-bg: #dde3ea;
@@ -126,6 +131,19 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
         --danger-text: #dc2626;
         --danger-bg: rgba(220, 38, 38, 0.10);
         --danger-border: rgba(220, 38, 38, 0.30);
+        /* Warning banner tokens (light) */
+        --warning-bg: rgba(251, 191, 36, 0.12);
+        --warning-border: rgba(251, 191, 36, 0.5);
+        /* Success banner tokens (light) */
+        --success-bg: rgba(22, 163, 74, 0.06);
+        --success-border: rgba(22, 163, 74, 0.3);
+        /* Board dropzone token (light) */
+        --dropzone-bg: rgba(37, 99, 235, 0.04);
+        /* Sprint notice banner tokens (light) */
+        --sprint-notice-bg: rgba(37, 99, 235, 0.08);
+        --sprint-notice-border: rgba(37, 99, 235, 0.25);
+        /* Velocity chart bar-track token (light) */
+        --velocity-bar-bg: rgba(37, 99, 235, 0.15);
         /* Chart series tokens (light) - metrics dashboard */
         --chart-secondary: #d97706;
         --chart-seq-1: #86b6ef;
@@ -155,6 +173,11 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
           --priority-medium-bg: rgba(129, 140, 248, 0.18);
           --priority-low-text: #cbd5e1;
           --priority-low-bg: rgba(148, 163, 184, 0.18);
+          /* Priority solid pill tokens (dark) - brighter for contrast on near-black */
+          --priority-urgent-solid: #f87171;
+          --priority-high-solid: #f59e0b;
+          --priority-medium-solid: #60a5fa;
+          --priority-low-solid: #94a3b8;
           /* Code tokens (dark) - light text on slightly deeper slate bg */
           --code-color: #e2e8f0;
           --code-bg: #141b2b;
@@ -176,6 +199,19 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
           --danger-text: #f87171;
           --danger-bg: rgba(248, 113, 113, 0.12);
           --danger-border: rgba(248, 113, 113, 0.32);
+          /* Warning banner tokens (dark) - lighter amber tint at higher alpha */
+          --warning-bg: rgba(252, 211, 77, 0.18);
+          --warning-border: rgba(252, 211, 77, 0.55);
+          /* Success banner tokens (dark) - lighter green tint at higher alpha */
+          --success-bg: rgba(74, 222, 128, 0.12);
+          --success-border: rgba(74, 222, 128, 0.4);
+          /* Board dropzone token (dark) - lighter indigo tint at higher alpha */
+          --dropzone-bg: rgba(129, 140, 248, 0.08);
+          /* Sprint notice banner tokens (dark) - lighter indigo tint at higher alpha */
+          --sprint-notice-bg: rgba(129, 140, 248, 0.12);
+          --sprint-notice-border: rgba(129, 140, 248, 0.35);
+          /* Velocity chart bar-track token (dark) - lighter indigo tint at higher alpha */
+          --velocity-bar-bg: rgba(129, 140, 248, 0.20);
           /* Chart series tokens (dark) - metrics dashboard */
           --chart-secondary: #d97706;
           --chart-seq-1: #bcd7f7;
@@ -203,6 +239,10 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
         --priority-medium-bg: rgba(129, 140, 248, 0.18);
         --priority-low-text: #cbd5e1;
         --priority-low-bg: rgba(148, 163, 184, 0.18);
+        --priority-urgent-solid: #f87171;
+        --priority-high-solid: #f59e0b;
+        --priority-medium-solid: #60a5fa;
+        --priority-low-solid: #94a3b8;
         --code-color: #e2e8f0;
         --code-bg: #141b2b;
         --epic-text: #c4b5fd;
@@ -219,6 +259,14 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
         --danger-text: #f87171;
         --danger-bg: rgba(248, 113, 113, 0.12);
         --danger-border: rgba(248, 113, 113, 0.32);
+        --warning-bg: rgba(252, 211, 77, 0.18);
+        --warning-border: rgba(252, 211, 77, 0.55);
+        --success-bg: rgba(74, 222, 128, 0.12);
+        --success-border: rgba(74, 222, 128, 0.4);
+        --dropzone-bg: rgba(129, 140, 248, 0.08);
+        --sprint-notice-bg: rgba(129, 140, 248, 0.12);
+        --sprint-notice-border: rgba(129, 140, 248, 0.35);
+        --velocity-bar-bg: rgba(129, 140, 248, 0.20);
         --chart-secondary: #d97706;
         --chart-seq-1: #bcd7f7;
         --chart-seq-2: #8ab8f0;
@@ -243,6 +291,10 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
         --priority-medium-bg: rgba(79, 70, 229, 0.12);
         --priority-low-text: #6b7280;
         --priority-low-bg: rgba(107, 114, 128, 0.12);
+        --priority-urgent-solid: #dc2626;
+        --priority-high-solid: #d97706;
+        --priority-medium-solid: #2563eb;
+        --priority-low-solid: #6b7280;
         --code-color: #1e293b;
         --code-bg: #dde3ea;
         --epic-text: #7c3aed;
@@ -259,6 +311,14 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
         --danger-text: #dc2626;
         --danger-bg: rgba(220, 38, 38, 0.10);
         --danger-border: rgba(220, 38, 38, 0.30);
+        --warning-bg: rgba(251, 191, 36, 0.12);
+        --warning-border: rgba(251, 191, 36, 0.5);
+        --success-bg: rgba(22, 163, 74, 0.06);
+        --success-border: rgba(22, 163, 74, 0.3);
+        --dropzone-bg: rgba(37, 99, 235, 0.04);
+        --sprint-notice-bg: rgba(37, 99, 235, 0.08);
+        --sprint-notice-border: rgba(37, 99, 235, 0.25);
+        --velocity-bar-bg: rgba(37, 99, 235, 0.15);
         --chart-secondary: #d97706;
         --chart-seq-1: #86b6ef;
         --chart-seq-2: #5598e7;


### PR DESCRIPTION
## Summary
- Task 13 of PROJ-527 (tracked as PROJ-541): pure token replacement for raw hex/rgb color literals in IssueDetail.tsx, BoardView.tsx, FiltersPopover.tsx, and ApiHealth.tsx.
- Adds new CSS custom properties to Base.astro (all 4 theme blocks — `:root`, `prefers-color-scheme: dark`, `[data-theme='dark']`, `[data-theme='light']`) for cases with no existing matching token: `--warning-bg`/`--warning-border`, `--success-bg`/`--success-border`, `--dropzone-bg`, `--sprint-notice-bg`/`--sprint-notice-border`, `--velocity-bar-bg`, and `--priority-{urgent,high,medium,low}-solid` (opaque swatch variants for filled pill backgrounds, distinct from the existing tint-based `--priority-*-text`/`-bg` tokens). Dark-mode values follow the established convention of a lighter hue at a higher alpha relative to light mode.
- Also fixed a Task 9 coverage gap in SprintManager.tsx (flagged as a known risk in PROJ-541): completion summary panel, velocity chart bars, and the active-sprint notice banner still had raw `rgba()` literals — these now use the new tokens above.

## Verification
- `grep -n '#[0-9a-fA-F]{3,8}\|rgba?(' apps/web/src/islands/IssueDetail.tsx apps/web/src/islands/issue-list/BoardView.tsx apps/web/src/islands/issue-list/FiltersPopover.tsx apps/web/src/islands/ApiHealth.tsx apps/web/src/islands/SprintManager.tsx` — no matches
- `pnpm --filter web test` — 575 tests passed
- `pnpm biome check apps/web/src` — clean
- Local pre-commit hook (type-check across workspace, lint) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01548ouh4go9LE9JxnEmEyAv