### PR TITLE
chore(web): remove dead .metric-help-popover CSS (PROJ-608)

### DIFF
--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -725,22 +725,6 @@ const navItems: Array<{ href: string; label: string; glossaryId?: GlossaryTermId
         padding: 0.375rem;
         font-size: 0.875rem;
       }
-      .metric-help-popover {
-        position: absolute;
-        top: calc(100% + 4px);
-        left: 0;
-        z-index: 200;
-        background: var(--bg);
-        border: 1px solid var(--border);
-        box-shadow: var(--shadow-sm);
-        width: 16rem;
-        max-width: min(16rem, 80vw);
-        padding: 0.625rem 0.75rem;
-        border-radius: 6px;
-        font-weight: normal;
-        text-transform: none;
-        letter-spacing: normal;
-      }
 
       /* ── Account menu (island) ─────────────────────────────────────── */
       .account-menu { position: relative; display: inline-flex; }


### PR DESCRIPTION
## Summary
- \`.metric-help-popover\` in \`apps/web/src/layouts/Base.astro\` had zero remaining consumers — \`MetricHelp.tsx\` was moved to \`class="popover-metric-help"\` in an earlier refactor. Confirmed via grep: no other reference in the repo.
- Flagged by the Opus review of PR #256 (PROJ-607).

## Test plan
- [x] Confirmed no remaining reference via grep
- [x] \`pnpm turbo type-check --filter=@projektor/web --force\` — 0 errors
- [x] \`vitest run src/layouts/Base.mobile-viewport.test.ts\` — 12/12 passing
- [x] \`pnpm build\` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYPsSekdCWXUL8UZR5sGEf