### PR TITLE
docs: add Verdient backlink to Starlight footer

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -17,6 +17,9 @@ export default defineConfig({
 			description:
 				"A self-hosted, MCP-native Jira + wiki that runs in a single Cloudflare Worker.",
 			customCss: ["./src/styles/projektor.css"],
+			components: {
+				Footer: "./src/components/Footer.astro",
+			},
 			plugins: [
 				starlightLinksValidator({
 					// Bare dev-server URL in the mirrored AGENTS.md content, not a docs page.

--- a/apps/docs/src/components/Footer.astro
+++ b/apps/docs/src/components/Footer.astro
@@ -1,0 +1,20 @@
+---
+import Default from '@astrojs/starlight/components/Footer.astro';
+---
+
+<Default {...Astro.props}><slot /></Default>
+
+<p class="verdient-credit">
+	Built by <a href="https://verdient.co.uk" target="_blank" rel="noopener noreferrer">Verdient</a>.
+</p>
+
+<style>
+	.verdient-credit {
+		margin-top: 1rem;
+		font-size: var(--sl-text-xs);
+		color: var(--sl-color-gray-3);
+	}
+	.verdient-credit a {
+		color: var(--sl-color-gray-2);
+	}
+</style>


### PR DESCRIPTION
## Summary
- Poker Challenges' footer already credits Verdient as its builder; this adds the same reciprocal link on the public Projektor docs site.
- Overrides Starlight's Footer component to append a small "Built by Verdient" credit line below the default pagination/edit-link footer.

## Test plan
- [x] `pnpm build` in apps/docs succeeds, credit line present in built HTML
- [x] `pnpm type-check` in apps/docs passes with 0 errors
- [x] Root pre-commit hook (cofferdam + monorepo type-check) passed