### PR TITLE
feat(design-system): implement DesignSystemConvention rule 3 (new primitive-shaped CSS class)

### DIFF
--- a/plugins/design-system/expected.json
+++ b/plugins/design-system/expected.json
@@ -51,6 +51,19 @@
       "end_byte": 1074,
       "message": "Hand-rolled \"btn\" markup — import Button from islands/ui instead of using the raw class.",
       "baselined": false
+    },
+    {
+      "id": "Warning.DesignSystemConvention",
+      "category": "warning",
+      "priority": 15,
+      "severity": "high",
+      "file": "fixtures/apps/web/src/islands/fixture.tsx",
+      "line": 51,
+      "column": 1,
+      "start_byte": 1911,
+      "end_byte": 1937,
+      "message": "New primitive-shaped CSS class \".my-custom-dropdown-menu\" — reuse or extend an existing islands/ui primitive's CSS instead of defining a new one.",
+      "baselined": false
     }
   ]
 }

--- a/plugins/design-system/fixtures/apps/web/src/islands/fixture.tsx
+++ b/plugins/design-system/fixtures/apps/web/src/islands/fixture.tsx
@@ -45,4 +45,20 @@ function UsesButtonCorrectly() {
 
 // Rule 3: new primitive-shaped CSS class
 
+// Positive: hand-rolled CSS-in-JS-shaped rule for a new dropdown/menu class
+// — matches both the "dropdown" and "menu-" alternatives — flagged.
+const dropdownStyles = `
+.my-custom-dropdown-menu {
+  position: absolute;
+}
+`;
+
+// Negative: a CSS-in-JS-shaped rule for an unrelated class name — doesn't
+// match any of the primitive-name alternatives, so it's never flagged.
+const widgetStyles = `
+.my-widget {
+  display: flex;
+}
+`;
+
 // Rule 4: inline token-shaped style

--- a/plugins/design-system/src/index.ts
+++ b/plugins/design-system/src/index.ts
@@ -32,6 +32,8 @@ const RAW_COLOR_PATTERN = /#[0-9a-fA-F]{3,8}\b|rgba?\(/g;
 // necessary by review: the naive pattern false-positives on anchor hrefs.
 const COLOR_CONTEXT_PATTERN = /(color|background|border|shadow|fill|stroke)/i;
 
+const NEW_PRIMITIVE_CSS_CLASS_PATTERN = /\.[\w-]*(btn|badge|popover|dropdown|menu-)[\w-]*\s*\{/;
+
 // cofferdam-ignore: Design.OrphanExport: loaded dynamically via cofferdam.toml's `plugins = ["./plugins/design-system"]`, not a static import
 export default defineCheck({
   id: "DesignSystemConvention",
@@ -89,6 +91,16 @@ export default defineCheck({
           });
         }
       }
+    }
+
+    for (const ln of file.lines()) {
+      if (ln.isComment) continue;
+      const m = NEW_PRIMITIVE_CSS_CLASS_PATTERN.exec(ln.text);
+      if (!m) continue;
+      ctx.report({
+        message: `New primitive-shaped CSS class "${m[0].trim().replace(/\s*\{$/, "")}" — reuse or extend an existing islands/ui primitive's CSS instead of defining a new one.`,
+        span: ln.spanFor(m.index, m.index + m[0].length),
+      });
     }
   },
 });


### PR DESCRIPTION
## Summary
- Task 17 of PROJ-527 design-system epic (PROJ-545): adds Rule 3 to the DesignSystemConvention cofferdam plugin — a line-scan flagging hand-rolled `.btn`/`.badge`/`.popover`/`.dropdown`/`.menu-*`-shaped CSS class definitions instead of reusing islands/ui primitives.
- Fixture (`fixture.tsx`) gains a positive case (`.my-custom-dropdown-menu`) and a negative case (`.my-widget`) under the "Rule 3" section.
- `expected.json` updated with the 5th finding's real captured position; Rules 1 and 2 positions unchanged.

## Test plan
- [x] `npm run build` in plugins/design-system
- [x] `npm test` in plugins/design-system → `OK — 5 DesignSystemConvention finding(s) match expected.json`
- [x] `npm run test` in plugins/island-api unaffected → `OK — 5 IslandApiConvention finding(s) match expected.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01548ouh4go9LE9JxnEmEyAv