### PR TITLE
docs: add playbooks landing page (PROJ-609)

### DIFF
--- a/apps/api/scripts/gen-playbooks.ts
+++ b/apps/api/scripts/gen-playbooks.ts
@@ -1,7 +1,8 @@
 /**
  * Regenerates the playbook docs pages (each has no hand-edited prose, like
  * workflow-spec.md) from the single source of truth in
- * src/services/playbook-content.ts.
+ * src/services/playbook-content.ts. index.md in the output directory is the one
+ * exception — a hand-authored section landing page this script never touches.
  *
  * CI runs this and fails if the committed files are stale (see
  * .github/workflows/ci.yml), the same pattern as gen-workflow-spec.ts.
@@ -19,9 +20,12 @@ const outDir = join(repoRoot, "apps", "docs", "src", "content", "docs", "agents"
 
 mkdirSync(outDir, { recursive: true });
 
-// Clear stale entries (a renamed/removed playbook) before writing the current set,
-// same reasoning as any generated-directory sync step.
+// Clear stale generated entries (a renamed/removed playbook) before writing the
+// current set, same reasoning as any generated-directory sync step — but never
+// touch index.md, the hand-authored landing page for this section (PROJ-609).
+const expectedFiles = new Set(PLAYBOOKS.map((p) => `${p.name}.md`));
 for (const entry of readdirSync(outDir)) {
+	if (entry === "index.md" || expectedFiles.has(entry)) continue;
 	rmSync(join(outDir, entry), { recursive: true });
 }
 

--- a/apps/docs/src/content/docs/agents/playbooks/index.md
+++ b/apps/docs/src/content/docs/agents/playbooks/index.md
@@ -1,0 +1,67 @@
+---
+title: "Playbooks"
+description: "Generic, reusable agent working patterns, shipped and served the same way projektor serves its own workflow spec — fetchable at the moment of use, with server-side parameterised composition."
+sidebar:
+  order: 0
+---
+
+A playbook is a generic, reusable working pattern — not specific to projektor's own
+rules (that's [the workflow spec](/projektor/agents/workflow-spec/)), but a prompt
+pattern for how an agent should approach a class of task. The first one,
+[`epic-goal`](/projektor/agents/playbooks/epic-goal/), is a template for pointing an
+agent at an epic and having it work autonomously to completion.
+
+## Why playbooks, not just prompts you copy-paste
+
+The pattern that made [`workflow-spec`](/projektor/agents/workflow-spec/) work is
+this: ship it as a plain TS constant in the codebase, serve it identically over MCP,
+REST, and a CI-gated docs page, and point every entry point (the MCP `initialize`
+instructions, this docs site) at that one source. Agents actually follow it across
+long sessions because it's fetchable at the moment of use, not something they have
+to remember from a system prompt written hours (or context compactions) earlier.
+Playbooks apply the same idea to prompt *patterns* — reusable working styles, rather
+than projektor-specific rules.
+
+## Three ways to get one
+
+**Fetch it raw** — `list_playbooks` to see what's available, `get_playbook(name)` for
+the full template as markdown. Read it, adapt it, use it as-is.
+
+**Have it composed for you** — `compose_playbook(name, params)` fills the template
+server-side using live data the server already has and you'd otherwise have to look
+up yourself. For `epic-goal`: pass an `epicRef` and the server fills in the epic's
+actual title, how many child tickets are still open, and the project's agent WIP
+limit — so the directive you get back is accurate to the moment you asked, not a
+generic fill-in-the-blanks template.
+
+**As a native prompt** — MCP clients that support the `prompts` primitive
+(`prompts/list` / `prompts/get`) can surface a composable playbook as a slash command
+— `epic-goal`'s optional arguments (`variant`, `reviewModel`, `cadence`) become a
+form the client fills in, and `prompts/get` returns the same composed directive
+`compose_playbook` would.
+
+## What makes `epic-goal` flexible
+
+It isn't one fixed prompt — `compose_playbook("epic-goal", params)` takes:
+
+- **`epicRef`** *(required)* — which epic or ticket list to work through.
+- **`variant`** — `bounded` (default: generated follow-on work is triaged and
+  pruned, for delivery epics with a crisp outcome) or `full` (all generated work is
+  actioned, for exploratory/quality epics where the discovered work *is* the point).
+- **`reviewModel`** — which model runs the periodic adversarial review (default
+  `opus`).
+- **`cadence`** — how many completed tickets between review checkpoints (default 2).
+
+Same template, four independent knobs, filled with data specific to your epic at
+request time. See the full ingredient list and both template variants on the
+[`epic-goal`](/projektor/agents/playbooks/epic-goal/) page.
+
+## Available playbooks
+
+| Playbook | What it's for |
+|---|---|
+| [`epic-goal`](/projektor/agents/playbooks/epic-goal/) | Work through an epic (or ticket list) autonomously until it's fully done. |
+
+More will land here as they're extracted from real working sessions — the whole
+point of a playbook is that it started as something that actually worked, not a
+pattern designed in the abstract.


### PR DESCRIPTION
## Summary
- Adds a hand-authored `/agents/playbooks/` landing page explaining what playbooks are, the three ways to consume one (raw fetch, server-composed, native MCP prompt), and what makes `epic-goal` flexible.
- Fixes `gen-playbooks.ts` to spare `index.md` (and any current playbook file) when clearing stale generated entries, instead of wiping the whole output directory — this hand-authored page would otherwise be deleted on the next `gen:playbooks` run.

Closes PROJ-609, and unblocks PB-70 (personal-blog: swap a TODO placeholder for a real link to this page).

## Test plan
- [x] `pnpm --filter @projektor/api gen:playbooks` run twice — `index.md` survives both times, no spurious diff
- [x] `pnpm --filter @projektor/docs build` — succeeds, `starlight-links-validator` reports all internal links valid
- [x] `pnpm --filter @projektor/api type-check` — clean
- [x] pre-commit/pre-push hooks (lint, type-check across workspace) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXqgV3oMUxzVyCG3otfJCE