### PR TITLE
docs: add CI, release, and license badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # projektor
 
+[![CI](https://github.com/TAJD/projektor/actions/workflows/ci.yml/badge.svg)](https://github.com/TAJD/projektor/actions/workflows/ci.yml)
+[![Latest release](https://img.shields.io/github/v/release/TAJD/projektor)](https://github.com/TAJD/projektor/releases)
+[![License: MIT](https://img.shields.io/github/license/TAJD/projektor)](./LICENSE)
+
 > An issue tracker and wiki that an AI coding agent runs as a first-class client -
 > self-hosted, cross-project, and cheap enough to run serverless.
 


### PR DESCRIPTION
## Summary
- Adds CI status, latest release, and license badges under the README H1.
- Closes PROJ-591.

## Test plan
- Visual check only (README markdown badges); no code paths affected.

Claude-Session: https://claude.ai/code/session_01DYPsSekdCWXUL8UZR5sGEf