### PR TITLE
PROJ-559: wire DesignSystemConvention into CI and pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
       - run: pnpm --filter @projektor/docs build
       - name: Island API convention
         run: node scripts/check-island-api.mjs
+      - name: Design system convention
+        run: pnpm --filter @projektor/cofferdam-design-system build && node scripts/check-design-system.mjs
+      - name: Design system fixture regression test
+        run: pnpm --filter @projektor/cofferdam-design-system test
 # E2E tests: run manually with 'pnpm --filter @projektor/web test:e2e'
 # Long-running freeze regression tests (PROJ-310): 'pnpm --filter @projektor/web test:e2e:long'
 # Requires: E2E_BASE_URL pointing at a dev deployment with ENVIRONMENT=development and DEV_USER_EMAIL set.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,3 +6,5 @@ pre-commit:
       run: pnpm biome check --changed --no-errors-on-unmatched
     island-api:
       run: pnpm --filter @projektor/cofferdam-island-api build && node scripts/check-island-api.mjs
+    design-system:
+      run: pnpm --filter @projektor/cofferdam-design-system build && node scripts/check-design-system.mjs

--- a/scripts/check-design-system.mjs
+++ b/scripts/check-design-system.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+// Enforce the design-system convention via the DesignSystemConvention cofferdam
+// plugin (PROJ-527/PROJ-559) — no raw color literals, respect component import
+// boundaries, no new ad-hoc primitive-shaped CSS classes, no inline token-shaped
+// styles.
+//
+// `cofferdam check` has no single-check filter yet (CD-74), and this repo's
+// apps/web/src has pre-existing findings from unrelated built-in checks that
+// aren't this hook's concern — so this wrapper runs the full scan and gates
+// only on DesignSystemConvention findings, mirroring check-island-api.mjs.
+
+import { execFileSync } from "node:child_process";
+
+let raw;
+try {
+  raw = execFileSync("npx", ["--no-install", "cofferdam", "check", "apps/web/src", "--format", "json"], {
+    encoding: "utf8",
+    shell: process.platform === "win32",
+  });
+} catch (err) {
+  if (typeof err.stdout !== "string" || err.stdout.length === 0) throw err;
+  raw = err.stdout;
+}
+
+const { findings } = JSON.parse(raw);
+const violations = findings.filter((f) => f.id === "Warning.DesignSystemConvention");
+
+for (const v of violations) {
+  console.error(`ERROR: ${v.file}:${v.line} — ${v.message}`);
+}
+
+if (violations.length > 0) {
+  console.error(`\nDesign system convention: ${violations.length} violation(s)`);
+  process.exit(1);
+}
+
+console.log("Design system convention: OK");


### PR DESCRIPTION
## Summary
- The `plugins/design-system` cofferdam plugin (DesignSystemConvention check) existed and worked, but was never actually run by CI or the pre-commit hook, so the epic's core goal ("fails the build on future drift") was unmet. Fixes PROJ-559.
- Adds `scripts/check-design-system.mjs`, mirroring `scripts/check-island-api.mjs`: runs `cofferdam check apps/web/src --format json` and gates only on `Warning.DesignSystemConvention` findings.
- Adds a "Design system convention" step to `.github/workflows/ci.yml` (builds `plugins/design-system` first, then runs the new script), plus a separate step running the plugin's own fixture regression test (`pnpm --filter @projektor/cofferdam-design-system test`).
- Adds a matching `design-system` command to `lefthook.yml`'s pre-commit section, mirroring the existing `island-api` command.

## Test plan
- [x] `node scripts/check-design-system.mjs` gates non-zero on an injected violation, and 0 on a clean tree.
- [x] `pnpm --filter @projektor/cofferdam-design-system build` succeeds.
- [x] `cd plugins/design-system && npm test` passes (fixture regression).
- [x] `pnpm lint` (biome) and `pnpm turbo type-check` pass.
- [ ] CI green on this PR.

Refs PROJ-559.