### PR TITLE
chore(deps): upgrade cofferdam to 0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@biomejs/biome": "^2.5.1",
     "@biomejs/cli-win32-x64": "2.5.1",
     "@cloudflare/workers-types": "^4.20250620.0",
-    "@cofferdam/cofferdam": "^0.4.0",
+    "@cofferdam/cofferdam": "^0.4.2",
     "lefthook": "^1.11.0",
     "tsx": "^4.19.0",
     "turbo": "^2.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^4.20250620.0
         version: 4.20260621.1
       '@cofferdam/cofferdam':
-        specifier: ^0.4.0
-        version: 0.4.0
+        specifier: ^0.4.2
+        version: 0.4.2
       lefthook:
         specifier: ^1.11.0
         version: 1.13.6
@@ -1168,8 +1168,8 @@ packages:
     resolution: {integrity: sha512-CsgDhJ2w8mIt6sHSnPUNsDFmkwN5DMZ4GRB19hAbeiZzetHIG9RWJsgoWz+0CfONsoTf3inrCprvT2GhzDkK4A==}
     engines: {node: '>=16'}
 
-  '@cofferdam/cofferdam@0.4.0':
-    resolution: {integrity: sha512-+VRNb4PUPblGPToChaKl7TCBBG5lHcNoY6G/Dr3ls1Pf/T60lnmC16j/nuD1YSID8Xecly46lf9nW+7DUe0YoQ==}
+  '@cofferdam/cofferdam@0.4.2':
+    resolution: {integrity: sha512-OGgeprWiyT1FSNsxHioAa7fhSgZweImEsl+fquGYtuiBDJN2VC2yTw31I31bfR8jz/zBPg82Lha1KmdLMWVJtg==}
     engines: {node: '>=16', npm: '>=7'}
     cpu: [x64, arm64]
     os: [linux, darwin, win32]
@@ -8131,7 +8131,7 @@ snapshots:
 
   '@cofferdam/check-sdk@0.3.7': {}
 
-  '@cofferdam/cofferdam@0.4.0': {}
+  '@cofferdam/cofferdam@0.4.2': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:


### PR DESCRIPTION
`@cofferdam/cofferdam` 0.4.0 → 0.4.2. Lockfile refresh plus the range bump.

## Effect on the CI gates

None. CI gates on two scoped plugin checks, and both still pass under 0.4.2:

- `cofferdam check apps/web/src/islands --only Warning.IslandApiConvention` — exit 0
- `cofferdam check apps/web/src --only Warning.DesignSystemConvention` — exit 0
- design-system fixture regression test — 8 findings, matches `expected.json`

Both plugins build and load against 0.4.2 unchanged.

## New findings

The full-project run picks up 19 `Consistency.SpellingDialect` findings, a new check in 0.4.2 that tallies British against American spellings in comments and prose string literals and flags the minority. Neither gate reads them, so nothing here has to change. Identifiers are never scanned.

Worth separating from this PR: a whole-project `cofferdam check apps/web/` reports 58 findings as new against the committed baseline **on 0.4.0 as well as 0.4.2** — I verified by running 0.4.0 against the same tree. That gap predates this upgrade and is not something the bump caused, but the baseline is evidently not matching what it was written for. Worth its own look.

## Verified

- `pnpm install` — cofferdam at 0.4.2
- lint, type-check clean; both plugin builds succeed
- both CI gate commands reproduced locally, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019afugU2bTYCtXn6Vy9dn1v