### PR TITLE
Consolidate and surface the technical differentiation (PROJ-622)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,43 @@ Implementation details:
 - **Monorepo:** pnpm workspaces + turbo. `apps/api` (the Worker), `apps/web` (Astro + Preact static site, served in production via CF Workers Static Assets — see below), `apps/docs` (the Astro docs site linked throughout this file), `packages/*` (db, types, plugin-sdk), `plugins/*`
 - **Deploy:** projektor publishes a self-contained **release artifact** on each `v*` tag; a config-only deploy repo (e.g. `projektor-deploy-example`) downloads it and ships it with `wrangler` — no submodule, no source checkout downstream. The Worker (`apps/api`) and the built frontend (`apps/web/dist`) ship together: `wrangler.toml` declares an `[assets]` binding with `run_worker_first = ["/api/*", "/mcp/*"]`, so `/api/*` and `/mcp/*` always hit the Hono Worker while every other path serves the static Astro output (per-route HTML, asset-first). The release build compiles `apps/web` and bundles the Worker into a single `worker.js`.
 
+## Coordination model (read this first)
+
+Projektor expects multiple agents to work the same workspace concurrently. Before
+editing anything:
+
+- **Claim before editing.** File claims (`claim_files`) are path-level — they stop two
+  agents editing the same files. Matching is **exact string equality**, not globs:
+  claiming `src/` reserves nothing under `src/`, so name concrete paths and name them the
+  same way the rest of the fleet does. Issue leases (`claim_issue`) are work-item-level —
+  they stop two agents picking up the same ticket. The two are independent; you need both.
+- **Your session goes stale if you stop heartbeating.** Liveness is heartbeat-based:
+  `ACTIVE_TTL` in `apps/api/src/services/agents.ts` (mirrored as `SESSION_TTL_SECONDS` in
+  `apps/api/src/services/issue-leases.ts`) is **120 seconds**. Register, then go quiet for
+  two minutes without a `heartbeat_agent` call, and your session goes stale — you must
+  heartbeat again before you can claim.
+- **Leases self-heal; file claims do not.** An issue lease held by a stale session is
+  reclaimed by the next claimer in the same call. File claims have no TTL: they release
+  only on `release_files`, on `end_agent`, or when someone claims with `force`. So call
+  `end_agent` when you finish, or your paths stay locked behind you.
+- **There's a per-project cap on concurrently leased issues** —
+  `DEFAULT_AGENT_WIP_LIMIT = 3` in `apps/api/src/services/issue-leases.ts`,
+  overridable per project via `projects.agent_wip_limit`. It's admission control on
+  the backlog, not a rate limit: it bounds how much work can be in flight at once,
+  not how fast you can ask.
+- **A refused claim tells you who to talk to.** Rejection is all-or-nothing: nothing is
+  claimed, and the error names the issue and agent holding the path — message them with
+  `post_message` if you need it. Nothing is pushed to the holder either way, including
+  when you use `force` (that posts an audit message to *your* issue scope, not theirs), so
+  if you override someone, tell them yourself. Every contended path is recorded regardless.
+
+This is the mechanism; the mechanical call sequence for this repo is under "Fleet
+coordination protocol" below, and the design rationale (why leases, claims, and the
+WIP cap are shaped this way) is the [coordination model](https://tajd.github.io/projektor/philosophy/coordination-model/)
+doc. The workflow rules themselves (definition of ready, state machine, human review
+gates) live in exactly one place, the [workflow spec](https://tajd.github.io/projektor/agents/workflow-spec/)
+— call `get_workflow` before claiming work; they aren't restated here.
+
 ## Planning and design docs live in the wiki, not the repo
 
 Design records, implementation plans, and specs belong in the projektor wiki (`create_wiki_page`/`update_wiki_page`), not in a repo `docs/` folder. Keeping them in the wiki makes them discoverable and searchable (`search_wiki`) instead of buried in git history. Root-level user-facing docs (`README.md`, `AGENTS.md`, `CONTRIBUTING.md`, `SECURITY.md`) are the only docs that belong in the repo itself.

--- a/README.md
+++ b/README.md
@@ -20,12 +20,49 @@ It holds issues, boards, sprints and a wiki, and it exposes
 so the agent files the ticket, moves it and writes the page instead of asking you to.
 The whole thing is one Cloudflare Worker in your own account.
 
-Other trackers were built for people and had agent access bolted on later. Git-file
-trackers such as beads are agent-native but live inside a single repo. Projektor is
-agent-native from the schema up, works across projects, and is cheap enough to leave
-running.
+## One work graph, not a tracker plus a sidecar
 
-## Every action, both surfaces
+Running a fleet of agents normally means assembling three things: a tracker for the
+work, a coordination layer so two agents do not edit the same file, and worktree
+tooling to keep their checkouts apart. That leaves two or three sources of truth about
+what is being worked on, and nothing that can answer a question spanning them.
+
+In Projektor the coordination state *is* the work graph. The lease is on the issue and
+the claim is on the file, in one schema behind one auth boundary:
+
+- **Issue leases** — an agent takes a work-item lease before starting, and a
+  per-project cap (`agent_wip_limit`, default 3) bounds how many issues the fleet can
+  hold at once. That is admission control on the backlog, not a rate limit: it decides
+  how much work is allowed to be in flight.
+- **File claims** — path-level claims stop two agents editing the same code. A refused
+  claim is rejected whole and names the issue and agent already holding the path, so the
+  blocked agent knows who to talk to, and every contended path is recorded.
+- **Liveness** — an issue lease is derived from its holder's heartbeat, so a lease whose
+  agent stopped reporting is reclaimed by the next claim in the same call. An agent that
+  crashes mid-ticket does not deadlock the backlog behind it. File claims are released on
+  session end or explicitly, not by TTL — the
+  [coordination model](https://tajd.github.io/projektor/philosophy/coordination-model/)
+  is explicit about that asymmetry.
+
+Because it is one graph, "which issue is this claim for" is a join, not an integration.
+The [coordination model](https://tajd.github.io/projektor/philosophy/coordination-model/)
+documents the design. [How Projektor differs](https://tajd.github.io/projektor/philosophy/alternatives/)
+compares it against beads, MCP Agent Mail, Linear and the worktree tools, and is honest
+about what each of those does better.
+
+## Contention is data
+
+When a claim collides, most systems return an error and forget it. Projektor writes the
+contended path to an event log — whether the claim was refused or forced through — and
+ranks it, so the code heatmap has two modes: where the fleet is *working*, and where the
+fleet is *colliding*.
+
+That closes a loop back into the backlog. A directory that shows up hot in contention
+week after week is telling you something about how the work is sliced — two tickets that
+keep fighting over the same module probably wanted to be one ticket, or the module
+wanted splitting. Refused claims are evidence about your plan, not just failures.
+
+## Both surfaces, checked mechanically
 
 REST and MCP are two doors into one service layer:
 
@@ -35,10 +72,20 @@ REST  /api/*         ─┐
 MCP   /mcp/:wsId    ─┘
 ```
 
-Routes and MCP tools are thin wrappers. The business logic and the SQL live in
-`services/`. That is what makes the parity claim hold: an agent is not driving a
-reduced API built for robots, it is calling the code the browser calls. Shipping a
-feature to one surface and not the other counts as a bug, not a backlog item.
+Routes and MCP tools are thin wrappers; the business logic and the SQL live in
+`services/`. An agent is not driving a reduced API built for robots, it is calling the
+code the browser calls.
+
+That used to be a convention held up by review. It is now a test: `mcp-parity.node.test.ts`
+cross-references every exported service function against the REST routes, the runtime MCP
+registry and the documented catalog, and fails the build on drift — including a catalog
+reordered without the dispatch table. Operations deliberately on one surface only are
+enumerated with a reason each, and the test fails if that list goes stale, so the
+exceptions stay few and visible rather than accumulating quietly.
+
+Every surface described here was used to build Projektor: the epics, the tickets, the
+coordination primitives and the wiki pages all carried their own development. The tool
+catalog is a discovered surface, not a designed one.
 
 ## You still run the project
 
@@ -48,9 +95,6 @@ revision history, flow metrics, and a feedback widget that turns user reports in
 issues. Nothing an agent does is buried in a log - it lands on the board, where you can
 read it, argue with it and move it.
 
-Agents get their own coordination primitives as well - a registry, file claims and
-messages - so several can work one repo without treading on each other.
-
 ## What is in it
 
 - **Issues** - status, priority, assignee, labels, parent/child hierarchy and
@@ -59,7 +103,8 @@ messages - so several can work one repo without treading on each other.
 - **Wiki** - nested markdown pages, full-text search, revision history.
 - **MCP server** - the primary surface, not an add-on. Any MCP agent connects; Claude
   Code does it with `claude mcp add`.
-- **Fleet coordination** - agent registry, file claims and messages for parallel agents.
+- **Fleet coordination** - agent registry, issue leases with a per-project WIP cap, file
+  claims, agent messages, and a contention heatmap over every contended path.
 - **Ops** - file attachments, workspaces, projects and members with roles, scoped API
   tokens, share links, installable PWA.
 
@@ -96,6 +141,8 @@ the protocol reference and the full tool catalog.
 | [Self-hosting](https://tajd.github.io/projektor/guides/self-hosting/) and [deploying](https://tajd.github.io/projektor/guides/deploying/) | Cloudflare setup, API token scopes, updates |
 | [MCP connection](https://tajd.github.io/projektor/agents/mcp-connection/) and [tool catalog](https://tajd.github.io/projektor/agents/tool-catalog/) | wiring an agent up, every tool it gets |
 | [Agentic workflows](https://tajd.github.io/projektor/agents/agent-workflows/) | how agents are meant to use the tracker |
+| [Coordination model](https://tajd.github.io/projektor/philosophy/coordination-model/) | leases, claims, liveness and contention as a designed system |
+| [How Projektor differs](https://tajd.github.io/projektor/philosophy/alternatives/) | compared against beads, MCP Agent Mail, Hiveship, Linear |
 | [System design](https://tajd.github.io/projektor/architecture/system-design/) | the two surfaces and the service layer beneath them |
 | [AGENTS.md](./AGENTS.md) | contributor guide: conventions, file layout, the service-layer contract |
 

--- a/apps/api/src/routes/mcp.ts
+++ b/apps/api/src/routes/mcp.ts
@@ -202,7 +202,10 @@ function getAllTools(workspaceId: string): MCPTool[] {
 	return [...coreMCPTools, ...pluginRegistry.getToolsForWorkspace(workspaceId)];
 }
 
-const coreMCPTools: MCPTool[] = [
+// Exported for the parity test (src/test/mcp-parity.node.test.ts), which asserts this
+// array agrees with mcp/catalog.ts on both membership and order. Not part of the
+// runtime surface — nothing else should import it.
+export const coreMCPTools: MCPTool[] = [
 	...workspacesTools,
 	...groupsTools,
 	...projectsTools,
@@ -210,13 +213,13 @@ const coreMCPTools: MCPTool[] = [
 	...issuesTools,
 	...issueLinksTools,
 	...commentsTools,
-	...feedbackTools,
 	...wikiTools,
 	...filesTools,
 	...taskTypesTools,
 	...taskStatusesTools,
 	...customFieldsTools,
 	...sprintsTools,
+	...feedbackTools,
 	...agentsTools,
 	...fileClaimsTools,
 	...issueLeasesTools,

--- a/apps/api/src/test/file-claims.test.ts
+++ b/apps/api/src/test/file-claims.test.ts
@@ -306,4 +306,53 @@ describe("File Claims API", () => {
 			.all();
 		expect(rows.results).toHaveLength(0);
 	});
+
+	async function listMessagesForScope(scope: string) {
+		const res = await SELF.fetch(
+			`http://localhost/api/agent-messages?scope=${encodeURIComponent(scope)}`,
+			{ headers: authHeaders(token, slug) }
+		);
+		expect(res.status).toBe(200);
+		return (await res.json()) as { items: Array<{ body: string }> };
+	}
+
+	// PROJ-624: rejection (force=false) must not post any agent message — this was
+	// previously mis-stated in the project's own docs as a message-posting path.
+	it("PROJ-624: a rejected claim (force=false) posts no agent message to any scope", async () => {
+		await claimFiles({ issueId, paths: ["src/no-message-on-reject.ts"] });
+
+		const issue2 = await seedIssue(workspaceId, projectId, userId, {
+			title: "Rejected, no message",
+		});
+		const res = await claimFiles({ issueId: issue2.id, paths: ["src/no-message-on-reject.ts"] });
+		expect(res.status).toBe(409);
+
+		const holderMessages = await listMessagesForScope(`issue:${issueId}`);
+		expect(holderMessages.items).toHaveLength(0);
+
+		const rejectedMessages = await listMessagesForScope(`issue:${issue2.id}`);
+		expect(rejectedMessages.items).toHaveLength(0);
+	});
+
+	// PROJ-624: force:true DOES post a message, scoped to the issue that ends up
+	// holding the claim after the override (not the prior holder that lost it).
+	it("PROJ-624: force:true override posts a message scoped to the now-holding issue", async () => {
+		await claimFiles({ issueId, paths: ["src/message-on-force.ts"] });
+
+		const issue2 = await seedIssue(workspaceId, projectId, userId, { title: "Force claims" });
+		const forceRes = await claimFiles({
+			issueId: issue2.id,
+			paths: ["src/message-on-force.ts"],
+			force: true,
+		});
+		expect(forceRes.status).toBe(201);
+
+		const messages = await listMessagesForScope(`issue:${issue2.id}`);
+		expect(messages.items).toHaveLength(1);
+		expect(messages.items[0].body).toContain("src/message-on-force.ts");
+		expect(messages.items[0].body).toContain(issueId);
+
+		const priorHolderMessages = await listMessagesForScope(`issue:${issueId}`);
+		expect(priorHolderMessages.items).toHaveLength(0);
+	});
 });

--- a/apps/api/src/test/issue-leases.test.ts
+++ b/apps/api/src/test/issue-leases.test.ts
@@ -1,5 +1,8 @@
 import { env, SELF } from "cloudflare:test";
+import { drizzle, schema } from "@projektor/db";
 import { beforeEach, describe, expect, it } from "vitest";
+import { fetchAgentWipCap } from "../services/issue-leases";
+import type { ServiceCtx } from "../services/types";
 import { authHeaders, seedFixture, seedIssue, seedProjectFixture } from "./helpers";
 
 // cofferdam-ignore: Readability.MaxFunctionLength: full integration test suite in one describe block, normal test style
@@ -271,6 +274,34 @@ describe("claim_issue agent WIP limit (PROJ-253)", () => {
 		expect(res.status).toBe(409);
 		const body = (await res.json()) as { error?: string };
 		expect(JSON.stringify(body)).toMatch(/WIP limit/i);
+	});
+
+	// PROJ-624: the Nth claim (at the cap) must succeed and the (N+1)th must be
+	// rejected with an error that names the actual configured cap — read from
+	// fetchAgentWipCap (exported), not retyped as a literal, so the assertion
+	// stays honest if DEFAULT_AGENT_WIP_LIMIT ever changes.
+	it("PROJ-624: claim at the cap succeeds; the (cap+1)th is rejected and the error names the cap", async () => {
+		const orm = drizzle(env.DB, { schema });
+		const cap = await fetchAgentWipCap(orm, { workspaceId } as ServiceCtx, projectId);
+
+		const agent = await registerAgent("worker");
+		const issues = await Promise.all(
+			Array.from({ length: cap + 1 }, (_, i) =>
+				seedIssue(workspaceId, projectId, userId, { title: `Cap ${i}` })
+			)
+		);
+
+		for (const issue of issues.slice(0, cap)) {
+			expect((await claim(issue.id, agent)).status).toBe(201);
+		}
+
+		const res = await claim(issues[cap].id, agent);
+		expect(res.status).toBe(409);
+		const body = (await res.json()) as { error?: string };
+		// Anchored to the phrase, not a bare `toContain(String(cap))`: the message
+		// also lists `cap` held issue UUIDs, and a single digit occurs in those by
+		// chance often enough that the loose form passes even if the cap is dropped.
+		expect(body.error).toMatch(new RegExp(`WIP limit reached \\(${cap}\\)`));
 	});
 
 	it("records a wip_cap_denials event when a claim is rejected over-cap (PROJ-342)", async () => {

--- a/apps/api/src/test/mcp-parity.node.test.ts
+++ b/apps/api/src/test/mcp-parity.node.test.ts
@@ -1,0 +1,311 @@
+// PROJ-623: mechanical parity across the four tool surfaces.
+//
+// Parity used to be held by convention plus two hand-written spot checks in mcp.test.ts
+// (issues and wiki — 2 of 22 domains), and mcp/catalog.ts carried a comment asking a
+// human to keep its order in sync with the runtime registry by hand. This test replaces
+// both with a check that fails the build.
+//
+// The four surfaces:
+//   1. service functions   src/services/*.ts   — the operations that exist at all
+//   2. REST routes         src/routes/*.ts     — the browser/HTTP surface
+//   3. runtime MCP registry src/routes/mcp.ts  — what tools/call can actually dispatch
+//   4. docs catalog        src/mcp/catalog.ts  — what the generated tool catalog documents
+//
+// This runs in node, not workerd: it reads the repo's own source off disk, and workerd
+// has no node:fs. See the `projects` block in vitest.config.mts.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { TOOL_DOMAINS } from "../mcp/catalog";
+import { coreMCPTools } from "../routes/mcp";
+
+const SRC = join(import.meta.dirname, "..");
+
+// ---------------------------------------------------------------------------
+// Deliberate exceptions.
+//
+// Note what is NOT here: internal helpers. A service function referenced by neither
+// src/mcp nor src/routes is internal *by construction*, so it needs no entry — which is
+// why this list stays short as the codebase grows. Only an operation deliberately
+// exposed on one surface but not the other has to be named, and every name carries its
+// reason. A stale entry (one that no longer applies) fails the test too, so the list
+// shrinks when a gap is closed instead of quietly rotting.
+// ---------------------------------------------------------------------------
+
+/** MCP tools with no REST equivalent. Each is a real parity gap, tracked in PROJ-633. */
+const MCP_ONLY: Record<string, string> = {
+	"issues.ts:getPrioritizedIssues": "agent-facing ranking; no browser view consumes it yet",
+	"playbook-compose.ts:composePlaybook": "agent-facing template fill; no browser view yet",
+	"projects.ts:listProjects":
+		"REST serves the browser's project list via listAllProjects/getProjectBySlug instead",
+	"workspaces.ts:createWorkspace": "workspace creation over REST goes through /bootstrap and auth",
+	"workspaces.ts:listUserWorkspaces":
+		"REST serves the equivalent from user-tokens.getUserWorkspaces",
+	"files.ts:getAttachmentMetadata":
+		"REST exposes getAttachmentForDownload (streams bytes); metadata-only is agent-facing",
+};
+
+/**
+ * REST operations with no MCP tool. Browser-only by design unless noted — auth, upload
+ * plumbing, and public ingest have no agent-facing meaning.
+ */
+const REST_ONLY: Record<string, string> = {
+	// Auth / token plumbing — an agent authenticates, it does not mint credentials.
+	"types.ts:ctxFromHono": "adapter from Hono context to ServiceCtx, not an operation",
+	"user-tokens.ts:getUserWorkspaces": "session bootstrap for the browser",
+	"user-tokens.ts:createUserToken": "personal access tokens are minted by a human in the UI",
+	"user-tokens.ts:deleteUserToken": "revoking a human's own PAT is a UI action",
+	"workspaces.ts:createToken": "workspace API tokens are minted by a human in the UI",
+	"workspaces.ts:listTokens": "token inventory is a human audit view",
+	"workspaces.ts:revokeToken": "revoking a workspace token is a human action",
+	"workspaces.ts:getWorkspaceMcpInfo": "connection instructions for a human setting up a client",
+	// Public share links — issued by a human, consumed anonymously.
+	"share.ts:createShareToken": "public share links are issued by a human",
+	"share.ts:getSharedIssue": "anonymous read path, no workspace auth",
+	"share.ts:revokeShareToken": "revoking a public share link is a human action",
+	// Upload plumbing — multipart/quota mechanics, not operations.
+	"files.ts:storageQuotaBytes": "quota arithmetic used by the upload route",
+	"files.ts:assertUploadAllowed": "upload precondition check",
+	"files.ts:recordUpload": "second half of the multipart upload handshake",
+	"files.ts:getAttachmentForDownload": "streams bytes; agents use get_attachment metadata",
+	// Feedback: public ingest is anonymous, triage is a human review queue.
+	"feedback.ts:hashFeedbackToken": "ingest token hashing",
+	"feedback.ts:submitFeedback": "anonymous public ingest, no workspace auth",
+	"feedback.ts:listFeedback": "human triage queue (PROJ-634 considers agent access)",
+	"feedback.ts:updateFeedbackStatus": "human triage action (PROJ-634)",
+	"feedback.ts:convertFeedbackToIssue": "human triage action (PROJ-634)",
+	"feedback.ts:bulkMarkReviewed": "human triage action (PROJ-634)",
+	"feedback.ts:bulkConvertToIssue": "human triage action (PROJ-634)",
+	"feedback.ts:getFeedbackSummary": "human triage dashboard (PROJ-634)",
+	// Misc.
+	"issues.ts:resolveIssueIdParam": "URL param coercion, not an operation",
+	"projects.ts:getProjectBySlug": "slug routing for the browser; agents address projects by id",
+	"wiki-export.ts:exportWiki": "file download response, not a JSON operation",
+};
+
+/**
+ * Tools whose name deliberately differs from snake_case(serviceFunction). The tool name
+ * is the public contract and reads better; the service name is internal.
+ */
+const TOOL_NAME_ALIASES: Record<string, string> = {
+	"issue-links.ts:createLink": "create_issue_link",
+	"issue-links.ts:deleteLink": "delete_issue_link",
+	"issue-links.ts:listLinksForIssue": "list_issue_links",
+	"wiki.ts:getWikiBacklinks": "get_backlinks",
+	"wiki.ts:listStaleWikiPages": "list_stale_pages",
+	"wiki.ts:purgeExpiredWikiPages": "purge_wiki_trash",
+	"wiki.ts:getWikiTree": "wiki_tree",
+	"workspaces.ts:getWorkspaceWithMembers": "list_members",
+	"workspaces.ts:listUserWorkspaces": "list_workspaces",
+	"files.ts:getAttachmentMetadata": "get_attachment",
+};
+
+// ---------------------------------------------------------------------------
+// Source scanning
+// ---------------------------------------------------------------------------
+
+function tsFiles(dir: string): string[] {
+	return readdirSync(dir).filter((f) => f.endsWith(".ts"));
+}
+
+function snakeCase(name: string): string {
+	return name.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+}
+
+/**
+ * Every service identifier referenced by any file in `dir`, covering the binding styles
+ * that can wire a surface up: named (`import { listIssues } from "../services/issues"`),
+ * re-export (`export { listIssues } from "../services/issues"`), and namespace
+ * (`import * as wikiService` then `wikiService.listWikiPages(...)`).
+ *
+ * The re-export form isn't used in this codebase today, but it binds a service function
+ * to a surface just as effectively as an import, and missing it would be a false
+ * negative — the one failure mode this test cannot afford.
+ */
+function serviceIdentifiersUsedIn(dir: string): Set<string> {
+	const names = new Set<string>();
+	for (const file of tsFiles(dir)) {
+		const src = readFileSync(join(dir, file), "utf8");
+		for (const m of src.matchAll(
+			/(?:import|export)\s*(?:type\s*)?\{([^}]+)\}\s*from\s*"[^"]*services\/[^"]+"/g
+		)) {
+			for (const part of m[1].split(",")) {
+				const id = part
+					.trim()
+					.replace(/^type\s+/, "")
+					.split(/\s+as\s+/)[0]
+					.trim();
+				if (id) names.add(id);
+			}
+		}
+		for (const m of src.matchAll(
+			/import\s*\*\s*as\s+([A-Za-z0-9_$]+)\s*from\s*"[^"]*services\/[^"]+"/g
+		)) {
+			for (const use of src.matchAll(new RegExp(`\\b${m[1]}\\.([A-Za-z0-9_$]+)`, "g"))) {
+				names.add(use[1]);
+			}
+		}
+	}
+	return names;
+}
+
+interface ServiceFn {
+	/** `issues.ts:listIssues` — the key used by every exception map above. */
+	key: string;
+	fn: string;
+	onMcp: boolean;
+	onRest: boolean;
+}
+
+const restIdentifiers = serviceIdentifiersUsedIn(join(SRC, "routes"));
+const mcpIdentifiers = serviceIdentifiersUsedIn(join(SRC, "mcp"));
+
+const serviceFns: ServiceFn[] = [];
+for (const file of tsFiles(join(SRC, "services"))) {
+	const src = readFileSync(join(SRC, "services", file), "utf8");
+	for (const m of src.matchAll(/^export\s+(?:async\s+)?function\s+([A-Za-z0-9_]+)/gm)) {
+		const fn = m[1];
+		serviceFns.push({
+			key: `${file}:${fn}`,
+			fn,
+			onMcp: mcpIdentifiers.has(fn),
+			onRest: restIdentifiers.has(fn),
+		});
+	}
+}
+
+const catalogToolNames = TOOL_DOMAINS.flatMap((d) => d.tools.map((t) => t.name));
+const runtimeToolNames = coreMCPTools.map((t) => t.name);
+
+// ---------------------------------------------------------------------------
+
+describe("MCP surface parity (PROJ-623)", () => {
+	it("finds the source it is meant to be checking", () => {
+		// Guards against the scanners silently matching nothing — a regex that stops
+		// matching would otherwise turn every assertion below into a vacuous pass.
+		expect(serviceFns.length).toBeGreaterThan(150);
+		expect(restIdentifiers.size).toBeGreaterThan(50);
+		expect(mcpIdentifiers.size).toBeGreaterThan(50);
+		expect(catalogToolNames.length).toBeGreaterThan(100);
+	});
+
+	it("has no service function name exported from two different files", () => {
+		// Wiring is keyed by bare function name, not (file, name), because resolving
+		// each import specifier back to a service file would mean half a module
+		// resolver. That shortcut is only sound while names are globally unique: two
+		// files both exporting `list`, one MCP-only and one REST-only, would be
+		// conflated and read as "wired on both surfaces" — a false negative that
+		// hides exactly the drift this file exists to catch. Fail loudly here instead.
+		const byName = new Map<string, string[]>();
+		for (const { fn, key } of serviceFns) {
+			byName.set(fn, [...(byName.get(fn) ?? []), key.split(":")[0]]);
+		}
+		const collisions = [...byName].filter(([, files]) => files.length > 1);
+		expect(collisions).toEqual([]);
+	});
+
+	describe("catalog vs runtime registry", () => {
+		it("agrees on membership and order", () => {
+			// Not two set comparisons: the arrays must be identical sequences. tools/list
+			// returns the runtime order and the docs table renders the catalog order, so
+			// reordering one without the other makes the docs lie about dispatch.
+			expect(runtimeToolNames).toEqual(catalogToolNames);
+		});
+
+		it("has no duplicate tool names", () => {
+			const counts = new Map<string, number>();
+			for (const name of runtimeToolNames) counts.set(name, (counts.get(name) ?? 0) + 1);
+			const dupes = [...counts].filter(([, n]) => n > 1).map(([name]) => name);
+			expect(dupes).toEqual([]);
+		});
+
+		it("classifies every tool into exactly one group", () => {
+			const byTool = new Map<string, string[]>();
+			for (const domain of TOOL_DOMAINS) {
+				for (const tool of domain.tools) {
+					byTool.set(tool.name, [...(byTool.get(tool.name) ?? []), domain.group]);
+				}
+			}
+			const unclassified = runtimeToolNames.filter((n) => (byTool.get(n) ?? []).length !== 1);
+			expect(unclassified).toEqual([]);
+			for (const groups of byTool.values()) {
+				expect(["Coordination", "Project data"]).toContain(groups[0]);
+			}
+		});
+
+		it("gives every tool a description and an object inputSchema", () => {
+			const bad = coreMCPTools
+				.filter(
+					(t) =>
+						!t.description?.trim() ||
+						(t.inputSchema as { type?: string } | undefined)?.type !== "object"
+				)
+				.map((t) => t.name);
+			expect(bad).toEqual([]);
+		});
+	});
+
+	describe("service functions vs both surfaces", () => {
+		it("exposes every MCP-wired operation over REST too", () => {
+			const gaps = serviceFns
+				.filter((s) => s.onMcp && !s.onRest && !(s.key in MCP_ONLY))
+				.map((s) => s.key);
+			expect(gaps).toEqual([]);
+		});
+
+		it("exposes every REST-wired operation as an MCP tool too", () => {
+			const gaps = serviceFns
+				.filter((s) => s.onRest && !s.onMcp && !(s.key in REST_ONLY))
+				.map((s) => s.key);
+			expect(gaps).toEqual([]);
+		});
+
+		it("names every MCP-wired operation's tool after its service function", () => {
+			const mismatched = serviceFns
+				.filter((s) => s.onMcp)
+				.filter((s) => {
+					const expected = TOOL_NAME_ALIASES[s.key] ?? snakeCase(s.fn);
+					return !catalogToolNames.includes(expected);
+				})
+				.map((s) => `${s.key} -> ${TOOL_NAME_ALIASES[s.key] ?? snakeCase(s.fn)}`);
+			expect(mismatched).toEqual([]);
+		});
+	});
+
+	describe("the exception lists stay honest", () => {
+		const keys = new Set(serviceFns.map((s) => s.key));
+
+		it("names only service functions that still exist", () => {
+			const stale = [
+				...Object.keys(MCP_ONLY),
+				...Object.keys(REST_ONLY),
+				...Object.keys(TOOL_NAME_ALIASES),
+			].filter((k) => !keys.has(k));
+			expect(stale).toEqual([]);
+		});
+
+		it("drops entries whose gap has been closed", () => {
+			const byKey = new Map(serviceFns.map((s) => [s.key, s]));
+			const fixed = [
+				...Object.keys(MCP_ONLY).filter((k) => byKey.get(k)?.onRest),
+				...Object.keys(REST_ONLY).filter((k) => byKey.get(k)?.onMcp),
+			];
+			expect(fixed).toEqual([]);
+		});
+
+		it("states a reason for every entry", () => {
+			const empty = [...Object.entries(MCP_ONLY), ...Object.entries(REST_ONLY)]
+				.filter(([, reason]) => reason.trim().length < 10)
+				.map(([k]) => k);
+			expect(empty).toEqual([]);
+		});
+
+		it("aliases only names that differ from the derived one", () => {
+			const redundant = Object.entries(TOOL_NAME_ALIASES)
+				.filter(([key, alias]) => snakeCase(key.split(":")[1]) === alias)
+				.map(([k]) => k);
+			expect(redundant).toEqual([]);
+		});
+	});
+});

--- a/apps/api/vitest.config.mts
+++ b/apps/api/vitest.config.mts
@@ -1,6 +1,6 @@
 import { cloudflareTest } from '@cloudflare/vitest-pool-workers'
 import { readFileSync } from 'node:fs'
-import { defineConfig } from 'vitest/config'
+import { configDefaults, defineConfig } from 'vitest/config'
 
 // Wrangler 4 auto-loads a developer's local `apps/api/.dev.vars` into the test
 // runtime, which would override the deterministic values in wrangler.test.toml
@@ -20,25 +20,47 @@ function testTomlVars(): Record<string, string> {
 }
 
 export default defineConfig({
-  // vitest-pool-workers ≥0.13 (vitest 4) exposes the Workers test runtime as a
-  // plugin instead of `poolOptions.workers` / `defineWorkersConfig`.
-  plugins: [
-    cloudflareTest({
-      wrangler: { configPath: './wrangler.test.toml' },
-      miniflare: {
-        bindings: {
-          // wrangler.test.toml is the source of truth for the test env.
-          ...testTomlVars(),
-          // The dev-only auth bypass must stay OFF in tests even if a
-          // developer's .dev.vars sets DEV_USER_EMAIL (wrangler 4 loads
-          // .dev.vars into the test runtime). Empty = bypass disabled.
-          DEV_USER_EMAIL: '',
+  test: {
+    // Two projects because they need different runtimes. Behavioural tests run in
+    // workerd (the real Worker runtime, D1 bindings, miniflare). Source-parity tests
+    // (*.node.test.ts) read the repo's own source files off disk to prove the four
+    // tool surfaces agree — workerd has no node:fs, so they can't run there.
+    projects: [
+      {
+        // vitest-pool-workers ≥0.13 (vitest 4) exposes the Workers test runtime as a
+        // plugin instead of `poolOptions.workers` / `defineWorkersConfig`.
+        plugins: [
+          cloudflareTest({
+            wrangler: { configPath: './wrangler.test.toml' },
+            miniflare: {
+              bindings: {
+                // wrangler.test.toml is the source of truth for the test env.
+                ...testTomlVars(),
+                // The dev-only auth bypass must stay OFF in tests even if a
+                // developer's .dev.vars sets DEV_USER_EMAIL (wrangler 4 loads
+                // .dev.vars into the test runtime). Empty = bypass disabled.
+                DEV_USER_EMAIL: '',
+              },
+            },
+          }),
+        ],
+        test: {
+          name: 'workers',
+          include: ['src/**/*.test.ts'],
+          // Spread the defaults: setting `exclude` replaces them wholesale, which
+          // would drop node_modules/dist from the ignore list.
+          exclude: [...configDefaults.exclude, 'src/**/*.node.test.ts'],
+          setupFiles: ['./src/test/setup.ts'],
         },
       },
-    }),
-  ],
-  test: {
-    setupFiles: ['./src/test/setup.ts'],
+      {
+        test: {
+          name: 'node',
+          environment: 'node',
+          include: ['src/**/*.node.test.ts'],
+        },
+      },
+    ],
     // workerd has no node:inspector, so the v8 coverage provider can't attach —
     // use istanbul (source instrumentation) instead, per @cloudflare/vitest-pool-workers.
     coverage: {
@@ -62,6 +84,10 @@ export default defineConfig({
     // These are expected — every failing test asserts the resulting JSON-RPC
     // error and passes. Suppress only our discriminated ServiceError kinds;
     // any other unhandled error still fails the run.
+    //
+    // Must stay at root, not inside the `projects` entry above: vitest 4 only honours
+    // onUnhandledError from the root config, and moving it into the workers project
+    // silently stops suppressing (224/224 tests pass but the file still fails).
     onUnhandledError(error: Readonly<{ kind?: string }>) {
       const KNOWN = ['validation', 'not_found', 'forbidden', 'conflict']
       if (error?.kind && KNOWN.includes(error.kind)) return false

--- a/apps/docs/src/content/docs/architecture/system-design.mdx
+++ b/apps/docs/src/content/docs/architecture/system-design.mdx
@@ -27,7 +27,23 @@ State lives entirely on Cloudflare's edge. **D1** (SQLite) holds the relational 
 workspaces, users, projects, issues, comments, wiki pages, tokens, activity, and
 revisions. **KV** caches Access certs and email lookups. **R2** holds
 file attachments. There are no servers and no containers: the whole system deploys as a
-Worker plus its bound data stores, which is what makes a five-minute self-host possible.
+Worker plus its bound data stores.
+
+That storage choice is load-bearing, not incidental. Coordination state — issue leases,
+file claims, workspace membership — is shared, durable, and workspace-scoped in D1,
+reachable by any client that can make an HTTPS request. Two agents on two machines, or
+an agent and a CI job, read and write the same lease and claim rows and see each other's
+state immediately. A tool that keeps this state in a local SQLite file or an in-repo
+JSONL log cannot do that: two machines don't share a filesystem, and a CI job doesn't
+have a persistent one to write to. That's a ceiling on what a local-first design can
+coordinate — a whole class of cross-machine and agent/CI fleets is unreachable no matter
+how good its primitives are — not a convenience Projektor happens to also offer.
+
+Deployment is also operationally simple, which is a separate, smaller claim: a release
+artifact plus a config-only repo as the distribution unit, a pinned version, wrangler
+auto-provisioning D1/KV/R2, migrations applied automatically at deploy, `/bootstrap`
+gated to non-production environments, and an agent-executable runbook. See
+[Deploying & operating](/projektor/guides/deploying/) for the full mechanics.
 
 The sections below give the picture in increasing detail — first a diagram, then a
 layer-by-layer breakdown, then the request flow through a single agent call.
@@ -105,6 +121,36 @@ surface** for agents. The two are usually kept at parity (see `AGENTS.md`'s
 service-layer contract), but a small, documented subset of REST endpoints — file
 attachments, tokens, public share links, feedback submission — has no MCP
 equivalent and is safe to depend on; see [REST endpoints](/projektor/agents/rest-endpoints/).
+
+## Platform constraints
+
+A few Cloudflare platform limits are encoded directly in the service layer, not just
+implied by the runtime:
+
+- **D1 rejects any query with more than 100 bound parameters.** A query whose parameter
+  count scales with an input array — `inArray`, a raw `IN (...)`, a batched mutation
+  keyed by ids — throws once the array is large enough. This is invisible in tests: the
+  vitest runner backs D1 with SQLite, whose limit is 32766, so an un-chunked query passes
+  CI and only fails against real D1. `inChunks` in `apps/api/src/services/sql.ts` splits
+  such queries into chunks of 90 (leaving headroom for the query's other predicates), and
+  is used wherever a query binds a caller- or row-scaled array, e.g.
+  `apps/api/src/services/issue-links.ts` and `apps/api/src/services/wiki-links.ts`.
+- **D1 has no interactive transactions.** A read-then-insert can race: two concurrent
+  claims can each see "one slot free" and both proceed. `claimIssue` in
+  `apps/api/src/services/issue-leases.ts` (PROJ-290) avoids this by folding both
+  atomicity guards — a per-issue uniqueness check and a per-project WIP-cap count — into
+  a single INSERT, relying on SQLite's write lock rather than a transaction boundary.
+  Multi-statement atomic writes elsewhere use `ctx.db.batch()` instead, e.g.
+  `apps/api/src/services/wiki.ts`.
+- **D1 limits compound SELECT to a small number of terms.** `fetchActivityRows` in
+  `apps/api/src/services/project-activity.ts` runs one query per event category and
+  merges and sorts the results in JS rather than a single UNION.
+- **A Worker isolate has a 128 MB memory ceiling.**
+  `apps/api/src/services/wiki-export.ts` bounds wiki export size against it — a hard cap
+  of 500 pages and 100 MB of attachments per export, on top of the existing 50 MB
+  per-file upload cap in `apps/api/src/services/files.ts`. A streaming zip build is the
+  primary defense against buffering the whole export into memory; these caps are a
+  fast-failing backstop against pathological page counts or attachment totals.
 
 ## Request flow
 

--- a/apps/docs/src/content/docs/contributing/conventions.md
+++ b/apps/docs/src/content/docs/contributing/conventions.md
@@ -31,6 +31,43 @@ Implementation details:
 - **Monorepo:** pnpm workspaces + turbo. `apps/api` (the Worker), `apps/web` (Astro + Preact static site, served in production via CF Workers Static Assets — see below), `apps/docs` (the Astro docs site linked throughout this file), `packages/*` (db, types, plugin-sdk), `plugins/*`
 - **Deploy:** projektor publishes a self-contained **release artifact** on each `v*` tag; a config-only deploy repo (e.g. `projektor-deploy-example`) downloads it and ships it with `wrangler` — no submodule, no source checkout downstream. The Worker (`apps/api`) and the built frontend (`apps/web/dist`) ship together: `wrangler.toml` declares an `[assets]` binding with `run_worker_first = ["/api/*", "/mcp/*"]`, so `/api/*` and `/mcp/*` always hit the Hono Worker while every other path serves the static Astro output (per-route HTML, asset-first). The release build compiles `apps/web` and bundles the Worker into a single `worker.js`.
 
+## Coordination model (read this first)
+
+Projektor expects multiple agents to work the same workspace concurrently. Before
+editing anything:
+
+- **Claim before editing.** File claims (`claim_files`) are path-level — they stop two
+  agents editing the same files. Matching is **exact string equality**, not globs:
+  claiming `src/` reserves nothing under `src/`, so name concrete paths and name them the
+  same way the rest of the fleet does. Issue leases (`claim_issue`) are work-item-level —
+  they stop two agents picking up the same ticket. The two are independent; you need both.
+- **Your session goes stale if you stop heartbeating.** Liveness is heartbeat-based:
+  `ACTIVE_TTL` in `apps/api/src/services/agents.ts` (mirrored as `SESSION_TTL_SECONDS` in
+  `apps/api/src/services/issue-leases.ts`) is **120 seconds**. Register, then go quiet for
+  two minutes without a `heartbeat_agent` call, and your session goes stale — you must
+  heartbeat again before you can claim.
+- **Leases self-heal; file claims do not.** An issue lease held by a stale session is
+  reclaimed by the next claimer in the same call. File claims have no TTL: they release
+  only on `release_files`, on `end_agent`, or when someone claims with `force`. So call
+  `end_agent` when you finish, or your paths stay locked behind you.
+- **There's a per-project cap on concurrently leased issues** —
+  `DEFAULT_AGENT_WIP_LIMIT = 3` in `apps/api/src/services/issue-leases.ts`,
+  overridable per project via `projects.agent_wip_limit`. It's admission control on
+  the backlog, not a rate limit: it bounds how much work can be in flight at once,
+  not how fast you can ask.
+- **A refused claim tells you who to talk to.** Rejection is all-or-nothing: nothing is
+  claimed, and the error names the issue and agent holding the path — message them with
+  `post_message` if you need it. Nothing is pushed to the holder either way, including
+  when you use `force` (that posts an audit message to *your* issue scope, not theirs), so
+  if you override someone, tell them yourself. Every contended path is recorded regardless.
+
+This is the mechanism; the mechanical call sequence for this repo is under "Fleet
+coordination protocol" below, and the design rationale (why leases, claims, and the
+WIP cap are shaped this way) is the [coordination model](https://tajd.github.io/projektor/philosophy/coordination-model/)
+doc. The workflow rules themselves (definition of ready, state machine, human review
+gates) live in exactly one place, the [workflow spec](https://tajd.github.io/projektor/agents/workflow-spec/)
+— call `get_workflow` before claiming work; they aren't restated here.
+
 ## Planning and design docs live in the wiki, not the repo
 
 Design records, implementation plans, and specs belong in the projektor wiki (`create_wiki_page`/`update_wiki_page`), not in a repo `docs/` folder. Keeping them in the wiki makes them discoverable and searchable (`search_wiki`) instead of buried in git history. Root-level user-facing docs (`README.md`, `AGENTS.md`, `CONTRIBUTING.md`, `SECURITY.md`) are the only docs that belong in the repo itself.

--- a/apps/docs/src/content/docs/philosophy/alternatives.md
+++ b/apps/docs/src/content/docs/philosophy/alternatives.md
@@ -1,0 +1,188 @@
+---
+title: "Projektor and the agent-coordination field"
+description: "A point-in-time comparison of Projektor against other tools agents use to coordinate work — what each is genuinely good at, and where the differences are deliberate design choices rather than gaps."
+sidebar:
+  order: 4
+---
+*Snapshot as of 2026-08-12.* This page compares Projektor against other tools
+in the agent-coordination space, based on a survey of their public
+documentation, READMEs, and product pages on that date. Nothing was
+installed or run, and no source was read for closed-source products —
+absence from documentation is weaker evidence than absence from a schema, and
+that limitation is intentionally not smoothed over below. Tools evolve
+quickly in this space; treat every claim here as dated the moment you read
+it, not as a permanent ranking.
+
+The goal isn't to declare a winner. Several of these tools are better than
+Projektor at the thing they're built for. The point of writing this down is
+to be specific about which thing that is, so the comparison holds up rather
+than reading as marketing.
+
+## The axes Projektor is making a bet on
+
+1. **Leases on work items, not just files.** Projektor claims at two levels:
+   path-level file claims (`apps/api/src/services/file-claims.ts`) and
+   issue-level leases (`apps/api/src/services/issue-leases.ts`). The lease
+   layer enforces a per-project `agent_wip_limit` — an admission-control cap
+   on how many issues a project can have actively leased at once, defaulting
+   to 3, denials of which are themselves recorded (`wip_cap_denials`). This
+   is backlog-level flow control, not just "don't edit the same file twice."
+2. **Contention as a derived asset.** Every rejected or force-overridden file
+   claim is written to a `claim_conflicts` table (path, rejecting issue/agent,
+   holding issue/agent, whether it was forced, when) and aggregated over a
+   time window into a contention ranking exposed to a health view. Refused
+   claims are data here, not just errors.
+3. **Deployed, self-hostable, and unified.** Local-first tools structurally
+   can't coordinate a fleet across machines and CI; hosted tools can't be
+   self-hosted. Projektor tries to sit in the quadrant that does both, which
+   as far as this survey found is uncontested — nobody else in the list below
+   occupies it.
+4. **Validated by use.** Projektor's own backlog is tracked in Projektor, and
+   this comparison page is itself a PROJ ticket worked by an agent claiming
+   it through the mechanism described above.
+
+Claims 1 and 3 above are checked directly against
+`apps/api/src/services/issue-leases.ts`, `apps/api/src/services/file-claims.ts`,
+and `packages/db/migrations/0032_claim_conflicts.sql` as of this snapshot,
+not just asserted from documentation.
+
+## Contention telemetry: what "tracks conflicts" actually means
+
+This phrase gets used loosely enough that it's worth separating three
+distinct things:
+
+1. **Live conflict detection** — a claim attempt is refused and the caller
+   is told why, in the moment.
+2. **Reservation lifecycle history** — a queryable record of past
+   reservations, including released or expired ones.
+3. **Conflict events as their own persisted records**, aggregated over a
+   window into a ranking of which paths are hot.
+
+Most tools that "track conflicts" do (1). Projektor's contention claim is
+specifically (3): a refused claim never becomes a reservation, so under a
+model that only stores reservations, a refusal leaves no row at all unless
+someone deliberately records the refusal as its own event. Projektor does
+that. Of the tools surveyed in August 2026, none exposed an equivalent
+aggregation — the closest, MCP Agent Mail's Rust TUI, surfaces conflicts live
+and has an analytics screen aimed at system anomalies rather than path
+contention.
+
+## The tools, alternative by alternative
+
+### MCP Agent Mail (Python) — `Dicklesworthstone/mcp_agent_mail`
+
+Its real strength is negotiation *after* detection, which Projektor doesn't
+have at all: agents hold advisory file reservations with TTL expiry and
+stale reclaim, can message each other in a threaded conversation about a
+conflict, and a pre-commit guard blocks a commit that conflicts with another
+agent's exclusive reservation. That's a materially richer conflict-resolution
+loop than "the claim is rejected, go pick something else."
+
+Its data model is `file_reservations(id, project_id, agent_id, path_pattern,
+exclusive, reason, created_ts, expires_ts, released_ts)` — no separate
+conflict-event table. Its web UI's File Reservations list, showing active and
+historical reservations, is category (2) above: reservation history, not
+aggregated conflict events. That's a genuinely useful view; it answers "what
+was reserved and when," just not "which paths are contended most."
+
+### MCP Agent Mail (Rust) — `mcp_agent_mail_rust`
+
+The Rust rewrite is the most feature-dense tool in this list: roughly 34
+tools and a 16-screen TUI, including a Reservations screen described as
+covering "file reservation status, conflicts, and create/release actions,"
+plus Tool Metrics, Analytics, Timeline, ATC, and System Health screens, and a
+dedicated `check_file_reservation_conflicts` tool. Its live conflict
+visibility is richer than Projektor's — this is worth stating plainly rather
+than downplaying. It also has an analytics surface, documented as an
+anomaly-insight feed with confidence scores and deep links: system anomalies,
+not path-contention ranking. That's a real gap in what Projektor's
+contention view covers versus what this tool's analytics covers, just not
+the same gap — they're aimed at different questions.
+
+### Hiveship
+
+An agent-first issue tracker strong on run observability: live SSE run
+streams, per-run activity logs, a review queue, PR links, and signed
+webhooks for the human review flow. That's a well-built operational surface
+for watching what an agent is doing in real time, which Projektor doesn't
+attempt to match.
+
+Its public pages document no file-level or path-level coordination at all.
+That reads as a different scope rather than a missing feature — Hiveship
+appears to be optimized for run visibility and review, not for multiple
+agents contending over the same paths, so there's no contention signal for
+it to aggregate in the first place.
+
+### beads / Gas Town
+
+`bd update <id> --claim` is a clean, atomic issue-level claim (sets assignee
+and moves to in_progress), and beads' dependency-aware ready queue is
+genuinely good — it's a sharper "what should I work on next" primitive than
+Projektor's own prioritization in several respects and worth crediting
+plainly rather than hedging. Gas Town layers tmux sessions, background
+daemons, and worktree-based agent identities on top.
+
+Neither documents file-level or path-level locks, or a stats/metrics
+command. If two agents claim different issues that happen to touch the same
+file, beads' issue-level claim model has no mechanism to see that coming.
+
+### Linear + MCP
+
+Linear shipped native MCP agent support in April 2026, with issue-level
+assignment to agents. Product polish and ecosystem breadth here are hard to
+match — this is a mature, widely-integrated product, not a coordination
+experiment. It's hosted only; there's no self-hosted deployment path, which
+is a deliberate product decision on Linear's part, not an oversight.
+
+### Atlassian MCP
+
+Issue-level agent access to Jira and Confluence, backed by Atlassian's
+enterprise reach and integration breadth. For an organization already
+standardized on Jira, the switching cost of adopting anything else is real
+and Atlassian MCP avoids it entirely. It doesn't appear to add file- or
+path-level coordination beyond issue assignment.
+
+### Worktree tooling — agentree, gwq, Clash, ccswarm
+
+These solve isolation and parallel-run mechanics — giving each agent its own
+worktree, managing branch lifecycle, running agents concurrently — well.
+They're complementary to an issue tracker, not competing with one: nothing
+stops someone running Projektor for coordination and one of these for the
+worktree mechanics underneath. Worth naming as a "both," not an "either/or."
+
+### Lightweight git-native trackers
+
+Plain-text issues committed alongside the code they describe. The strengths
+are real and easy to undervalue: zero infrastructure, and every change to an
+issue is reviewable in a normal diff and PR. For a single repo with a small
+number of contributors, that's plausibly all the coordination anyone needs.
+It's a local-first, single-repo bet — the same structural tradeoff described
+in the "deployed and self-hostable" section above, just from the other side:
+no server to run, and no coordination across repos or machines either.
+
+## Reading this table
+
+The table below is a compressed index, not the argument — read the prose
+above for the parts that don't survive compression (Agent Mail Rust's
+analytics screen, in particular, is easy to misread from a checkmark alone).
+
+| Tool | Issue-level claim | File/path-level claim | Live conflict detection | Aggregated contention over time | Deployment |
+|---|---|---|---|---|---|
+| Projektor | yes (leases + WIP cap) | yes | yes (rejection) | yes | self-hosted, deployed |
+| MCP Agent Mail (Python) | no | yes (reservations) | yes | no (reservation history only) | self-hosted |
+| MCP Agent Mail (Rust) | no | yes (reservations) | yes | no (system-anomaly analytics, not path contention) | self-hosted |
+| Hiveship | yes | not documented | not documented | not documented | hosted |
+| beads / Gas Town | yes (`--claim`) | no | no | no | local-first |
+| Linear + MCP | yes | no | no | no | hosted only |
+| Atlassian MCP | yes | no | no | no | hosted only |
+| Worktree tooling | n/a (not a tracker) | isolation, not claims | n/a | n/a | local |
+| Lightweight git trackers | manual | no | no | no | local-first |
+
+## What would change this page
+
+This is a snapshot, and the field is moving quickly — several of the tools
+above are pre-1.0 or shipped major features within the last few months of
+this writing. If a tool listed here adds path-level contention aggregation,
+or if closed-source documentation surfaces evidence this survey didn't have
+access to, this page should be corrected rather than left to go stale
+silently.

--- a/apps/docs/src/content/docs/philosophy/coordination-model.md
+++ b/apps/docs/src/content/docs/philosophy/coordination-model.md
@@ -1,0 +1,174 @@
+---
+title: "Coordination model"
+description: "How Projektor coordinates concurrent agents: identity, leases, file claims, and conflict routing, as a designed distributed system."
+sidebar:
+  order: 3
+---
+Projektor is designed to have several agents working the same workspace at once. That
+means it has to answer the questions any concurrent system has to answer: how do
+participants prove they're alive, how is contended work handed out without two workers
+grabbing the same thing, what happens when a participant disappears mid-task, and how
+does contention get surfaced instead of silently failing. This page describes the
+mechanism Projektor uses to answer them — not as a feature list, but as a small
+distributed system with its own liveness, admission-control, and conflict-resolution
+properties.
+
+This page does not restate the workflow rules (definition of ready, the state machine,
+human review gates) — those live in exactly one place, the
+[workflow spec](/projektor/agents/workflow-spec/), fetched programmatically via
+`get_workflow`.
+
+## Identity and liveness
+
+An agent's presence in the system is an `agent_sessions` row, created by
+`register_agent` and kept alive by periodic `heartbeat_agent` calls
+(`apps/api/src/services/agents.ts`). There is no separate presence/heartbeat service:
+liveness is a plain column comparison. A session counts as live when its `status` is
+`"active"` and its `last_heartbeat_at` is newer than `ACTIVE_TTL` seconds ago — currently
+**120 seconds**, defined as `ACTIVE_TTL` in `apps/api/src/services/agents.ts`. The same
+constant is duplicated (deliberately, to avoid a circular import between the two
+services) as `SESSION_TTL_SECONDS` in `apps/api/src/services/issue-leases.ts`, with a
+comment pointing back at the original.
+
+That one number is the liveness window for the whole coordination layer: it decides
+when `list_active_agents` stops listing a session, when a lease on that session's issue
+becomes reclaimable, and when a claiming agent is rejected as not-live in
+`assertAgentSessionLive`. There's no separate expiry sweep — liveness is computed at
+read time from `lastHeartbeatAt`, so nothing can drift out of sync with a background
+job that didn't run.
+
+## Two tiers of claiming
+
+Projektor separates "who owns this unit of work" from "who owns this file", and
+enforces both independently.
+
+**Issue leases** (`apps/api/src/services/issue-leases.ts`, table `issue_leases`) are
+work-item-level: `claim_issue` grants one agent session exclusive ownership of one
+issue, enforced by a partial `UNIQUE` index on `(workspace_id, issue_id) WHERE
+released_at IS NULL`. This is what prevents two agents from independently picking up
+and duplicating the same ticket.
+
+**File claims** (`apps/api/src/services/file-claims.ts`, table `issue_file_claims`) are
+path-level: `claim_files` reserves a set of paths against an issue. This is what prevents
+two agents working *different* issues from editing the same files and producing a merge
+conflict neither of them can resolve on their own.
+
+Conflict detection here is **exact string matching**, not glob or prefix matching:
+`claim_files` takes an array of path strings (`apps/api/src/schemas/file-claims.ts`, up to
+100 per call) and the conflict query is an `inArray` over literal path values. Claiming
+`src/` does not reserve `src/foo.ts`, and claiming `src/*.ts` reserves a path whose
+literal name is `src/*.ts`. Two agents can therefore collide on the same file if they
+name it differently, and coordination depends on the fleet using consistent, concrete
+paths.
+
+Neither tier can do the other's job. An issue lease says nothing about which files an
+issue touches — an agent could hold a lease and still stomp on a file another lease
+holder is also relying on. A file claim says nothing about which agent is responsible
+for finishing the issue — without the lease, two agents could each claim disjoint file
+sets for the same issue and both believe they own it. Because the tiers are independent,
+an agent can claim files under an issue it doesn't hold the lease on (a reviewer editing
+a small file while the implementer holds the lease, for instance) — the schemas allow
+`issueId` on a file claim without requiring a live lease on that issue.
+
+## WIP limit as admission control
+
+`agent_wip_limit` (read via `fetchAgentWipCap` in `apps/api/src/services/issue-leases.ts`)
+caps how many issues in a project can be under a live lease at once — currently
+`DEFAULT_AGENT_WIP_LIMIT = 3`, overridable per project via `projects.agent_wip_limit`.
+It is not a rate limit on claim attempts; it's an admission-control gate on how much of
+the backlog can be in flight simultaneously. `claimIssue` enforces it as part of the same
+`INSERT ... SELECT ... WHERE (live-lease count) < cap` statement that grants the lease,
+so the check and the grant happen atomically — D1 has no interactive transactions, and a
+separate read-then-insert would let two concurrent claims each see `cap - 1` and both
+proceed. Hitting the cap raises a `ConflictError` and writes a row to `wip_cap_denials`
+(`packages/db/migrations/0039_wip_cap_denials.sql`) — event data for factory-health
+tooling, not just an error message that disappears once returned.
+
+## Stale reclaim, not deadlock
+
+A lease's liveness is derived from its holder's session, not stored independently:
+`reclaimStaleLeaseOrThrow` in `issue-leases.ts` looks at the existing lease's owning
+session and only treats it as a genuine conflict if that session is still active and
+within the heartbeat TTL. If the holder stopped heartbeating — crashed, was killed,
+lost its process — the lease is released with `release_reason: "expired"` and the new
+claim proceeds in the same call. There is no separate expiry job, no manual "force
+release" step, and no permanently stuck issue: a crashed agent can never leave a lease
+that outlives it by more than the TTL.
+
+**The two tiers are not symmetric here, and this is the layer's weakest point.** Issue
+leases are reclaimed from liveness, as above. File claims are not: there is no TTL-based
+expiry for them at all. A claim is released when the agent calls `release_files`, or when
+its session formally ends and `releaseClaimsForAgent` marks the rows
+`release_reason: "agent_ended"` (`file-claims.ts`, PROJ-334). An agent that dies without
+ending its session — the crash case the lease tier handles cleanly — leaves its file
+claims held indefinitely, and the only way out is a `force` claim by someone else. The
+comment on `releaseClaimsForAgent` says as much: agent-end is the only abandonment path
+today.
+
+So a crashed agent frees its ticket automatically but not its files. Worth knowing before
+relying on claims as the only guard in a long-running fleet.
+
+## Conflict routing
+
+A collision resolves in one of two ways, and it is worth being exact about who learns
+what, because the answer is narrower than "agents negotiate".
+
+**Rejection.** When `claim_files` finds an existing active claim on a requested path and
+the caller did not pass `force`, `assertNoConflicts` in `file-claims.ts` rejects the whole
+request — all-or-nothing, so no partial claim survives — and throws a `ConflictError`
+naming the holding issue and agent. The blocked agent therefore learns exactly who to
+talk to, and can do so with `post_message`. Nothing is pushed to the holder: it is still
+working and nothing about its claim changed.
+
+**Forced override.** When the caller passes `force`, the existing claim is released as
+`overridden` and `overrideConflictingClaims` posts a message via `postMessage`
+(`apps/api/src/services/agent-messages.ts`). Note the scope: the message goes to
+`issue:<claiming issue>` — the issue that just took the path — naming the displaced issue
+in the body. It is an audit record on the overrider, not a notification to the overridden.
+
+So the routing is *informational, not conversational*. Both paths tell the agent doing the
+claiming who it collided with, and both persist the collision as a `claim_conflicts` row.
+Neither pushes anything to the agent that lost the path; that agent finds out when its
+next write or claim fails. A tool built specifically around negotiation — MCP Agent Mail,
+whose agents message each other and pick different files — is genuinely better at this
+particular step, and [how Projektor differs](/projektor/philosophy/alternatives/) says so.
+What Projektor does instead of negotiating is *record*, which is the subject of the next
+section.
+
+## Conflict as an event log
+
+Every contended path, whether the claim was rejected or forced through, is written to
+`claim_conflicts` (`packages/db/migrations/0032_claim_conflicts.sql`): the path, the
+issue and agent that lost the attempt, the issue and agent that held it, a `forced` flag
+(`0` for a hard rejection, `1` for an override), and `occurred_at`. It's an append-only
+event log, not a derived view — a rejected claim leaves no row anywhere else (the
+rejection happens entirely in-process, before any insert into `issue_file_claims`), so
+this table is the only record that the contention happened at all.
+
+The table carries two indexes: `(workspace_id, occurred_at)` and `(workspace_id, path)`.
+Both exist because `get_code_heatmap`
+(`apps/api/src/services/code-heatmap.ts`) runs in two modes over the same data shape.
+Claims mode groups `issue_file_claims` rows by path prefix within a time window, sized
+by how much work happened in a directory. Contention mode groups `claim_conflicts` the
+same way, sized by how much *contention* happened there — which paths agents keep
+colliding on, not just which paths get touched. Windowed contention ranking (`since`,
+`until`, drilling into a path prefix) is what the `(workspace_id, occurred_at)` and
+`(workspace_id, path)` indexes make cheap; without them, "which files caused the most
+conflicts this week" would mean scanning the whole event log per query.
+
+## Why coordination lives in the tracker, not beside it
+
+The alternative to this design is a tracker plus a separate coordination sidecar — a
+lock service, a presence system, a message queue bolted on next to the issue database.
+That split creates two sources of truth that can disagree: the tracker says an issue is
+in progress, the sidecar says the lease expired, and nothing reconciles them except
+whoever notices first.
+
+Projektor keeps the lease on the issue and the claim on the file in the same schema as
+the issue itself, behind the same workspace/auth boundary as everything else (`ctx.workspaceId`
+scoping on every query above). An issue's lease history, an agent's heartbeat, and a
+file's claim conflicts are all queryable alongside the issue's comments and status
+transitions, because they're rows in the same database, not calls to a different system
+that happens to reference the same issue IDs. Coordination state is derived from the
+work graph — who's allowed to touch what, right now — rather than kept next to it and
+hoping the two stay in sync.

--- a/apps/docs/src/content/docs/philosophy/design-principles.md
+++ b/apps/docs/src/content/docs/philosophy/design-principles.md
@@ -114,4 +114,7 @@ you can't evaluate them without flow metrics. Measure first.
 
 For how these principles play out in practice — the multi-agent loop,
 coordination primitives, and the tool catalog — see
-[Agentic workflows](/projektor/agents/agent-workflows/).
+[Agentic workflows](/projektor/agents/agent-workflows/). For the coordination layer
+itself examined as a designed distributed system — identity, leases, file claims,
+stale reclaim, conflict routing — see
+[Coordination model](/projektor/philosophy/coordination-model/).

--- a/llms.txt
+++ b/llms.txt
@@ -25,12 +25,27 @@ Required headers:
 Protocol: JSON-RPC 2.0 (MCP Streamable HTTP - not SSE)
 Methods: initialize  tools/list  tools/call
 
-## Core tools (13 essentials; 64 total - see https://tajd.github.io/projektor/agents/tool-catalog/)
+## Core tools (13 essentials; 113 total - see https://tajd.github.io/projektor/agents/tool-catalog/)
 
 Projects:   list_projects  create_project
 Issues:     list_issues  get_issue  create_issue  update_issue
 Comments:   list_comments  add_comment
 Wiki:       list_wiki_pages  search_wiki  get_wiki_page  create_wiki_page  update_wiki_page
+
+## Coordination (multi-agent)
+
+Claim before editing: claim_files (exact path strings, no globs) and claim_issue
+(work-item-level) are independent — you need both. Your session goes stale if you stop
+heartbeating: liveness TTL is 120s (ACTIVE_TTL, apps/api/src/services/agents.ts), and a
+stale session cannot claim. An issue lease held by a stale session is reclaimed by the
+next claimer automatically; file claims are NOT — they release only on release_files, on
+end_agent, or when someone claims with force. Each project caps concurrent agent-leased
+issues (DEFAULT_AGENT_WIP_LIMIT = 3, admission control, not a rate limit). A refused
+claim does not notify the holder: it returns an error naming the holding issue and agent,
+so message them yourself with post_message. Every contended path is recorded either way.
+Workflow rules (definition of ready, state machine, human gates) live only at
+get_workflow / GET /api/workflow.
+See https://tajd.github.io/projektor/philosophy/coordination-model/ for the full model.
 
 ## Key docs
 


### PR DESCRIPTION
Works the ten tickets on **PROJ-622**. Two of them add machine checks; the rest rewrite the public narrative around what is actually unusual here, and correct several claims that were wrong.

## The problem this addresses

A competitive review found that "we have agent coordination primitives" no longer distinguishes Projektor. MCP Agent Mail independently arrived at advisory file reservations with TTL expiry, stale reclaim, agent identity and inter-agent messaging — and is **better** at negotiating a conflict once one is detected. beads has issue-level claim/release plus a dependency-aware ready queue. Linear shipped native MCP agent support in April 2026.

Two claims survived scrutiny and are now what the docs lead with:

1. **The coordination state is the work graph.** Leases are on issues, claims are on files, in one schema behind one auth boundary — so "which issue is this claim for" is a join, not an integration between a tracker and a lock service. The `agent_wip_limit` makes this admission control on the backlog, not just mutual exclusion on files.
2. **Refused claims are kept, not discarded.** Every contended path lands in `claim_conflicts` whether the claim was rejected or forced, and the heatmap reads it in a second mode — which paths the fleet keeps colliding on, not just which it touches. Of the tools surveyed, none exposed an equivalent aggregation.

## What is in the diff

**A parity test replacing a convention** (`apps/api/src/test/mcp-parity.node.test.ts`). Four surfaces have to agree about every operation — exported service functions, REST routes, the runtime MCP registry, the documented catalog — and `catalog.ts` carried a comment asking the next person to keep the order in sync by hand.

It had already drifted: `feedbackTools` sat at position 8 in the runtime registry and 14 in the catalog, so `tools/list` returned an order the docs table did not describe. Fixed, and the test asserts sequence equality rather than set equality so the next reorder fails the build. One-surface-only operations are enumerated with a reason each, and four further tests fail if that list goes stale.

**Three tests on the coordination layer** it had no coverage for: the WIP cap boundary (cap read from the exported `fetchAgentWipCap`, not retyped), that a refused claim posts zero messages, and that a forced claim posts exactly one scoped to the *claiming* issue.

**Docs.** New coordination-model and alternatives pages; `system-design` separates deployed-ness from deployment simplicity and documents the four D1/isolate limits that actually shape the code.

## Three claims that were false

The handoff note this epic came from asserted that a refused claim messages the holder. It does not — and my first correction was also wrong, saying the `force` path notifies the agent it displaced. It does not either: `overrideConflictingClaims` posts to `issue:<claiming issue>`. **Nothing is pushed to the losing agent on either path.** That claim had already reached `AGENTS.md`, `llms.txt` and the README before the code was checked.

Also corrected: claims do not "expire" (the *session* goes stale, and only the lease tier self-heals from that), and `claim_files` matches paths by **exact string equality, not globs** — claiming `src/` reserves nothing beneath it. `llms.txt` also still advertised 64 tools; it is 113.

The docs now state the two places this design is weakest, because a page listing only strengths is not worth reading: exact-match claiming, and the asymmetry where a crashed agent's issue lease is reclaimed but its file claims are held until someone forces them. Both are filed (PROJ-635, PROJ-636).

## Verification

- `apps/api` full suite: **62 files / 1185 tests green**
- `pnpm turbo type-check`: 7/7
- `pnpm exec biome check .`: 366 files clean
- docs build: 22 pages, all internal links valid
- `pnpm gen:docs`: idempotent

Two sonnet reviewers audited the diff. Both findings were latent fragility rather than live defects and are fixed here: a `toContain(String(cap))` assertion that would have passed even with the cap dropped from the error message (a single digit turns up by chance in the held-issue UUIDs), and an identifier scanner that missed `export { … } from` re-exports — the one direction a parity check cannot afford to be wrong in.

## Not in scope

PROJ-625 (surfacing contention telemetry to agents) stays parked — it is the only ticket in the epic proposing new product surface. Also parked with evidence: PROJ-633, PROJ-634, PROJ-635, PROJ-636, and PROJ-637 (three tests that fail intermittently in the full suite and pass in isolation; a baseline run on `main` was green, so this branch is not implicated, but that is not the same as proving `main` never flakes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7BN9JBdhFp5Pkk7kV9JJf
