### PR TITLE
chore(release): bump version to 0.4.18

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@projektor/web",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "private": true,
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
## Summary
- Bump apps/web/package.json to 0.4.18 for the next patch release
- Covers PROJ-566, PROJ-567, PROJ-568, PROJ-569, and the Verdient docs footer link, all merged since v0.4.17

## Test plan
- [x] Pre-commit hooks passed (design-system, lint, type-check)