### PR TITLE
docs: list the prompts methods in the MCP request flow (PROJ-616)

### DIFF
--- a/apps/docs/src/content/docs/architecture/system-design.mdx
+++ b/apps/docs/src/content/docs/architecture/system-design.mdx
@@ -111,7 +111,12 @@ equivalent and is safe to depend on; see [REST endpoints](/projektor/agents/rest
 1. **Agent** → `POST /mcp/:workspaceId` with `Authorization: Bearer pk_…` + `X-Workspace-Slug`.
 2. `authMiddleware`: CF Access JWT → API-token (D1 hash lookup) → dev bypass.
 3. `workspaceMiddleware`: resolve slug → load workspace → verify `workspace_members` row.
-4. MCP router dispatches `initialize` / `tools/list` / `tools/call` → core tool handler → D1.
+4. MCP router dispatches one of three method groups:
+   - `initialize` — server info and capabilities.
+   - `tools/list` / `tools/call` → core tool handler → D1.
+   - `prompts/list` / `prompts/get` → a composed [playbook](/projektor/agents/playbooks/)
+     directive. `prompts/get` delegates to `compose_playbook`, so it reads the epic it is
+     given but is otherwise served from the shipped templates, not the database.
 
 Workspace membership is only the outer gate. Which *projects* a member can see and
 what they can do inside them is decided per-request in the service layer — see


### PR DESCRIPTION
Step 4 of the request flow in `architecture/system-design.mdx` named only `initialize` / `tools/list` / `tools/call`. The router also dispatches `prompts/list` and `prompts/get` (`routes/mcp.ts:168,171`), so a reader learning what the MCP endpoint speaks never discovered the prompts primitive — the one the playbooks pages tell them to use.

Rewrites step 4 as three method groups and notes that `prompts/get` delegates to `compose_playbook`, so it is served from the shipped templates rather than D1.

**Verification:** `pnpm --filter @projektor/docs build` — all internal links valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYPsSekdCWXUL8UZR5sGEf