### PR TITLE
feat(web): enable changing an issue's type from the human UI (PROJ-567)

### DIFF
--- a/apps/web/src/islands/IssueDetail.test.tsx
+++ b/apps/web/src/islands/IssueDetail.test.tsx
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { cleanup, render, screen, waitFor } from "@testing-library/preact";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/preact";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import IssueDetail from "./IssueDetail";
 
@@ -161,6 +161,9 @@ function setupFetch(issueData: IssueFixture, parentData?: IssueFixture) {
 				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
 			}
 			if (u.includes("task-statuses")) {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			}
+			if (u.includes("task-types")) {
 				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
 			}
 			// Parent fetch: /api/issues/<parent_id>
@@ -705,5 +708,84 @@ describe("PROJ-438 — inline prefetch script contract", () => {
 		const pathFallback = source.indexOf("pretty[1] + '-' + pretty[2]");
 		expect(idFirst).toBeGreaterThan(-1);
 		expect(pathFallback).toBeGreaterThan(idFirst);
+	});
+});
+
+// ─── PROJ-567: change issue type from the sidebar ─────────────────────────────
+
+describe("PROJ-567 — issue type change in the sidebar", () => {
+	const TASK_TYPES = [
+		{ id: "type-story", key: "story", name: "Story" },
+		{ id: "type-bug", key: "bug", name: "Bug" },
+	];
+
+	function setupFetchWithTypes(issueData: IssueFixture) {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation((url: string) => {
+				const u = String(url);
+				if (u.includes("/comments")) {
+					return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+				}
+				if (u.includes("/links")) {
+					return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+				}
+				if (u.includes("task-statuses")) {
+					return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+				}
+				if (u.includes("task-types")) {
+					return Promise.resolve({ ok: true, json: () => Promise.resolve(TASK_TYPES) });
+				}
+				if (u.includes("?parentId=")) {
+					return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [] }) });
+				}
+				return Promise.resolve({ ok: true, json: () => Promise.resolve(issueData) });
+			})
+		);
+	}
+
+	it("renders a Type select in the sidebar once task types load", async () => {
+		setupFetchWithTypes(PLAIN_ISSUE_DATA);
+		render(<IssueDetail issueId="plain-1" />);
+
+		await waitFor(() => {
+			expect(screen.getByLabelText("Change type")).toBeTruthy();
+		});
+	});
+
+	it("PATCHes the issue's typeId when a new type is chosen", async () => {
+		const fetchMock = vi.fn().mockImplementation((url: string, opts?: RequestInit) => {
+			const u = String(url);
+			if (opts?.method === "PATCH") {
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+			}
+			if (u.includes("/comments"))
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			if (u.includes("/links"))
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			if (u.includes("task-statuses"))
+				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+			if (u.includes("task-types"))
+				return Promise.resolve({ ok: true, json: () => Promise.resolve(TASK_TYPES) });
+			if (u.includes("?parentId="))
+				return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [] }) });
+			return Promise.resolve({ ok: true, json: () => Promise.resolve(PLAIN_ISSUE_DATA) });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		render(<IssueDetail issueId="plain-1" />);
+
+		const trigger = await screen.findByRole("combobox", { name: "Change type" });
+		fireEvent.click(trigger);
+		fireEvent.click(await screen.findByRole("option", { name: "Bug" }));
+
+		await waitFor(() => {
+			const patchCall = (fetchMock.mock.calls as [string, RequestInit][]).find(
+				([, opts]) => opts?.method === "PATCH"
+			);
+			expect(patchCall).toBeDefined();
+			const body = JSON.parse(String(patchCall?.[1]?.body));
+			expect(body.typeId).toBe("type-bug");
+		});
 	});
 });

--- a/apps/web/src/islands/IssueDetail.tsx
+++ b/apps/web/src/islands/IssueDetail.tsx
@@ -22,6 +22,7 @@ import type {
 	IssueLink,
 	Member,
 	TaskStatus,
+	TaskType,
 } from "./issue-detail-helpers";
 
 interface Props {
@@ -229,6 +230,7 @@ function useIssueCore({
 	const [issue, setIssue] = useState<IssueData | null>(seedIssue);
 	const [comments, setComments] = useState<Comment[]>([]);
 	const [statuses, setStatuses] = useState<TaskStatus[]>([]);
+	const [taskTypes, setTaskTypes] = useState<TaskType[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
 	const [members, setMembers] = useState<Member[]>([]);
@@ -280,6 +282,14 @@ function useIssueCore({
 			try {
 				const data = await apiFetch<TaskStatus[]>("/api/task-statuses", { workspaceSlug });
 				if (Array.isArray(data)) setStatuses(data);
+			} catch {
+				// non-fatal
+			}
+		})();
+		(async () => {
+			try {
+				const data = await apiFetch<TaskType[]>("/api/task-types", { workspaceSlug });
+				if (Array.isArray(data)) setTaskTypes(data);
 			} catch {
 				// non-fatal
 			}
@@ -343,6 +353,7 @@ function useIssueCore({
 		setIssue,
 		comments,
 		statuses,
+		taskTypes,
 		loading,
 		error,
 		members,
@@ -359,14 +370,17 @@ function useIssueMutations(
 		issueId: string;
 		workspaceSlug: string | undefined;
 		statuses: TaskStatus[];
+		taskTypes: TaskType[];
 		members: Member[];
 		fetchIssue: () => Promise<void>;
 	}>
 ) {
-	const { issue, setIssue, issueId, workspaceSlug, statuses, members, fetchIssue } = args;
+	const { issue, setIssue, issueId, workspaceSlug, statuses, taskTypes, members, fetchIssue } =
+		args;
 	const [updatingStatus, setUpdatingStatus] = useState(false);
 	const [updatingPriority, setUpdatingPriority] = useState(false);
 	const [updatingAssignee, setUpdatingAssignee] = useState(false);
+	const [updatingType, setUpdatingType] = useState(false);
 
 	async function changeStatus(statusId: string) {
 		if (!issue) return;
@@ -418,6 +432,35 @@ function useIssueMutations(
 		}
 	}
 
+	async function changeType(typeId: string) {
+		if (!issue) return;
+		const type = taskTypes.find((t) => t.id === typeId);
+
+		setIssue((prev) =>
+			prev
+				? {
+						...prev,
+						type_id: typeId || null,
+						type_key: type?.key ?? null,
+						type_name: type?.name ?? null,
+					}
+				: prev
+		);
+
+		setUpdatingType(true);
+		try {
+			await apiFetch(`/api/issues/${issueId}`, {
+				workspaceSlug,
+				method: "PATCH",
+				body: { typeId: typeId || null },
+			});
+		} catch {
+			await fetchIssue();
+		} finally {
+			setUpdatingType(false);
+		}
+	}
+
 	async function changeAssignee(assigneeId: string) {
 		if (!issue) return;
 		const member = members.find((m) => m.id === assigneeId) ?? null;
@@ -450,9 +493,11 @@ function useIssueMutations(
 		updatingStatus,
 		updatingPriority,
 		updatingAssignee,
+		updatingType,
 		changeStatus,
 		changePriority,
 		changeAssignee,
+		changeType,
 	};
 }
 
@@ -495,13 +540,16 @@ function IssueDetailView(
 		currentUserId: string | null;
 		fetchComments: () => Promise<void>;
 		statuses: TaskStatus[];
+		taskTypes: TaskType[];
 		members: Member[];
 		updatingStatus: boolean;
 		updatingPriority: boolean;
 		updatingAssignee: boolean;
+		updatingType: boolean;
 		changeStatus: (statusId: string) => void;
 		changePriority: (priority: string) => void;
 		changeAssignee: (assigneeId: string) => void;
+		changeType: (typeId: string) => void;
 		fetchIssue: () => Promise<void>;
 	}>
 ) {
@@ -592,13 +640,16 @@ function IssueDetailView(
 					issueId={issueId}
 					workspaceSlug={workspaceSlug}
 					statuses={props.statuses}
+					taskTypes={props.taskTypes}
 					members={props.members}
 					updatingStatus={props.updatingStatus}
 					updatingPriority={props.updatingPriority}
 					updatingAssignee={props.updatingAssignee}
+					updatingType={props.updatingType}
 					changeStatus={props.changeStatus}
 					changePriority={props.changePriority}
 					changeAssignee={props.changeAssignee}
+					changeType={props.changeType}
 					fetchIssue={props.fetchIssue}
 				/>
 			</div>
@@ -628,6 +679,7 @@ export default function IssueDetail({
 		setIssue,
 		comments,
 		statuses,
+		taskTypes,
 		loading,
 		error,
 		members,
@@ -649,10 +701,21 @@ export default function IssueDetail({
 		updatingStatus,
 		updatingPriority,
 		updatingAssignee,
+		updatingType,
 		changeStatus,
 		changePriority,
 		changeAssignee,
-	} = useIssueMutations({ issue, setIssue, issueId, workspaceSlug, statuses, members, fetchIssue });
+		changeType,
+	} = useIssueMutations({
+		issue,
+		setIssue,
+		issueId,
+		workspaceSlug,
+		statuses,
+		taskTypes,
+		members,
+		fetchIssue,
+	});
 
 	// Error first: a failed resolve leaves issueId empty, so this has to be checked
 	// before the branches below or it would show as a permanent "Loading…".
@@ -703,13 +766,16 @@ export default function IssueDetail({
 			currentUserId={currentUserId}
 			fetchComments={fetchComments}
 			statuses={statuses}
+			taskTypes={taskTypes}
 			members={members}
 			updatingStatus={updatingStatus}
 			updatingPriority={updatingPriority}
 			updatingAssignee={updatingAssignee}
+			updatingType={updatingType}
 			changeStatus={changeStatus}
 			changePriority={changePriority}
 			changeAssignee={changeAssignee}
+			changeType={changeType}
 			fetchIssue={fetchIssue}
 		/>
 	);

--- a/apps/web/src/islands/IssueDetailParts.test.tsx
+++ b/apps/web/src/islands/IssueDetailParts.test.tsx
@@ -30,6 +30,7 @@ const ISSUE: IssueData = {
 	parent_id: null,
 	project_key: "PROJ",
 	project_name: "Projektor",
+	type_id: null,
 	type_key: null,
 	type_name: null,
 	status_id: null,

--- a/apps/web/src/islands/IssueDetailParts.tsx
+++ b/apps/web/src/islands/IssueDetailParts.tsx
@@ -14,6 +14,7 @@ import type {
 	IssueLink,
 	Member,
 	TaskStatus,
+	TaskType,
 } from "./issue-detail-helpers";
 import {
 	formatBytes,
@@ -1802,6 +1803,37 @@ function StatusField({
 	return <span class="text-sm text-text-muted">—</span>;
 }
 
+function TypeField({
+	issue,
+	taskTypes,
+	updatingType,
+	changeType,
+}: {
+	issue: IssueData;
+	taskTypes: TaskType[];
+	updatingType: boolean;
+	changeType: (typeId: string) => void;
+}) {
+	if (taskTypes.length > 0) {
+		return (
+			<Select
+				ariaLabel="Change type"
+				value={issue.type_id ?? ""}
+				disabled={updatingType}
+				onChange={(v) => changeType(v)}
+				options={[
+					{ value: "", label: "No type" },
+					...taskTypes.map((t) => ({ value: t.id, label: t.name })),
+				]}
+			/>
+		);
+	}
+	if (issue.type_name) {
+		return <span class="text-sm text-text-base">{issue.type_name}</span>;
+	}
+	return <span class="text-sm text-text-muted">—</span>;
+}
+
 function PointsField({
 	issueId,
 	workspaceSlug,
@@ -1885,26 +1917,32 @@ export function SidebarPanel({
 	issueId,
 	workspaceSlug,
 	statuses,
+	taskTypes,
 	members,
 	updatingStatus,
 	updatingPriority,
 	updatingAssignee,
+	updatingType,
 	changeStatus,
 	changePriority,
 	changeAssignee,
+	changeType,
 	fetchIssue,
 }: {
 	issue: IssueData;
 	issueId: string;
 	workspaceSlug?: string;
 	statuses: TaskStatus[];
+	taskTypes: TaskType[];
 	members: Member[];
 	updatingStatus: boolean;
 	updatingPriority: boolean;
 	updatingAssignee: boolean;
+	updatingType: boolean;
 	changeStatus: (statusId: string) => void;
 	changePriority: (priority: string) => void;
 	changeAssignee: (assigneeId: string) => void;
+	changeType: (typeId: string) => void;
 	fetchIssue: () => Promise<void>;
 }) {
 	const priorityStyle = PRIORITY_COLORS[issue.priority] ?? PRIORITY_COLORS.none;
@@ -1919,6 +1957,15 @@ export function SidebarPanel({
 						statuses={statuses}
 						updatingStatus={updatingStatus}
 						changeStatus={changeStatus}
+					/>
+				</SidebarField>
+
+				<SidebarField label="Type">
+					<TypeField
+						issue={issue}
+						taskTypes={taskTypes}
+						updatingType={updatingType}
+						changeType={changeType}
 					/>
 				</SidebarField>
 

--- a/apps/web/src/islands/issue-detail-helpers.ts
+++ b/apps/web/src/islands/issue-detail-helpers.ts
@@ -36,6 +36,7 @@ export interface IssueData {
 	parent_id: string | null;
 	project_key: string | null;
 	project_name: string | null;
+	type_id: string | null;
 	type_key: string | null;
 	type_name: string | null;
 	status_id: string | null;
@@ -61,6 +62,12 @@ export interface Member {
 	id: string;
 	name: string | null;
 	email: string;
+}
+
+export interface TaskType {
+	id: string;
+	key: string;
+	name: string;
 }
 
 export const PRIORITY_COLORS: Record<string, { bg: string; text: string }> = {


### PR DESCRIPTION
## Summary
- Fixes PROJ-567: no way to change an issue's type once it's open in the human UI.
- `PATCH /api/issues/:id` already accepted `typeId` (`services/issues.ts`) — this was purely a missing frontend affordance, no backend change needed.
- Adds a `Type` field to the issue detail sidebar (`IssueDetailParts.tsx`), mirroring the existing `StatusField` pattern: a `Select` bound to `/api/task-types` when types are available, falling back to a read-only label (or `—`) otherwise.
- Threads `taskTypes`/`updatingType`/`changeType` through `IssueDetail.tsx`'s data hooks the same way `statuses`/`updatingStatus`/`changeStatus` already flow.

## Test plan
- [x] Added tests: the Type select renders once task types load, and choosing an option PATCHes `typeId`
- [x] `pnpm turbo type-check` — 0 errors
- [x] `pnpm lint` (biome) clean
- [x] `pnpm --filter @projektor/web test:coverage` — 579 tests pass, coverage thresholds hold
- [x] `pnpm --filter @projektor/web build` succeeds