### PR TITLE
docs: cite the public deploy-example repo, not the private workspace one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Implementation details:
 - **Data:** D1 (SQLite) for relational data, KV for caching (Access certs, user-by-email), R2 for file attachments
 - **Schema:** Drizzle is the schema and primary query layer; raw `DB.prepare` remains in the auth/workspace middleware hot path, the dev bootstrap, and a handful of service queries (FTS, counters) where hand-written SQL is clearer.
 - **Monorepo:** pnpm workspaces + turbo. `apps/api` (the Worker), `apps/web` (Astro + Preact static site, served in production via CF Workers Static Assets - see below), `apps/docs` (the Astro docs site linked throughout this file), `packages/*` (db, types, plugin-sdk), `plugins/*`
-- **Deploy:** projektor publishes a self-contained **release artifact** on each `v*` tag; a config-only deploy repo (e.g. `projektor-workspace`) downloads it and ships it with `wrangler` - no submodule, no source checkout downstream. The Worker (`apps/api`) and the built frontend (`apps/web/dist`) ship together: `wrangler.toml` declares an `[assets]` binding with `run_worker_first = ["/api/*", "/mcp/*"]`, so `/api/*` and `/mcp/*` always hit the Hono Worker while every other path serves the static Astro output (per-route HTML, asset-first). The release build compiles `apps/web` and bundles the Worker into a single `worker.js`.
+- **Deploy:** projektor publishes a self-contained **release artifact** on each `v*` tag; a config-only deploy repo (e.g. `projektor-deploy-example`) downloads it and ships it with `wrangler` - no submodule, no source checkout downstream. The Worker (`apps/api`) and the built frontend (`apps/web/dist`) ship together: `wrangler.toml` declares an `[assets]` binding with `run_worker_first = ["/api/*", "/mcp/*"]`, so `/api/*` and `/mcp/*` always hit the Hono Worker while every other path serves the static Astro output (per-route HTML, asset-first). The release build compiles `apps/web` and bundles the Worker into a single `worker.js`.
 
 ## Planning and design docs live in the wiki, not the repo
 
@@ -291,7 +291,7 @@ Frontend islands are **not** domain-locked in the same way, but two agents must 
 own the same island file. Assign each island to exactly one agent per batch.
 
 **Deploy:** tag a release (`git tag vX.Y.Z && git push --tags`) - `release.yml`
-builds the artifact and the config-only deploy repo (`projektor-workspace`) picks
+builds the artifact and the config-only deploy repo (`projektor-deploy-example`) picks
 it up. See the [deploy guide](https://tajd.github.io/projektor/guides/deploying/).
 
 **CI commands** (must all pass before opening a PR):

--- a/apps/docs/src/content/docs/architecture/system-design.mdx
+++ b/apps/docs/src/content/docs/architecture/system-design.mdx
@@ -95,7 +95,7 @@ flowchart TB
 | Data model | Drizzle ORM → D1 | `packages/db` | Drizzle is the schema and primary query layer; raw `DB.prepare` remains in the auth/workspace middleware hot path, the dev bootstrap, and a handful of service queries (FTS, counters) where hand-written SQL is clearer. |
 | Shared types | TS | `packages/types` | `HonoEnv`, `Plugin`, `MCPTool`, `PluginContext`. |
 | Auth | CF Access JWT (RS256) + API tokens (SHA-256) | `middleware/auth.ts` | Plus dev bypass via `DEV_USER_EMAIL`. |
-| Deploy | wrangler + GitHub Actions | `projektor-deploy-example`, `projektor-workspace` | projektor publishes a release artifact; a config-only deploy repo downloads + ships it (no submodule). |
+| Deploy | wrangler + GitHub Actions | `projektor-deploy-example` | projektor publishes a release artifact; a config-only deploy repo downloads + ships it (no submodule). |
 
 ## API surfaces
 

--- a/apps/docs/src/content/docs/contributing/conventions.md
+++ b/apps/docs/src/content/docs/contributing/conventions.md
@@ -29,7 +29,7 @@ Implementation details:
 - **Data:** D1 (SQLite) for relational data, KV for caching (Access certs, user-by-email), R2 for file attachments
 - **Schema:** Drizzle is the schema and primary query layer; raw `DB.prepare` remains in the auth/workspace middleware hot path, the dev bootstrap, and a handful of service queries (FTS, counters) where hand-written SQL is clearer.
 - **Monorepo:** pnpm workspaces + turbo. `apps/api` (the Worker), `apps/web` (Astro + Preact static site, served in production via CF Workers Static Assets - see below), `apps/docs` (the Astro docs site linked throughout this file), `packages/*` (db, types, plugin-sdk), `plugins/*`
-- **Deploy:** projektor publishes a self-contained **release artifact** on each `v*` tag; a config-only deploy repo (e.g. `projektor-workspace`) downloads it and ships it with `wrangler` - no submodule, no source checkout downstream. The Worker (`apps/api`) and the built frontend (`apps/web/dist`) ship together: `wrangler.toml` declares an `[assets]` binding with `run_worker_first = ["/api/*", "/mcp/*"]`, so `/api/*` and `/mcp/*` always hit the Hono Worker while every other path serves the static Astro output (per-route HTML, asset-first). The release build compiles `apps/web` and bundles the Worker into a single `worker.js`.
+- **Deploy:** projektor publishes a self-contained **release artifact** on each `v*` tag; a config-only deploy repo (e.g. `projektor-deploy-example`) downloads it and ships it with `wrangler` - no submodule, no source checkout downstream. The Worker (`apps/api`) and the built frontend (`apps/web/dist`) ship together: `wrangler.toml` declares an `[assets]` binding with `run_worker_first = ["/api/*", "/mcp/*"]`, so `/api/*` and `/mcp/*` always hit the Hono Worker while every other path serves the static Astro output (per-route HTML, asset-first). The release build compiles `apps/web` and bundles the Worker into a single `worker.js`.
 
 ## Planning and design docs live in the wiki, not the repo
 
@@ -299,7 +299,7 @@ Frontend islands are **not** domain-locked in the same way, but two agents must 
 own the same island file. Assign each island to exactly one agent per batch.
 
 **Deploy:** tag a release (`git tag vX.Y.Z && git push --tags`) - `release.yml`
-builds the artifact and the config-only deploy repo (`projektor-workspace`) picks
+builds the artifact and the config-only deploy repo (`projektor-deploy-example`) picks
 it up. See the [deploy guide](https://tajd.github.io/projektor/guides/deploying/).
 
 **CI commands** (must all pass before opening a PR):


### PR DESCRIPTION
@
`AGENTS.md` and `architecture/system-design.mdx` both named `projektor-workspace` — a private repo — as the example config-only deploy repo. Every reader-facing path in the docs already points at `projektor-deploy-example`, which is the one a self-hoster can actually open.

- `AGENTS.md:24` — "a config-only deploy repo (e.g. `projektor-workspace`)" → `projektor-deploy-example`
- `AGENTS.md:294` — same, in the Deploy section
- `system-design.mdx:98` — the Deploy layer row listed both repos; now just the public one
- `contributing/conventions.md` — regenerated from `AGENTS.md` via `scripts/gen-conventions-page.ts` (generated page, never hand-edited)

`apps/api/wrangler.toml:2` keeps its `projektor-workspace` reference deliberately: it states where the real dogfood instance config lives, which `deploy-example` is not.

## Verification

- `npx tsx scripts/gen-conventions-page.ts` — regenerated, no drift
- `grep -rn projektor-workspace` now returns only the `wrangler.toml` comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYPsSekdCWXUL8UZR5sGEf
@