### PR TITLE
fix(web): give wiki page tables a horizontal scroll boundary (PROJ-612)

### DIFF
--- a/apps/web/src/islands/WikiPage.test.tsx
+++ b/apps/web/src/islands/WikiPage.test.tsx
@@ -1282,3 +1282,27 @@ describe("WikiPage — inline images & attachment badges (PROJ-494)", () => {
 		expect(form.get("entityId")).toBe(PAGE.id);
 	});
 });
+
+describe("WikiPage — wide table scroll boundary (PROJ-612)", () => {
+	it("gives the .table-scroll wrapper around a rendered table its own horizontal scroll boundary", async () => {
+		const PAGE_WITH_TABLE = {
+			...PAGE,
+			content: "| Column A | Column B |\n| --- | --- |\n| a | b |\n",
+		};
+		mockFetchWiki(PAGE_WITH_TABLE);
+		render(<WikiPage slug="my-page" />);
+
+		// renderMdWithWikilinks (markdown.ts) wraps every rendered <table> in a
+		// .table-scroll div (PROJ-605) — the scroll boundary belongs on that
+		// wrapper, not the table itself.
+		const table = await screen.findByRole("table");
+		expect(table.parentElement?.className).toBe("table-scroll");
+
+		const styleTags = Array.from(document.querySelectorAll("style"));
+		const rule = styleTags
+			.map((s) => s.textContent)
+			.find((css) => css?.includes(".prose .table-scroll"));
+		expect(rule).toBeTruthy();
+		expect(rule).toContain("overflow-x: auto");
+	});
+});

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -2864,6 +2864,13 @@ const WIKI_PAGE_STYLES = `
 		width: auto;
 		height: auto;
 	}
+	/* PROJ-612: renderMdWithWikilinks (markdown.ts) wraps every rendered <table> in
+	 * a .table-scroll div (PROJ-605), but this page never defined the scroll rule
+	 * for it — unlike IssueDetailParts.tsx and share/view.astro, a wide table here
+	 * had no horizontal scroll boundary at all. */
+	.prose .table-scroll {
+		overflow-x: auto;
+	}
 	@media (max-width: 640px) {
 		.wiki-breadcrumb button {
 			max-width: 8rem;


### PR DESCRIPTION
## Summary
- \`renderMdWithWikilinks\` (markdown.ts) wraps every rendered \`<table>\` in a \`.table-scroll\` div (PROJ-605), but \`WikiPage.tsx\`'s \`WIKI_PAGE_STYLES\` never defined the scroll rule for it — unlike \`IssueDetailParts.tsx\` and \`share/view.astro\`, a wide table in a wiki page had no horizontal scroll boundary at all.
- Added \`.prose .table-scroll { overflow-x: auto; }\` to \`WIKI_PAGE_STYLES\`.
- Note: \`MarkdownEditor.tsx\`'s preview pane was investigated too but doesn't need this — its \`.prose\` container already has \`overflow-auto\` directly on it (a bounded scroll viewport by design), so wide tables there already scroll.

## Test plan
- [x] \`vitest run src/islands/WikiPage.test.tsx\` — 54/54 passing, new test asserts the wrapper + rule
- [x] \`pnpm turbo type-check --filter=@projektor/web --force\` — 0 errors
- [x] \`pnpm build\` — succeeds
- [x] biome check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYPsSekdCWXUL8UZR5sGEf