### PR TITLE
fix(web): hide create-project action for the public demo viewer (PROJ-568)

### DIFF
--- a/apps/docs/src/content/docs/guides/live-demo.md
+++ b/apps/docs/src/content/docs/guides/live-demo.md
@@ -8,11 +8,11 @@ Want to see Projektor running before you deploy your own? Visit the
 [live demo](https://projektor-demo.tajdickson.workers.dev) - a fresh, unseeded instance
 standing up the wiki and issue tracker on a single Cloudflare Worker.
 
-No login is configured on the demo, so the app shell loads and then the
-project/issue views get stuck on "Loading projects..." - that's expected, not broken.
-The API requires Cloudflare Access, which the demo leaves unconfigured, so
-`/api/projects` returns 401 and the UI never gets past the loading state. It's the same
-Worker code you'd deploy yourself, kept empty and login-less on purpose. To use
+No login is configured on the demo - it runs with `PUBLIC_READ_ONLY` enabled (PROJ-373),
+so anyone gets dropped straight into a read-only viewer session instead of a Cloudflare
+Access challenge. You'll see an empty "No projects yet" list and can browse around, but
+creating projects, issues, or wiki pages is disabled - that's expected, not broken. It's
+the same Worker code you'd deploy yourself, kept empty and login-less on purpose. To use
 Projektor, deploy your own instance.
 
 When you're ready to stand up your own instance, the

--- a/apps/docs/src/content/docs/guides/live-demo.md
+++ b/apps/docs/src/content/docs/guides/live-demo.md
@@ -11,7 +11,7 @@ standing up the wiki and issue tracker on a single Cloudflare Worker.
 No login is configured on the demo - it runs with `PUBLIC_READ_ONLY` enabled (PROJ-373),
 so anyone gets dropped straight into a read-only viewer session instead of a Cloudflare
 Access challenge. You'll see an empty "No projects yet" list and can browse around, but
-creating projects, issues, or wiki pages is disabled - that's expected, not broken. It's
+creating a project is disabled, since the read-only session has nowhere to write it. It's
 the same Worker code you'd deploy yourself, kept empty and login-less on purpose. To use
 Projektor, deploy your own instance.
 

--- a/apps/web/src/islands/AccountMenu.tsx
+++ b/apps/web/src/islands/AccountMenu.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useRef, useState } from "preact/hooks";
 import { apiFetch } from "../utils/api-client";
 import { clearAllDrafts } from "../utils/drafts";
+import { PUBLIC_VIEWER_EMAIL } from "../utils/public-viewer";
 import { resolveWorkspaceSlug } from "../utils/workspace";
 import { Popover } from "./ui/Popover";
 
@@ -13,8 +14,6 @@ interface MeResponse {
 }
 
 const POPOVER_MARGIN = 8;
-// PROJ-373 anonymous fallback — apps/api/src/middleware/auth.ts
-const PUBLIC_VIEWER_EMAIL = "public-viewer@projektor.local";
 
 function initials(name: string, email: string): string {
 	const source = name.trim() || email;

--- a/apps/web/src/islands/ProjectList.test.tsx
+++ b/apps/web/src/islands/ProjectList.test.tsx
@@ -15,6 +15,21 @@ function mockFetchOk(payload: unknown) {
 	);
 }
 
+function mockFetchByUrl(routes: { projects: unknown[]; meEmail: string }) {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn().mockImplementation((url: string) => {
+			if (String(url).includes("/auth/me")) {
+				return Promise.resolve({
+					ok: true,
+					json: () => Promise.resolve({ user: { id: "u1", email: routes.meEmail, name: "User" } }),
+				});
+			}
+			return Promise.resolve({ ok: true, json: () => Promise.resolve(routes.projects) });
+		})
+	);
+}
+
 const PROJECT = {
 	id: "p1",
 	name: "Projektor",
@@ -53,5 +68,25 @@ describe("ProjectList", () => {
 		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
 		render(<ProjectList />);
 		expect(await screen.findByText(/Failed to load projects/i)).toBeTruthy();
+	});
+});
+
+// PROJ-568: the public read-only demo viewer (PROJ-373) must not be offered a
+// "+ New project" action that always fails the POST — see apps/api/src/middleware/auth.ts.
+describe("ProjectList — public read-only demo viewer (PROJ-568)", () => {
+	it("hides the create-project button for the public viewer", async () => {
+		mockFetchByUrl({ projects: [], meEmail: "public-viewer@projektor.local" });
+		render(<ProjectList />);
+		await screen.findByText(/No projects yet/i);
+		expect(await screen.findByText(/Read-only demo/i)).toBeTruthy();
+		expect(screen.queryByText("+ New project")).toBeNull();
+	});
+
+	it("shows the create-project button for a real user", async () => {
+		mockFetchByUrl({ projects: [], meEmail: "real-user@example.com" });
+		render(<ProjectList />);
+		await screen.findByText(/No projects yet/i);
+		expect(await screen.findByText("+ New project")).toBeTruthy();
+		expect(screen.queryByText(/Read-only demo/i)).toBeNull();
 	});
 });

--- a/apps/web/src/islands/ProjectList.tsx
+++ b/apps/web/src/islands/ProjectList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "preact/hooks";
 import { useAccessGate } from "../utils/access-gate";
 import { apiFetch } from "../utils/api-client";
+import { usePublicViewer } from "../utils/public-viewer";
 import AccessPending from "./AccessPending";
 import { Button } from "./ui/Button";
 
@@ -322,6 +323,7 @@ export default function ProjectList({ workspaceSlug }: { workspaceSlug?: string 
 	}, [workspaceSlug]);
 
 	const gate = useAccessGate(workspaceSlug);
+	const isPublicViewer = usePublicViewer(workspaceSlug);
 
 	const createForm = useProjectCreateForm(workspaceSlug, (p) =>
 		setProjects((prev) => [...prev, p])
@@ -339,14 +341,20 @@ export default function ProjectList({ workspaceSlug }: { workspaceSlug?: string 
 	return (
 		<>
 			<div class="flex justify-end mb-4">
-				{!createForm.formOpen && (
-					<Button type="button" variant="primary" size="sm" onClick={createForm.open}>
-						+ New project
-					</Button>
+				{isPublicViewer ? (
+					<p class="text-xs text-[var(--text-muted)] m-0">
+						Read-only demo — projects can't be created here.
+					</p>
+				) : (
+					!createForm.formOpen && (
+						<Button type="button" variant="primary" size="sm" onClick={createForm.open}>
+							+ New project
+						</Button>
+					)
 				)}
 			</div>
 
-			{createForm.formOpen && (
+			{!isPublicViewer && createForm.formOpen && (
 				<ProjectCreateForm
 					nameRef={createForm.nameRef}
 					formName={createForm.formName}

--- a/apps/web/src/utils/public-viewer.ts
+++ b/apps/web/src/utils/public-viewer.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "preact/hooks";
+import { apiFetch } from "./api-client";
+
+// PROJ-373 anonymous fallback — apps/api/src/middleware/auth.ts
+export const PUBLIC_VIEWER_EMAIL = "public-viewer@projektor.local";
+
+/**
+ * True once we've confirmed the current session is the PROJ-373 anonymous
+ * read-only demo viewer (starts false, so writes aren't hidden pre-flight).
+ */
+export function usePublicViewer(workspaceSlug: string | undefined): boolean {
+	const [isPublicViewer, setIsPublicViewer] = useState(false);
+
+	useEffect(() => {
+		let cancelled = false;
+		apiFetch<{ user: { email: string } }>("/auth/me", { workspaceSlug, on401: "throw" })
+			.then((data) => {
+				if (!cancelled) setIsPublicViewer(data.user.email === PUBLIC_VIEWER_EMAIL);
+			})
+			.catch(() => {});
+		return () => {
+			cancelled = true;
+		};
+	}, [workspaceSlug]);
+
+	return isPublicViewer;
+}


### PR DESCRIPTION
## Summary
- The live demo (https://projektor-demo.tajdickson.workers.dev) runs with `PUBLIC_READ_ONLY` enabled (PROJ-373), giving anonymous visitors a read-only viewer session instead of a Cloudflare Access login.
- `ProjectList` still showed a "+ New project" button in that session; submitting it always failed with a raw `API POST /api/projects failed: 400`, since the anonymous viewer has no workspace to create into. Live-tested via claude-in-chrome and reproduced the exact error.
- Factored the PROJ-373 viewer-email check (previously inline in `AccountMenu`) into a shared `usePublicViewer` hook and used it in `ProjectList` to hide the create button and show a "Read-only demo" note instead.
- Corrected `live-demo.md`, which still described a stale 401/stuck-on-"Loading projects" behavior from before PROJ-373 shipped — live testing showed `/api/projects` now returns 200 with an empty list, not 401.

## Test plan
- [x] `pnpm --filter @projektor/web test` — 579 passed, incl. new PROJ-568 tests for hidden/shown create button
- [x] `pnpm turbo type-check` — 0 errors
- [x] `pnpm lint` (biome) — clean
- [x] `pnpm --filter @projektor/web build` and `pnpm --filter @projektor/docs build` — both clean
- [x] Verified live on the demo Worker via browser automation before the fix (reproduced the 400 error on submit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)