### PR TITLE
fix(web): give ShareView tables borders and cell padding (PROJ-611)

### DIFF
--- a/apps/web/src/pages/share/view.astro
+++ b/apps/web/src/pages/share/view.astro
@@ -95,8 +95,17 @@ import ShareView from '../../islands/ShareView';
          each table (markdown.ts), not on the table itself — a bare "display: block"
          on <table> would keep the table full-width but shrink a narrow table's
          inner anonymous table box to content width. */
-      .prose table { width: 100%; }
+      /* PROJ-611: Tailwind Typography (used by IssueDetailParts.tsx's prose) supplies
+         table border/padding by default; this hand-rolled stylesheet doesn't, so a
+         table here rendered as bare unbordered text. Mirrors Typography's own
+         thead/tbody border + cell padding shape. */
+      .prose table { width: 100%; border-collapse: collapse; }
       .prose .table-scroll { overflow-x: auto; }
+      .prose thead { border-bottom: 1px solid var(--border); }
+      .prose thead th { font-weight: 600; text-align: left; padding: 0.4em 0.75em; }
+      .prose tbody td { padding: 0.4em 0.75em; }
+      .prose tbody tr { border-bottom: 1px solid var(--border); }
+      .prose tbody tr:last-child { border-bottom: none; }
       .prose blockquote {
         border-left: 3px solid var(--border); margin: 0.75em 0;
         padding: 0.25em 1em; color: var(--text-muted);

--- a/apps/web/src/test/share-view.test.ts
+++ b/apps/web/src/test/share-view.test.ts
@@ -29,4 +29,14 @@ describe("share view — wide table scroll boundary (PROJ-606)", () => {
 		const scrollBlock = source.slice(scrollStart, source.indexOf("}", scrollStart));
 		expect(scrollBlock).toMatch(/overflow-x:\s*auto/);
 	});
+
+	it("gives table rows and headers borders and cell padding (PROJ-611)", () => {
+		// This page's markdown styling is hand-rolled, so it never inherited
+		// Tailwind Typography's default table border/padding — a table rendered as
+		// bare unbordered text with no row/column separation without these rules.
+		expect(source).toMatch(/\.prose thead \{[^}]*border-bottom:\s*1px solid var\(--border\)/);
+		expect(source).toMatch(/\.prose tbody tr \{[^}]*border-bottom:\s*1px solid var\(--border\)/);
+		expect(source).toMatch(/\.prose thead th \{[^}]*padding:/);
+		expect(source).toMatch(/\.prose tbody td \{[^}]*padding:/);
+	});
 });


### PR DESCRIPTION
## Summary
- ShareView's hand-rolled `.prose` stylesheet (`apps/web/src/pages/share/view.astro`) had no `table`/`th`/`td` border, padding, or `border-collapse` rules — unlike Tailwind Typography (used by `IssueDetailParts.tsx`'s prose). A shared-issue table rendered as bare unbordered text with no row/column separation.
- Added `border-collapse: collapse`, thead/tbody border rules, and cell padding, mirroring Typography's own default table shape (thead bottom border, per-row bottom border, cell padding).

## Test plan
- [x] `vitest run src/test/share-view.test.ts` — passing, new test asserts the border/padding rules
- [x] `pnpm turbo type-check --filter=@projektor/web --force` — 0 errors
- [x] `pnpm build` — succeeds
- [x] biome check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYPsSekdCWXUL8UZR5sGEf