### PR TITLE
docs(web): fix stale Popover strategy JSDoc (PROJ-607)

### DIFF
--- a/apps/web/src/islands/ui/Popover.tsx
+++ b/apps/web/src/islands/ui/Popover.tsx
@@ -58,11 +58,13 @@ export interface PopoverProps {
 	/**
 	 * "anchored" renders in place, positioned by the parent's own
 	 * `position: relative` + the modifier class's own `position:
-	 * absolute; top/left` rule (matches `.metric-help-popover`'s existing
-	 * CSS — `MetricHelp.tsx`'s own usage). "portal-fixed" portals to
+	 * absolute; top/left` rule. No current production caller uses it (see
+	 * PROJ-607) — it's kept for a future toggletip that doesn't need to
+	 * escape an ancestor's overflow/transform. "portal-fixed" portals to
 	 * `document.body` with caller-computed fixed coordinates (matches
-	 * `AccountMenu.tsx`/`GlossaryHelp.tsx`'s existing pattern, needed to
-	 * escape an ancestor's `transform`, e.g. the topbar's scroll-hide).
+	 * `AccountMenu.tsx`/`GlossaryHelp.tsx`/`MetricHelp.tsx`'s existing
+	 * pattern, needed to escape an ancestor's `transform`, e.g. the
+	 * topbar's scroll-hide).
 	 */
 	strategy: "anchored" | "portal-fixed";
 	/** Required when strategy is "portal-fixed". */


### PR DESCRIPTION
## Summary
- Popover's `strategy` JSDoc claimed `"anchored"` matches `MetricHelp.tsx`'s usage, but PROJ-565 moved `MetricHelp.tsx` to `strategy="portal-fixed"` — no production caller uses `"anchored"` any more.
- Fixes the stale claim, notes that no current production caller uses `"anchored"` (kept for a future toggletip use case), and adds `MetricHelp.tsx` to the `"portal-fixed"` caller list.

Comment-only change — no runtime behavior change.

## Test plan
- [x] `pnpm exec biome check apps/web/src/islands/ui/Popover.tsx` — clean
- [x] `vitest run src/islands/ui/Popover.test.tsx` — 12/12 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYPsSekdCWXUL8UZR5sGEf