### PR TITLE
fix(api): block changing an epic's type away from Epic while it has children (PROJ-571)

### DIFF
--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -817,6 +817,7 @@ type UpdateIssueData = z.infer<typeof UpdateIssueSchema>;
 type ExistingIssue = {
 	id: string;
 	parentId: string | null;
+	typeId: string | null;
 	status: string;
 	statusCategory: string | null;
 	readyAt: number | null;
@@ -1119,6 +1120,40 @@ function formatCompletionReportComment(
 	return lines.join("\n");
 }
 
+// PROJ-571: changing an epic's type away from Epic silently orphans its children
+// from the epic UI/rollups (parentId is untouched, but nothing surfaces the epic
+// view for them anymore). Block it at the service layer so REST and MCP both get
+// the guard, rather than only a frontend confirm dialog.
+async function assertNotDemotingEpicWithChildren(
+	ctx: ServiceCtx,
+	orm: ReturnType<typeof drizzle>,
+	existing: ExistingIssue,
+	newTypeId: string | null
+): Promise<void> {
+	if (!existing.typeId || existing.typeId === newTypeId) return;
+
+	const currentType = await orm
+		.select({ key: schema.taskTypes.key })
+		.from(schema.taskTypes)
+		.where(eq(schema.taskTypes.id, existing.typeId))
+		.get();
+	if (currentType?.key !== "epic") return;
+
+	const childCount = await orm
+		.select({ count: sql<number>`count(*)` })
+		.from(schema.issues)
+		.where(
+			and(eq(schema.issues.parentId, existing.id), eq(schema.issues.workspaceId, ctx.workspaceId))
+		)
+		.get();
+	if ((childCount?.count ?? 0) > 0) {
+		throw new ValidationError({
+			formErrors: ["Cannot change type: this epic still has child issues"],
+			fieldErrors: {},
+		});
+	}
+}
+
 async function buildUpdateSetValues(
 	ctx: ServiceCtx,
 	orm: ReturnType<typeof drizzle>,
@@ -1130,7 +1165,9 @@ async function buildUpdateSetValues(
 	Object.assign(setValues, statusFields.setValues);
 	const reviewOrDoneTransition = statusFields.reviewOrDoneTransition;
 	if ("typeId" in data) {
-		setValues.typeId = await resolveTypeId(ctx, data.typeId);
+		const resolvedTypeId = await resolveTypeId(ctx, data.typeId);
+		await assertNotDemotingEpicWithChildren(ctx, orm, existing, resolvedTypeId);
+		setValues.typeId = resolvedTypeId;
 	}
 	// PROJ-293: only stamp/post the report when the issue actually transitions into
 	// review or done — a title-only update carrying a completionReport must not
@@ -1231,6 +1268,7 @@ export async function updateIssue(ctx: ServiceCtx, id: string, raw: unknown) {
 			id: schema.issues.id,
 			projectId: schema.issues.projectId,
 			parentId: schema.issues.parentId,
+			typeId: schema.issues.typeId,
 			status: schema.issues.status,
 			statusCategory: schema.issues.statusCategory,
 			readyAt: schema.issues.readyAt,

--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -1135,7 +1135,12 @@ async function assertNotDemotingEpicWithChildren(
 	const currentType = await orm
 		.select({ key: schema.taskTypes.key })
 		.from(schema.taskTypes)
-		.where(eq(schema.taskTypes.id, existing.typeId))
+		.where(
+			and(
+				eq(schema.taskTypes.id, existing.typeId),
+				eq(schema.taskTypes.workspaceId, ctx.workspaceId)
+			)
+		)
 		.get();
 	if (currentType?.key !== "epic") return;
 
@@ -1148,7 +1153,9 @@ async function assertNotDemotingEpicWithChildren(
 		.get();
 	if ((childCount?.count ?? 0) > 0) {
 		throw new ValidationError({
-			formErrors: ["Cannot change type: this epic still has child issues"],
+			formErrors: [
+				"Cannot change type: this epic still has child issues — move or remove them first",
+			],
 			fieldErrors: {},
 		});
 	}

--- a/apps/api/src/test/issues.test.ts
+++ b/apps/api/src/test/issues.test.ts
@@ -1541,6 +1541,60 @@ describe("Issues MCP — typeId", () => {
 		expect(issue.type_id).toBeNull();
 	});
 
+	// PROJ-571: changing an epic's type away from Epic while it still has children
+	// silently orphans them from the epic UI/rollups — block it at the service layer
+	// so both REST and MCP callers get the guard.
+	it("MCP update_issue rejects demoting an epic that still has children", async () => {
+		const { id: epicTypeId } = await seedTaskType(workspaceId, { key: "epic", name: "Epic" });
+		const { id: storyTypeId } = await seedTaskType(workspaceId, { key: "story", name: "Story" });
+
+		const createResp = await mcpCall({
+			name: "create_issue",
+			arguments: { projectId, title: "Parent epic", typeId: epicTypeId },
+		});
+		const { id: epicId } = JSON.parse(createResp.result!.content[0].text) as { id: string };
+
+		await mcpCall({
+			name: "create_issue",
+			arguments: { projectId, title: "Child of epic", parentId: epicId },
+		});
+
+		const updateResp = await mcpCall({
+			name: "update_issue",
+			arguments: { id: epicId, typeId: storyTypeId },
+		});
+		expect(updateResp.error).toBeDefined();
+
+		const getRes = await SELF.fetch(`http://localhost/api/issues/${epicId}`, {
+			headers: authHeaders(token, slug),
+		});
+		const issue = (await getRes.json()) as { type_id: string };
+		expect(issue.type_id).toBe(epicTypeId);
+	});
+
+	it("MCP update_issue allows changing an epic's type once it has no children", async () => {
+		const { id: epicTypeId } = await seedTaskType(workspaceId, { key: "epic", name: "Epic" });
+		const { id: storyTypeId } = await seedTaskType(workspaceId, { key: "story", name: "Story" });
+
+		const createResp = await mcpCall({
+			name: "create_issue",
+			arguments: { projectId, title: "Childless epic", typeId: epicTypeId },
+		});
+		const { id: epicId } = JSON.parse(createResp.result!.content[0].text) as { id: string };
+
+		const updateResp = await mcpCall({
+			name: "update_issue",
+			arguments: { id: epicId, typeId: storyTypeId },
+		});
+		expect(updateResp.error).toBeUndefined();
+
+		const getRes = await SELF.fetch(`http://localhost/api/issues/${epicId}`, {
+			headers: authHeaders(token, slug),
+		});
+		const issue = (await getRes.json()) as { type_id: string };
+		expect(issue.type_id).toBe(storyTypeId);
+	});
+
 	it("MCP list_issues typeId filter returns only matching issues", async () => {
 		const { id: bugTypeId } = await seedTaskType(workspaceId, { key: "bug", name: "Bug" });
 		const { id: storyTypeId } = await seedTaskType(workspaceId, { key: "story", name: "Story" });

--- a/apps/api/src/test/issues.test.ts
+++ b/apps/api/src/test/issues.test.ts
@@ -1564,12 +1564,41 @@ describe("Issues MCP — typeId", () => {
 			arguments: { id: epicId, typeId: storyTypeId },
 		});
 		expect(updateResp.error).toBeDefined();
+		expect(updateResp.error?.message).toContain("child issues");
 
 		const getRes = await SELF.fetch(`http://localhost/api/issues/${epicId}`, {
 			headers: authHeaders(token, slug),
 		});
 		const issue = (await getRes.json()) as { type_id: string };
 		expect(issue.type_id).toBe(epicTypeId);
+	});
+
+	it("MCP update_issue allows retyping a non-epic parent that still has children", async () => {
+		const { id: storyTypeId } = await seedTaskType(workspaceId, { key: "story", name: "Story" });
+		const { id: bugTypeId } = await seedTaskType(workspaceId, { key: "bug", name: "Bug" });
+
+		const createResp = await mcpCall({
+			name: "create_issue",
+			arguments: { projectId, title: "Story parent", typeId: storyTypeId },
+		});
+		const { id: parentId } = JSON.parse(createResp.result!.content[0].text) as { id: string };
+
+		await mcpCall({
+			name: "create_issue",
+			arguments: { projectId, title: "Child of story", parentId },
+		});
+
+		const updateResp = await mcpCall({
+			name: "update_issue",
+			arguments: { id: parentId, typeId: bugTypeId },
+		});
+		expect(updateResp.error).toBeUndefined();
+
+		const getRes = await SELF.fetch(`http://localhost/api/issues/${parentId}`, {
+			headers: authHeaders(token, slug),
+		});
+		const issue = (await getRes.json()) as { type_id: string };
+		expect(issue.type_id).toBe(bugTypeId);
 	});
 
 	it("MCP update_issue allows changing an epic's type once it has no children", async () => {


### PR DESCRIPTION
## Summary
- Changing an issue's `typeId` doesn't touch `parentId`, so demoting an Epic with children away from the Epic type silently orphaned them from the epic view/rollups — children keep their `parentId` but nothing surfaces the epic UI for them anymore.
- Added `assertNotDemotingEpicWithChildren` in `apps/api/src/services/issues.ts`, called from `buildUpdateSetValues` whenever `typeId` changes: if the issue's current type is `epic` and it has at least one child, the update is rejected with a `ValidationError`.
- Implemented at the service layer (not a frontend confirm dialog) so both REST and MCP `update_issue` get the guard, per the REST/MCP-parity contract in AGENTS.md.

Fixes PROJ-571.

## Test plan
- [x] New MCP `update_issue` tests: rejects demoting an epic with children; allows the type change once the epic has no children.
- [x] Full API suite green (1150/1150).