### PR TITLE
feat(design-system): implement Rule 2 — AST-based per-primitive import boundary

### DIFF
--- a/plugins/design-system/expected.json
+++ b/plugins/design-system/expected.json
@@ -25,6 +25,32 @@
       "end_byte": 369,
       "message": "Raw color literal \"rgba(\" — use a var(--*) token from Base.astro instead.",
       "baselined": false
+    },
+    {
+      "id": "Warning.DesignSystemConvention",
+      "category": "warning",
+      "priority": 15,
+      "severity": "high",
+      "file": "fixtures/apps/web/src/islands/fixture.tsx",
+      "line": 19,
+      "column": 34,
+      "start_byte": 660,
+      "end_byte": 671,
+      "message": "Hand-rolled \"btn\" markup — import Button from islands/ui instead of using the raw class.",
+      "baselined": false
+    },
+    {
+      "id": "Warning.DesignSystemConvention",
+      "category": "warning",
+      "priority": 15,
+      "severity": "high",
+      "file": "fixtures/apps/web/src/islands/fixture.tsx",
+      "line": 29,
+      "column": 15,
+      "start_byte": 1063,
+      "end_byte": 1074,
+      "message": "Hand-rolled \"btn\" markup — import Button from islands/ui instead of using the raw class.",
+      "baselined": false
     }
   ]
 }

--- a/plugins/design-system/fixtures/apps/web/src/islands/fixture.tsx
+++ b/plugins/design-system/fixtures/apps/web/src/islands/fixture.tsx
@@ -12,6 +12,37 @@ const link = <a href="#add">Add</a>;
 
 // Rule 2: import boundary
 
+import { Select } from "./ui/Select";
+
+// Positive: hand-rolled .btn markup with no Button import anywhere in this
+// file — flagged.
+const handRolledButton = <button class="btn">Click</button>;
+
+// Regression: this section imports Select (an unrelated primitive family)
+// but still has a raw .btn-classed element — proves per-primitive-family
+// gating isn't silenced by an unrelated islands/ui import. Named for
+// clarity per the task spec.
+function HandRolledStillFlaggedDespiteUnrelatedImport() {
+  return (
+    <div>
+      <Select options={[]} />
+      <button class="btn">Still flagged</button>
+    </div>
+  );
+}
+
+// Negative: an element correctly using the Button component — no raw
+// class="btn" literal, so it's never a Rule 2 candidate regardless of
+// import state. Deliberately NOT importing Button here: the importedNames
+// set built from ImportDeclaration is file-scoped, not scope-local, so
+// importing Button anywhere in this file would also suppress the
+// positive case above — fixtures aren't type-checked (tsconfig only
+// includes src/index.ts), so the missing import doesn't break `npm run
+// build`.
+function UsesButtonCorrectly() {
+  return <Button>OK</Button>;
+}
+
 // Rule 3: new primitive-shaped CSS class
 
 // Rule 4: inline token-shaped style

--- a/plugins/design-system/src/index.ts
+++ b/plugins/design-system/src/index.ts
@@ -8,6 +8,22 @@
 
 import { Category, defineCheck, Severity } from "@cofferdam/check-sdk";
 
+// Rule 2 is deliberately AST-based and per-primitive-family (NOT a
+// whole-file "does this file import anything from islands/ui" gate) — a
+// file-level gate goes permanently blind to every OTHER primitive family's
+// findings once any one islands/ui import exists in that file. Confirmed
+// by review.
+const PRIMITIVE_FAMILIES: { pattern: RegExp; importedFrom: string; label: string }[] = [
+  { pattern: /\bbtn\b/, importedFrom: "Button", label: "btn" },
+  { pattern: /\bbadge\b/, importedFrom: "Badge", label: "badge" },
+  { pattern: /\bselect-(button|menu|caret|option)\b/, importedFrom: "Select", label: "select-*" },
+  {
+    pattern: /\b(account-menu-popover|metric-help-popover|popover-account-menu|popover-metric-help|popover-select-menu)\b/,
+    importedFrom: "Popover",
+    label: "popover",
+  },
+];
+
 const RAW_COLOR_PATTERN = /#[0-9a-fA-F]{3,8}\b|rgba?\(/g;
 // A bare hex-shaped token isn't necessarily a color — href="#add" or
 // id="#deed" are valid hex-digit strings but not colors. rgb(/rgba( are
@@ -52,6 +68,26 @@ export default defineCheck({
           message: `Raw color literal "${m[0]}" — use a var(--*) token from Base.astro instead.`,
           span: ln.spanFor(m.index, m.index + m[0].length),
         });
+      }
+    }
+
+    if (file.ast) {
+      const importedNames = new Set<string>();
+      for (const imp of file.ast.findAll("ImportDeclaration")) {
+        if (!/\/ui\/(Button|Badge|Select|Popover)$/.test(imp.source)) continue;
+        for (const spec of imp.specifiers) importedNames.add(spec.imported ?? spec.localName);
+      }
+      for (const el of file.ast.findAll("JSXElement")) {
+        const classAttr = el.attributes.find((a) => a.name === "class" || a.name === "className");
+        if (!classAttr || classAttr.value === undefined) continue; // skip dynamic/expression class values
+        for (const family of PRIMITIVE_FAMILIES) {
+          if (!family.pattern.test(classAttr.value)) continue;
+          if (importedNames.has(family.importedFrom)) continue;
+          ctx.report({
+            message: `Hand-rolled "${family.label}" markup — import ${family.importedFrom} from islands/ui instead of using the raw class.`,
+            span: classAttr.span,
+          });
+        }
       }
     }
   },


### PR DESCRIPTION
## Summary
- Task 16 of PROJ-527 design-system epic (tracked as PROJ-544).
- Implements Rule 2 in `plugins/design-system/src/index.ts`: an AST-based, per-primitive-family import-boundary check. Flags hand-rolled `btn`/`badge`/`select-*`/popover-classed JSX markup unless the matching primitive (Button/Badge/Select/Popover) is imported from `islands/ui/*` anywhere in the file.
- Deliberately per-primitive-family, not a whole-file gate — an import of one primitive family does not silence findings for a different family in the same file (regression case in the fixture proves this).
- Added Rule 2 fixture cases to `fixture.tsx`: a positive hand-rolled `.btn` case (no Button import), a regression case (`HandRolledStillFlaggedDespiteUnrelatedImport`, imports `Select` but still flags a raw `.btn`), and a negative case using the actual `Button` component.
- Updated `expected.json` with real captured line/column/byte spans for the 2 new Rule 2 findings; Rule 1's existing 2 entries are unchanged (line numbers didn't shift).

## Test plan
- [x] `cd plugins/design-system && npm run build` — passes
- [x] `npm test` — `OK — 4 DesignSystemConvention finding(s) match expected.json`
- [x] `cd plugins/island-api && npm run test` — unaffected, `OK — 5 IslandApiConvention finding(s) match expected.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01548ouh4go9LE9JxnEmEyAv