### PR TITLE
docs: rebrand the README as AI-native project management, self-hosted on Cloudflare

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 [![Latest release](https://img.shields.io/github/v/release/TAJD/projektor)](https://github.com/TAJD/projektor/releases)
 [![License: MIT](https://img.shields.io/github/license/TAJD/projektor)](./LICENSE)
 
-> An issue tracker and wiki that an AI coding agent runs as a first-class client -
-> self-hosted, cross-project, and cheap enough to run serverless.
+> **AI-native project management, self-hosted on Cloudflare.**
 
 **[Docs](https://tajd.github.io/projektor/)** ·
 **[Live demo](https://projektor-demo.tajdickson.workers.dev)** ·
@@ -15,61 +14,90 @@
 
 ## What it is
 
-A complete project tracker - issues, boards, sprints, a wiki - where every action a
-person can take in the browser, an agent can take over MCP. Filing issues, moving
-tickets, planning sprints, searching the wiki: the agent does it instead of asking you
-to.
+Projektor is an issue tracker and wiki that an AI coding agent runs as well as you do.
+It holds issues, boards, sprints and a wiki, and it exposes
+<!-- gen-mcp-stats:start -->113 tools across 22 domains<!-- gen-mcp-stats:end --> over MCP,
+so the agent files the ticket, moves it and writes the page instead of asking you to.
+The whole thing is one Cloudflare Worker in your own account.
 
-Jira and Notion are mature but human-first - agent access is bolted on, and you can't
-cheaply self-host a slice of them. Git-file trackers like beads are agent-native but
-live inside a single repo. Projektor is agent-native like beads, deployed and
-cross-project like Jira, and runs on a single Cloudflare Worker in your own account.
+Other trackers were built for people and had agent access bolted on later. Git-file
+trackers such as beads are agent-native but live inside a single repo. Projektor is
+agent-native from the schema up, works across projects, and is cheap enough to leave
+running.
 
-## Core features
+## Every action, both surfaces
 
-- **Issues** - Jira-style tickets: status, priority, assignee, labels, parent/child
-  hierarchy, cross-issue links. Referenced as `PROJ-42`.
-- **Boards and sprints** - kanban board, list view, sprint planning.
-- **Wiki** - nested markdown pages with full-text search and revision history.
-- **MCP server** - <!-- gen-mcp-stats:start -->113 tools across 22 domains<!-- gen-mcp-stats:end -->,
-  driven by any MCP agent (Claude Code connects via `claude mcp add`). This is the
-  primary surface, not an add-on.
-- **Fleet coordination** - agent registry, file claims, and messages let parallel
-  agents work one repo without colliding.
-- **Ops** - file attachments, workspace/project/member management with roles, API
-  tokens, installable PWA.
+REST and MCP are two doors into one service layer:
 
-Runs serverless on your own Cloudflare account: Hono on Workers, D1 for data, KV for
-cache, R2 for attachments. No servers, no containers.
+```
+REST  /api/*         ─┐
+                      ├─►  services/<domain>.ts  ─►  D1 (SQLite)
+MCP   /mcp/:wsId    ─┘
+```
 
-## Get started
+Routes and MCP tools are thin wrappers. The business logic and the SQL live in
+`services/`. That is what makes the parity claim hold: an agent is not driving a
+reduced API built for robots, it is calling the code the browser calls. Shipping a
+feature to one surface and not the other counts as a bug, not a backlog item.
 
-**Deploy it.** projektor installs into your Cloudflare account from a small config-only
-repo that downloads a pre-built release - no source checkout, no build step. The
+## You still run the project
+
+Agents do the filing. You do the steering, and you do it in a normal web app: backlog
+and kanban board, epics, sprint planning, a nested wiki with full-text search and
+revision history, flow metrics, and a feedback widget that turns user reports into
+issues. Nothing an agent does is buried in a log - it lands on the board, where you can
+read it, argue with it and move it.
+
+Agents get their own coordination primitives as well - a registry, file claims and
+messages - so several can work one repo without treading on each other.
+
+## What is in it
+
+- **Issues** - status, priority, assignee, labels, parent/child hierarchy and
+  cross-issue links. Referenced as `PROJ-42`.
+- **Boards and sprints** - kanban board, list view, sprint planning, flow metrics.
+- **Wiki** - nested markdown pages, full-text search, revision history.
+- **MCP server** - the primary surface, not an add-on. Any MCP agent connects; Claude
+  Code does it with `claude mcp add`.
+- **Fleet coordination** - agent registry, file claims and messages for parallel agents.
+- **Ops** - file attachments, workspaces, projects and members with roles, scoped API
+  tokens, share links, installable PWA.
+
+Serverless on your own Cloudflare account: Hono on Workers, D1 for data, KV for cache,
+R2 for attachments. No servers, no containers.
+
+## Deploy it
+
+Projektor installs into your Cloudflare account from a small config-only repo that
+downloads a pre-built release. There is no source checkout and no build step. The
 one-click **Deploy to Cloudflare** button in
-[projektor-deploy-example](https://github.com/TAJD/projektor-deploy-example)
-auto-provisions D1, KV, and R2 and deploys. A script and a CI flow are also available;
-see the [deploy guide](https://tajd.github.io/projektor/guides/deploying/). Afterwards
-you put **Cloudflare Access** in front of the Worker and mint an agent token -
-[CONFIGURE.md](https://github.com/TAJD/projektor-deploy-example/blob/main/CONFIGURE.md)
-walks through it end to end.
+[projektor-deploy-example](https://github.com/TAJD/projektor-deploy-example) provisions
+D1, KV and R2 for you and deploys. A script and a CI flow do the same job; see the
+[deploy guide](https://tajd.github.io/projektor/guides/deploying/).
 
-**Connect an agent.** projektor exposes a JSON-RPC 2.0 MCP endpoint at
-`POST /mcp/<workspaceId>`. In **Settings → Tokens**, create a token and copy the
-ready-to-run `claude mcp add` command shown beside it - workspace and token pre-filled.
-Full protocol reference and tool catalog: the
-[agent connection guide](https://tajd.github.io/projektor/agents/mcp-connection/).
+Put **Cloudflare Access** in front of the Worker before anyone logs in, then mint a
+token for your agents.
+[CONFIGURE.md](https://github.com/TAJD/projektor-deploy-example/blob/main/CONFIGURE.md)
+covers both.
+
+## Connect an agent
+
+Projektor serves a JSON-RPC 2.0 MCP endpoint at `POST /mcp/<workspaceId>`. Open
+**Settings → Tokens**, create a token, and copy the `claude mcp add` command shown
+beside it with the workspace and token filled in. The
+[agent connection guide](https://tajd.github.io/projektor/agents/mcp-connection/) has
+the protocol reference and the full tool catalog.
 
 ## Where to go next
 
 | | |
 |---|---|
 | [Getting started](https://tajd.github.io/projektor/guides/getting-started/) | first workspace, projects, issues |
-| [Self-hosting](https://tajd.github.io/projektor/guides/self-hosting/) & [deploying](https://tajd.github.io/projektor/guides/deploying/) | Cloudflare setup, API token scopes, updates |
-| [MCP connection](https://tajd.github.io/projektor/agents/mcp-connection/) & [tool catalog](https://tajd.github.io/projektor/agents/tool-catalog/) | wiring an agent up, every tool it gets |
+| [Self-hosting](https://tajd.github.io/projektor/guides/self-hosting/) and [deploying](https://tajd.github.io/projektor/guides/deploying/) | Cloudflare setup, API token scopes, updates |
+| [MCP connection](https://tajd.github.io/projektor/agents/mcp-connection/) and [tool catalog](https://tajd.github.io/projektor/agents/tool-catalog/) | wiring an agent up, every tool it gets |
 | [Agentic workflows](https://tajd.github.io/projektor/agents/agent-workflows/) | how agents are meant to use the tracker |
-| [System design](https://tajd.github.io/projektor/architecture/system-design/) | two surfaces (REST + MCP) over one service layer |
-| [AGENTS.md](./AGENTS.md) | contributor guide: conventions, file layout, service-layer contract |
+| [System design](https://tajd.github.io/projektor/architecture/system-design/) | the two surfaces and the service layer beneath them |
+| [AGENTS.md](./AGENTS.md) | contributor guide: conventions, file layout, the service-layer contract |
 
 ## Development
 
@@ -83,22 +111,23 @@ pnpm dev   # API on :8787, web on :4321
 ```
 
 `pnpm dev` applies D1 migrations to the local Miniflare database first, so a fresh
-checkout won't 500 with "no such table". Seed a workspace with
+checkout will not 500 with "no such table". Seed a workspace with
 `curl -H "X-Bootstrap-Secret: localdev" http://127.0.0.1:8787/bootstrap`, then open
-<http://localhost:4321> - with `DEV_USER_EMAIL` set you're logged in automatically.
+<http://localhost:4321>. With `DEV_USER_EMAIL` set, the dev-auth bypass logs you in.
 
 ```bash
 pnpm --filter @projektor/api test   # vitest against an in-process Worker + Miniflare D1
 pnpm turbo type-check               # tsc --noEmit across the monorepo
 ```
 
-Both must be green before opening a PR; `pnpm install` also wires lefthook pre-commit
-and pre-push hooks. CI runs more - see [AGENTS.md](./AGENTS.md) for the full list and
-the engineering conventions.
+Both must be green before you open a PR. `pnpm install` also wires the lefthook
+pre-commit and pre-push hooks. CI runs more; [AGENTS.md](./AGENTS.md) lists it, along
+with the engineering conventions.
 
 ## Contributing
 
-projektor is built with itself - the live dogfood instance tracks its own bugs and
-feature requests. See [CONTRIBUTING.md](./CONTRIBUTING.md) for how issues and PRs are
-handled, [SECURITY.md](./SECURITY.md) to report vulnerabilities, and
-[AGENTS.md](./AGENTS.md) before opening a PR. Licensed under [MIT](./LICENSE).
+Projektor is built with itself - the live dogfood instance tracks its own bugs and
+feature requests. [CONTRIBUTING.md](./CONTRIBUTING.md) explains how issues and PRs are
+handled, [SECURITY.md](./SECURITY.md) how to report a vulnerability, and
+[AGENTS.md](./AGENTS.md) what to read before opening a PR. Licensed under
+[MIT](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -7,188 +7,98 @@
 > An issue tracker and wiki that an AI coding agent runs as a first-class client -
 > self-hosted, cross-project, and cheap enough to run serverless.
 
-Projektor fills a gap. Jira and Notion are mature but human-first: agent access is
-bolted on, and you can't cheaply self-host a slice of them. Git-file trackers like
-beads are agent-native but live inside a single repo. Projektor is agent-native
-like beads, deployed and cross-project like Jira, and runs on a single Cloudflare
-Worker. Every action a person can take in the browser, an agent can take over MCP -
-filing issues, moving tickets, planning sprints, searching the wiki - instead of
-asking you to.
-
-**Documentation:** <https://tajd.github.io/projektor/> - self-hosting, connecting an
-agent, architecture, and the full MCP tool catalog.
-
-**Live demo:** <https://projektor-demo.tajdickson.workers.dev> - see it running before
-you deploy your own ([why there's no login](https://tajd.github.io/projektor/guides/live-demo/)).
-
-## What it is
+**[Docs](https://tajd.github.io/projektor/)** ·
+**[Live demo](https://projektor-demo.tajdickson.workers.dev)** ·
+**[Deploy your own](https://github.com/TAJD/projektor-deploy-example)**
 
 ![Projektor issue backlog - list view with projects sidebar, issue refs, status, priority, and assignees](docs/images/backlog.png)
 
-A complete project tracker - issues, boards, sprints, a wiki - built so an AI agent
-can do everything a person can. The shape of the tool follows from that; see
-[Agentic workflows](https://tajd.github.io/projektor/agents/agent-workflows/).
+## What it is
+
+A complete project tracker - issues, boards, sprints, a wiki - where every action a
+person can take in the browser, an agent can take over MCP. Filing issues, moving
+tickets, planning sprints, searching the wiki: the agent does it instead of asking you
+to.
+
+Jira and Notion are mature but human-first - agent access is bolted on, and you can't
+cheaply self-host a slice of them. Git-file trackers like beads are agent-native but
+live inside a single repo. Projektor is agent-native like beads, deployed and
+cross-project like Jira, and runs on a single Cloudflare Worker in your own account.
+
+## Core features
 
 - **Issues** - Jira-style tickets: status, priority, assignee, labels, parent/child
   hierarchy, cross-issue links. Referenced as `PROJ-42`.
 - **Boards and sprints** - kanban board, list view, sprint planning.
 - **Wiki** - nested markdown pages with full-text search and revision history.
-- **MCP server** - any MCP agent (Claude Code connects via `claude mcp add`) drives
-  the full tool catalog. This is the primary surface, not an add-on.
+- **MCP server** - <!-- gen-mcp-stats:start -->113 tools across 22 domains<!-- gen-mcp-stats:end -->,
+  driven by any MCP agent (Claude Code connects via `claude mcp add`). This is the
+  primary surface, not an add-on.
 - **Fleet coordination** - agent registry, file claims, and messages let parallel
   agents work one repo without colliding.
-- **Ops** - file attachments (R2), workspace/project/member management with roles
-  (`owner`/`admin`/`member`/`viewer`), workspace-scoped API tokens, installable PWA.
+- **Ops** - file attachments, workspace/project/member management with roles, API
+  tokens, installable PWA.
 
-Runs on your own Cloudflare account: Hono on Workers, D1 for data, KV for cache,
-R2 for attachments. No servers, no containers.
+Runs serverless on your own Cloudflare account: Hono on Workers, D1 for data, KV for
+cache, R2 for attachments. No servers, no containers.
 
-## Self-hosting
+## Get started
 
-projektor deploys to **your own Cloudflare account** from a small **config-only repo**
-([`projektor-deploy-example`](https://github.com/TAJD/projektor-deploy-example)) that
-downloads a pre-built release artifact - no source checkout, no build step. Three ways
-in, easiest first.
+**Deploy it.** projektor installs into your Cloudflare account from a small config-only
+repo that downloads a pre-built release - no source checkout, no build step. The
+one-click **Deploy to Cloudflare** button in
+[projektor-deploy-example](https://github.com/TAJD/projektor-deploy-example)
+auto-provisions D1, KV, and R2 and deploys. A script and a CI flow are also available;
+see the [deploy guide](https://tajd.github.io/projektor/guides/deploying/). Afterwards
+you put **Cloudflare Access** in front of the Worker and mint an agent token -
+[CONFIGURE.md](https://github.com/TAJD/projektor-deploy-example/blob/main/CONFIGURE.md)
+walks through it end to end.
 
-### One click
+**Connect an agent.** projektor exposes a JSON-RPC 2.0 MCP endpoint at
+`POST /mcp/<workspaceId>`. In **Settings → Tokens**, create a token and copy the
+ready-to-run `claude mcp add` command shown beside it - workspace and token pre-filled.
+Full protocol reference and tool catalog: the
+[agent connection guide](https://tajd.github.io/projektor/agents/mcp-connection/).
 
-Use the **Deploy to Cloudflare** button in the
-[deploy repo](https://github.com/TAJD/projektor-deploy-example): Cloudflare clones it
-into your account, **auto-provisions D1, KV, and R2**, and deploys. Fill in your admin
-email on the setup page and you're live.
+## Where to go next
 
-### One command - or one prompt
-
-Clone the deploy repo and run the zero-config script; wrangler auto-provisions the
-resources, applies migrations, and deploys:
-
-```bash
-PROJEKTOR_REPO=you/projektor ADMIN_EMAILS=you@example.com ./deploy-auto.sh
-```
-
-Or hand the repo to an AI agent - *"deploy projektor to my Cloudflare account"* - and
-let it run the same flow. See
-[AGENT-DEPLOY.md](https://github.com/TAJD/projektor-deploy-example/blob/main/AGENT-DEPLOY.md).
-
-### Then: configure access
-
-The Worker is live, but **Cloudflare Access** must front it before anyone can log in
-(a `*.workers.dev` toggle, or a custom domain). Then log in - the first user in
-`ADMIN_EMAILS` becomes owner - and mint a token for agents. Full handoff:
-[CONFIGURE.md](https://github.com/TAJD/projektor-deploy-example/blob/main/CONFIGURE.md).
-
-### Manual / CI
-
-Prefer to create the resources yourself, keep your config private, or deploy from CI on
-every push? See the **[deploy guide](https://tajd.github.io/projektor/guides/deploying/)** for the manual flow, the
-Cloudflare API token recipe (it **must include D1**), and push-based auto-updates.
-
-**Updating later:** bump `projektor.version` and re-deploy (or just push, if you wired CI).
-
-## Connect an AI agent
-
-projektor exposes a JSON-RPC 2.0 MCP endpoint at `POST /mcp/<workspaceId>`.
-Any MCP-compatible agent (Claude Code, custom agents via the Anthropic SDK) can connect.
-
-### Development - one command
-
-```bash
-# Provision workspace + user + token in one shot (dev/staging only)
-curl -s "https://<your-worker>.workers.dev/bootstrap" \
-  -H "X-Bootstrap-Secret: <your-bootstrap-secret>" \
-  | jq -r .mcpAddCommand
-```
-
-Pipe the printed command straight into your shell:
-
-```bash
-claude mcp add projektor \
-  "https://<your-worker>.workers.dev/mcp/<workspace-uuid>" \
-  --transport http \
-  --header "Authorization: Bearer pk_<64 hex chars>" \
-  --header "X-Workspace-Slug: projektor"
-```
-
-Once connected, the agent has access to the full tool catalog - create issues, update statuses, search the wiki, plan sprints - anything a browser user can do.
-
-### Production - mint a long-lived token
-
-`/bootstrap` is disabled in production. Instead, log in through Cloudflare Access and
-open **Settings → Tokens**: create a token and copy the ready-to-run `claude mcp add`
-command shown beside it (token + workspace pre-filled). The full walkthrough - Access
-setup, first login, token, MCP - is in
-[CONFIGURE.md](https://github.com/TAJD/projektor-deploy-example/blob/main/CONFIGURE.md).
-
-See the **[agent connection guide](https://tajd.github.io/projektor/agents/mcp-connection/)** for the full connection guide, protocol reference, and tool catalog (<!-- gen-mcp-stats:start -->113 tools across 22 domains<!-- gen-mcp-stats:end --> - project data plus agent-coordination primitives).
+| | |
+|---|---|
+| [Getting started](https://tajd.github.io/projektor/guides/getting-started/) | first workspace, projects, issues |
+| [Self-hosting](https://tajd.github.io/projektor/guides/self-hosting/) & [deploying](https://tajd.github.io/projektor/guides/deploying/) | Cloudflare setup, API token scopes, updates |
+| [MCP connection](https://tajd.github.io/projektor/agents/mcp-connection/) & [tool catalog](https://tajd.github.io/projektor/agents/tool-catalog/) | wiring an agent up, every tool it gets |
+| [Agentic workflows](https://tajd.github.io/projektor/agents/agent-workflows/) | how agents are meant to use the tracker |
+| [System design](https://tajd.github.io/projektor/architecture/system-design/) | two surfaces (REST + MCP) over one service layer |
+| [AGENTS.md](./AGENTS.md) | contributor guide: conventions, file layout, service-layer contract |
 
 ## Development
 
 ```bash
 pnpm install
 
-# Copy dev config (one-time)
 cp apps/api/.dev.vars.example apps/api/.dev.vars   # set DEV_USER_EMAIL + BOOTSTRAP_SECRET
 cp apps/web/.env.example      apps/web/.env        # set PUBLIC_WORKSPACE_SLUG=projektor
 
 pnpm dev   # API on :8787, web on :4321
 ```
 
-`pnpm dev` automatically applies D1 migrations to the local Miniflare database before starting, so a fresh checkout won't 500 with "no such table".
-
-Seed a local workspace in one shot:
-
-```bash
-curl -H "X-Bootstrap-Secret: localdev" http://127.0.0.1:8787/bootstrap
-```
-
-Then open **http://localhost:4321** - with `DEV_USER_EMAIL` set, the dev-auth bypass logs you in automatically.
-
-### Tests
+`pnpm dev` applies D1 migrations to the local Miniflare database first, so a fresh
+checkout won't 500 with "no such table". Seed a workspace with
+`curl -H "X-Bootstrap-Secret: localdev" http://127.0.0.1:8787/bootstrap`, then open
+<http://localhost:4321> - with `DEV_USER_EMAIL` set you're logged in automatically.
 
 ```bash
 pnpm --filter @projektor/api test   # vitest against an in-process Worker + Miniflare D1
 pnpm turbo type-check               # tsc --noEmit across the monorepo
 ```
 
-Both must be green before opening a PR. CI (`.github/workflows/ci.yml`) runs these plus more -
-coverage-enforced test runs, the `@projektor/db` and `@projektor/docs` suites, the web build, and
-a generated-docs freshness check. See [AGENTS.md](./AGENTS.md) for the full list.
+Both must be green before opening a PR; `pnpm install` also wires lefthook pre-commit
+and pre-push hooks. CI runs more - see [AGENTS.md](./AGENTS.md) for the full list and
+the engineering conventions.
 
-### Git hooks (lefthook)
+## Contributing
 
-`pnpm install` wires two hooks automatically:
-
-- **pre-commit** - `pnpm turbo type-check` (fast; turbo-cached), `pnpm biome check --changed` (lint, changed files only), and the island API convention check
-- **pre-push** - `pnpm biome check .`, `pnpm --filter @projektor/api test`, and `pnpm --filter @projektor/web test`
-
-Bypass for WIP commits: `git commit --no-verify -m "wip: …"`
-
-## Architecture (brief)
-
-For a visual of how the system fits together, see the
-[architecture overview](https://tajd.github.io/projektor/architecture/system-design/); the deep architecture lives in
-[AGENTS.md](./AGENTS.md).
-
-projektor has two surfaces over one service layer:
-
-```
-REST  /api/*         ─┐
-                       ├─►  services/<domain>.ts  ─►  D1 (SQLite)
-MCP   /mcp/:wsId    ─┘
-```
-
-Routes and MCP tools are thin wrappers. All business logic and SQL live in `services/`. Both surfaces must stay at parity - adding a feature to only one is a bug.
-
-Runtime: **Hono on Cloudflare Workers** - no Node.js, no containers.
-Storage: **D1** (relational), **KV** (cache), **R2** (attachments).
-Frontend: **Astro + Preact**, served as static assets via Workers Static Assets; `/api/*` and `/mcp/*` always hit the Worker.
-
-## Roadmap / Contributing
-
-The live projektor dogfood instance tracks feature requests and bugs - projektor is built with itself.
-
-[AGENTS.md](./AGENTS.md) is the contributor guide: conventions, file layout, the service-layer contract, and how to work in parallel without conflicts. Read it before opening a PR.
-
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for how issues and PRs are handled,
-[SECURITY.md](./SECURITY.md) to report vulnerabilities, and [AGENTS.md](./AGENTS.md) for
-the engineering conventions. Licensed under [MIT](./LICENSE).
+projektor is built with itself - the live dogfood instance tracks its own bugs and
+feature requests. See [CONTRIBUTING.md](./CONTRIBUTING.md) for how issues and PRs are
+handled, [SECURITY.md](./SECURITY.md) to report vulnerabilities, and
+[AGENTS.md](./AGENTS.md) before opening a PR. Licensed under [MIT](./LICENSE).

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Projektor
-description: A self-hosted issue tracker and wiki where AI agents are the primary client. Everything a person does in the browser, an agent does over MCP.
+description: AI-native project management, self-hosted on Cloudflare. An issue tracker and wiki where every action a person takes in the browser, an agent takes over MCP.
 template: splash
 hero:
-  tagline: An issue tracker and wiki your AI coding agent runs as a first-class client — agent-native like a git tracker, deployed and cross-project like Jira, on a single Cloudflare Worker.
+  tagline: AI-native project management, self-hosted on Cloudflare. An issue tracker and wiki your coding agent runs as well as you do — one Worker, in your own account.
   actions:
     - text: Connect an agent
       link: /projektor/agents/mcp-connection/
@@ -20,36 +20,44 @@ hero:
 
 import { Image } from 'astro:assets';
 import { Card, CardGrid } from '@astrojs/starlight/components';
+import mcpStats from '../../generated/mcp-stats.json';
 import backlogScreenshot from '../../assets/backlog.png';
 
 <Image src={backlogScreenshot} alt="Projektor issue backlog — list view with projects sidebar, issue refs, status, priority, and assignees" />
 
+Projektor holds issues, boards, sprints and a wiki, and exposes {mcpStats.tools} tools
+across {mcpStats.domains} domains over MCP. The agent files the ticket, moves it and
+writes the page instead of asking you to. Other trackers were built for people and had
+agent access bolted on later; git-file trackers are agent-native but live inside a
+single repo. Projektor is agent-native from the schema up, works across projects, and
+is cheap enough to leave running.
+
 <CardGrid stagger>
-  <Card title="Agents drive it" icon="puzzle">
-    Filing issues, moving tickets, planning sprints, searching the wiki — an agent
-    does it all over MCP, instead of asking you to. The MCP server is the primary
-    surface, not a bolt-on.
+  <Card title="Every action, both surfaces" icon="puzzle">
+    REST and MCP are two doors into one service layer. An agent is not driving a
+    reduced API built for robots — it calls the code the browser calls. Shipping a
+    feature to one surface and not the other counts as a bug.
   </Card>
-  <Card title="Fills the gap" icon="approve-check">
-    Agent-native like a git-file tracker, but deployed and cross-project like Jira -
-    and cheap to self-host. When you outgrow it, you swap the database, not the tool.
+  <Card title="You still run the project" icon="approve-check">
+    Agents do the filing; you do the steering, in a normal web app. Backlog and kanban
+    board, epics, sprint planning, a nested wiki with full-text search, flow metrics.
+    Nothing an agent does is buried in a log.
   </Card>
   <Card title="Built for fleets" icon="seti:notebook">
-    An agent registry, file claims, and coordination messages let many agents work
-    the same repo in parallel without colliding.
+    An agent registry, file claims and coordination messages let many agents work the
+    same repo in parallel without colliding.
   </Card>
   <Card title="Runs on the edge" icon="cloudflare">
-    One Cloudflare Worker: Hono, D1 for data, KV for cache, R2 for attachments.
-    No servers, no containers. Deploy to your own account in minutes.
+    One Cloudflare Worker: Hono, D1 for data, KV for cache, R2 for attachments. No
+    servers, no containers. Deploy to your own account in minutes.
   </Card>
 </CardGrid>
 
 ## Self-host in minutes
 
-Deploy to your own Cloudflare account from a config-only repo — wrangler
-auto-provisions D1, KV, and R2, applies migrations, and ships. One button, one
-command, or hand the repo to an agent and say *"deploy projektor to my Cloudflare
-account."*
+Deploy to your own Cloudflare account from a config-only repo. Wrangler provisions D1,
+KV and R2, applies the migrations and ships. Use the one-click button, run one command,
+or hand the repo to an agent and say *"deploy projektor to my Cloudflare account."*
 
 [Your first ten minutes →](/projektor/guides/getting-started/) ·
 [Why Projektor looks like this →](/projektor/agents/agent-workflows/) ·


### PR DESCRIPTION
## Why

The README opened with an eleven-section flat list, and roughly half of it restated the docs site: three deploy variants, the `/bootstrap` curl, a dev-only `claude mcp add` sample, the lefthook hook contents. The positioning was spread across a blockquote, a "What it is" heading and a separate comparison paragraph, so the claim never landed.

## What it does now

Leads with one claim - **AI-native project management, self-hosted on Cloudflare** - then argues it in three moves before reaching the feature list:

1. **Every action, both surfaces.** REST and MCP as two doors into one service layer, with the ASCII diagram kept as the evidence. The point made explicitly: an agent is not driving a reduced API built for robots, and one-surface features are bugs rather than backlog items.
2. **You still run the project.** The human side - board, epics, sprints, wiki, flow metrics, feedback widget - so the pitch does not read as "for robots only". Agent coordination primitives follow as a smaller note.
3. **What is in it.** The existing feature bullets, trimmed.

Then deploy → connect an agent → a "Where to go next" link table → development → contributing.

Prose edited for Economist style: active voice, one idea per sentence, no serial commas, sentence-case headings, no hype adjectives.

## Cut (all of it already on the docs site)

Three-way deploy walkthrough, `deploy-auto.sh` invocation, `/bootstrap` curl plus sample `claude mcp add` output, lefthook hook listing, the "Updating later" note.

194 → 133 lines. Nothing that lived only in the README was dropped.

## Verification

- `pnpm --filter @projektor/api gen:catalog` re-run: regenerates cleanly and leaves the README untouched, so the generated-docs freshness check stays green. The `gen-mcp-stats` markers moved into the opening paragraph; the generator throws if they go missing.
- lefthook pre-commit (type-check + biome) passed on both commits.
- Rendered on GitHub from the branch: screenshot resolves, table and diagram render.

## Open question

The feature-set claims are drawn from the code (`apps/web/src/pages` for the human surface, the MCP catalog for the tool count). Worth a check that "flow metrics" and "a feedback widget that turns user reports into issues" describe what those pages actually do today rather than what they are heading towards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ar6L7v8MTCgEY6xW3FJ4PE