### PR TITLE
fix(web): viewport-clamp FiltersPopover and MetricHelp (PROJ-588)

### DIFF
--- a/apps/web/src/islands/IssueList.test.tsx
+++ b/apps/web/src/islands/IssueList.test.tsx
@@ -862,4 +862,17 @@ describe("Filters popover stacking (CD-294)", () => {
 		expect(popover).toBeTruthy();
 		expect(Number(popover.style.zIndex)).toBeGreaterThan(110);
 	});
+
+	// PROJ-588 review: the pure computeFiltersPopoverPosition tests never assert the
+	// component actually wires maxHeight/overflow onto the rendered panel.
+	it("clamps the rendered panel's maxHeight and makes it scrollable (PROJ-588)", async () => {
+		render(<IssueList />);
+		await waitForLoaded();
+		openFiltersPopover();
+
+		const panel = await screen.findByRole("button", { name: "Todo" });
+		const popover = panel.closest("[style*='position: fixed']") as HTMLElement;
+		expect(popover.style.maxHeight).toBeTruthy();
+		expect(popover.style.overflowY).toBe("auto");
+	});
 });

--- a/apps/web/src/islands/MetricHelp.test.tsx
+++ b/apps/web/src/islands/MetricHelp.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen } from "@testing-library/preact";
+import { describe, expect, it } from "vitest";
+import { MetricHelp } from "./MetricHelp";
+import { METRIC_DEFINITIONS, type MetricId } from "./metric-definitions";
+
+const FIRST_METRIC_ID = Object.keys(METRIC_DEFINITIONS)[0] as MetricId;
+const FIRST_METRIC_LABEL = METRIC_DEFINITIONS[FIRST_METRIC_ID].label;
+
+describe("MetricHelp", () => {
+	it("shows the trigger but not the definition until clicked", () => {
+		render(<MetricHelp id={FIRST_METRIC_ID} />);
+		expect(screen.getByRole("button", { name: `About ${FIRST_METRIC_LABEL}` })).toBeTruthy();
+		expect(screen.queryByRole("dialog")).toBeNull();
+	});
+
+	it("toggles the definition popover open and closed on click", () => {
+		render(<MetricHelp id={FIRST_METRIC_ID} />);
+		const trigger = screen.getByRole("button", { name: `About ${FIRST_METRIC_LABEL}` });
+
+		fireEvent.click(trigger);
+		expect(screen.getByRole("dialog", { name: `${FIRST_METRIC_LABEL} definition` })).toBeTruthy();
+
+		fireEvent.click(trigger);
+		expect(screen.queryByRole("dialog")).toBeNull();
+	});
+
+	it("closes on Escape", () => {
+		render(<MetricHelp id={FIRST_METRIC_ID} />);
+		fireEvent.click(screen.getByRole("button", { name: `About ${FIRST_METRIC_LABEL}` }));
+		expect(screen.getByRole("dialog")).toBeTruthy();
+
+		fireEvent.keyDown(document, { key: "Escape" });
+		expect(screen.queryByRole("dialog")).toBeNull();
+	});
+
+	it("closes on an outside click", () => {
+		render(<MetricHelp id={FIRST_METRIC_ID} />);
+		fireEvent.click(screen.getByRole("button", { name: `About ${FIRST_METRIC_LABEL}` }));
+		expect(screen.getByRole("dialog")).toBeTruthy();
+
+		fireEvent.mouseDown(document.body);
+		expect(screen.queryByRole("dialog")).toBeNull();
+	});
+
+	// PROJ-588: a plain CSS `absolute; left: 0` popover overflows the viewport's right
+	// edge when the trigger sits near it on a narrow phone. `fixed` + a rect-derived,
+	// viewport-clamped left escapes that — same fix as GlossaryHelp.tsx (PROJ-419).
+	it("clamps the popover's left position within the viewport", () => {
+		render(
+			<div style={{ position: "absolute", left: `${window.innerWidth - 20}px` }}>
+				<MetricHelp id={FIRST_METRIC_ID} />
+			</div>
+		);
+		fireEvent.click(screen.getByRole("button", { name: `About ${FIRST_METRIC_LABEL}` }));
+		const dialog = screen.getByRole("dialog");
+		expect(dialog.style.position).toBe("fixed");
+		expect(parseFloat(dialog.style.left)).toBeLessThanOrEqual(window.innerWidth - 256 - 8 + 1);
+	});
+
+	it("closes when an ancestor scrolls, rather than leaving a stale-positioned popover", () => {
+		render(<MetricHelp id={FIRST_METRIC_ID} />);
+		fireEvent.click(screen.getByRole("button", { name: `About ${FIRST_METRIC_LABEL}` }));
+		expect(screen.getByRole("dialog")).toBeTruthy();
+
+		fireEvent.scroll(window);
+		expect(screen.queryByRole("dialog")).toBeNull();
+	});
+
+	it("stays open on a height-only resize, but closes when the width changes (CD-294)", () => {
+		render(<MetricHelp id={FIRST_METRIC_ID} />);
+		fireEvent.click(screen.getByRole("button", { name: `About ${FIRST_METRIC_LABEL}` }));
+
+		window.innerHeight = window.innerHeight - 300;
+		fireEvent.resize(window);
+		expect(screen.queryByRole("dialog")).toBeTruthy();
+
+		window.innerWidth = window.innerWidth - 100;
+		fireEvent.resize(window);
+		expect(screen.queryByRole("dialog")).toBeNull();
+	});
+
+	it("portals the popover onto document.body and doesn't self-close on a click inside it", () => {
+		render(<MetricHelp id={FIRST_METRIC_ID} />);
+		fireEvent.click(screen.getByRole("button", { name: `About ${FIRST_METRIC_LABEL}` }));
+		const dialog = screen.getByRole("dialog");
+
+		expect(dialog.parentElement).toBe(document.body);
+
+		fireEvent.mouseDown(dialog);
+		expect(screen.queryByRole("dialog")).toBeTruthy();
+	});
+});

--- a/apps/web/src/islands/MetricHelp.test.tsx
+++ b/apps/web/src/islands/MetricHelp.test.tsx
@@ -1,7 +1,22 @@
 import { fireEvent, render, screen } from "@testing-library/preact";
-import { describe, expect, it } from "vitest";
-import { MetricHelp } from "./MetricHelp";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { computeMetricHelpPosition, MetricHelp } from "./MetricHelp";
 import { METRIC_DEFINITIONS, type MetricId } from "./metric-definitions";
+
+/** jsdom has no layout: every rect is 0×0 unless stubbed. */
+function rectAt(top: number, left = 10, height = 24, width = 100): DOMRect {
+	return {
+		top,
+		bottom: top + height,
+		left,
+		right: left + width,
+		width,
+		height,
+		x: left,
+		y: top,
+		toJSON: () => ({}),
+	} as DOMRect;
+}
 
 const FIRST_METRIC_ID = Object.keys(METRIC_DEFINITIONS)[0] as MetricId;
 const FIRST_METRIC_LABEL = METRIC_DEFINITIONS[FIRST_METRIC_ID].label;
@@ -45,13 +60,46 @@ describe("MetricHelp", () => {
 	// PROJ-588: a plain CSS `absolute; left: 0` popover overflows the viewport's right
 	// edge when the trigger sits near it on a narrow phone. `fixed` + a rect-derived,
 	// viewport-clamped left escapes that — same fix as GlossaryHelp.tsx (PROJ-419).
-	it("clamps the popover's left position within the viewport", () => {
-		render(
-			<div style={{ position: "absolute", left: `${window.innerWidth - 20}px` }}>
-				<MetricHelp id={FIRST_METRIC_ID} />
-			</div>
-		);
-		fireEvent.click(screen.getByRole("button", { name: `About ${FIRST_METRIC_LABEL}` }));
+	//
+	// jsdom's getBoundingClientRect is always 0×0, so a wrapper's inline `left` (as the
+	// old version of this test used) never reaches the component — it'd pass identically
+	// with the clamp deleted. Stub the trigger's own rect instead, as FiltersPopover's
+	// suite does for computeFiltersPopoverPosition.
+	describe("computeMetricHelpPosition (PROJ-588)", () => {
+		const originalHeight = window.innerHeight;
+		const originalWidth = window.innerWidth;
+		afterEach(() => {
+			window.innerHeight = originalHeight;
+			window.innerWidth = originalWidth;
+		});
+
+		it("clamps left so the panel's 16rem width stays within a narrow viewport", () => {
+			window.innerWidth = 300;
+			const pos = computeMetricHelpPosition(rectAt(50, 280, 24, 40));
+			expect(pos.left).toBeLessThanOrEqual(300 - 256 - 8);
+			expect(pos.left).toBeGreaterThanOrEqual(8);
+		});
+
+		it("flips above the trigger when there's too little room below but more above", () => {
+			window.innerHeight = 500;
+			// Trigger near the bottom: 500 - 480 - 4 - 8 = 8px below (< the 140px estimate).
+			const pos = computeMetricHelpPosition(rectAt(460, 10, 20));
+			expect(pos.top).toBeLessThan(460);
+		});
+
+		it("stays below the trigger when there's ample room", () => {
+			window.innerHeight = 2000;
+			const pos = computeMetricHelpPosition(rectAt(100, 10, 20));
+			expect(pos.top).toBe(124);
+		});
+	});
+
+	it("stubs the trigger's rect so the popover renders with fixed positioning near the clamped edge", () => {
+		render(<MetricHelp id={FIRST_METRIC_ID} />);
+		const trigger = screen.getByRole("button", { name: `About ${FIRST_METRIC_LABEL}` });
+		vi.spyOn(trigger, "getBoundingClientRect").mockReturnValue(rectAt(50, window.innerWidth - 20));
+
+		fireEvent.click(trigger);
 		const dialog = screen.getByRole("dialog");
 		expect(dialog.style.position).toBe("fixed");
 		expect(parseFloat(dialog.style.left)).toBeLessThanOrEqual(window.innerWidth - 256 - 8 + 1);

--- a/apps/web/src/islands/MetricHelp.tsx
+++ b/apps/web/src/islands/MetricHelp.tsx
@@ -9,6 +9,25 @@ import { Popover } from "./ui/Popover";
 // reposition it back on-screen.
 const POPOVER_WIDTH = 256; // 16rem, matches .popover-metric-help's `width`
 const POPOVER_MARGIN = 8;
+const POPOVER_GAP = 4;
+// PROJ-588 review: unlike FiltersPopover the content here is two short, unscrollable
+// paragraphs, so there's no maxHeight to clamp — just flip above the trigger when there
+// isn't room below. 140px comfortably covers two wrapped paragraphs in a 256px-wide panel.
+const POPOVER_EST_HEIGHT = 140;
+
+export function computeMetricHelpPosition(rect: DOMRect): { top: number; left: number } {
+	const left = Math.max(
+		POPOVER_MARGIN,
+		Math.min(rect.left, window.innerWidth - POPOVER_WIDTH - POPOVER_MARGIN)
+	);
+	const below = window.innerHeight - rect.bottom - POPOVER_GAP - POPOVER_MARGIN;
+	const above = rect.top - POPOVER_GAP - POPOVER_MARGIN;
+	const flip = below < POPOVER_EST_HEIGHT && above > below;
+	const top = flip
+		? Math.max(POPOVER_MARGIN, rect.top - POPOVER_GAP - POPOVER_EST_HEIGHT)
+		: rect.bottom + POPOVER_GAP;
+	return { top, left };
+}
 
 // PROJ-335: shared help affordance for every stat/chart, backed by metric-definitions.ts.
 // A toggletip, not a native <dialog>/alert: a button that toggles a popover, dismissed via
@@ -27,11 +46,7 @@ export function MetricHelp({ id }: { id: MetricId }) {
 	const reposition = useCallback(() => {
 		const rect = triggerRef.current?.getBoundingClientRect();
 		if (!rect) return;
-		const left = Math.max(
-			POPOVER_MARGIN,
-			Math.min(rect.left, window.innerWidth - POPOVER_WIDTH - POPOVER_MARGIN)
-		);
-		setPopoverPos({ top: rect.bottom + 4, left });
+		setPopoverPos(computeMetricHelpPosition(rect));
 	}, []);
 
 	function openPopover() {

--- a/apps/web/src/islands/MetricHelp.tsx
+++ b/apps/web/src/islands/MetricHelp.tsx
@@ -1,6 +1,14 @@
-import { useEffect, useId, useRef, useState } from "preact/hooks";
+import { useCallback, useEffect, useId, useRef, useState } from "preact/hooks";
 import { METRIC_DEFINITIONS, type MetricId } from "./metric-definitions";
 import { Popover } from "./ui/Popover";
+
+// PROJ-588: same clamped-portal approach as GlossaryHelp.tsx — an `anchored` popover
+// pinned to `left: 0` of its trigger can overflow the viewport's right edge on a narrow
+// phone when the trigger itself sits near that edge (e.g. a chart section heading in a
+// dashboard's right column). `max-width: min(16rem, 80vw)` clips the overflow but doesn't
+// reposition it back on-screen.
+const POPOVER_WIDTH = 256; // 16rem, matches .popover-metric-help's `width`
+const POPOVER_MARGIN = 8;
 
 // PROJ-335: shared help affordance for every stat/chart, backed by metric-definitions.ts.
 // A toggletip, not a native <dialog>/alert: a button that toggles a popover, dismissed via
@@ -10,45 +18,92 @@ import { Popover } from "./ui/Popover";
 export function MetricHelp({ id }: { id: MetricId }) {
 	const def = METRIC_DEFINITIONS[id];
 	const [open, setOpen] = useState(false);
+	const [popoverPos, setPopoverPos] = useState<{ top: number; left: number } | null>(null);
 	const rootRef = useRef<HTMLSpanElement>(null);
+	const triggerRef = useRef<HTMLButtonElement>(null);
+	const popoverRef = useRef<HTMLDivElement>(null);
 	const popoverId = useId();
+
+	const reposition = useCallback(() => {
+		const rect = triggerRef.current?.getBoundingClientRect();
+		if (!rect) return;
+		const left = Math.max(
+			POPOVER_MARGIN,
+			Math.min(rect.left, window.innerWidth - POPOVER_WIDTH - POPOVER_MARGIN)
+		);
+		setPopoverPos({ top: rect.bottom + 4, left });
+	}, []);
+
+	function openPopover() {
+		reposition();
+		setOpen(true);
+	}
+
+	function isInside(node: Node) {
+		return !!(rootRef.current?.contains(node) || popoverRef.current?.contains(node));
+	}
 
 	useEffect(() => {
 		if (!open) return;
 		function onPointerDown(e: MouseEvent) {
-			if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+			if (!(e.target instanceof Node) || !isInside(e.target)) setOpen(false);
 		}
 		function onKeyDown(e: KeyboardEvent) {
 			if (e.key === "Escape") setOpen(false);
 		}
+		function onScroll(e: Event) {
+			if (e.target instanceof Node && isInside(e.target)) return;
+			setOpen(false);
+		}
+		// CD-294: only a width change (rotation, desktop resize) invalidates the popover
+		// enough to dismiss it — see GlossaryHelp.tsx's identical split for why.
+		let lastWidth = window.innerWidth;
+		function onResize() {
+			if (window.innerWidth !== lastWidth) {
+				lastWidth = window.innerWidth;
+				setOpen(false);
+				return;
+			}
+			reposition();
+		}
+		const vv = window.visualViewport;
 		document.addEventListener("mousedown", onPointerDown);
 		document.addEventListener("keydown", onKeyDown);
+		window.addEventListener("scroll", onScroll, true);
+		window.addEventListener("resize", onResize);
+		vv?.addEventListener("resize", onResize);
 		return () => {
 			document.removeEventListener("mousedown", onPointerDown);
 			document.removeEventListener("keydown", onKeyDown);
+			window.removeEventListener("scroll", onScroll, true);
+			window.removeEventListener("resize", onResize);
+			vv?.removeEventListener("resize", onResize);
 		};
-	}, [open]);
+	}, [open, reposition]);
 
 	return (
 		<span class="metric-help" ref={rootRef}>
 			<button
+				ref={triggerRef}
 				type="button"
 				class="metric-help-trigger"
 				aria-label={`About ${def.label}`}
 				aria-expanded={open}
 				aria-describedby={open ? popoverId : undefined}
-				onClick={() => setOpen((o) => !o)}
+				onClick={() => (open ? setOpen(false) : openPopover())}
 			>
 				<span aria-hidden="true">ⓘ</span>
 			</button>
-			{open && (
+			{open && popoverPos && (
 				<Popover
 					id={popoverId}
-					strategy="anchored"
+					strategy="portal-fixed"
 					class="popover-metric-help"
 					role="dialog"
 					ariaModal={false}
 					ariaLabel={`${def.label} definition`}
+					elementRef={popoverRef}
+					position={popoverPos}
 				>
 					<p class="m-0 mb-1 text-[0.8rem] text-text-base">{def.definition}</p>
 					<p class="m-0 text-[0.72rem] text-text-muted">{def.computation}</p>

--- a/apps/web/src/islands/issue-list/FiltersPopover.test.tsx
+++ b/apps/web/src/islands/issue-list/FiltersPopover.test.tsx
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { computeFiltersPopoverPosition } from "./FiltersPopover";
+
+/** jsdom has no layout: every rect is 0×0 unless stubbed. */
+function rectAt(top: number, left = 10, height = 24, width = 100): DOMRect {
+	return {
+		top,
+		bottom: top + height,
+		left,
+		right: left + width,
+		width,
+		height,
+		x: left,
+		y: top,
+		toJSON: () => ({}),
+	} as DOMRect;
+}
+
+// PROJ-588: opened low on a phone, this fixed-position panel had no viewport clamping —
+// the date-range fields and "Clear all" could fall below the viewport with nothing to
+// scroll to reach them.
+describe("computeFiltersPopoverPosition (PROJ-588)", () => {
+	const originalHeight = window.innerHeight;
+	const originalWidth = window.innerWidth;
+	afterEach(() => {
+		window.innerHeight = originalHeight;
+		window.innerWidth = originalWidth;
+	});
+
+	it("opens below the trigger and clamps maxHeight to the space available", () => {
+		window.innerHeight = 500;
+		// 500 - 224 - 4 - 8 = 264px below.
+		expect(computeFiltersPopoverPosition(rectAt(200))).toEqual({
+			top: 228,
+			left: 10,
+			maxHeight: 264,
+		});
+	});
+
+	it("never exceeds the panel's 420px ceiling when there is ample room", () => {
+		window.innerHeight = 2000;
+		expect(computeFiltersPopoverPosition(rectAt(100)).maxHeight).toBe(420);
+	});
+
+	it("flips above the trigger when there's too little room below but more above", () => {
+		window.innerHeight = 500;
+		// Trigger near the bottom: 500 - 480 - 4 - 8 = 8px below (< the 160px floor).
+		// Above: 460 - 4 - 8 = 448px, clamped to the 420px ceiling.
+		const pos = computeFiltersPopoverPosition(rectAt(460, 10, 20));
+		expect(pos.top).toBeLessThan(460);
+		expect(pos.maxHeight).toBe(420);
+	});
+
+	it("clamps left so the panel's 16rem width stays within a narrow viewport", () => {
+		window.innerWidth = 300;
+		// Trigger near the right edge: left=280 would push the 256px-wide panel off-screen.
+		const pos = computeFiltersPopoverPosition(rectAt(50, 280, 24, 40));
+		expect(pos.left).toBeLessThanOrEqual(300 - 256 - 8);
+		expect(pos.left).toBeGreaterThanOrEqual(8);
+	});
+});

--- a/apps/web/src/islands/issue-list/FiltersPopover.tsx
+++ b/apps/web/src/islands/issue-list/FiltersPopover.tsx
@@ -392,6 +392,10 @@ export default function FiltersPopover({
 						padding: "0.75rem",
 						boxShadow: "var(--shadow-sm)",
 						minWidth: "16rem",
+						// PROJ-588 review: the left clamp assumes POPOVER_WIDTH (256px); without a
+						// matching maxWidth, content wider than that could still push the right edge
+						// past the viewport.
+						maxWidth: "calc(100vw - 16px)",
 						// PROJ-588: clamp+flip alone isn't enough on a short phone viewport where
 						// even the flipped side can't fit every field — scroll within the panel
 						// rather than letting it (or its contents) run off-screen.

--- a/apps/web/src/islands/issue-list/FiltersPopover.tsx
+++ b/apps/web/src/islands/issue-list/FiltersPopover.tsx
@@ -1,8 +1,40 @@
 import type { Dispatch, StateUpdater } from "preact/hooks";
-import { useEffect, useRef, useState } from "preact/hooks";
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { categoryColor, type TaskStatus } from "../board-utils";
 
 export type DateField = "" | "completed" | "updated";
+
+// PROJ-588: opened low on a phone, this fixed-position panel had no viewport clamping —
+// the date-range fields and "Clear all" could fall below the viewport with nothing to
+// scroll to reach them. Same flip/clamp/scroll shape as Select.tsx's computeMenuPosition,
+// tuned for this panel's own width and content height rather than a listbox row.
+const POPOVER_WIDTH = 256; // 16rem, matches the inline minWidth below
+const POPOVER_GAP = 4;
+const POPOVER_MARGIN = 8;
+const POPOVER_MIN_HEIGHT = 160;
+const POPOVER_MAX_HEIGHT = 420;
+
+export interface FiltersPopoverPos {
+	top: number;
+	left: number;
+	maxHeight: number;
+}
+
+export function computeFiltersPopoverPosition(rect: DOMRect): FiltersPopoverPos {
+	const left = Math.max(
+		POPOVER_MARGIN,
+		Math.min(rect.left, window.innerWidth - POPOVER_WIDTH - POPOVER_MARGIN)
+	);
+	const below = window.innerHeight - rect.bottom - POPOVER_GAP - POPOVER_MARGIN;
+	const above = rect.top - POPOVER_GAP - POPOVER_MARGIN;
+	const flip = below < POPOVER_MIN_HEIGHT && above > below;
+	const space = flip ? above : below;
+	const maxHeight = Math.max(POPOVER_MIN_HEIGHT, Math.min(POPOVER_MAX_HEIGHT, space));
+	const top = flip
+		? Math.max(POPOVER_MARGIN, rect.top - POPOVER_GAP - maxHeight)
+		: rect.bottom + POPOVER_GAP;
+	return { top, left, maxHeight };
+}
 
 const PILL_COLORS: Record<string, { bg: string; text: string }> = {
 	urgent: { bg: "var(--priority-urgent-solid)", text: "var(--on-accent)" },
@@ -299,7 +331,12 @@ export default function FiltersPopover({
 	const containerRef = useRef<HTMLDivElement>(null);
 	const popoverRef = useRef<HTMLDivElement>(null);
 	const buttonRef = useRef<HTMLButtonElement>(null);
-	const popoverPos = useRef<{ top: number; left: number }>({ top: 0, left: 0 });
+	const [popoverPos, setPopoverPos] = useState<FiltersPopoverPos | null>(null);
+
+	const reposition = useCallback(() => {
+		const rect = buttonRef.current?.getBoundingClientRect();
+		if (rect) setPopoverPos(computeFiltersPopoverPosition(rect));
+	}, []);
 
 	useEffect(() => {
 		if (!showFiltersPopover) return;
@@ -309,9 +346,15 @@ export default function FiltersPopover({
 				setShowFiltersPopover(false);
 			}
 		}
+		// Orientation change / desktop resize can invalidate a clamped position computed
+		// at open time (e.g. rotating the phone the popover was flipped-above on).
+		window.addEventListener("resize", reposition);
 		document.addEventListener("mousedown", onPointer);
-		return () => document.removeEventListener("mousedown", onPointer);
-	}, [showFiltersPopover]);
+		return () => {
+			window.removeEventListener("resize", reposition);
+			document.removeEventListener("mousedown", onPointer);
+		};
+	}, [showFiltersPopover, reposition]);
 
 	const dateFilterActive = !!(filterDateField && (filterDateFrom || filterDateTo));
 	const activeFilterCount =
@@ -327,19 +370,18 @@ export default function FiltersPopover({
 					if (showFiltersPopover) {
 						setShowFiltersPopover(false);
 					} else {
-						const rect = buttonRef.current?.getBoundingClientRect();
-						if (rect) popoverPos.current = { top: rect.bottom + 4, left: rect.left };
+						reposition();
 						setShowFiltersPopover(true);
 					}
 				}}
 			/>
-			{showFiltersPopover && (
+			{showFiltersPopover && popoverPos && (
 				<div
 					ref={popoverRef}
 					style={{
 						position: "fixed",
-						top: `${popoverPos.current.top}px`,
-						left: `${popoverPos.current.left}px`,
+						top: `${popoverPos.top}px`,
+						left: `${popoverPos.left}px`,
 						// CD-294: 200 is the popover layer (Base.astro's `.popover`). At 100 this
 						// sat *under* the fixed topbar (110), which it can slide beneath — the
 						// coordinates are captured once on open and never track the page scroll.
@@ -350,6 +392,12 @@ export default function FiltersPopover({
 						padding: "0.75rem",
 						boxShadow: "var(--shadow-sm)",
 						minWidth: "16rem",
+						// PROJ-588: clamp+flip alone isn't enough on a short phone viewport where
+						// even the flipped side can't fit every field — scroll within the panel
+						// rather than letting it (or its contents) run off-screen.
+						maxHeight: `${popoverPos.maxHeight}px`,
+						overflowY: "auto",
+						overscrollBehavior: "contain",
 					}}
 				>
 					<FiltersPopoverContent


### PR DESCRIPTION
## Summary
- **FiltersPopover.tsx**: the fixed-position filters panel had no `max-height`/overflow or viewport clamping. Opened low on a phone, the date-range fields and "Clear all" could fall below the viewport with no way to scroll to reach them. Adds `computeFiltersPopoverPosition` — the same flip/clamp/scroll shape as `Select.tsx`'s `computeMenuPosition`, tuned for this panel's own width (16rem) and content height (160–420px), plus a resize listener to recompute on orientation change.
- **MetricHelp.tsx**: `position: absolute; left: 0` off a small trigger, no scroll/resize handling, no portal (unlike sibling `GlossaryHelp.tsx`). A trigger near the right edge could overflow the viewport on a narrow phone — `max-width: min(16rem, 80vw)` clipped it but never repositioned it back on-screen. Now mirrors `GlossaryHelp`'s `portal-fixed` + clamped-left approach exactly.

Fixes PROJ-588.

## Test plan
- [x] New `computeFiltersPopoverPosition` unit tests (open-below/clamp maxHeight, ceiling, flip-above, clamp-left).
- [x] New `MetricHelp.test.tsx` (ported from `GlossaryHelp.test.tsx`'s coverage): open/close, Escape, outside-click, viewport-clamped left, scroll-dismiss, resize behavior, portal target.
- [x] Full web suite green (633/633), including the existing `IssueList.test.tsx` FiltersPopover z-index/stacking test.