### PR TITLE
chore(web): remove orphaned Popover as="ul"/fixed-inline code after PROJ-565 (PROJ-604)

### DIFF
--- a/apps/web/src/islands/ui/Popover.test.tsx
+++ b/apps/web/src/islands/ui/Popover.test.tsx
@@ -72,17 +72,6 @@ describe("Popover", () => {
 		expect(el.style.minWidth).toBe("40px");
 	});
 
-	it("stays in the render container with an inline fixed position when fixed-inline", () => {
-		const { container } = render(
-			<Popover strategy="fixed-inline" position={{ top: 10, left: 20 }}>
-				<span>Inline fixed content</span>
-			</Popover>
-		);
-		const el = screen.getByText("Inline fixed content").parentElement as HTMLElement;
-		expect(container.contains(el)).toBe(true);
-		expect(el.style.position).toBe("fixed");
-	});
-
 	it("renders no ARIA attributes when role is omitted", () => {
 		const { container } = render(
 			<Popover strategy="anchored">
@@ -95,9 +84,8 @@ describe("Popover", () => {
 		expect(container).toBeTruthy();
 	});
 
-	it("throws without `position` when strategy is 'portal-fixed' or 'fixed-inline'", () => {
+	it("throws without `position` when strategy is 'portal-fixed'", () => {
 		expect(() => render(<Popover strategy="portal-fixed">No position</Popover>)).toThrow();
-		expect(() => render(<Popover strategy="fixed-inline">No position</Popover>)).toThrow();
 	});
 
 	it("resolves elementRef to the rendered DOM element when anchored", () => {

--- a/apps/web/src/islands/ui/Popover.tsx
+++ b/apps/web/src/islands/ui/Popover.tsx
@@ -34,10 +34,6 @@ function Portal({ into, vnode }: { into: Element; vnode: VNode }) {
 
 export interface PopoverProps {
 	id?: string;
-	/** Root element tag. Defaults to "div". "ul" is needed for a listbox
-	 * popover (e.g. SavedViewsControl's saved-views menu) where the
-	 * popover element itself must carry `role="listbox"`, not wrap one. */
-	as?: "div" | "ul";
 	/** Omit both `role`/`ariaLabel` to render no ARIA attributes at all —
 	 * needed when the caller's own children already declare the
 	 * accessible role/name (e.g. AccountMenu's inner `role="menu"` div),
@@ -67,25 +63,15 @@ export interface PopoverProps {
 	 * `document.body` with caller-computed fixed coordinates (matches
 	 * `AccountMenu.tsx`/`GlossaryHelp.tsx`'s existing pattern, needed to
 	 * escape an ancestor's `transform`, e.g. the topbar's scroll-hide).
-	 * "fixed-inline" renders in place (no portal) but with caller-computed
-	 * `position: fixed` coordinates via inline style — matches
-	 * `SavedViewsControl.tsx`'s existing saved-views menu, which needs
-	 * fixed positioning (to escape a scrollable toolbar) but was never
-	 * portaled. Inline `style` always wins over the modifier class's own
-	 * `position`/`top`/`left` (inline styles beat class selectors
-	 * regardless of specificity), so sharing a modifier class between an
-	 * "anchored" call site and a "portal-fixed"/"fixed-inline" call site
-	 * for the same visual style is safe.
 	 */
-	strategy: "anchored" | "portal-fixed" | "fixed-inline";
-	/** Required when strategy is "portal-fixed" or "fixed-inline". */
+	strategy: "anchored" | "portal-fixed";
+	/** Required when strategy is "portal-fixed". */
 	position?: { top: number; left?: number; right?: number; width?: number };
 	children: ComponentChildren;
 }
 
 export function Popover({
 	id,
-	as = "div",
 	role,
 	ariaLabel,
 	ariaModal,
@@ -96,7 +82,6 @@ export function Popover({
 	children,
 }: PopoverProps) {
 	const classes = extraClass ? `popover ${extraClass}` : "popover";
-	const Tag = as;
 	const a11yProps = {
 		...(role !== undefined ? { role } : {}),
 		...(ariaLabel !== undefined ? { "aria-label": ariaLabel } : {}),
@@ -104,19 +89,15 @@ export function Popover({
 			? { "aria-modal": (ariaModal ? "true" : "false") as "true" | "false" }
 			: {}),
 	};
-	// biome-ignore lint/suspicious/noExplicitAny: dynamic `Tag = as` ("div" | "ul") makes JSX infer an unsatisfiable intersection ref type across both element kinds.
-	const refProp = { ref: elementRef as any };
-
 	if (strategy === "anchored") {
 		return (
-			<Tag id={id} class={classes} {...a11yProps} {...refProp}>
+			<div id={id} class={classes} {...a11yProps} ref={elementRef as Ref<HTMLDivElement>}>
 				{children}
-			</Tag>
+			</div>
 		);
 	}
 
-	if (!position)
-		throw new Error(`Popover: \`position\` is required when strategy is '${strategy}'`);
+	if (!position) throw new Error("Popover: `position` is required when strategy is 'portal-fixed'");
 
 	const style = {
 		position: "fixed" as const,
@@ -127,10 +108,16 @@ export function Popover({
 	};
 
 	const el = (
-		<Tag id={id} class={classes} style={style} {...a11yProps} {...refProp}>
+		<div
+			id={id}
+			class={classes}
+			style={style}
+			{...a11yProps}
+			ref={elementRef as Ref<HTMLDivElement>}
+		>
 			{children}
-		</Tag>
+		</div>
 	);
 
-	return strategy === "portal-fixed" ? <Portal into={document.body} vnode={el} /> : el;
+	return <Portal into={document.body} vnode={el} />;
 }

--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -725,14 +725,6 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
         padding: 0.375rem;
         font-size: 0.875rem;
       }
-      .popover-select-menu {
-        border-radius: 6px;
-        padding: 0.25rem;
-        max-height: 16rem;
-        overflow-y: auto;
-        /* CD-294: keep the menu's own scroll from chaining to the page behind it. */
-        overscroll-behavior: contain;
-      }
       .metric-help-popover {
         position: absolute;
         top: calc(100% + 4px);

--- a/apps/web/src/layouts/Base.mobile-viewport.test.ts
+++ b/apps/web/src/layouts/Base.mobile-viewport.test.ts
@@ -53,16 +53,6 @@ describe("Base layout — mobile Select menu sheet (CD-294)", () => {
 	});
 });
 
-describe("Base layout — scrollable popover menus contain their scroll (CD-294)", () => {
-	it("stops .popover-select-menu chaining its scroll to the page behind it", () => {
-		const start = source.indexOf("      .popover-select-menu {");
-		const block = source.slice(start, source.indexOf("\n      }", start));
-		expect(start).toBeGreaterThan(-1);
-		expect(block).toMatch(/overflow-y:\s*auto/);
-		expect(block).toMatch(/overscroll-behavior:\s*contain/);
-	});
-});
-
 describe("Base layout — account menu replaces legacy login/logout emoji", () => {
 	it("renders AccountMenu in the topbar and has no leftover key/door emoji links", () => {
 		expect(source).toContain("<AccountMenu");


### PR DESCRIPTION
## Summary
- PROJ-565 replaced `SavedViewsControl`'s hand-rolled `Popover`-based menu with `Select`, which has its own positioning logic. That left `Popover`'s `as="ul"` prop, `strategy="fixed-inline"`, and the `.popover-select-menu` CSS class unused in production.
- Confirmed via repo-wide grep: zero remaining references to `as="ul"` or `strategy="fixed-inline"` outside the now-removed test coverage, and zero references to `.popover-select-menu` outside the now-removed CSS/test.
- Removed the dead prop branches from `Popover.tsx` (simplified `strategy` to `"anchored" | "portal-fixed"`, dropped the dynamic `Tag`/`as` machinery), the stale JSDoc describing the dead use case, the `.popover-select-menu` CSS rule in `Base.astro`, and the orphaned test coverage in `Popover.test.tsx` / `Base.mobile-viewport.test.ts`.

## Test plan
- [x] `pnpm turbo type-check --filter=@projektor/web` — 0 errors
- [x] `vitest run src/islands/ui/Popover.test.tsx src/layouts/Base.mobile-viewport.test.ts` — 22/13 passed
- [x] Full `apps/web` suite — 653/653 passed
- [x] `pnpm exec biome check` — clean

https://claude.ai/code/session_01DYPsSekdCWXUL8UZR5sGEf