### PR TITLE
fix(web): reset topbar scroll state on first load, not just client-nav (PROJ-572)

### DIFF
--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -1042,11 +1042,11 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
         }
 
         window.addEventListener('scroll', onScroll, { passive: true });
-        // PROJ-572: astro:after-swap alone misses the very first load — a bfcache
-        // restore, browser scroll restoration, or an #anchor link can land the page
-        // already scrolled down before any swap has happened, so the initial
-        // lastY = window.scrollY above can still be stale by the time this runs.
-        // astro:page-load fires on first load too (unlike astro:after-swap).
+        // PROJ-572: astro:after-swap alone misses the very first load — browser scroll
+        // restoration or an #anchor link can land the page already scrolled down before
+        // any swap has happened, so the initial lastY = window.scrollY above can still
+        // be stale by the time this runs. astro:page-load fires on first load too
+        // (unlike astro:after-swap), so re-running the reset there catches it.
         document.addEventListener('astro:after-swap', resetTopbarScrollState);
         document.addEventListener('astro:page-load', resetTopbarScrollState);
       })();

--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -987,7 +987,7 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
          often than a frame renders. -->
     <script is:inline>
       (function () {
-        var lastY = 0;
+        var lastY = window.scrollY;
         var accumulatedDown = 0;
         var accumulatedUp = 0;
         // PROJ-569: the old 8px hide threshold with an instant, un-thresholded reveal
@@ -1033,14 +1033,22 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
           });
         }
 
-        window.addEventListener('scroll', onScroll, { passive: true });
-        document.addEventListener('astro:after-swap', function () {
+        function resetTopbarScrollState() {
           var topbar = document.getElementById('app-topbar');
           if (topbar) topbar.classList.remove('topbar-hidden');
           lastY = window.scrollY;
           accumulatedDown = 0;
           accumulatedUp = 0;
-        });
+        }
+
+        window.addEventListener('scroll', onScroll, { passive: true });
+        // PROJ-572: astro:after-swap alone misses the very first load — a bfcache
+        // restore, browser scroll restoration, or an #anchor link can land the page
+        // already scrolled down before any swap has happened, so the initial
+        // lastY = window.scrollY above can still be stale by the time this runs.
+        // astro:page-load fires on first load too (unlike astro:after-swap).
+        document.addEventListener('astro:after-swap', resetTopbarScrollState);
+        document.addEventListener('astro:page-load', resetTopbarScrollState);
       })();
     </script>
   </body>

--- a/apps/web/src/layouts/Base.mobile-viewport.test.ts
+++ b/apps/web/src/layouts/Base.mobile-viewport.test.ts
@@ -86,4 +86,18 @@ describe("Base layout — topbar hide-on-scroll thresholds (PROJ-569)", () => {
 		expect(script).toMatch(/accumulatedUp \+= -delta;/);
 		expect(script).toMatch(/if \(accumulatedUp > REVEAL_THRESHOLD\) topbar\.classList\.remove\('topbar-hidden'\);/);
 	});
+
+	it("initializes lastY from the real scroll position, and resets it on first load too (PROJ-572)", () => {
+		// A page loading already scrolled (bfcache restore, scroll restoration, #anchor
+		// link) must not compute its first delta against a stale lastY = 0 — that slams
+		// the topbar hidden immediately instead of respecting the 40px threshold.
+		const scriptStart = source.indexOf("var lastY");
+		const scriptEnd = source.indexOf("</script>", scriptStart);
+		const script = source.slice(scriptStart, scriptEnd);
+		expect(script).toMatch(/var lastY = window\.scrollY;/);
+		// astro:after-swap alone misses the very first load (it only fires on
+		// client-side navigations), so the reset must also run on astro:page-load.
+		expect(script).toMatch(/addEventListener\('astro:after-swap', resetTopbarScrollState\)/);
+		expect(script).toMatch(/addEventListener\('astro:page-load', resetTopbarScrollState\)/);
+	});
 });


### PR DESCRIPTION
## Summary
- `lastY` initialized to `0` regardless of actual scroll position, so a page loading already-scrolled (bfcache restore, scroll restoration, #anchor link) computed its first scroll delta against a stale baseline instead of the real position — could slam the topbar hidden immediately instead of respecting the 40px hide threshold.
- `astro:after-swap` only fires on client-side navigations, so the reset never ran on the very first page load. Refactored the inline reset into a named `resetTopbarScrollState()` and registered it on both `astro:after-swap` and `astro:page-load`.

Fixes PROJ-572.

## Test plan
- [x] `apps/web/src/layouts/Base.mobile-viewport.test.ts` — new regression test asserting `lastY = window.scrollY` init and both event-listener registrations.
- [x] Full API/web suite green.