### PR TITLE
fix: reorder 'claude mcp add' arguments so the printed command parses

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,11 @@ curl -s "https://<your-worker>.workers.dev/bootstrap" \
 Pipe the printed command straight into your shell:
 
 ```bash
-claude mcp add --transport http \
+claude mcp add projektor \
+  "https://<your-worker>.workers.dev/mcp/<workspace-uuid>" \
+  --transport http \
   --header "Authorization: Bearer pk_<64 hex chars>" \
-  --header "X-Workspace-Slug: projektor" \
-  projektor \
-  "https://<your-worker>.workers.dev/mcp/<workspace-uuid>"
+  --header "X-Workspace-Slug: projektor"
 ```
 
 Once connected, the agent has access to the full tool catalog - create issues, update statuses, search the wiki, plan sprints - anything a browser user can do.

--- a/apps/api/src/services/workspaces.ts
+++ b/apps/api/src/services/workspaces.ts
@@ -320,10 +320,10 @@ export async function getWorkspaceMcpInfo(
 }> {
 	const mcpUrl = `${origin}/mcp/${workspace.id}`;
 	const mcpAddCommandTemplate =
-		`claude mcp add --transport http ` +
+		`claude mcp add projektor "${mcpUrl}" ` +
+		`--transport http ` +
 		`--header "Authorization: Bearer {{TOKEN}}" ` +
-		`--header "X-Workspace-Slug: ${workspace.slug}" ` +
-		`projektor "${mcpUrl}"`;
+		`--header "X-Workspace-Slug: ${workspace.slug}"`;
 	return {
 		mcpUrl,
 		workspaceId: workspace.id,

--- a/apps/docs/src/content/docs/agents/mcp-connection.md
+++ b/apps/docs/src/content/docs/agents/mcp-connection.md
@@ -52,11 +52,11 @@ The bootstrap endpoint is enabled only when `ENVIRONMENT=development` - any othe
 Mint a token from the UI (Settings → Tokens) or via the API, then add the MCP server:
 
 ```bash
-claude mcp add --transport http \
+claude mcp add projektor \
+  "https://<your-worker>.workers.dev/mcp/<workspace-uuid>" \
+  --transport http \
   --header "Authorization: Bearer pk_<64 hex chars>" \
-  --header "X-Workspace-Slug: <slug>" \
-  projektor \
-  "https://<your-worker>.workers.dev/mcp/<workspace-uuid>"
+  --header "X-Workspace-Slug: <slug>"
 ```
 
 **Finding the workspace ID:** it is returned by `GET /api/workspaces` or shown in the bootstrap response. The slug is the short identifier you chose when creating the workspace (e.g. `projektor`).
@@ -175,13 +175,13 @@ If your projektor instance is behind Cloudflare Access (which it should be in pr
 Pass the service token credentials alongside the API token:
 
 ```bash
-claude mcp add --transport http \
+claude mcp add projektor \
+  "https://<your-worker>.workers.dev/mcp/<workspace-uuid>" \
+  --transport http \
   --header "Authorization: Bearer pk_<token>" \
   --header "X-Workspace-Slug: <slug>" \
   --header "CF-Access-Client-Id: <client-id>" \
-  --header "CF-Access-Client-Secret: <client-secret>" \
-  projektor \
-  "https://<your-worker>.workers.dev/mcp/<workspace-uuid>"
+  --header "CF-Access-Client-Secret: <client-secret>"
 ```
 
 Without a valid CF Access service token, the Worker returns a `403` before it reaches the MCP layer - the agent connection fails silently. The bootstrap flow bypasses Access; agent workflows in production need both headers.

--- a/apps/web/src/islands/TokenManager.tsx
+++ b/apps/web/src/islands/TokenManager.tsx
@@ -74,10 +74,10 @@ function buildMcpCommand(
 	}
 	if (!mcpUrl) return "";
 	const lines = [
-		"claude mcp add --transport http \\",
+		`claude mcp add projektor "${mcpUrl}" \\`,
+		"  --transport http \\",
 		`  --header "Authorization: Bearer ${token}" \\`,
-		`  --header "X-Workspace-Slug: ${workspaceSlug}" \\`,
-		`  projektor "${mcpUrl}"`,
+		`  --header "X-Workspace-Slug: ${workspaceSlug}"`,
 	];
 	return lines.join("\n");
 }

--- a/llms.txt
+++ b/llms.txt
@@ -10,7 +10,7 @@
 curl -s https://<worker>.workers.dev/bootstrap \
   -H "X-Bootstrap-Secret: <secret>" | jq -r .mcpAddCommand | sh
 
-# Then use the printed: claude mcp add --transport http ...
+# Then use the printed: claude mcp add projektor <url> --transport http ...
 ```
 
 ## MCP endpoint


### PR DESCRIPTION
## Problem

The `claude mcp add` command shown in **Settings → Tokens** (and in the API's `mcpAddCommandTemplate`, README, and docs) places `--transport`/`--header` options **before** the positional `name`/`url` arguments. The claude CLI enforces positional-first parsing for `mcp add`, so copy-pasting the command fails with:

```
error: missing required argument 'name'
```

## Fix

Reorder to positionals-first everywhere the command is emitted or documented:

```
claude mcp add projektor "https://.../mcp/<uuid>" \
  --transport http \
  --header "Authorization: Bearer pk_..." \
  --header "X-Workspace-Slug: ..."
```

Verified both forms against the claude CLI: options-first reproduces the error, positionals-first adds the server successfully. `AGENTS.md`'s interleaved variant (`add projektor --transport http <url>`) already parses, so it's left unchanged. Existing test assertions (`toContain("claude mcp add")`) still pass.

Files: `TokenManager.tsx` (UI), `services/workspaces.ts` (API template), `README.md`, `docs/agents/mcp-connection.md` (×2), `llms.txt`.

*Aware of the auto-close policy for external PRs — filing this as a reference patch, feel free to adopt however suits.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
