### PR TITLE
feat(design-system): implement DesignSystemConvention rule 4 (inline token-shaped style)

### DIFF
--- a/plugins/design-system/expected.json
+++ b/plugins/design-system/expected.json
@@ -64,6 +64,32 @@
       "end_byte": 1937,
       "message": "New primitive-shaped CSS class \".my-custom-dropdown-menu\" — reuse or extend an existing islands/ui primitive's CSS instead of defining a new one.",
       "baselined": false
+    },
+    {
+      "id": "Warning.DesignSystemConvention",
+      "category": "warning",
+      "priority": 15,
+      "severity": "high",
+      "file": "fixtures/apps/web/src/islands/fixture.tsx",
+      "line": 68,
+      "column": 41,
+      "start_byte": 2371,
+      "end_byte": 2390,
+      "message": "Inline style \"borderRadius: \"4px\"\" duplicates a primitive's CSS dimension — reuse the islands/ui primitive instead of hardcoding it.",
+      "baselined": false
+    },
+    {
+      "id": "Warning.DesignSystemConvention",
+      "category": "warning",
+      "priority": 15,
+      "severity": "high",
+      "file": "fixtures/apps/web/src/islands/fixture.tsx",
+      "line": 68,
+      "column": 62,
+      "start_byte": 2392,
+      "end_byte": 2419,
+      "message": "Inline style \"padding: \"0.375rem 0.75rem\"\" duplicates a primitive's CSS dimension — reuse the islands/ui primitive instead of hardcoding it.",
+      "baselined": false
     }
   ]
 }

--- a/plugins/design-system/fixtures/apps/web/src/islands/fixture.tsx
+++ b/plugins/design-system/fixtures/apps/web/src/islands/fixture.tsx
@@ -62,3 +62,10 @@ const widgetStyles = `
 `;
 
 // Rule 4: inline token-shaped style
+
+// Positive: inline style with token-shaped hardcoded values matching .btn's
+// border-radius and padding — flagged.
+const inlineTokenShaped = <div style={{ borderRadius: "4px", padding: "0.375rem 0.75rem" }}>Box</div>;
+
+// Negative: 12px isn't in the token-shaped list — never flagged.
+const inlineNotTokenShaped = <div style={{ borderRadius: "12px" }}>Box</div>;

--- a/plugins/design-system/src/index.ts
+++ b/plugins/design-system/src/index.ts
@@ -34,6 +34,28 @@ const COLOR_CONTEXT_PATTERN = /(color|background|border|shadow|fill|stroke)/i;
 
 const NEW_PRIMITIVE_CSS_CLASS_PATTERN = /\.[\w-]*(btn|badge|popover|dropdown|menu-)[\w-]*\s*\{/;
 
+// Values sourced from .btn's border-radius: 4px / padding: 0.375rem 0.75rem,
+// .badge's border-radius: 4px / padding: 0.125rem 0.5rem, and .popover-*'s
+// 6px / 8px border-radius. Both the camelCase JS-object form and the
+// CSS-text-string form are checked on the SAME LINE — a documented, accepted
+// limitation: multi-line style={{...}} objects would be missed, but every
+// real usage in this repo is single-line per its Prettier config.
+const TOKEN_SHAPED_STYLE_VALUES = [
+  "borderRadius:\\s*[\"']4px[\"']",
+  "borderRadius:\\s*[\"']6px[\"']",
+  "borderRadius:\\s*[\"']8px[\"']",
+  "padding:\\s*[\"']0\\.375rem 0\\.75rem[\"']",
+  "padding:\\s*[\"']0\\.125rem 0\\.5rem[\"']",
+  // CSS-text-string form, for completeness
+  "border-radius:\\s*4px",
+  "border-radius:\\s*6px",
+  "border-radius:\\s*8px",
+  "padding:\\s*0\\.375rem\\s*0\\.75rem",
+  "padding:\\s*0\\.125rem\\s*0\\.5rem",
+];
+const INLINE_STYLE_LINE_PATTERN = /style=(\{\{|")/;
+const TOKEN_SHAPED_VALUE_PATTERN = new RegExp(TOKEN_SHAPED_STYLE_VALUES.join("|"), "g");
+
 // cofferdam-ignore: Design.OrphanExport: loaded dynamically via cofferdam.toml's `plugins = ["./plugins/design-system"]`, not a static import
 export default defineCheck({
   id: "DesignSystemConvention",
@@ -101,6 +123,17 @@ export default defineCheck({
         message: `New primitive-shaped CSS class "${m[0].trim().replace(/\s*\{$/, "")}" — reuse or extend an existing islands/ui primitive's CSS instead of defining a new one.`,
         span: ln.spanFor(m.index, m.index + m[0].length),
       });
+    }
+
+    for (const ln of file.lines()) {
+      if (ln.isComment) continue;
+      if (!INLINE_STYLE_LINE_PATTERN.test(ln.text)) continue;
+      for (const m of ln.text.matchAll(TOKEN_SHAPED_VALUE_PATTERN)) {
+        ctx.report({
+          message: `Inline style "${m[0]}" duplicates a primitive's CSS dimension — reuse the islands/ui primitive instead of hardcoding it.`,
+          span: ln.spanFor(m.index, m.index + m[0].length),
+        });
+      }
     }
   },
 });


### PR DESCRIPTION
## Summary
- Adds Rule 4 to `plugins/design-system/src/index.ts`: flags inline `style={{...}}`/`style="..."` props whose value on the same line matches a hardcoded dimension already defined by `.btn`/`.badge`/`.popover-*` (border-radius: 4px/6px/8px, padding: 0.375rem 0.75rem, padding: 0.125rem 0.5rem), in both camelCase-JS and CSS-text-string forms.
- Both regex alternatives are matched independently per line via `matchAll` with a global flag, so a line with two token-shaped values produces two separate findings.
- Fixture (`fixtures/apps/web/src/islands/fixture.tsx`) gets a positive case (`borderRadius: "4px"` + `padding: "0.375rem 0.75rem"` on one line → 2 findings) and a negative case (`borderRadius: "12px"` → not flagged).
- `expected.json` updated to the actual observed total: **7 findings** (5 pre-existing + 2 new), not the plan's estimated 6 — both alternatives do fire independently on the shared line.

## Test plan
- [x] `cd plugins/design-system && npm run build && npm test` → `OK — 7 DesignSystemConvention finding(s) match expected.json`
- [x] `cd plugins/island-api && npm run test` → unaffected, `OK — 5 IslandApiConvention finding(s) match expected.json`
- [ ] CI green

Tracked as PROJ-546 (Task 18, PROJ-527 design-system epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01548ouh4go9LE9JxnEmEyAv