### PR TITLE
feat(web): extend Select with per-item actions, migrate SavedViewsControl (PROJ-565)

### DIFF
--- a/apps/web/src/islands/issue-list/SavedViewsControl.test.tsx
+++ b/apps/web/src/islands/issue-list/SavedViewsControl.test.tsx
@@ -57,7 +57,7 @@ describe("SavedViewsControl — views menu on Select (PROJ-565)", () => {
 
 		await waitFor(() => screen.getByRole("combobox", { name: "Saved views" }));
 		fireEvent.click(screen.getByRole("combobox", { name: "Saved views" }));
-		fireEvent.click(screen.getByRole("option", { name: /^My bugs/ }));
+		fireEvent.click(screen.getByRole("option", { name: "My bugs" }));
 
 		expect(onApply).toHaveBeenCalledWith(EMPTY_FILTERS);
 		expect(screen.getByRole("combobox", { name: "Saved views" }).textContent).toContain("My bugs");
@@ -70,13 +70,27 @@ describe("SavedViewsControl — views menu on Select (PROJ-565)", () => {
 
 		await waitFor(() => screen.getByRole("combobox", { name: "Saved views" }));
 		fireEvent.click(screen.getByRole("combobox", { name: "Saved views" }));
-		fireEvent.click(screen.getByRole("option", { name: /^My bugs/ }));
+		fireEvent.click(screen.getByRole("option", { name: "My bugs" }));
 		onApply.mockClear();
 		fireEvent.click(screen.getByRole("combobox", { name: "Saved views" }));
 		fireEvent.click(screen.getByRole("button", { name: "Delete view Sprint board" }));
 
 		expect(onApply).not.toHaveBeenCalled();
-		expect(screen.queryByRole("option", { name: /^Sprint board/ })).toBeNull();
+		expect(screen.queryByRole("option", { name: "Sprint board" })).toBeNull();
+		expect(JSON.parse(localStorage.getItem("issue-views-PROJ") ?? "[]")).toHaveLength(1);
+	});
+
+	it("deletes the highlighted view with Backspace, keyboard-only (PROJ-565)", async () => {
+		seedViews(["Sprint board", "My bugs"]);
+		render(<Harness onApply={() => {}} />);
+
+		await waitFor(() => screen.getByRole("combobox", { name: "Saved views" }));
+		const trigger = screen.getByRole("combobox", { name: "Saved views" });
+		fireEvent.click(trigger);
+		// Highlight moves to "Sprint board" (index 0) on open by default.
+		fireEvent.keyDown(trigger, { key: "Backspace" });
+
+		expect(screen.queryByRole("option", { name: "Sprint board" })).toBeNull();
 		expect(JSON.parse(localStorage.getItem("issue-views-PROJ") ?? "[]")).toHaveLength(1);
 	});
 });

--- a/apps/web/src/islands/issue-list/SavedViewsControl.test.tsx
+++ b/apps/web/src/islands/issue-list/SavedViewsControl.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/preact";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SavedViewFilters } from "../saved-views";
+import SavedViewsControl from "./SavedViewsControl";
+import { useSavedViews } from "./useSavedViews";
+
+afterEach(cleanup);
+
+const EMPTY_FILTERS: SavedViewFilters = {
+	statuses: [],
+	priorities: [],
+	project: "PROJ",
+	type: "",
+	epicId: "",
+	sprintId: "",
+	hideEpics: false,
+	dateField: "",
+	dateFrom: "",
+	dateTo: "",
+};
+
+function seedViews(names: string[]) {
+	localStorage.setItem(
+		"issue-views-PROJ",
+		JSON.stringify(names.map((name) => ({ name, filters: EMPTY_FILTERS })))
+	);
+}
+
+function Harness({ onApply }: { onApply: (f: SavedViewFilters) => void }) {
+	const saved = useSavedViews("PROJ", EMPTY_FILTERS, onApply);
+	return <SavedViewsControl saved={saved} />;
+}
+
+beforeEach(() => localStorage.clear());
+
+// PROJ-565: SavedViewsControl's views menu is now a plain Select instance instead of a
+// hand-rolled trigger/menu, so this exercises the migration end to end rather than the
+// pieces Select.test.tsx already covers in isolation.
+describe("SavedViewsControl — views menu on Select (PROJ-565)", () => {
+	it("renders nothing when there are no saved views", () => {
+		render(<Harness onApply={() => {}} />);
+		expect(screen.queryByRole("combobox", { name: "Saved views" })).toBeNull();
+	});
+
+	it("shows the placeholder label until a view is applied", async () => {
+		seedViews(["Sprint board"]);
+		render(<Harness onApply={() => {}} />);
+		await waitFor(() =>
+			expect(screen.getByRole("combobox", { name: "Saved views" }).textContent).toContain("Views")
+		);
+	});
+
+	it("applies a view on selection and updates the trigger label", async () => {
+		seedViews(["Sprint board", "My bugs"]);
+		const onApply = vi.fn();
+		render(<Harness onApply={onApply} />);
+
+		await waitFor(() => screen.getByRole("combobox", { name: "Saved views" }));
+		fireEvent.click(screen.getByRole("combobox", { name: "Saved views" }));
+		fireEvent.click(screen.getByRole("option", { name: /^My bugs/ }));
+
+		expect(onApply).toHaveBeenCalledWith(EMPTY_FILTERS);
+		expect(screen.getByRole("combobox", { name: "Saved views" }).textContent).toContain("My bugs");
+	});
+
+	it("deletes a view via its trailing action without applying it", async () => {
+		seedViews(["Sprint board", "My bugs"]);
+		const onApply = vi.fn();
+		render(<Harness onApply={onApply} />);
+
+		await waitFor(() => screen.getByRole("combobox", { name: "Saved views" }));
+		fireEvent.click(screen.getByRole("combobox", { name: "Saved views" }));
+		fireEvent.click(screen.getByRole("option", { name: /^My bugs/ }));
+		onApply.mockClear();
+		fireEvent.click(screen.getByRole("combobox", { name: "Saved views" }));
+		fireEvent.click(screen.getByRole("button", { name: "Delete view Sprint board" }));
+
+		expect(onApply).not.toHaveBeenCalled();
+		expect(screen.queryByRole("option", { name: /^Sprint board/ })).toBeNull();
+		expect(JSON.parse(localStorage.getItem("issue-views-PROJ") ?? "[]")).toHaveLength(1);
+	});
+});

--- a/apps/web/src/islands/issue-list/SavedViewsControl.tsx
+++ b/apps/web/src/islands/issue-list/SavedViewsControl.tsx
@@ -1,131 +1,32 @@
-import type { SavedView } from "../saved-views";
-import { Popover } from "../ui/Popover";
+import Select, { type SelectOption } from "../ui/Select";
 import type { useSavedViews } from "./useSavedViews";
 
 type Saved = ReturnType<typeof useSavedViews>;
 
-function ViewsMenuItem({
-	view,
-	activeViewName,
-	applyView,
-	deleteView,
-}: Pick<Saved, "applyView" | "deleteView"> & { view: SavedView; activeViewName: string | null }) {
-	return (
-		<li
-			key={view.name}
-			// cofferdam-ignore: Warning.DesignSystemConvention: reuses Select's option visual style for a non-value-driven menu with a per-item delete action; full Select reuse would need Select's option renderer extended for that, out of scope for PROJ-527, tracked as PROJ-565
-			class="select-option"
-			data-selected={view.name === activeViewName || undefined}
-			style={{
-				display: "flex",
-				justifyContent: "space-between",
-				alignItems: "center",
-				gap: "0.5rem",
-			}}
-		>
-			<button
-				type="button"
-				style={{
-					flexGrow: 1,
-					cursor: "pointer",
-					background: "none",
-					border: "none",
-					padding: 0,
-					textAlign: "left",
-					font: "inherit",
-					color: "inherit",
-				}}
-				onClick={() => applyView(view)}
-			>
-				{view.name}
-			</button>
-			<button
-				type="button"
-				aria-label={`Delete view ${view.name}`}
-				onClick={(e: MouseEvent) => {
-					e.stopPropagation();
-					deleteView(view.name);
-				}}
-				style={{
-					background: "none",
-					border: "none",
-					cursor: "pointer",
-					color: "var(--text-muted)",
-					padding: "0 0.2rem",
-					fontSize: "0.85rem",
-					lineHeight: "1",
-					flexShrink: 0,
-				}}
-			>
-				×
-			</button>
-		</li>
-	);
-}
-
+// PROJ-565: Select's option renderer now supports a per-item trailing action, so this no
+// longer needs its own hand-rolled trigger/menu — Select owns positioning, outside-click,
+// and keyboard handling in one shared place instead of duplicating it here.
 function ViewsMenu({ saved }: { saved: Saved }) {
-	const {
-		savedViews,
-		activeViewName,
-		showViewsMenu,
-		setShowViewsMenu,
-		viewsContainerRef,
-		viewsMenuRef,
-		viewsButtonRef,
-		viewsMenuPos,
-		applyView,
-		deleteView,
-	} = saved;
+	const { savedViews, activeViewName, applyView, deleteView } = saved;
 	if (savedViews.length === 0) return null;
 
+	const options: SelectOption[] = savedViews.map((v) => ({
+		value: v.name,
+		label: v.name,
+		action: { ariaLabel: `Delete view ${v.name}`, onClick: () => deleteView(v.name) },
+	}));
+
 	return (
-		<div class="relative" ref={viewsContainerRef}>
-			<button
-				ref={viewsButtonRef}
-				type="button"
-				// cofferdam-ignore: Warning.DesignSystemConvention: reuses Select's trigger visual style for a non-value-driven menu; full Select reuse would need Select's option renderer extended for per-item actions (rename/delete), out of scope for PROJ-527, tracked as PROJ-565
-				class="select-button"
-				aria-haspopup="listbox"
-				aria-expanded={showViewsMenu}
-				aria-label="Saved views"
-				onClick={() => {
-					if (showViewsMenu) {
-						setShowViewsMenu(false);
-					} else {
-						const rect = viewsButtonRef.current?.getBoundingClientRect();
-						if (rect)
-							viewsMenuPos.current = { top: rect.bottom + 4, left: rect.left, width: rect.width };
-						setShowViewsMenu(true);
-					}
-				}}
-			>
-				<span>{activeViewName ?? "Views"}</span>
-				{/* cofferdam-ignore: Warning.DesignSystemConvention: reuses Select's caret visual style for a non-value-driven menu, out of scope for PROJ-527, tracked as PROJ-565 */}
-				<span class="select-caret" aria-hidden="true">
-					▾
-				</span>
-			</button>
-			{showViewsMenu && (
-				<Popover
-					as="ul"
-					strategy="fixed-inline"
-					class="popover-select-menu"
-					ariaLabel="Saved views"
-					elementRef={viewsMenuRef}
-					position={viewsMenuPos.current}
-				>
-					{savedViews.map((v) => (
-						<ViewsMenuItem
-							key={v.name}
-							view={v}
-							activeViewName={activeViewName}
-							applyView={applyView}
-							deleteView={deleteView}
-						/>
-					))}
-				</Popover>
-			)}
-		</div>
+		<Select
+			value={activeViewName ?? ""}
+			options={options}
+			onChange={(name) => {
+				const view = savedViews.find((v) => v.name === name);
+				if (view) applyView(view);
+			}}
+			ariaLabel="Saved views"
+			placeholder="Views"
+		/>
 	);
 }
 

--- a/apps/web/src/islands/issue-list/useSavedViews.ts
+++ b/apps/web/src/islands/issue-list/useSavedViews.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
 import {
 	captureView,
 	filtersMatch,
@@ -10,7 +10,7 @@ import {
 	viewsStorageKey,
 } from "../saved-views";
 
-/** Owns saved-views state (localStorage-backed) and the views-menu UI state. */
+/** Owns saved-views state (localStorage-backed) and the save-view input UI state. */
 export function useSavedViews(
 	filterProject: string,
 	currentFilters: SavedViewFilters,
@@ -20,33 +20,11 @@ export function useSavedViews(
 	const [activeViewName, setActiveViewName] = useState<string | null>(null);
 	const [showSaveInput, setShowSaveInput] = useState(false);
 	const [saveViewName, setSaveViewName] = useState("");
-	const [showViewsMenu, setShowViewsMenu] = useState(false);
-	const viewsContainerRef = useRef<HTMLDivElement>(null);
-	const viewsMenuRef = useRef<HTMLUListElement>(null);
-	const viewsButtonRef = useRef<HTMLButtonElement>(null);
-	const viewsMenuPos = useRef<{ top: number; left: number; width: number }>({
-		top: 0,
-		left: 0,
-		width: 0,
-	});
 
 	// Load saved views from localStorage when the project context changes (PROJ-141)
 	useEffect(() => {
 		setSavedViews(parseSavedViews(localStorage.getItem(viewsStorageKey(filterProject))));
 	}, [filterProject]);
-
-	// Close views menu on outside click (PROJ-141)
-	useEffect(() => {
-		if (!showViewsMenu) return;
-		function onPointer(e: MouseEvent) {
-			const target = e.target as Node;
-			if (!viewsContainerRef.current?.contains(target) && !viewsMenuRef.current?.contains(target)) {
-				setShowViewsMenu(false);
-			}
-		}
-		document.addEventListener("mousedown", onPointer);
-		return () => document.removeEventListener("mousedown", onPointer);
-	}, [showViewsMenu]);
 
 	// Clear active view name when filters drift from the saved state (PROJ-141)
 	useEffect(() => {
@@ -85,7 +63,6 @@ export function useSavedViews(
 	function applyView(view: SavedView) {
 		onApply(view.filters);
 		setActiveViewName(view.name);
-		setShowViewsMenu(false);
 	}
 
 	return {
@@ -95,12 +72,6 @@ export function useSavedViews(
 		setShowSaveInput,
 		saveViewName,
 		setSaveViewName,
-		showViewsMenu,
-		setShowViewsMenu,
-		viewsContainerRef,
-		viewsMenuRef,
-		viewsButtonRef,
-		viewsMenuPos,
 		doSaveView,
 		deleteView,
 		applyView,

--- a/apps/web/src/islands/ui/Select.test.tsx
+++ b/apps/web/src/islands/ui/Select.test.tsx
@@ -73,6 +73,67 @@ describe("Select", () => {
 		// browser; keyboard handling also early-returns on `disabled`.
 		expect((button as HTMLButtonElement).disabled).toBe(true);
 	});
+
+	it("shows the placeholder when value matches no option", () => {
+		render(
+			<Select
+				value=""
+				options={OPTIONS}
+				onChange={() => {}}
+				ariaLabel="Status"
+				placeholder="Pick one"
+			/>
+		);
+		expect(screen.getByRole("combobox", { name: "Status" }).textContent).toContain("Pick one");
+	});
+});
+
+// PROJ-565: SavedViewsControl needs a per-item trailing action (delete a saved view)
+// without regressing plain value-driven usages elsewhere (priority/status pickers etc.).
+describe("Select — per-item action (PROJ-565)", () => {
+	const OPTIONS_WITH_ACTION: SelectOption[] = [
+		{
+			value: "a",
+			label: "Alpha",
+			action: { ariaLabel: "Delete Alpha", onClick: vi.fn() },
+		},
+		{ value: "b", label: "Beta" },
+	];
+
+	it("renders a trailing action button only for options that declare one", () => {
+		render(
+			<Select value="a" options={OPTIONS_WITH_ACTION} onChange={() => {}} ariaLabel="Views" />
+		);
+		fireEvent.click(screen.getByRole("combobox", { name: "Views" }));
+
+		expect(screen.getByRole("button", { name: "Delete Alpha" })).toBeTruthy();
+		expect(screen.queryByRole("button", { name: /Delete Beta/ })).toBeNull();
+	});
+
+	it("clicking the action fires its onClick without selecting the option", () => {
+		const onAction = vi.fn();
+		const onChange = vi.fn();
+		const options: SelectOption[] = [
+			{ value: "a", label: "Alpha", action: { ariaLabel: "Delete Alpha", onClick: onAction } },
+		];
+		render(<Select value="a" options={options} onChange={onChange} ariaLabel="Views" />);
+		fireEvent.click(screen.getByRole("combobox", { name: "Views" }));
+		fireEvent.click(screen.getByRole("button", { name: "Delete Alpha" }));
+
+		expect(onAction).toHaveBeenCalledTimes(1);
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it("clicking the option row itself still selects it", () => {
+		const onChange = vi.fn();
+		render(
+			<Select value="a" options={OPTIONS_WITH_ACTION} onChange={onChange} ariaLabel="Views" />
+		);
+		fireEvent.click(screen.getByRole("combobox", { name: "Views" }));
+		fireEvent.click(screen.getByRole("option", { name: /^Beta/ }));
+
+		expect(onChange).toHaveBeenCalledWith("b");
+	});
 });
 
 // CD-294: the real iOS failure mode. Safari fires `resize` when the on-screen

--- a/apps/web/src/islands/ui/Select.test.tsx
+++ b/apps/web/src/islands/ui/Select.test.tsx
@@ -130,9 +130,48 @@ describe("Select — per-item action (PROJ-565)", () => {
 			<Select value="a" options={OPTIONS_WITH_ACTION} onChange={onChange} ariaLabel="Views" />
 		);
 		fireEvent.click(screen.getByRole("combobox", { name: "Views" }));
-		fireEvent.click(screen.getByRole("option", { name: /^Beta/ }));
+		fireEvent.click(screen.getByRole("option", { name: "Beta" }));
 
 		expect(onChange).toHaveBeenCalledWith("b");
+	});
+
+	it("gives an option with an action a name that is just its label, not the action's too", () => {
+		render(
+			<Select value="a" options={OPTIONS_WITH_ACTION} onChange={() => {}} ariaLabel="Views" />
+		);
+		fireEvent.click(screen.getByRole("combobox", { name: "Views" }));
+
+		// Without an explicit aria-label, the nested "Delete Alpha" button's own
+		// accessible name would fold into the option's, per the accname spec.
+		expect(screen.getByRole("option", { name: "Alpha" })).toBeTruthy();
+	});
+
+	it("still marks the selected option (checkmark) when it also has an action", () => {
+		render(
+			<Select value="a" options={OPTIONS_WITH_ACTION} onChange={() => {}} ariaLabel="Views" />
+		);
+		fireEvent.click(screen.getByRole("combobox", { name: "Views" }));
+
+		expect(screen.getByRole("option", { name: "Alpha" }).getAttribute("data-selected")).toBe(
+			"true"
+		);
+		expect(screen.getByRole("option", { name: "Beta" }).getAttribute("data-selected")).toBeNull();
+	});
+
+	it("runs the highlighted option's action on Backspace/Delete, keyboard-only", () => {
+		const onAction = vi.fn();
+		const options: SelectOption[] = [
+			{ value: "a", label: "Alpha", action: { ariaLabel: "Delete Alpha", onClick: onAction } },
+		];
+		render(<Select value="a" options={options} onChange={() => {}} ariaLabel="Views" />);
+		const trigger = screen.getByRole("combobox", { name: "Views" });
+		fireEvent.click(trigger);
+
+		fireEvent.keyDown(trigger, { key: "Backspace" });
+		expect(onAction).toHaveBeenCalledTimes(1);
+
+		fireEvent.keyDown(trigger, { key: "Delete" });
+		expect(onAction).toHaveBeenCalledTimes(2);
 	});
 });
 

--- a/apps/web/src/islands/ui/Select.test.tsx
+++ b/apps/web/src/islands/ui/Select.test.tsx
@@ -173,6 +173,70 @@ describe("Select — per-item action (PROJ-565)", () => {
 		fireEvent.keyDown(trigger, { key: "Delete" });
 		expect(onAction).toHaveBeenCalledTimes(2);
 	});
+
+	it("targets the highlighted option, not just the first one", () => {
+		const onA = vi.fn();
+		const onB = vi.fn();
+		const options: SelectOption[] = [
+			{ value: "a", label: "Alpha", action: { ariaLabel: "Delete Alpha", onClick: onA } },
+			{ value: "b", label: "Beta", action: { ariaLabel: "Delete Beta", onClick: onB } },
+		];
+		render(<Select value="a" options={options} onChange={() => {}} ariaLabel="Views" />);
+		const trigger = screen.getByRole("combobox", { name: "Views" });
+		fireEvent.click(trigger);
+
+		fireEvent.keyDown(trigger, { key: "ArrowDown" });
+		fireEvent.keyDown(trigger, { key: "Backspace" });
+
+		expect(onA).not.toHaveBeenCalled();
+		expect(onB).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not swallow Backspace/Delete on plain options with no action", () => {
+		const onChange = vi.fn();
+		render(<Select value="open" options={OPTIONS} onChange={onChange} ariaLabel="Status" />);
+		const trigger = screen.getByRole("combobox", { name: "Status" });
+		fireEvent.click(trigger);
+
+		const event = new KeyboardEvent("keydown", {
+			key: "Backspace",
+			bubbles: true,
+			cancelable: true,
+		});
+		fireEvent(trigger, event);
+
+		expect(event.defaultPrevented).toBe(false);
+	});
+
+	it("clamps highlight when the highlighted option's action removes it from the list", () => {
+		const options: SelectOption[] = [
+			{ value: "a", label: "Alpha" },
+			{ value: "b", label: "Beta" },
+			{
+				value: "c",
+				label: "Gamma",
+				action: { ariaLabel: "Delete Gamma", onClick: () => {} },
+			},
+		];
+		const { rerender } = render(
+			<Select value="a" options={options} onChange={() => {}} ariaLabel="Views" />
+		);
+		const trigger = screen.getByRole("combobox", { name: "Views" });
+		fireEvent.click(trigger);
+		fireEvent.keyDown(trigger, { key: "End" });
+		expect(trigger.getAttribute("aria-activedescendant")).toMatch(/-opt-2$/);
+
+		// Simulate the action removing "Gamma" from the list, as a real delete would.
+		rerender(
+			<Select value="a" options={options.slice(0, 2)} onChange={() => {}} ariaLabel="Views" />
+		);
+
+		const after = trigger.getAttribute("aria-activedescendant");
+		expect(after).toMatch(/-opt-1$/);
+		// The regression: aria-activedescendant pointing at a removed <li> id,
+		// stranding a screen-reader user. Confirm the id it points to still exists.
+		expect(after && document.getElementById(after)).toBeTruthy();
+	});
 });
 
 // CD-294: the real iOS failure mode. Safari fires `resize` when the on-screen

--- a/apps/web/src/islands/ui/Select.tsx
+++ b/apps/web/src/islands/ui/Select.tsx
@@ -117,8 +117,8 @@ interface SelectKeyDownConfig {
 	setHighlight: (fn: (h: number) => number) => void;
 	choose: (index: number) => void;
 	close: () => void;
-	/** PROJ-565: runs the highlighted option's `action`, if it has one. */
-	runAction: (index: number) => void;
+	/** PROJ-565: runs the highlighted option's `action`, if it has one. Returns whether it did. */
+	runAction: (index: number) => boolean;
 }
 
 function createSelectKeyDownHandler({
@@ -175,13 +175,13 @@ function createSelectKeyDownHandler({
 			// nested <button>, but this listbox uses the aria-activedescendant pattern —
 			// DOM focus never leaves the trigger, so the button is otherwise unreachable
 			// by keyboard. Delete/Backspace on the highlighted option runs it instead.
+			// Only preventDefault when there's actually an action to run, so plain
+			// Selects (no action on any option) don't swallow the keystroke.
 			Delete: (ev) => {
-				ev.preventDefault();
-				runAction(highlight);
+				if (runAction(highlight)) ev.preventDefault();
 			},
 			Backspace: (ev) => {
-				ev.preventDefault();
-				runAction(highlight);
+				if (runAction(highlight)) ev.preventDefault();
 			},
 		};
 		handlers[e.key]?.(e);
@@ -248,7 +248,7 @@ function SelectMenu({
 					onMouseEnter={() => onHighlight(i)}
 					onClick={() => onChoose(i)}
 				>
-					{opt.label}
+					{opt.action ? <span style={{ flexGrow: 1 }}>{opt.label}</span> : opt.label}
 					{opt.action && (
 						<button
 							type="button"
@@ -349,9 +349,19 @@ export default function Select({
 	}
 
 	// PROJ-565: keyboard equivalent of clicking an option's trailing action button.
-	function runAction(index: number) {
-		options[index]?.action?.onClick();
+	// Returns whether an action actually ran, so the caller only preventDefaults then.
+	function runAction(index: number): boolean {
+		const action = options[index]?.action;
+		if (!action) return false;
+		action.onClick();
+		return true;
 	}
+
+	// PROJ-565: an action (e.g. delete) can shrink `options` while the menu is open —
+	// clamp so `highlight`/`aria-activedescendant` never point past the new end.
+	useEffect(() => {
+		if (highlight > options.length - 1) setHighlight(Math.max(0, options.length - 1));
+	}, [options.length, highlight]);
 
 	useCloseOnOutside(open, close, reposition, rootRef);
 

--- a/apps/web/src/islands/ui/Select.tsx
+++ b/apps/web/src/islands/ui/Select.tsx
@@ -117,6 +117,8 @@ interface SelectKeyDownConfig {
 	setHighlight: (fn: (h: number) => number) => void;
 	choose: (index: number) => void;
 	close: () => void;
+	/** PROJ-565: runs the highlighted option's `action`, if it has one. */
+	runAction: (index: number) => void;
 }
 
 function createSelectKeyDownHandler({
@@ -128,6 +130,7 @@ function createSelectKeyDownHandler({
 	setHighlight,
 	choose,
 	close,
+	runAction,
 }: SelectKeyDownConfig) {
 	return function onKeyDown(e: KeyboardEvent) {
 		if (disabled) return;
@@ -168,6 +171,18 @@ function createSelectKeyDownHandler({
 				close();
 			},
 			Tab: () => close(),
+			// PROJ-565: the trailing per-item action (e.g. delete a saved view) is a
+			// nested <button>, but this listbox uses the aria-activedescendant pattern —
+			// DOM focus never leaves the trigger, so the button is otherwise unreachable
+			// by keyboard. Delete/Backspace on the highlighted option runs it instead.
+			Delete: (ev) => {
+				ev.preventDefault();
+				runAction(highlight);
+			},
+			Backspace: (ev) => {
+				ev.preventDefault();
+				runAction(highlight);
+			},
 		};
 		handlers[e.key]?.(e);
 	};
@@ -221,18 +236,15 @@ function SelectMenu({
 					id={`${baseId}-opt-${i}`}
 					role="option"
 					aria-selected={opt.value === value}
+					// PROJ-565: an explicit aria-label pins the accessible name to just the
+					// label — without it, the nested action button's own aria-label gets
+					// folded into the option's computed name (browser accname rules
+					// substitute a descendant's aria-label into the concatenation), so an
+					// option like "My bugs" would announce as "My bugs Delete view My bugs".
+					aria-label={opt.action ? opt.label : undefined}
+					data-selected={opt.value === value || undefined}
 					class={i === highlight ? "select-option highlighted" : "select-option"}
-					style={{
-						textTransform: capitalize ? "capitalize" : undefined,
-						...(opt.action
-							? {
-									display: "flex",
-									justifyContent: "space-between",
-									alignItems: "center",
-									gap: "0.5rem",
-								}
-							: undefined),
-					}}
+					style={{ textTransform: capitalize ? "capitalize" : undefined }}
 					onMouseEnter={() => onHighlight(i)}
 					onClick={() => onChoose(i)}
 				>
@@ -246,6 +258,7 @@ function SelectMenu({
 								opt.action?.onClick();
 							}}
 							style={{
+								marginLeft: "auto",
 								background: "none",
 								border: "none",
 								cursor: "pointer",
@@ -335,6 +348,11 @@ export default function Select({
 		setOpen(false);
 	}
 
+	// PROJ-565: keyboard equivalent of clicking an option's trailing action button.
+	function runAction(index: number) {
+		options[index]?.action?.onClick();
+	}
+
 	useCloseOnOutside(open, close, reposition, rootRef);
 
 	const onKeyDown = createSelectKeyDownHandler({
@@ -346,6 +364,7 @@ export default function Select({
 		setHighlight,
 		choose,
 		close,
+		runAction,
 	});
 
 	const label = selected?.label ?? (value || placeholder || "");

--- a/apps/web/src/islands/ui/Select.tsx
+++ b/apps/web/src/islands/ui/Select.tsx
@@ -4,6 +4,16 @@ import { useCallback, useEffect, useId, useRef, useState } from "preact/hooks";
 export interface SelectOption {
 	value: string;
 	label: string;
+	/**
+	 * PROJ-565: an optional trailing action rendered inside the option row (e.g. delete a
+	 * saved view). Stops propagation so it never triggers `onChange` for the option itself.
+	 */
+	action?: {
+		ariaLabel: string;
+		/** Defaults to "×". */
+		icon?: string;
+		onClick: () => void;
+	};
 }
 
 const OPEN_TRIGGER_KEYS = new Set(["ArrowDown", "Enter", " "]);
@@ -212,11 +222,43 @@ function SelectMenu({
 					role="option"
 					aria-selected={opt.value === value}
 					class={i === highlight ? "select-option highlighted" : "select-option"}
-					style={{ textTransform: capitalize ? "capitalize" : undefined }}
+					style={{
+						textTransform: capitalize ? "capitalize" : undefined,
+						...(opt.action
+							? {
+									display: "flex",
+									justifyContent: "space-between",
+									alignItems: "center",
+									gap: "0.5rem",
+								}
+							: undefined),
+					}}
 					onMouseEnter={() => onHighlight(i)}
 					onClick={() => onChoose(i)}
 				>
 					{opt.label}
+					{opt.action && (
+						<button
+							type="button"
+							aria-label={opt.action.ariaLabel}
+							onClick={(e: MouseEvent) => {
+								e.stopPropagation();
+								opt.action?.onClick();
+							}}
+							style={{
+								background: "none",
+								border: "none",
+								cursor: "pointer",
+								color: "var(--text-muted)",
+								padding: "0 0.2rem",
+								fontSize: "0.85rem",
+								lineHeight: "1",
+								flexShrink: 0,
+							}}
+						>
+							{opt.action.icon ?? "×"}
+						</button>
+					)}
 				</li>
 			))}
 		</ul>
@@ -235,6 +277,11 @@ interface Props {
 	capitalize?: boolean;
 	/** Extra class appended to the trigger button. */
 	buttonClass?: string;
+	/**
+	 * PROJ-565: label shown when `value` matches no option (e.g. no saved view is active
+	 * yet). Falls back to the raw `value` when omitted, unchanged from prior behavior.
+	 */
+	placeholder?: string;
 }
 
 /**
@@ -253,6 +300,7 @@ export default function Select({
 	buttonStyle,
 	capitalize = false,
 	buttonClass,
+	placeholder,
 }: Props) {
 	const [open, setOpen] = useState(false);
 	const [highlight, setHighlight] = useState(0);
@@ -300,7 +348,7 @@ export default function Select({
 		close,
 	});
 
-	const label = selected?.label ?? value;
+	const label = selected?.label ?? (value || placeholder || "");
 
 	return (
 		<div class="select" ref={rootRef}>


### PR DESCRIPTION
## Summary
- `Select.tsx`: options can now declare an optional trailing `action` (aria-label + icon + onClick), rendered inside the option row without triggering the option's own `onChange`. Also adds an optional `placeholder` label for when `value` matches no option.
- `SavedViewsControl.tsx`: the hand-rolled trigger/menu (its own `.select-button`/`.select-option`/`.select-caret` markup, called out as a fast-follow in PROJ-533) is dropped entirely — the views menu is now a plain `Select` instance using the new per-item action for delete.
- `useSavedViews.ts`: drops the menu-visibility/position state (`showViewsMenu`, `viewsMenuPos`, `viewsContainerRef`, `viewsMenuRef`, `viewsButtonRef`) that `Select` now owns internally.

## Test plan
- [x] `pnpm vitest run` — 647/647 passing, including new `Select.test.tsx` coverage for the action feature and a new `SavedViewsControl.test.tsx` exercising the full apply/delete flow through `Select`
- [x] `pnpm turbo type-check --filter=@projektor/web` — 0 errors
- [x] Existing `Select` usages (priority/status pickers etc.) unaffected — `action`/`placeholder` are both optional

Tracked as PROJ-565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYPsSekdCWXUL8UZR5sGEf