### PR TITLE
docs: link the build-story blog post from the homepage

### DIFF
--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -53,7 +53,8 @@ account."*
 
 [Your first ten minutes →](/projektor/guides/getting-started/) ·
 [Why Projektor looks like this →](/projektor/agents/agent-workflows/) ·
-[Poke around a live instance first →](/projektor/guides/live-demo/)
+[Poke around a live instance first →](/projektor/guides/live-demo/) ·
+[How and why it was built →](https://tom-dickson.com/blog/projektor-mcp-issue-tracker-cloudflare-workers/)
 
 Projektor's own roadmap is tracked inside Projektor; these docs are generated from
 the same repo.


### PR DESCRIPTION
## Summary
- Adds a fourth link to the docs homepage's link row: "How and why it was built →", pointing at https://tom-dickson.com/blog/projektor-mcp-issue-tracker-cloudflare-workers/
- That post covers the idea (agent-first ticket design, WIP enforcement), the Cloudflare Workers/Hono/D1 stack, the config-driven agent-operable deploy path, and cofferdam as the static-analysis tool that keeps the codebase honest — a narrative complement to the existing task-focused guides (getting started, live demo, agent workflows).

## Test plan
- [x] `pnpm run build` in `apps/docs` succeeds, starlight-links-validator reports "All internal links are valid."
- [x] Confirmed the blog URL returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUdouregEuuGRxXqexJeGp