### PR TITLE
fix(web): give ShareView's markdown tables a scroll boundary (PROJ-606)

### DIFF
--- a/apps/web/src/pages/share/view.astro
+++ b/apps/web/src/pages/share/view.astro
@@ -88,6 +88,10 @@ import ShareView from '../../islands/ShareView';
       .prose pre { background: var(--code-bg); padding: 1em; border-radius: 6px; overflow-x: auto; }
       .prose pre code { background: none; padding: 0; }
       .prose a { color: var(--accent); }
+      /* PROJ-606: unlike IssueDetailParts.tsx's prose (PROJ-603), this hand-rolled
+         stylesheet gets no table handling from Tailwind Typography, so a wide table
+         has no scroll boundary at all without this. */
+      .prose table { display: block; overflow-x: auto; }
       .prose blockquote {
         border-left: 3px solid var(--border); margin: 0.75em 0;
         padding: 0.25em 1em; color: var(--text-muted);

--- a/apps/web/src/pages/share/view.astro.test.ts
+++ b/apps/web/src/pages/share/view.astro.test.ts
@@ -1,0 +1,21 @@
+// view.astro isn't a Preact component, so it can't be rendered with
+// @testing-library/preact — this asserts directly on the source instead
+// (matches the pattern in layouts/Base.mobile-viewport.test.ts).
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(join(__dirname, "view.astro"), "utf-8");
+
+describe("share view — wide table scroll boundary (PROJ-606)", () => {
+	it("gives .prose tables their own horizontal scroll boundary", () => {
+		// This page's markdown styling is hand-rolled (not Tailwind Typography), so
+		// without this rule a wide table has no scroll boundary at all — unlike
+		// IssueDetailParts.tsx's prose, which gets one via the same rule (PROJ-603).
+		const start = source.indexOf(".prose table {");
+		expect(start).toBeGreaterThan(-1);
+		const block = source.slice(start, source.indexOf("}", start));
+		expect(block).toMatch(/display:\s*block/);
+		expect(block).toMatch(/overflow-x:\s*auto/);
+	});
+});

--- a/apps/web/src/test/share-view.test.ts
+++ b/apps/web/src/test/share-view.test.ts
@@ -1,11 +1,14 @@
 // view.astro isn't a Preact component, so it can't be rendered with
 // @testing-library/preact — this asserts directly on the source instead
-// (matches the pattern in layouts/Base.mobile-viewport.test.ts).
+// (matches the pattern in layouts/Base.mobile-viewport.test.ts). It also can't
+// live alongside view.astro under src/pages: Astro treats every .ts file in
+// src/pages as a route module and tries to build it as one, which breaks the
+// build since this file imports vitest.
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-const source = readFileSync(join(__dirname, "view.astro"), "utf-8");
+const source = readFileSync(join(__dirname, "../pages/share/view.astro"), "utf-8");
 
 describe("share view — wide table scroll boundary (PROJ-606)", () => {
 	it("gives .prose tables their own horizontal scroll boundary", () => {


### PR DESCRIPTION
## Summary
- `apps/web/src/pages/share/view.astro`'s markdown styling is hand-rolled (bare `class="prose"`, not Tailwind Typography), so unlike `IssueDetailParts.tsx`'s prose (fixed for PROJ-603) it had zero table handling — a wide table in a shared issue/wiki view had no horizontal scroll boundary at all.
- Added the same `.prose table { display: block; overflow-x: auto }` rule used for PROJ-603.

## Test plan
- [x] `pnpm turbo type-check --filter=@projektor/web` — 0 errors
- [x] New source-string test (`view.astro.test.ts`, matching the existing `Base.mobile-viewport.test.ts` pattern for testing `.astro` files) — passes
- [x] `pnpm exec biome check` — clean (`.astro` files are excluded from Biome by config, same as `layouts/`)

https://claude.ai/code/session_01DYPsSekdCWXUL8UZR5sGEf