### PR TITLE
fix(web): keep narrow markdown tables full-width (PROJ-605)

### DIFF
--- a/apps/web/src/islands/IssueDetailParts.test.tsx
+++ b/apps/web/src/islands/IssueDetailParts.test.tsx
@@ -9,10 +9,13 @@
 // entire box into a scrollport that clips anything an ordered/unordered list
 // marker renders outside its gutter (PROJ-603). The fix moves the scroll
 // boundary onto the individual elements that actually need it: <pre> already
-// gets `overflow-x: auto` from Typography by default, and `.prose table` gets
-// the same via MERMAID_PROSE_STYLES (the `display: block` + `overflow-x: auto`
-// trick GFM's own stylesheet uses). jsdom doesn't lay out real pixel widths, so
-// this asserts the containing classes/rules rather than measured overflow.
+// gets `overflow-x: auto` from Typography by default, and each rendered
+// <table> is wrapped in a `.table-scroll` div that gets the same via
+// MERMAID_PROSE_STYLES (PROJ-605: the wrapper carries the scroll boundary
+// instead of `display: block` on <table> itself, so a narrow table still
+// renders full-width instead of shrinking to content). jsdom doesn't lay out
+// real pixel widths, so this asserts the containing classes/rules rather than
+// measured overflow.
 import { render, screen, waitFor } from "@testing-library/preact";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BodySection } from "./IssueDetailParts";
@@ -78,7 +81,7 @@ describe("BodySection", () => {
 		expect(pre?.closest(".prose")).toBe(container);
 	});
 
-	it("gives wide tables their own horizontal scroll boundary via .prose table CSS (PROJ-603)", async () => {
+	it("gives wide tables their own horizontal scroll boundary via a .table-scroll wrapper (PROJ-603, PROJ-605)", async () => {
 		render(
 			<BodySection
 				issue={ISSUE}
@@ -88,11 +91,15 @@ describe("BodySection", () => {
 			/>
 		);
 
-		await screen.findByRole("table");
+		const table = await screen.findByRole("table");
+		// renderMd's table renderer (markdown.ts) wraps every rendered <table> in
+		// this div — the scroll boundary lives on the wrapper, not the table.
+		expect(table.parentElement?.className).toBe("table-scroll");
+
 		const styleTags = Array.from(document.querySelectorAll("style"));
 		const tableRule = styleTags
 			.map((s) => s.textContent)
-			.find((css) => css?.includes(".prose table"));
+			.find((css) => css?.includes(".prose .table-scroll"));
 		expect(tableRule).toBeTruthy();
 		expect(tableRule).toContain("overflow-x: auto");
 	});

--- a/apps/web/src/islands/IssueDetailParts.tsx
+++ b/apps/web/src/islands/IssueDetailParts.tsx
@@ -46,10 +46,14 @@ const MERMAID_PROSE_STYLES = `
 	/* PROJ-603: the .prose box itself no longer scrolls (that forced overflow-y
 	 * to auto too, clipping outside-positioned <ol>/<ul> markers). Typography
 	 * already gives <pre> its own overflow-x: auto; tables get none by default,
-	 * so give them one directly — this is the same "display: block" trick GFM's
-	 * own stylesheet uses to make a table scroll without an outer scrollport. */
-	.prose table {
-		display: block;
+	 * so give them one directly. PROJ-605: a bare "display: block" on <table>
+	 * makes Typography's width: 100% size the table's own block box while the
+	 * anonymous table-formatting box inside it shrink-wraps to content, so a
+	 * narrow table no longer spans the container — renderMd's table renderer
+	 * (markdown.ts) wraps rendered tables in a .table-scroll div instead, so
+	 * the table itself stays display: table (full width) and the wrapper
+	 * carries the scroll boundary. */
+	.prose .table-scroll {
 		overflow-x: auto;
 	}
 `;

--- a/apps/web/src/pages/share/view.astro
+++ b/apps/web/src/pages/share/view.astro
@@ -90,8 +90,13 @@ import ShareView from '../../islands/ShareView';
       .prose a { color: var(--accent); }
       /* PROJ-606: unlike IssueDetailParts.tsx's prose (PROJ-603), this hand-rolled
          stylesheet gets no table handling from Tailwind Typography, so a wide table
-         has no scroll boundary at all without this. */
-      .prose table { display: block; overflow-x: auto; }
+         has no scroll boundary at all without this. PROJ-605: the scroll boundary
+         lives on the .table-scroll wrapper renderMd's table renderer adds around
+         each table (markdown.ts), not on the table itself — a bare "display: block"
+         on <table> would keep the table full-width but shrink a narrow table's
+         inner anonymous table box to content width. */
+      .prose table { width: 100%; }
+      .prose .table-scroll { overflow-x: auto; }
       .prose blockquote {
         border-left: 3px solid var(--border); margin: 0.75em 0;
         padding: 0.25em 1em; color: var(--text-muted);

--- a/apps/web/src/test/share-view.test.ts
+++ b/apps/web/src/test/share-view.test.ts
@@ -11,14 +11,22 @@ import { describe, expect, it } from "vitest";
 const source = readFileSync(join(__dirname, "../pages/share/view.astro"), "utf-8");
 
 describe("share view — wide table scroll boundary (PROJ-606)", () => {
-	it("gives .prose tables their own horizontal scroll boundary", () => {
+	it("keeps tables full-width and gives the .table-scroll wrapper the scroll boundary (PROJ-605)", () => {
 		// This page's markdown styling is hand-rolled (not Tailwind Typography), so
-		// without this rule a wide table has no scroll boundary at all — unlike
-		// IssueDetailParts.tsx's prose, which gets one via the same rule (PROJ-603).
-		const start = source.indexOf(".prose table {");
-		expect(start).toBeGreaterThan(-1);
-		const block = source.slice(start, source.indexOf("}", start));
-		expect(block).toMatch(/display:\s*block/);
-		expect(block).toMatch(/overflow-x:\s*auto/);
+		// without these rules a wide table has no scroll boundary at all — unlike
+		// IssueDetailParts.tsx's prose, which gets one via the same rules (PROJ-603).
+		// renderMd's table renderer (markdown.ts) wraps every rendered <table> in a
+		// .table-scroll div, so the boundary lives on the wrapper, not the table
+		// itself — a bare "display: block" on <table> would shrink a narrow table
+		// to content width instead of spanning the container (PROJ-605).
+		const tableStart = source.indexOf(".prose table {");
+		expect(tableStart).toBeGreaterThan(-1);
+		const tableBlock = source.slice(tableStart, source.indexOf("}", tableStart));
+		expect(tableBlock).toMatch(/width:\s*100%/);
+
+		const scrollStart = source.indexOf(".prose .table-scroll {");
+		expect(scrollStart).toBeGreaterThan(-1);
+		const scrollBlock = source.slice(scrollStart, source.indexOf("}", scrollStart));
+		expect(scrollBlock).toMatch(/overflow-x:\s*auto/);
 	});
 });

--- a/apps/web/src/utils/markdown.test.ts
+++ b/apps/web/src/utils/markdown.test.ts
@@ -62,6 +62,21 @@ describe("renderMd — XSS sanitization", () => {
 	});
 });
 
+// PROJ-605: wrapping in a div (not `display: block` on <table> itself) keeps the
+// table's own display: table intact, so consumers' CSS can size the wrapper for
+// scroll without shrinking a narrow table to content width.
+describe("renderMd — table rendering (PROJ-605)", () => {
+	it("wraps a rendered table in a .table-scroll div", () => {
+		const html = renderMd("| A | B |\n| --- | --- |\n| 1 | 2 |\n");
+		const wrapStart = html.indexOf('<div class="table-scroll">');
+		expect(wrapStart).toBeGreaterThan(-1);
+		const tableStart = html.indexOf("<table", wrapStart);
+		expect(tableStart).toBeGreaterThan(wrapStart);
+		const closeTableEnd = html.indexOf("</table>") + "</table>".length;
+		expect(html.slice(closeTableEnd).trim()).toBe("</div>");
+	});
+});
+
 describe("renderMd — legitimate markdown still renders", () => {
 	it("renders bold and italic", () => {
 		const html = renderMd("**bold** and _italic_");

--- a/apps/web/src/utils/markdown.ts
+++ b/apps/web/src/utils/markdown.ts
@@ -17,6 +17,15 @@ renderer.code = (token: Tokens.Code) => {
 	return defaultCode(token);
 };
 
+// PROJ-605: giving `.prose table` itself `display: block; overflow-x: auto` (the
+// PROJ-603 fix) makes the *table* the block box that Typography's `width: 100%`
+// sizes, while the anonymous table-formatting box inside it shrink-wraps to
+// content — so a narrow table no longer spans the container. Wrapping the table
+// in a real scroll div instead keeps the table itself `display: table` (full
+// width, normal table layout) and puts the scroll boundary on the wrapper.
+const defaultTable = renderer.table.bind(renderer);
+renderer.table = (token: Tokens.Table) => `<div class="table-scroll">${defaultTable(token)}</div>`;
+
 /**
  * Render untrusted markdown to sanitized HTML.
  *


### PR DESCRIPTION
## Summary
- PROJ-603 gave wide tables a horizontal scroll boundary via `.prose table { display: block; overflow-x: auto }`, but that made the `<table>` element itself the block box that Typography's `width: 100%` sizes — the anonymous table-formatting box inside shrink-wraps to content, so a narrow table no longer spans the container.
- Fix: wrap rendered tables in a `.table-scroll` div at render time (marked's custom `table` renderer in `apps/web/src/utils/markdown.ts`) instead of relying on `display: block` on the table itself. The table stays `display: table` (full width, normal layout); the wrapper carries the scroll boundary.
- Ported to both `IssueDetailParts.tsx`'s prose styles and `view.astro`'s hand-rolled ShareView stylesheet (mirrors the PROJ-606 pattern).

## Test plan
- [x] `vitest run` — 661/661 passing (full web suite)
- [x] `pnpm exec biome check` on changed files — clean
- [x] `pnpm build` — succeeds
- [x] New test in `markdown.test.ts` asserting the `.table-scroll` wrapper; updated `IssueDetailParts.test.tsx` and `share-view.test.ts` for the new CSS shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYPsSekdCWXUL8UZR5sGEf