### PR TITLE
fix(web): reset font-weight on MarkdownEditor root (PROJ-566)

### DIFF
--- a/apps/web/src/islands/LazyMarkdownEditor.test.tsx
+++ b/apps/web/src/islands/LazyMarkdownEditor.test.tsx
@@ -57,4 +57,13 @@ describe("LazyMarkdownEditor (PROJ-431)", () => {
 		const source = readFileSync(join(__dirname, "LazyMarkdownEditor.tsx"), "utf-8");
 		expect(source).toMatch(/text-base sm:text-sm/);
 	});
+
+	// PROJ-566: the fallback's textarea inherits font-weight via preflight the same way
+	// the real editor's CodeMirror content does — without this reset it briefly renders
+	// bold on a slow connection, matching the reported bug, until the real editor mounts.
+	it("resets font-weight on the fallback root so it can't inherit an ancestor's bold (PROJ-566)", () => {
+		const { container } = render(<LazyMarkdownEditor value="" onChange={() => {}} />);
+		const root = container.firstElementChild;
+		expect(root?.className).toContain("font-normal");
+	});
 });

--- a/apps/web/src/islands/LazyMarkdownEditor.tsx
+++ b/apps/web/src/islands/LazyMarkdownEditor.tsx
@@ -19,7 +19,7 @@ import type { Props } from "./MarkdownEditor";
 // is typed here is already in `value` when CodeMirror mounts and adopts it.
 function EditorFallback({ value, onChange, minHeight }: Props) {
 	return (
-		<div class="flex flex-col border border-border rounded overflow-hidden bg-bg normal-case">
+		<div class="flex flex-col border border-border rounded overflow-hidden bg-bg normal-case font-normal">
 			<div
 				class={
 					"px-2 py-[2px] text-[0.7rem] text-text-muted bg-surface border-b border-border " +

--- a/apps/web/src/islands/MarkdownEditor.test.tsx
+++ b/apps/web/src/islands/MarkdownEditor.test.tsx
@@ -62,6 +62,16 @@ describe("MarkdownEditor", () => {
 		expect(root?.className).toContain("normal-case");
 	});
 
+	it("resets font-weight so it can't inherit an ancestor's bold (PROJ-566)", () => {
+		// The create-issue Description sits inside a <label class="font-semibold">, and
+		// font-weight inherits — without this guard everything typed renders bold.
+		// The reset must live on the editor's own root so it holds wherever the
+		// editor is mounted.
+		const { container } = render(<MarkdownEditor value="" onChange={() => {}} />);
+		const root = container.firstElementChild;
+		expect(root?.className).toContain("font-normal");
+	});
+
 	describe("debounced preview render (PROJ-227)", () => {
 		beforeEach(() => {
 			vi.useFakeTimers();

--- a/apps/web/src/islands/MarkdownEditor.tsx
+++ b/apps/web/src/islands/MarkdownEditor.tsx
@@ -414,7 +414,7 @@ export default function MarkdownEditor({
 		useMarkdownCommands(viewRef);
 
 	return (
-		<div class="flex flex-col border border-border rounded overflow-hidden bg-bg normal-case">
+		<div class="flex flex-col border border-border rounded overflow-hidden bg-bg normal-case font-normal">
 			<EditorToolbar
 				onBold={bold}
 				onItalic={italic}


### PR DESCRIPTION
## Summary
- Fixes PROJ-566: the create-issue Description field defaulted to bold text.
- Root cause: `CreateIssueModal`'s Description `<label>` carries `font-semibold`; `font-weight` inherits into the CodeMirror editor, which never reset it. The Title `<input>` next to it already resets with `font-normal`, but `MarkdownEditor` didn't.
- Fix mirrors the existing PROJ-210 `text-transform` reset pattern: add the reset (`font-normal`) to the editor's own root so it holds wherever the component is mounted, not just this one call site.

## Test plan
- [x] Added a regression test asserting the root carries `font-normal`
- [x] `pnpm vitest run MarkdownEditor.test.tsx` passes
- [x] `pnpm turbo type-check` — 0 errors
- [x] `pnpm lint` (biome) clean
- [x] `pnpm --filter @projektor/web build` succeeds