### PR TITLE
docs: ground the epic-goal playbook in the repo, not the blog post

### DIFF
--- a/apps/api/src/services/playbook-content.ts
+++ b/apps/api/src/services/playbook-content.ts
@@ -72,29 +72,48 @@ export const PLAYBOOKS: Playbook[] = [
 		body: `A prompt pattern for pointing an agent at an epic (or ticket list) and having it work
 autonomously until everything — including work it discovers along the way — is done.
 
-## The six ingredients
+It's deliberately generic. [The workflow spec](/projektor/agents/workflow-spec/) is the
+projektor-specific half — definition of ready, the status state machine, human review
+gates, fleet coordination rules. This playbook is the shape of the *run* that drives
+those rules, so an agent working an epic normally fetches both.
 
-The productive runs all combined these; the weak ones ("implement 134") had only the first:
+## Getting the directive
 
-1. **Concrete entry point** — an epic ref/URL or explicit ticket IDs.
-2. **Explicit autonomy grant** — "autonomously", "do not stop until…". Sessions with this
-   stall far less.
-3. **Review cadence with a named model** — "use opus for reviews every two tickets". The
-   cadence survives context compaction and gets self-enforced.
-4. **Self-feeding loop** — file tickets for discovered bugs/improvements, link them to the
-   epic, action them. Turns the epic into a generator, not a fixed list.
-5. **Verifiable termination condition** — "complete when the epic is implemented AND shown
-   to work on all test repos", not "when done".
-6. **Decisions log instead of interruptions** — record decisions and judgment calls as
-   comments on the epic for review at the end, rather than asking questions mid-run.
+\`get_playbook("epic-goal")\` returns this page verbatim, template and all — read it and
+adapt it by hand.
 
-Plus one situational clause that earned its place: **audit-first** — on resumed work,
-audit origin/main, open PRs, and local state before implementing anything, so finished
-work is folded in rather than redone.
+\`compose_playbook("epic-goal", { epicRef, variant, reviewModel, cadence })\` returns just
+the directive, with every placeholder already filled from data the server holds:
 
-Call \`compose_playbook("epic-goal", { epicRef, variant, reviewModel, cadence })\` to have
-the server fill the template below with live data (epic title, open child count, project
-WIP limit) instead of copying it out by hand.
+| Parameter / source | Fills |
+|---|---|
+| \`epicRef\` *(required)* — resolved to the epic's ref and title | the **Goal** clause |
+| \`variant\` — \`bounded\` (default) or \`full\` | the **Self-feed** and **Done when** clauses |
+| \`cadence\` (default 2) and \`reviewModel\` (default \`opus\`) | the **Review cadence** clause |
+| the epic's open child count and the project's agent WIP limit | an extra **Live data** clause |
+
+MCP clients that support the \`prompts\` primitive surface the same composed directive as a
+slash command, with the three optional parameters as prompt arguments.
+
+## What each clause is for
+
+- **Goal** — a concrete entry point (an epic ref, not a prose description) plus an explicit
+  autonomy grant. Without the grant a run tends to stop after the first ticket to ask
+  what's next.
+- **Audit first** — on a resumed run, an agent that doesn't look first repeats work that
+  is already merged to origin/main or sitting in an open PR. This is also the clause that
+  matters most after a context compaction, when the agent's memory of the run is gone but
+  the directive isn't.
+- **Loop** — \`get_prioritized_issues\` chooses the next ticket rather than the agent, so
+  ordering follows the project's own priority and blocked-by rules.
+- **Self-feed** — filing discovered bugs and follow-ons back onto the epic turns it into a
+  generator rather than a fixed list. This is the only clause the two variants differ on.
+- **Review cadence** — naming the model and the interval up front makes the checkpoint
+  something the agent can self-enforce; "review as you go" doesn't survive a long run.
+- **Done when** — a checkable condition (every ticket closed, verification green,
+  everything pushed) instead of a judgment call.
+- **Decisions log** — judgment calls land as comments on the epic for review at the end,
+  so an ambiguity doesn't block the run on a question.
 
 ## Template — bounded variant (default)
 
@@ -125,16 +144,18 @@ And "done when" covers original + generated tickets.
 | Situation | Variant |
 |---|---|
 | Epic has a crisp outcome; scope creep is the risk | bounded |
-| Exploratory/quality epic where discovered work IS the point | full |
+| Exploratory/quality epic where the discovered work *is* the point | full |
 
 Full-variant runs can generate more tickets than the epic started with; if that happens
 mid-run, switch to bounded and park the tail.
 
-## Fleet / multi-agent use
+## Fleet and multi-agent use
 
-For epics too large for one session, the same template works as a worker prompt: post it
-as a comment on the epic and pass the ticket URL as the worker's entry point, with each
-worker taking disjoint tickets.
+For epics too large for one session, the same directive works as a worker prompt: post it
+as a comment on the epic and give each worker the ticket URL as its entry point. Nobody
+hands out the tickets: each worker takes its own through \`claim_issue\`, and the lease
+keeps the others off it. That is why the composed directive reports the project's agent
+WIP limit, the cap on how many tickets one worker may hold at a time.
 `,
 	},
 ];

--- a/apps/docs/src/content/docs/agents/playbooks/epic-goal.md
+++ b/apps/docs/src/content/docs/agents/playbooks/epic-goal.md
@@ -7,29 +7,48 @@ sidebar:
 A prompt pattern for pointing an agent at an epic (or ticket list) and having it work
 autonomously until everything — including work it discovers along the way — is done.
 
-## The six ingredients
+It's deliberately generic. [The workflow spec](/projektor/agents/workflow-spec/) is the
+projektor-specific half — definition of ready, the status state machine, human review
+gates, fleet coordination rules. This playbook is the shape of the *run* that drives
+those rules, so an agent working an epic normally fetches both.
 
-The productive runs all combined these; the weak ones ("implement 134") had only the first:
+## Getting the directive
 
-1. **Concrete entry point** — an epic ref/URL or explicit ticket IDs.
-2. **Explicit autonomy grant** — "autonomously", "do not stop until…". Sessions with this
-   stall far less.
-3. **Review cadence with a named model** — "use opus for reviews every two tickets". The
-   cadence survives context compaction and gets self-enforced.
-4. **Self-feeding loop** — file tickets for discovered bugs/improvements, link them to the
-   epic, action them. Turns the epic into a generator, not a fixed list.
-5. **Verifiable termination condition** — "complete when the epic is implemented AND shown
-   to work on all test repos", not "when done".
-6. **Decisions log instead of interruptions** — record decisions and judgment calls as
-   comments on the epic for review at the end, rather than asking questions mid-run.
+`get_playbook("epic-goal")` returns this page verbatim, template and all — read it and
+adapt it by hand.
 
-Plus one situational clause that earned its place: **audit-first** — on resumed work,
-audit origin/main, open PRs, and local state before implementing anything, so finished
-work is folded in rather than redone.
+`compose_playbook("epic-goal", { epicRef, variant, reviewModel, cadence })` returns just
+the directive, with every placeholder already filled from data the server holds:
 
-Call `compose_playbook("epic-goal", { epicRef, variant, reviewModel, cadence })` to have
-the server fill the template below with live data (epic title, open child count, project
-WIP limit) instead of copying it out by hand.
+| Parameter / source | Fills |
+|---|---|
+| `epicRef` *(required)* — resolved to the epic's ref and title | the **Goal** clause |
+| `variant` — `bounded` (default) or `full` | the **Self-feed** and **Done when** clauses |
+| `cadence` (default 2) and `reviewModel` (default `opus`) | the **Review cadence** clause |
+| the epic's open child count and the project's agent WIP limit | an extra **Live data** clause |
+
+MCP clients that support the `prompts` primitive surface the same composed directive as a
+slash command, with the three optional parameters as prompt arguments.
+
+## What each clause is for
+
+- **Goal** — a concrete entry point (an epic ref, not a prose description) plus an explicit
+  autonomy grant. Without the grant a run tends to stop after the first ticket to ask
+  what's next.
+- **Audit first** — on a resumed run, an agent that doesn't look first repeats work that
+  is already merged to origin/main or sitting in an open PR. This is also the clause that
+  matters most after a context compaction, when the agent's memory of the run is gone but
+  the directive isn't.
+- **Loop** — `get_prioritized_issues` chooses the next ticket rather than the agent, so
+  ordering follows the project's own priority and blocked-by rules.
+- **Self-feed** — filing discovered bugs and follow-ons back onto the epic turns it into a
+  generator rather than a fixed list. This is the only clause the two variants differ on.
+- **Review cadence** — naming the model and the interval up front makes the checkpoint
+  something the agent can self-enforce; "review as you go" doesn't survive a long run.
+- **Done when** — a checkable condition (every ticket closed, verification green,
+  everything pushed) instead of a judgment call.
+- **Decisions log** — judgment calls land as comments on the epic for review at the end,
+  so an ambiguity doesn't block the run on a question.
 
 ## Template — bounded variant (default)
 
@@ -60,13 +79,15 @@ And "done when" covers original + generated tickets.
 | Situation | Variant |
 |---|---|
 | Epic has a crisp outcome; scope creep is the risk | bounded |
-| Exploratory/quality epic where discovered work IS the point | full |
+| Exploratory/quality epic where the discovered work *is* the point | full |
 
 Full-variant runs can generate more tickets than the epic started with; if that happens
 mid-run, switch to bounded and park the tail.
 
-## Fleet / multi-agent use
+## Fleet and multi-agent use
 
-For epics too large for one session, the same template works as a worker prompt: post it
-as a comment on the epic and pass the ticket URL as the worker's entry point, with each
-worker taking disjoint tickets.
+For epics too large for one session, the same directive works as a worker prompt: post it
+as a comment on the epic and give each worker the ticket URL as its entry point. Nobody
+hands out the tickets: each worker takes its own through `claim_issue`, and the lease
+keeps the others off it. That is why the composed directive reports the project's agent
+WIP limit, the cap on how many tickets one worker may hold at a time.


### PR DESCRIPTION
@
The `epic-goal` playbook body read as an excerpt from the write-up it came from — a "six ingredients" retrospective over past sessions, with an example about "all test repos" that do not exist in this repo.

## What changed

- **Replaced the retrospective with "What each clause is for"** — one bullet per clause that actually ships in `EPIC_GOAL_TEMPLATE`, so the page documents the artifact rather than the essay behind it.
- **Added "Getting the directive"** — a table mapping each `compose_playbook` parameter and live-data source to the clause it fills (`epicRef` → Goal, `variant` → Self-feed/Done-when, `cadence`/`reviewModel` → Review cadence, open-child-count + agent WIP limit → the appended Live data clause), matching `playbook-compose.ts`. Plus the `prompts/list`/`prompts/get` route.
- **Sited it against the workflow spec** — this playbook is the generic run shape; `workflow-spec` is the projektor-specific half.
- **Grounded the fleet section** in `claim_issue` leases and the WIP limit the composed directive reports.
- **Style pass**: `judgment` (not `judgement`, which clashed with the shipped `decisionsLog` clause on the same rendered page), consistent contractions, no capitals for emphasis, both get-passives rewritten, `Fleet / multi-agent use` → `Fleet and multi-agent use` (nothing links to the old anchor).

Templates, variant table and frontmatter are otherwise unchanged.

## Verification

Edited the source constant in `playbook-content.ts` and regenerated — the docs page is generated by `gen-playbooks.ts` under a CI staleness gate, so editing the `.md` directly would fail CI.

- `pnpm --filter @projektor/api gen:playbooks` — clean regen
- `playbooks.test.ts` + `playbook-compose.test.ts` + `mcp-prompts.test.ts` — 19/19 pass
- `biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYPsSekdCWXUL8UZR5sGEf
@