### PR TITLE
fix(web): stop mobile topbar scroll-hide from flickering (PROJ-569)

### DIFF
--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -951,7 +951,13 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
       (function () {
         var lastY = 0;
         var accumulatedDown = 0;
-        var HIDE_THRESHOLD = 8;
+        var accumulatedUp = 0;
+        // PROJ-569: the old 8px hide threshold with an instant, un-thresholded reveal
+        // meant mobile touch-scroll jitter (momentum deceleration, rubber-band bounce)
+        // flickered the bar hidden/shown on every tiny direction reversal. Both
+        // directions now need a deliberate amount of scroll before the bar reacts.
+        var HIDE_THRESHOLD = 40;
+        var REVEAL_THRESHOLD = 24;
         var ticking = false;
 
         function shouldStayVisible() {
@@ -971,16 +977,19 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
             if (shouldStayVisible() || y <= 0) {
               topbar.classList.remove('topbar-hidden');
               accumulatedDown = 0;
+              accumulatedUp = 0;
               lastY = y;
               return;
             }
             var delta = y - lastY;
             if (delta > 0) {
               accumulatedDown += delta;
+              accumulatedUp = 0;
               if (accumulatedDown > HIDE_THRESHOLD) topbar.classList.add('topbar-hidden');
-            } else {
+            } else if (delta < 0) {
+              accumulatedUp += -delta;
               accumulatedDown = 0;
-              topbar.classList.remove('topbar-hidden');
+              if (accumulatedUp > REVEAL_THRESHOLD) topbar.classList.remove('topbar-hidden');
             }
             lastY = y;
           });
@@ -992,6 +1001,7 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
           if (topbar) topbar.classList.remove('topbar-hidden');
           lastY = window.scrollY;
           accumulatedDown = 0;
+          accumulatedUp = 0;
         });
       })();
     </script>

--- a/apps/web/src/layouts/Base.mobile-viewport.test.ts
+++ b/apps/web/src/layouts/Base.mobile-viewport.test.ts
@@ -28,3 +28,20 @@ describe("Base layout — account menu replaces legacy login/logout emoji", () =
 		expect(source).not.toContain("🚪");
 	});
 });
+
+describe("Base layout — topbar hide-on-scroll thresholds (PROJ-569)", () => {
+	it("requires a deliberate scroll in each direction before toggling, not a single pixel", () => {
+		// PROJ-569: an 8px hide threshold with an un-thresholded reveal flickered the
+		// topbar on mobile touch-scroll jitter. Both directions need real headroom now.
+		expect(source).toMatch(/var HIDE_THRESHOLD = 40;/);
+		expect(source).toMatch(/var REVEAL_THRESHOLD = 24;/);
+	});
+
+	it("accumulates upward scroll before revealing instead of un-hiding on any negative delta", () => {
+		const scriptStart = source.indexOf("var HIDE_THRESHOLD");
+		const scriptEnd = source.indexOf("</script>", scriptStart);
+		const script = source.slice(scriptStart, scriptEnd);
+		expect(script).toMatch(/accumulatedUp \+= -delta;/);
+		expect(script).toMatch(/if \(accumulatedUp > REVEAL_THRESHOLD\) topbar\.classList\.remove\('topbar-hidden'\);/);
+	});
+});

--- a/apps/web/src/layouts/Base.mobile-viewport.test.ts
+++ b/apps/web/src/layouts/Base.mobile-viewport.test.ts
@@ -33,8 +33,8 @@ describe("Base layout — topbar hide-on-scroll thresholds (PROJ-569)", () => {
 	it("requires a deliberate scroll in each direction before toggling, not a single pixel", () => {
 		// PROJ-569: an 8px hide threshold with an un-thresholded reveal flickered the
 		// topbar on mobile touch-scroll jitter. Both directions need real headroom now.
-		expect(source).toMatch(/var HIDE_THRESHOLD = 40;/);
-		expect(source).toMatch(/var REVEAL_THRESHOLD = 24;/);
+		expect(source).toMatch(/HIDE_THRESHOLD\s*=\s*40/);
+		expect(source).toMatch(/REVEAL_THRESHOLD\s*=\s*24/);
 	});
 
 	it("accumulates upward scroll before revealing instead of un-hiding on any negative delta", () => {


### PR DESCRIPTION
## Summary
- PROJ-569: "Sliding topic/scroll at the top is really annoying on mobile" — the PROJ-428 hide-on-scroll topbar (`apps/web/src/layouts/Base.astro`) hid after only 8px of accumulated downward scroll and un-hid instantly on any single pixel of upward movement.
- Mobile touch-scroll physics (momentum deceleration, rubber-band bounce near scroll boundaries) constantly produce small direction reversals, so the topbar was flickering hidden/shown on ordinary scrolling instead of staying settled — that's the "sliding ... annoying" behavior reported.
- Both directions now require a deliberate amount of accumulated scroll before the bar reacts: 40px to hide, 24px to reveal (asymmetric on purpose — revealing should feel a bit more eager than hiding, a common pattern for this kind of nav).

## Test plan
- [x] `pnpm --filter @projektor/web test` — 581 passed, incl. 2 new tests in `Base.mobile-viewport.test.ts` asserting the new thresholds and the accumulated-upward-scroll reveal logic (following the existing source-string-assertion pattern for `Base.astro`, which isn't a testable Preact component)
- [x] `pnpm turbo type-check` — 0 errors
- [x] `pnpm lint` (biome) — clean
- [x] `pnpm --filter @projektor/web build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)