### PR TITLE
Fix the parity scanner's blind spot, close the real gaps, and fix the attachment authz hole (PROJ-638, 633, 639, 637)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ the claim is on the file, in one schema behind one auth boundary:
   [coordination model](https://tajd.github.io/projektor/philosophy/coordination-model/)
   is explicit about that asymmetry.
 
+And because it is deployed rather than local, the fleet is not limited to one machine.
+A coordination store on somebody's laptop can only be consulted by processes on that
+laptop: a CI runner cannot take a lease, an agent on a second machine cannot see the
+first one's claims, and a hosted agent cannot participate. Those participants are
+excluded by construction, not by throughput — and exposing a localhost server to fix it
+means taking on TLS, auth and uptime, which is the deployment problem you were avoiding.
+Projektor's ceiling is a property of the
+deployment — one that can be raised without changing how anything works — rather than a
+property of a laptop that also happens to be running the agents.
+
 Because it is one graph, "which issue is this claim for" is a join, not an integration.
 The [coordination model](https://tajd.github.io/projektor/philosophy/coordination-model/)
 documents the design. [How Projektor differs](https://tajd.github.io/projektor/philosophy/alternatives/)

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -36,12 +36,12 @@ import { wikiRouter } from "./routes/wiki";
 import { workflowRouter } from "./routes/workflow";
 import { workspacesRouter } from "./routes/workspaces";
 import { seedDefaultCustomFields } from "./services/custom-fields";
-import { listAllProjects } from "./services/projects";
+import { listProjectsAcrossWorkspaces } from "./services/projects";
 import { seedDefaultTaskStatuses } from "./services/task-statuses";
 import { seedDefaultTaskTypes } from "./services/task-types";
 import type { ServiceCtx } from "./services/types";
 import { purgeExpiredWikiPages } from "./services/wiki";
-import { createWorkspace, listUserWorkspaces } from "./services/workspaces";
+import { createWorkspace, listWorkspaces } from "./services/workspaces";
 
 const app = new Hono<HonoEnv>();
 
@@ -201,7 +201,7 @@ app.route("/auth", authRouter);
 // Workspace list + create — auth only, no workspace context
 app.get("/api/workspaces", authMiddleware, async (c) => {
 	const user = c.get("user") as { id: string };
-	return c.json(await listUserWorkspaces(c.env.DB, user.id));
+	return c.json(await listWorkspaces(c.env.DB, user.id));
 });
 
 app.post("/api/workspaces", authMiddleware, async (c) => {
@@ -220,7 +220,7 @@ app.use("/api/workspaces/:slug/*", authMiddleware, workspaceMiddleware);
 app.get("/api/projects", authMiddleware, etagMiddleware, async (c) => {
 	const user = c.get("user") as { id: string };
 	try {
-		return c.json(await listAllProjects(user.id, c.env.DB));
+		return c.json(await listProjectsAcrossWorkspaces(user.id, c.env.DB));
 	} catch (e) {
 		return serviceErrToResponse(c, e);
 	}
@@ -267,6 +267,13 @@ app.use("/api/workflow", authMiddleware);
 app.use("/api/workflow/*", authMiddleware);
 app.use("/api/playbooks", authMiddleware);
 app.use("/api/playbooks/*", authMiddleware);
+// PROJ-633: compose is the one exception to the line above. Reading a playbook is a pure
+// function of static templates, but composing one resolves a live epic, so it needs
+// workspace context. Scoped to this single path rather than the whole prefix: applying
+// workspaceMiddleware to `/api/playbooks/*` would make GET /api/playbooks and
+// GET /api/playbooks/:name start returning 400 without an X-Workspace-Slug header, which
+// is a breaking change to two endpoints that are deliberately global.
+app.use("/api/playbooks/:name/compose", workspaceMiddleware);
 
 // PROJ-439: conditional GETs on the read-heavy JSON routes. Registered *after* the
 // auth/workspace .use() calls above so an unauthorised request short-circuits before

--- a/apps/api/src/mcp/files.ts
+++ b/apps/api/src/mcp/files.ts
@@ -2,7 +2,7 @@ import type { MCPTool } from "@projektor/types";
 import {
 	createLinkAttachment,
 	deleteAttachment,
-	getAttachmentMetadata,
+	getAttachment,
 	listAttachments,
 } from "../services/files";
 import type { ServiceCtx } from "../services/types";
@@ -38,7 +38,7 @@ export const filesTools: MCPTool[] = [
 			properties: { id: { type: "string" } },
 		},
 		async handler(input, ctx) {
-			return getAttachmentMetadata(ctx as unknown as ServiceCtx, input);
+			return getAttachment(ctx as unknown as ServiceCtx, input);
 		},
 	},
 	{

--- a/apps/api/src/mcp/workspaces.ts
+++ b/apps/api/src/mcp/workspaces.ts
@@ -8,7 +8,7 @@ import {
 	deleteWorkspace,
 	getWorkspaceWithMembers,
 	inviteMember,
-	listUserWorkspaces,
+	listWorkspaces,
 	removeMember,
 	updateMemberRole,
 	updateWorkspace,
@@ -20,7 +20,7 @@ export const workspacesTools: MCPTool[] = [
 		description: "List all workspaces the authenticated user belongs to, with their role in each",
 		inputSchema: { type: "object", properties: {} },
 		async handler(_input, ctx) {
-			return listUserWorkspaces(ctx.db, ctx.userId);
+			return listWorkspaces(ctx.db, ctx.userId);
 		},
 	},
 	{

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -97,6 +97,10 @@ router.post("/", async (c) => {
 			r2Key,
 		}));
 	} catch (e) {
+		// The bytes are already in R2 by this point, and PROJ-639 gave recordUpload a reason
+		// to reject after the fact (uploading onto an entity in a project the caller can't
+		// write). Drop the object rather than leaving it billable and unreferenced.
+		await c.env.R2.delete(r2Key);
 		return serviceErrToResponse(c, e);
 	}
 

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -103,6 +103,15 @@ router.post("/", async (c) => {
 	return c.json({ id, filename: file.name, contentType, size: file.size }, 201);
 });
 
+router.get("/:id/metadata", async (c) => {
+	const ctx = ctxFromHono(c);
+	try {
+		return c.json(await filesService.getAttachment(ctx, { id: c.req.param("id") }));
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
+});
+
 router.get("/:id", async (c) => {
 	const ctx = ctxFromHono(c);
 	const { id } = c.req.param();

--- a/apps/api/src/routes/issues.ts
+++ b/apps/api/src/routes/issues.ts
@@ -6,6 +6,7 @@ import {
 	createIssue,
 	deleteIssue,
 	getIssue,
+	getPrioritizedIssues,
 	ISSUE_REF_PATTERN,
 	listIssues,
 	searchIssues,
@@ -72,6 +73,24 @@ router.get("/", async (c) => {
 				includeBody,
 				cursor,
 				limit,
+			})
+		);
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
+});
+
+router.get("/prioritized", async (c) => {
+	const ctx = ctxFromHono(c);
+	const { limit, includeBacklog, excludeClaimed, includeNotReady, projectId } = c.req.query();
+	try {
+		return c.json(
+			await getPrioritizedIssues(ctx, {
+				limit: limit !== undefined ? Number(limit) : undefined,
+				includeBacklog: includeBacklog !== undefined ? includeBacklog !== "false" : undefined,
+				excludeClaimed: excludeClaimed !== undefined ? excludeClaimed === "true" : undefined,
+				includeNotReady: includeNotReady !== undefined ? includeNotReady === "true" : undefined,
+				projectId,
 			})
 		);
 	} catch (e) {

--- a/apps/api/src/routes/playbooks.ts
+++ b/apps/api/src/routes/playbooks.ts
@@ -1,11 +1,24 @@
 import type { HonoEnv } from "@projektor/types";
 import { Hono } from "hono";
 import { serviceErrToResponse } from "../http/error-adapter";
+import { composePlaybook } from "../services/playbook-compose";
 import { getPlaybook, listPlaybooks } from "../services/playbooks";
+import { ctxFromHono } from "../services/types";
 
 const router = new Hono<HonoEnv>();
 
 router.get("/", (c) => c.json(listPlaybooks()));
+
+router.post("/:name/compose", async (c) => {
+	const ctx = ctxFromHono(c);
+	try {
+		return c.json(
+			await composePlaybook(ctx, { name: c.req.param("name"), params: await c.req.json() })
+		);
+	} catch (e) {
+		return serviceErrToResponse(c, e);
+	}
+});
 
 router.get("/:name", (c) => {
 	try {

--- a/apps/api/src/services/files.ts
+++ b/apps/api/src/services/files.ts
@@ -6,7 +6,7 @@ import {
 	ListAttachmentsSchema,
 	RecordFileUploadSchema,
 } from "../schemas/files";
-import { visibleProjectSqlFragment } from "./access";
+import { canWriteProject, requireProjectAccess, visibleProjectSqlFragment } from "./access";
 import {
 	ForbiddenError,
 	NotFoundError,
@@ -24,6 +24,60 @@ import * as wikiService from "./wiki";
 // so resolving a project to check per-project role isn't possible in general.
 function requireAttachmentWrite(ctx: ServiceCtx): void {
 	if (ctx.role === "viewer") throw new ForbiddenError("Insufficient permissions");
+}
+
+// PROJ-639: nothing resolved an attachment to the project it hangs off, so project
+// visibility was never consulted on any attachment path. Workspace membership alone got
+// you the filename, size and *bytes* of every attachment in the workspace, including
+// those on issues and wiki pages in projects you hold no grant on.
+//
+// entity_id is deliberately not a foreign key (see requireAttachmentWrite), so it can
+// reference a row that does not exist. The guard is therefore "no resolvable owning row
+// is invisible" rather than "the owning row is visible": an unresolvable entity_id has no
+// project and so nothing to authorise, and stays workspace-scoped exactly as before.
+// Inverting that — requiring a visible owner — would make every free-floating attachment
+// vanish from its own uploader's view. Wiki pages with a null project_id are
+// workspace-level and visible to every member.
+//
+// Queries applying this must alias `attachments` as `a`. Returns null for workspace
+// owner/admin, who see every project.
+function ownerVisibleFilter(ctx: ServiceCtx): { sql: string; params: unknown[] } | null {
+	const issue = visibleProjectSqlFragment(ctx, "i.project_id");
+	const page = visibleProjectSqlFragment(ctx, "p.project_id");
+	if (!issue || !page) return null;
+	return {
+		sql: `NOT EXISTS (SELECT 1 FROM issues i
+		        WHERE a.entity_type = 'issue' AND i.id = a.entity_id AND NOT ${issue.sql})
+		      AND NOT EXISTS (SELECT 1 FROM wiki_pages p
+		        WHERE a.entity_type = 'wiki_page' AND p.id = a.entity_id
+		          AND p.project_id IS NOT NULL AND NOT ${page.sql})`,
+		params: [...issue.params, ...page.params],
+	};
+}
+
+/**
+ * Read-side twin of `ownerVisibleFilter` for the write paths, which are keyed by
+ * (entityType, entityId) rather than by attachment id. Resolves the owning row's project
+ * and requires the caller both to see it and to hold write rights inside it — planting an
+ * attachment on an issue in a project you were never granted is the write-side half of
+ * the same hole. An entity_id that resolves to nothing is left to the flat
+ * `requireAttachmentWrite` guard, for the reason given above.
+ */
+async function assertEntityWritable(
+	ctx: ServiceCtx,
+	entityType: "issue" | "wiki_page",
+	entityId: string
+): Promise<void> {
+	const table = entityType === "issue" ? "issues" : "wiki_pages";
+	const row = await ctx.db
+		.prepare(`SELECT project_id FROM ${table} WHERE id = ? AND workspace_id = ?`)
+		.bind(entityId, ctx.workspaceId)
+		.first<{ project_id: string | null }>();
+
+	if (!row?.project_id) return;
+	if (!canWriteProject(await requireProjectAccess(ctx, row.project_id))) {
+		throw new ForbiddenError("Insufficient permissions");
+	}
 }
 
 export interface AttachmentDto {
@@ -108,6 +162,8 @@ export async function listAttachments(ctx: ServiceCtx, input: unknown): Promise<
 		? `w.id = a.linked_wiki_page_id AND w.deleted_at IS NULL AND (w.project_id IS NULL OR ${visible.sql})`
 		: "w.id = a.linked_wiki_page_id AND w.deleted_at IS NULL";
 
+	const owner = ownerVisibleFilter(ctx);
+
 	const rows = await ctx.db
 		.prepare(
 			`SELECT a.id, a.kind, a.filename, a.content_type, a.size, a.url, a.created_at,
@@ -116,9 +172,16 @@ export async function listAttachments(ctx: ServiceCtx, input: unknown): Promise<
 	     FROM attachments a
 	     LEFT JOIN wiki_pages w ON ${joinCond}
 	     WHERE a.workspace_id = ? AND a.entity_type = ? AND a.entity_id = ?
+	       ${owner ? `AND ${owner.sql}` : ""}
 	     ORDER BY a.created_at ASC`
 		)
-		.bind(...(visible ? visible.params : []), ctx.workspaceId, entityType, entityId)
+		.bind(
+			...(visible ? visible.params : []),
+			ctx.workspaceId,
+			entityType,
+			entityId,
+			...(owner ? owner.params : [])
+		)
 		.all<AttachmentRow>();
 
 	return (rows.results ?? []).map(toDto);
@@ -133,6 +196,7 @@ export async function createLinkAttachment(
 	const data = parsed.data;
 
 	requireAttachmentWrite(ctx);
+	await assertEntityWritable(ctx, data.entityType, data.entityId);
 
 	if (data.kind === "wiki_ref") {
 		// PROJ-311: getWikiPage enforces project-grant visibility, not just existence —
@@ -211,6 +275,7 @@ export async function recordUpload(ctx: ServiceCtx, input: unknown): Promise<{ i
 	const { entityType, entityId, filename, contentType, size, r2Key } = parsed.data;
 
 	requireAttachmentWrite(ctx);
+	await assertEntityWritable(ctx, entityType, entityId);
 
 	const id = crypto.randomUUID();
 	const now = Math.floor(Date.now() / 1000);
@@ -243,11 +308,14 @@ export async function getAttachmentForDownload(
 	ctx: ServiceCtx,
 	id: string
 ): Promise<{ r2Key: string; filename: string; contentType: string }> {
+	const owner = ownerVisibleFilter(ctx);
+
 	const row = await ctx.db
 		.prepare(
-			"SELECT r2_key, filename, content_type FROM attachments WHERE id = ? AND workspace_id = ?"
+			`SELECT a.r2_key, a.filename, a.content_type FROM attachments a
+	     WHERE a.id = ? AND a.workspace_id = ? ${owner ? `AND ${owner.sql}` : ""}`
 		)
-		.bind(id, ctx.workspaceId)
+		.bind(id, ctx.workspaceId, ...(owner ? owner.params : []))
 		.first<{ r2_key: string; filename: string; content_type: string }>();
 
 	if (!row) throw new NotFoundError("Not found");
@@ -263,6 +331,7 @@ export async function getAttachment(ctx: ServiceCtx, input: unknown): Promise<At
 	const joinCond = visible
 		? `w.id = a.linked_wiki_page_id AND w.deleted_at IS NULL AND (w.project_id IS NULL OR ${visible.sql})`
 		: "w.id = a.linked_wiki_page_id AND w.deleted_at IS NULL";
+	const owner = ownerVisibleFilter(ctx);
 
 	const row = await ctx.db
 		.prepare(
@@ -271,9 +340,15 @@ export async function getAttachment(ctx: ServiceCtx, input: unknown): Promise<At
 	            w.project_id AS wiki_page_project_id
 	     FROM attachments a
 	     LEFT JOIN wiki_pages w ON ${joinCond}
-	     WHERE a.workspace_id = ? AND a.id = ?`
+	     WHERE a.workspace_id = ? AND a.id = ?
+	       ${owner ? `AND ${owner.sql}` : ""}`
 		)
-		.bind(...(visible ? visible.params : []), ctx.workspaceId, parsed.data.id)
+		.bind(
+			...(visible ? visible.params : []),
+			ctx.workspaceId,
+			parsed.data.id,
+			...(owner ? owner.params : [])
+		)
 		.first<AttachmentRow>();
 
 	if (!row) throw new NotFoundError("Not found");
@@ -289,10 +364,14 @@ export async function deleteAttachment(
 	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
 
 	requireAttachmentWrite(ctx);
+	const owner = ownerVisibleFilter(ctx);
 
 	const row = await ctx.db
-		.prepare("SELECT r2_key FROM attachments WHERE id = ? AND workspace_id = ?")
-		.bind(parsed.data.id, ctx.workspaceId)
+		.prepare(
+			`SELECT a.r2_key FROM attachments a
+	     WHERE a.id = ? AND a.workspace_id = ? ${owner ? `AND ${owner.sql}` : ""}`
+		)
+		.bind(parsed.data.id, ctx.workspaceId, ...(owner ? owner.params : []))
 		.first<{ r2_key: string }>();
 
 	if (!row) throw new NotFoundError("Not found");

--- a/apps/api/src/services/files.ts
+++ b/apps/api/src/services/files.ts
@@ -255,10 +255,7 @@ export async function getAttachmentForDownload(
 }
 
 /** Attachment metadata in the same shape `listAttachments` returns, for the MCP get_attachment tool. */
-export async function getAttachmentMetadata(
-	ctx: ServiceCtx,
-	input: unknown
-): Promise<AttachmentDto> {
+export async function getAttachment(ctx: ServiceCtx, input: unknown): Promise<AttachmentDto> {
 	const parsed = GetAttachmentSchema.safeParse(input);
 	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
 

--- a/apps/api/src/services/projects.ts
+++ b/apps/api/src/services/projects.ts
@@ -53,7 +53,10 @@ export interface ProjectSummary {
 	updated_at: number;
 }
 
-export async function listAllProjects(userId: string, db: D1Database): Promise<ProjectSummary[]> {
+export async function listProjectsAcrossWorkspaces(
+	userId: string,
+	db: D1Database
+): Promise<ProjectSummary[]> {
 	const rows = await db
 		.prepare(
 			`SELECT

--- a/apps/api/src/services/workspaces.ts
+++ b/apps/api/src/services/workspaces.ts
@@ -22,7 +22,7 @@ async function sha256hex(s: string): Promise<string> {
 		.join("");
 }
 
-export async function listUserWorkspaces(db: D1Database, userId: string) {
+export async function listWorkspaces(db: D1Database, userId: string) {
 	const orm = drizzle(db, { schema });
 	return orm
 		.select({

--- a/apps/api/src/test/feedback.test.ts
+++ b/apps/api/src/test/feedback.test.ts
@@ -283,13 +283,7 @@ describe("Feedback submit (public)", () => {
 		const f = await seedProjectFixture({ role: "owner" });
 		const token = await mintSource(f);
 		const tokenHash = await hashFeedbackToken(token);
-		const slot = Math.floor(Date.now() / 1000 / 60) * 60; // RATE_LIMIT_WINDOW_SECS=60
-		// RATE_LIMIT_FEEDBACK_MAX=5 in wrangler.test.toml — seed straight to the limit.
-		await env.DB.prepare(
-			"INSERT OR REPLACE INTO rate_limit (key, count, window_start) VALUES (?, 5, ?)"
-		)
-			.bind(`feedback:${tokenHash}`, slot)
-			.run();
+		await seedRateLimitAtCap(`feedback:${tokenHash}`);
 
 		const res = await SELF.fetch("http://localhost/api/feedback/submit", {
 			method: "POST",
@@ -302,14 +296,9 @@ describe("Feedback submit (public)", () => {
 	it("429s once the per-IP limit (RATE_LIMIT_FEEDBACK_IP_MAX) is exceeded", async () => {
 		const f = await seedProjectFixture({ role: "owner" });
 		const token = await mintSource(f);
-		const slot = Math.floor(Date.now() / 1000 / 60) * 60; // RATE_LIMIT_WINDOW_SECS=60
-		// RATE_LIMIT_FEEDBACK_IP_MAX=5 in wrangler.test.toml — no CF-Connecting-IP
-		// header in tests, so the middleware falls back to the fixed '127.0.0.1' key.
-		await env.DB.prepare(
-			"INSERT OR REPLACE INTO rate_limit (key, count, window_start) VALUES (?, 5, ?)"
-		)
-			.bind("feedback-ip:127.0.0.1", slot)
-			.run();
+		// No CF-Connecting-IP header in tests, so the route falls back to the fixed
+		// '127.0.0.1' key.
+		await seedRateLimitAtCap("feedback-ip:127.0.0.1");
 
 		const res = await SELF.fetch("http://localhost/api/feedback/submit", {
 			method: "POST",
@@ -319,6 +308,29 @@ describe("Feedback submit (public)", () => {
 		expect(res.status).toBe(429);
 	});
 });
+
+// PROJ-637: the limiter is a fixed window keyed by (key, window_start), and its upsert
+// resets count to 1 whenever the request's slot differs from the stored one. So if the
+// request lands in a later slot than the row seeded here, the cap is silently cleared and
+// the call is allowed — seeding near the end of a window is a coin flip on the wall clock.
+// That was the intermittent "expected 201 to be 429", which reads as a limiter bug rather
+// than a test one. Wait out the tail of the window so the seeded row and the request agree.
+async function seedRateLimitAtCap(key: string): Promise<void> {
+	const WINDOW_MS = 60_000; // RATE_LIMIT_WINDOW_SECS=60 in wrangler.test.toml
+	// Slots are floor(epochSeconds / 60) * 60, so boundaries land on epoch minutes and the
+	// modulo below is genuinely "how far into the current window we are".
+	const intoWindow = Date.now() % WINDOW_MS;
+	const HEADROOM_MS = 5_000; // covers the seed + fetch even on a loaded machine
+	if (intoWindow > WINDOW_MS - HEADROOM_MS) {
+		await new Promise((resolve) => setTimeout(resolve, WINDOW_MS - intoWindow + 50));
+	}
+	// RATE_LIMIT_FEEDBACK_MAX and _IP_MAX are both 5 in wrangler.test.toml — seed to the cap.
+	await env.DB.prepare(
+		"INSERT OR REPLACE INTO rate_limit (key, count, window_start) VALUES (?, 5, ?)"
+	)
+		.bind(key, Math.floor(Date.now() / 1000 / 60) * 60)
+		.run();
+}
 
 async function seedFeedbackRow(
 	sourceId: string,

--- a/apps/api/src/test/files.test.ts
+++ b/apps/api/src/test/files.test.ts
@@ -5,6 +5,8 @@ import {
 	type JsonRpcError,
 	type JsonRpcResult,
 	seedFixture,
+	seedGroupGrant,
+	seedIssue,
 	seedMember,
 	seedProject,
 	seedToken,
@@ -918,5 +920,285 @@ describe("Files MCP tools", () => {
 			authHeaders(viewer.token, workspace.slug)
 		)) as JsonRpcError;
 		expect(res.error).toBeDefined();
+	});
+});
+
+// PROJ-639: an attachment hangs off an issue or a wiki page, and those live in projects
+// that are default-deny. Nothing resolved that chain, so workspace membership alone got
+// you the filename, size and bytes of every attachment in the workspace.
+describe("Attachment project visibility", () => {
+	let slug: string;
+	let workspaceId: string;
+	let memberToken: string;
+	let memberId: string;
+	let adminToken: string;
+	// A project the member holds no grant on, with an issue and an attachment on it.
+	let hiddenIssueId: string;
+	let hiddenAttachmentId: string;
+	let hiddenR2Key: string;
+	// A project the member can write.
+	let grantedProjectId: string;
+
+	async function seedAttachment(entityType: string, entityId: string, filename: string) {
+		const id = crypto.randomUUID();
+		const r2Key = `${workspaceId}/${crypto.randomUUID()}`;
+		await env.R2.put(r2Key, "secret bytes");
+		await env.DB.prepare(
+			`INSERT INTO attachments (id, workspace_id, kind, r2_key, filename, content_type, size,
+	       entity_type, entity_id, created_by_id, created_at)
+	     VALUES (?, ?, 'file', ?, ?, 'text/plain', 12, ?, ?, ?, ?)`
+		)
+			.bind(
+				id,
+				workspaceId,
+				r2Key,
+				filename,
+				entityType,
+				entityId,
+				memberId,
+				Math.floor(Date.now() / 1000)
+			)
+			.run();
+		return { id, r2Key };
+	}
+
+	beforeEach(async () => {
+		const fixture = await seedFixture();
+		slug = fixture.workspace.slug;
+		workspaceId = fixture.workspace.id;
+		memberToken = fixture.token;
+		memberId = fixture.user.id;
+
+		const admin = await seedUser(`admin-${crypto.randomUUID().slice(0, 8)}@example.com`);
+		await seedMember(workspaceId, admin.id, "admin");
+		adminToken = await seedToken(workspaceId, admin.id);
+
+		const granted = await seedProject(workspaceId, "OPEN");
+		grantedProjectId = granted.id;
+		await seedGroupGrant(workspaceId, memberId, granted.id, "member");
+
+		const hidden = await seedProject(workspaceId, "SECRET");
+		const issue = await seedIssue(workspaceId, hidden.id, admin.id, { title: "Hidden issue" });
+		hiddenIssueId = issue.id;
+		const att = await seedAttachment("issue", issue.id, "confidential.txt");
+		hiddenAttachmentId = att.id;
+		hiddenR2Key = att.r2Key;
+	});
+
+	const asMember = () => authHeaders(memberToken, slug);
+
+	it("hides attachments on an issue in a project the member has no grant on", async () => {
+		const res = await SELF.fetch(
+			`http://localhost/api/files?entityType=issue&entityId=${hiddenIssueId}`,
+			{ headers: asMember() }
+		);
+		expect(res.status).toBe(200);
+		// The filename alone is the leak this closes — "acquisition-terms.pdf" on a ticket
+		// you cannot see tells you plenty without the bytes.
+		expect(await res.json()).toEqual([]);
+	});
+
+	it("404s the metadata read for an attachment on an invisible issue", async () => {
+		const res = await SELF.fetch(`http://localhost/api/files/${hiddenAttachmentId}/metadata`, {
+			headers: asMember(),
+		});
+		expect(res.status).toBe(404);
+	});
+
+	it("404s the download rather than streaming the bytes", async () => {
+		const res = await SELF.fetch(`http://localhost/api/files/${hiddenAttachmentId}`, {
+			headers: asMember(),
+		});
+		expect(res.status).toBe(404);
+		// Assert on the body too: the route 404s separately when the R2 object is missing,
+		// so a status check alone would pass even if authz were bypassed and the object
+		// simply absent. This proves the row was never handed over.
+		expect(await res.text()).not.toContain("secret bytes");
+	});
+
+	it("404s the delete and leaves the R2 object intact", async () => {
+		const res = await SELF.fetch(`http://localhost/api/files/${hiddenAttachmentId}`, {
+			method: "DELETE",
+			headers: asMember(),
+		});
+		expect(res.status).toBe(404);
+		expect(await env.R2.get(hiddenR2Key)).not.toBeNull();
+		const row = await env.DB.prepare("SELECT id FROM attachments WHERE id = ?")
+			.bind(hiddenAttachmentId)
+			.first();
+		expect(row).not.toBeNull();
+	});
+
+	it("hides attachments on a wiki page in an invisible project, but not workspace-level ones", async () => {
+		const now = Math.floor(Date.now() / 1000);
+		const hiddenProject = await env.DB.prepare(
+			"SELECT id FROM projects WHERE workspace_id = ? AND key = 'SECRET'"
+		)
+			.bind(workspaceId)
+			.first<{ id: string }>();
+
+		const pages: Record<string, string> = {
+			scoped: crypto.randomUUID(),
+			global: crypto.randomUUID(),
+		};
+		for (const [name, id] of Object.entries(pages)) {
+			await env.DB.prepare(
+				`INSERT INTO wiki_pages (id, workspace_id, project_id, slug, title, content,
+		       parent_id, created_by_id, updated_by_id, created_at, updated_at)
+		     VALUES (?, ?, ?, ?, ?, '', NULL, ?, ?, ?, ?)`
+			)
+				.bind(
+					id,
+					workspaceId,
+					name === "scoped" ? hiddenProject?.id : null,
+					`page-${name}-${id.slice(0, 8)}`,
+					name,
+					memberId,
+					memberId,
+					now,
+					now
+				)
+				.run();
+			await seedAttachment("wiki_page", id, `${name}.txt`);
+		}
+
+		const scoped = await SELF.fetch(
+			`http://localhost/api/files?entityType=wiki_page&entityId=${pages.scoped}`,
+			{ headers: asMember() }
+		);
+		expect(await scoped.json()).toEqual([]);
+
+		// A null project_id is a workspace-level page. Filtering these out too would be a
+		// silent regression that the invisible-project assertions above cannot catch.
+		const global = await SELF.fetch(
+			`http://localhost/api/files?entityType=wiki_page&entityId=${pages.global}`,
+			{ headers: asMember() }
+		);
+		expect(((await global.json()) as unknown[]).length).toBe(1);
+	});
+
+	it("still shows the attachment to a workspace admin", async () => {
+		// The filter must be scoped to grant-less members; an admin losing access would be
+		// this fix overshooting into a denial of service.
+		const list = await SELF.fetch(
+			`http://localhost/api/files?entityType=issue&entityId=${hiddenIssueId}`,
+			{ headers: authHeaders(adminToken, slug) }
+		);
+		expect(((await list.json()) as unknown[]).length).toBe(1);
+
+		const meta = await SELF.fetch(`http://localhost/api/files/${hiddenAttachmentId}/metadata`, {
+			headers: authHeaders(adminToken, slug),
+		});
+		expect(meta.status).toBe(200);
+	});
+
+	it("still lists an attachment whose entity_id resolves to nothing", async () => {
+		// entity_id is not a foreign key, so free-floating attachments are legal and have no
+		// project to authorise against. Requiring a *visible* owner rather than the absence
+		// of an invisible one would make these vanish from their own uploader's view.
+		const orphanId = crypto.randomUUID();
+		await seedAttachment("issue", orphanId, "orphan.txt");
+
+		const res = await SELF.fetch(
+			`http://localhost/api/files?entityType=issue&entityId=${orphanId}`,
+			{ headers: asMember() }
+		);
+		expect(((await res.json()) as Array<{ filename: string }>).map((a) => a.filename)).toEqual([
+			"orphan.txt",
+		]);
+	});
+
+	it("rejects uploading onto an issue in an invisible project without orphaning the R2 object", async () => {
+		const before = await env.DB.prepare(
+			"SELECT COUNT(*) AS n FROM attachments WHERE workspace_id = ?"
+		)
+			.bind(workspaceId)
+			.first<{ n: number }>();
+
+		const form = new FormData();
+		form.append("file", new File(["planted"], "planted.txt", { type: "text/plain" }));
+		form.append("entityType", "issue");
+		form.append("entityId", hiddenIssueId);
+		const res = await SELF.fetch("http://localhost/api/files", {
+			method: "POST",
+			headers: { Authorization: `Bearer ${memberToken}`, "X-Workspace-Slug": slug },
+			body: form,
+		});
+		// 404, not 403: an invisible project 404s so its existence never leaks (see
+		// requireProjectAccess).
+		expect(res.status).toBe(404);
+
+		const after = await env.DB.prepare(
+			"SELECT COUNT(*) AS n FROM attachments WHERE workspace_id = ?"
+		)
+			.bind(workspaceId)
+			.first<{ n: number }>();
+		expect(after?.n).toBe(before?.n);
+
+		// The route puts bytes in R2 before recordUpload can reject, so it must clean up or
+		// every rejected upload leaves a billable orphan.
+		const keys = await env.R2.list({ prefix: `${workspaceId}/` });
+		expect(keys.objects.map((o) => o.key)).toEqual([hiddenR2Key]);
+	});
+
+	it("rejects a link attachment onto an issue in an invisible project", async () => {
+		const res = await SELF.fetch("http://localhost/api/files/links", {
+			method: "POST",
+			headers: asMember(),
+			body: JSON.stringify({
+				kind: "url",
+				entityType: "issue",
+				entityId: hiddenIssueId,
+				url: "https://example.com",
+			}),
+		});
+		expect(res.status).toBe(404);
+	});
+
+	it("rejects an upload onto a project where the member's grant is viewer-only", async () => {
+		const viewerUser = await seedUser(`viewer-${crypto.randomUUID().slice(0, 8)}@example.com`);
+		await seedMember(workspaceId, viewerUser.id, "member");
+		await seedGroupGrant(workspaceId, viewerUser.id, grantedProjectId, "viewer");
+		const viewerToken = await seedToken(workspaceId, viewerUser.id);
+		const issue = await seedIssue(workspaceId, grantedProjectId, memberId, { title: "Open issue" });
+
+		const form = new FormData();
+		form.append("file", new File(["nope"], "nope.txt", { type: "text/plain" }));
+		form.append("entityType", "issue");
+		form.append("entityId", issue.id);
+		const res = await SELF.fetch("http://localhost/api/files", {
+			method: "POST",
+			headers: { Authorization: `Bearer ${viewerToken}`, "X-Workspace-Slug": slug },
+			body: form,
+		});
+		// 403, not 404: the project is visible to them, the write is what's refused. Their
+		// workspace role is `member`, so the flat requireAttachmentWrite guard passes and only
+		// the per-project grant can reject this.
+		expect(res.status).toBe(403);
+	});
+
+	it("still allows an upload onto an issue in a project the member can write", async () => {
+		const issue = await seedIssue(workspaceId, grantedProjectId, memberId, { title: "Open issue" });
+		const form = new FormData();
+		form.append("file", new File(["fine"], "fine.txt", { type: "text/plain" }));
+		form.append("entityType", "issue");
+		form.append("entityId", issue.id);
+		const res = await SELF.fetch("http://localhost/api/files", {
+			method: "POST",
+			headers: { Authorization: `Bearer ${memberToken}`, "X-Workspace-Slug": slug },
+			body: form,
+		});
+		expect(res.status).toBe(201);
+	});
+
+	it("hides the attachment from the MCP surface too", async () => {
+		const res = (await mcpCall(
+			workspaceId,
+			"tools/call",
+			{ name: "get_attachment", arguments: { id: hiddenAttachmentId } },
+			asMember()
+		)) as JsonRpcError;
+		expect(res.error).toBeDefined();
+		expect(res.error.code).toBe(-32000);
 	});
 });

--- a/apps/api/src/test/files.test.ts
+++ b/apps/api/src/test/files.test.ts
@@ -173,6 +173,27 @@ describe("Files API", () => {
 		expect(getRes.headers.get("Content-Disposition")).toContain("inline");
 	});
 
+	it("GET /api/files/:id/metadata returns the attachment metadata", async () => {
+		const uploadRes = await makeUploadRequest(token, slug, "meta content", "meta.txt");
+		const { id } = (await uploadRes.json()) as { id: string };
+
+		const res = await SELF.fetch(`http://localhost/api/files/${id}/metadata`, {
+			headers: authHeaders(token, slug),
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { id: string; filename: string; contentType: string };
+		expect(body.id).toBe(id);
+		expect(body.filename).toBe("meta.txt");
+		expect(body.contentType).toBe("text/plain");
+	});
+
+	it("GET /api/files/:id/metadata returns 404 for an unknown id", async () => {
+		const res = await SELF.fetch(`http://localhost/api/files/${crypto.randomUUID()}/metadata`, {
+			headers: authHeaders(token, slug),
+		});
+		expect(res.status).toBe(404);
+	});
+
 	it("DELETE /api/files/:id removes the file", async () => {
 		const uploadRes = await makeUploadRequest(token, slug);
 		const { id } = (await uploadRes.json()) as { id: string };

--- a/apps/api/src/test/issues.test.ts
+++ b/apps/api/src/test/issues.test.ts
@@ -2105,3 +2105,60 @@ describe("get_prioritized_issues MCP tool", () => {
 		expect(titles).toContain("In other project");
 	});
 });
+
+// PROJ-633: REST parity for get_prioritized_issues
+describe("GET /api/issues/prioritized", () => {
+	let token: string;
+	let slug: string;
+	let workspaceId: string;
+	let projectId: string;
+	let userId: string;
+
+	beforeEach(async () => {
+		({ token, slug, workspaceId, userId, projectId } = await seedProjectFixture({ role: "owner" }));
+	});
+
+	async function getPrioritized(query: Record<string, string> = {}) {
+		const qs = new URLSearchParams(query).toString();
+		const res = await SELF.fetch(`http://localhost/api/issues/prioritized${qs ? `?${qs}` : ""}`, {
+			headers: authHeaders(token, slug),
+		});
+		return { res, body: (await res.json()) as { issues: Array<{ title: string }> } };
+	}
+
+	it("ranks higher-priority issues first", async () => {
+		await seedIssue(workspaceId, projectId, userId, { title: "Low prio", priority: "low" });
+		await seedIssue(workspaceId, projectId, userId, { title: "High prio", priority: "high" });
+
+		const { res, body } = await getPrioritized({ includeNotReady: "true" });
+		expect(res.status).toBe(200);
+		// Seeded low-first so a route that returned insertion order rather than the
+		// service's ranking would fail here instead of passing by coincidence.
+		expect(body.issues.map((i) => i.title)).toEqual(["High prio", "Low prio"]);
+	});
+
+	// Proves query-string coercion actually happens — a route that passed the raw
+	// string "3" through unparsed would fail `typeof input.limit === "number"` and
+	// silently fall back to the default of 10, returning all 5 seeded issues.
+	it("limit is honoured", async () => {
+		for (let i = 0; i < 5; i++) {
+			await seedIssue(workspaceId, projectId, userId, { title: `Issue ${i}` });
+		}
+
+		const { res, body } = await getPrioritized({ limit: "3", includeNotReady: "true" });
+		expect(res.status).toBe(200);
+		expect(body.issues).toHaveLength(3);
+	});
+
+	it("projectId scopes results to that project", async () => {
+		const otherProject = await seedProject(workspaceId, "OTHER");
+		await seedIssue(workspaceId, projectId, userId, { title: "In target project" });
+		await seedIssue(workspaceId, otherProject.id, userId, { title: "In other project" });
+
+		const { res, body } = await getPrioritized({ projectId, includeNotReady: "true" });
+		expect(res.status).toBe(200);
+		const titles = body.issues.map((i) => i.title);
+		expect(titles).toContain("In target project");
+		expect(titles).not.toContain("In other project");
+	});
+});

--- a/apps/api/src/test/mcp-parity.node.test.ts
+++ b/apps/api/src/test/mcp-parity.node.test.ts
@@ -35,15 +35,8 @@ const SRC = join(import.meta.dirname, "..");
 
 /** MCP tools with no REST equivalent. Each is a real parity gap, tracked in PROJ-633. */
 const MCP_ONLY: Record<string, string> = {
-	"issues.ts:getPrioritizedIssues": "agent-facing ranking; no browser view consumes it yet",
-	"playbook-compose.ts:composePlaybook": "agent-facing template fill; no browser view yet",
 	"projects.ts:listProjects":
-		"REST serves the browser's project list via listAllProjects/getProjectBySlug instead",
-	"workspaces.ts:createWorkspace": "workspace creation over REST goes through /bootstrap and auth",
-	"workspaces.ts:listUserWorkspaces":
-		"REST serves the equivalent from user-tokens.getUserWorkspaces",
-	"files.ts:getAttachmentMetadata":
-		"REST exposes getAttachmentForDownload (streams bytes); metadata-only is agent-facing",
+		"workspace-scoped list; the REST surface serves the cross-workspace listProjectsAcrossWorkspaces instead",
 };
 
 /**
@@ -68,7 +61,8 @@ const REST_ONLY: Record<string, string> = {
 	"files.ts:storageQuotaBytes": "quota arithmetic used by the upload route",
 	"files.ts:assertUploadAllowed": "upload precondition check",
 	"files.ts:recordUpload": "second half of the multipart upload handshake",
-	"files.ts:getAttachmentForDownload": "streams bytes; agents use get_attachment metadata",
+	"files.ts:getAttachmentForDownload":
+		"streams bytes for the browser; the metadata-shaped read is getAttachment, on both surfaces",
 	// Feedback: public ingest is anonymous, triage is a human review queue.
 	"feedback.ts:hashFeedbackToken": "ingest token hashing",
 	"feedback.ts:submitFeedback": "anonymous public ingest, no workspace auth",
@@ -78,9 +72,16 @@ const REST_ONLY: Record<string, string> = {
 	"feedback.ts:bulkMarkReviewed": "human triage action (PROJ-634)",
 	"feedback.ts:bulkConvertToIssue": "human triage action (PROJ-634)",
 	"feedback.ts:getFeedbackSummary": "human triage dashboard (PROJ-634)",
+	// Bootstrap seeds — called by GET /bootstrap in index.ts to populate a new workspace's
+	// defaults. Not operations a client invokes; they only run as part of provisioning.
+	"custom-fields.ts:seedDefaultCustomFields": "bootstrap seed for a new workspace",
+	"task-statuses.ts:seedDefaultTaskStatuses": "bootstrap seed for a new workspace",
+	"task-types.ts:seedDefaultTaskTypes": "bootstrap seed for a new workspace",
 	// Misc.
 	"issues.ts:resolveIssueIdParam": "URL param coercion, not an operation",
 	"projects.ts:getProjectBySlug": "slug routing for the browser; agents address projects by id",
+	"projects.ts:listProjectsAcrossWorkspaces":
+		"cross-workspace summary for the browser's project switcher; MCP is scoped to one workspace per endpoint",
 	"wiki-export.ts:exportWiki": "file download response, not a JSON operation",
 };
 
@@ -97,8 +98,6 @@ const TOOL_NAME_ALIASES: Record<string, string> = {
 	"wiki.ts:purgeExpiredWikiPages": "purge_wiki_trash",
 	"wiki.ts:getWikiTree": "wiki_tree",
 	"workspaces.ts:getWorkspaceWithMembers": "list_members",
-	"workspaces.ts:listUserWorkspaces": "list_workspaces",
-	"files.ts:getAttachmentMetadata": "get_attachment",
 };
 
 // ---------------------------------------------------------------------------
@@ -107,6 +106,11 @@ const TOOL_NAME_ALIASES: Record<string, string> = {
 
 function tsFiles(dir: string): string[] {
 	return readdirSync(dir).filter((f) => f.endsWith(".ts"));
+}
+
+/** A directory expands to its .ts files; a file path is taken as-is. */
+function expandToFiles(path: string): string[] {
+	return path.endsWith(".ts") ? [path] : tsFiles(path).map((f) => join(path, f));
 }
 
 function snakeCase(name: string): string {
@@ -123,10 +127,10 @@ function snakeCase(name: string): string {
  * to a surface just as effectively as an import, and missing it would be a false
  * negative — the one failure mode this test cannot afford.
  */
-function serviceIdentifiersUsedIn(dir: string): Set<string> {
+function serviceIdentifiersUsedIn(...paths: string[]): Set<string> {
 	const names = new Set<string>();
-	for (const file of tsFiles(dir)) {
-		const src = readFileSync(join(dir, file), "utf8");
+	for (const path of paths.flatMap(expandToFiles)) {
+		const src = readFileSync(path, "utf8");
 		for (const m of src.matchAll(
 			/(?:import|export)\s*(?:type\s*)?\{([^}]+)\}\s*from\s*"[^"]*services\/[^"]+"/g
 		)) {
@@ -158,7 +162,12 @@ interface ServiceFn {
 	onRest: boolean;
 }
 
-const restIdentifiers = serviceIdentifiersUsedIn(join(SRC, "routes"));
+// index.ts is part of the REST surface, not just app wiring: it registers eight endpoints
+// directly, three of which call service functions (GET/POST /api/workspaces, GET
+// /api/projects). Scanning only routes/ made those read as unwired, which is how two
+// MCP_ONLY entries came to claim a REST equivalent was missing when one existed, and how
+// listAllProjects got swallowed by the internal-by-construction rule. PROJ-638.
+const restIdentifiers = serviceIdentifiersUsedIn(join(SRC, "routes"), join(SRC, "index.ts"));
 const mcpIdentifiers = serviceIdentifiersUsedIn(join(SRC, "mcp"));
 
 const serviceFns: ServiceFn[] = [];
@@ -188,6 +197,16 @@ describe("MCP surface parity (PROJ-623)", () => {
 		expect(restIdentifiers.size).toBeGreaterThan(50);
 		expect(mcpIdentifiers.size).toBeGreaterThan(50);
 		expect(catalogToolNames.length).toBeGreaterThan(100);
+	});
+
+	it("sees the REST surface registered in index.ts, not just routes/", () => {
+		// PROJ-638: listProjectsAcrossWorkspaces is wired only by GET /api/projects in
+		// index.ts. When the scan covered routes/ alone it read as unwired, so the
+		// internal-by-construction rule swallowed it and two MCP_ONLY entries wrongly
+		// claimed no REST equivalent existed. Naming a specific index.ts-only identifier
+		// makes that regression fail here rather than resurface as a false parity gap.
+		expect(restIdentifiers.has("listProjectsAcrossWorkspaces")).toBe(true);
+		expect(restIdentifiers.has("createWorkspace")).toBe(true);
 	});
 
 	it("has no service function name exported from two different files", () => {

--- a/apps/api/src/test/playbook-compose.test.ts
+++ b/apps/api/src/test/playbook-compose.test.ts
@@ -173,3 +173,44 @@ describe("compose_playbook", () => {
 		expect(json.error.data?.validNames).toContain("epic-goal");
 	});
 });
+
+// PROJ-633: REST parity for compose_playbook
+describe("POST /api/playbooks/:name/compose", () => {
+	let token: string;
+	let slug: string;
+	let epicNumber: number;
+
+	beforeEach(async () => {
+		const fixture = await seedIssueFixture({ issueTitle: "Ship the widget" });
+		token = fixture.token;
+		slug = fixture.slug;
+		const row = await env.DB.prepare("SELECT number FROM issues WHERE id = ?")
+			.bind(fixture.issueId)
+			.first<{ number: number }>();
+		epicNumber = row!.number;
+	});
+
+	it("returns 200 for epic-goal with a valid params body", async () => {
+		const res = await SELF.fetch("http://localhost/api/playbooks/epic-goal/compose", {
+			method: "POST",
+			headers: { ...authHeaders(token, slug), "Content-Type": "application/json" },
+			body: JSON.stringify({ epicRef: `PROJ-${epicNumber}` }),
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { name: string; variant: string; directive: string };
+		expect(body.name).toBe("epic-goal");
+		expect(body.directive).toContain("Ship the widget");
+	});
+
+	it("returns a 4xx via the service's validation for a bad body", async () => {
+		const res = await SELF.fetch("http://localhost/api/playbooks/epic-goal/compose", {
+			method: "POST",
+			headers: { ...authHeaders(token, slug), "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+		});
+		// Specifically 400, not a 4xx range: an unregistered route would 404 and satisfy
+		// a range assertion, so the loose form cannot tell "validation rejected this"
+		// from "this endpoint does not exist".
+		expect(res.status).toBe(400);
+	});
+});

--- a/apps/api/src/test/playbooks.test.ts
+++ b/apps/api/src/test/playbooks.test.ts
@@ -23,6 +23,20 @@ describe("Playbooks", () => {
 		expect(body.find((p) => p.name === "epic-goal")).toBeTruthy();
 	});
 
+	// PROJ-633: the playbook reads are deliberately global — no workspace. Adding the
+	// compose route required workspace context, and applying workspaceMiddleware to the
+	// whole /api/playbooks prefix to get it would make these two 400 without a slug.
+	// Every other test here sends one, so only this asserts the prefix stays global.
+	it("GET /api/playbooks and /:name work without an X-Workspace-Slug header", async () => {
+		const auth = { Authorization: `Bearer ${token}` };
+
+		const list = await SELF.fetch("http://localhost/api/playbooks", { headers: auth });
+		expect(list.status).toBe(200);
+
+		const one = await SELF.fetch("http://localhost/api/playbooks/epic-goal", { headers: auth });
+		expect(one.status).toBe(200);
+	});
+
 	it("MCP list_playbooks returns the same content as REST", async () => {
 		const restRes = await SELF.fetch("http://localhost/api/playbooks", {
 			headers: authHeaders(token, slug),

--- a/apps/api/vitest.config.mts
+++ b/apps/api/vitest.config.mts
@@ -48,13 +48,13 @@ export default defineConfig({
           name: 'workers',
           include: ['src/**/*.test.ts'],
           // PROJ-637: every test here drives a real Worker over miniflare against D1, so
-          // vitest's 5s default is the wrong order of magnitude — an individual test does
-          // ~10ms of work but pays for whatever workerd is doing under load. The result was
-          // a rolling handful of "Test timed out in 5000ms" failures that moved between
-          // files run to run and vanished when the file was run alone, which reads as a
-          // product bug and repeatedly cost real time to re-diagnose. Not a fix for a slow
-          // test: nothing here legitimately takes seconds, so a generous ceiling only
-          // changes which side of the line contention lands on.
+          // vitest's 5s default is the wrong order of magnitude. The three heaviest tests
+          // measure 562ms / 1051ms / 1675ms run in isolation (issues.test.ts PROJ-303 total
+          // match count, issues.test.ts chunked enrichment, custom-fields.test.ts chunk-size
+          // spanning) but were observed at 5266ms / 5606ms / 15766ms inside the full suite —
+          // 3-10x contention on under 2s of real work. So the timeout is set from the loaded
+          // figure plus headroom, not from a guess, and it is not hiding a slow query: the
+          // isolated measurements are the evidence that the work itself is fast.
           testTimeout: 30_000,
           hookTimeout: 30_000,
           // Spread the defaults: setting `exclude` replaces them wholesale, which

--- a/apps/api/vitest.config.mts
+++ b/apps/api/vitest.config.mts
@@ -47,6 +47,16 @@ export default defineConfig({
         test: {
           name: 'workers',
           include: ['src/**/*.test.ts'],
+          // PROJ-637: every test here drives a real Worker over miniflare against D1, so
+          // vitest's 5s default is the wrong order of magnitude — an individual test does
+          // ~10ms of work but pays for whatever workerd is doing under load. The result was
+          // a rolling handful of "Test timed out in 5000ms" failures that moved between
+          // files run to run and vanished when the file was run alone, which reads as a
+          // product bug and repeatedly cost real time to re-diagnose. Not a fix for a slow
+          // test: nothing here legitimately takes seconds, so a generous ceiling only
+          // changes which side of the line contention lands on.
+          testTimeout: 30_000,
+          hookTimeout: 30_000,
           // Spread the defaults: setting `exclude` replaces them wholesale, which
           // would drop node_modules/dist from the ignore list.
           exclude: [...configDefaults.exclude, 'src/**/*.node.test.ts'],

--- a/apps/docs/src/content/docs/philosophy/alternatives.md
+++ b/apps/docs/src/content/docs/philosophy/alternatives.md
@@ -36,7 +36,8 @@ than reading as marketing.
    can't coordinate a fleet across machines and CI; hosted tools can't be
    self-hosted. Projektor tries to sit in the quadrant that does both, which
    as far as this survey found is uncontested — nobody else in the list below
-   occupies it.
+   occupies it. This is also a scaling difference rather than a preference,
+   and the section below is specific about why.
 4. **Validated by use.** Projektor's own backlog is tracked in Projektor, and
    this comparison page is itself a PROJ ticket worked by an agent claiming
    it through the mechanism described above.
@@ -45,6 +46,57 @@ Claims 1 and 3 above are checked directly against
 `apps/api/src/services/issue-leases.ts`, `apps/api/src/services/file-claims.ts`,
 and `packages/db/migrations/0032_claim_conflicts.sql` as of this snapshot,
 not just asserted from documentation.
+
+## Local deployment is a ceiling, not a preference
+
+A tool that runs on one developer's machine is not a smaller version of a
+deployed one. It is a different shape, and the difference is a hard limit
+rather than a tuning problem.
+
+**Reach.** A local coordination store can only be consulted by processes on
+that machine. A CI runner cannot take a lease before it starts work. An agent
+on a second developer's laptop cannot see the first one's reservations. A
+hosted agent — one running in someone else's cloud, with no filesystem you
+share — cannot participate. This is not a matter of throughput; those
+participants are excluded by construction, and no amount of optimisation
+admits them. Every mechanism the local tool has works perfectly, for exactly
+the agents that happen to share a kernel.
+
+To be fair to the tools rather than the argument: several of them run a local
+MCP server, and a localhost server can be exposed to a network. But doing that
+means taking on TLS, authentication, an address other machines can resolve, and
+uptime — the deployment problem the local-first design exists to avoid. The
+option is real; it just converts the tool into a deployed one, badly, rather
+than showing the ceiling was never there.
+
+**Ceiling.** The local tool's concurrency limit is one machine's, and that
+machine is also running the agents. Every agent added competes with the
+coordination store for the same CPU and the same disk, so the coordination
+layer gets slower precisely as the fleet it coordinates grows. Projektor's
+request tier has no equivalent coupling: Workers isolates are created per
+request across Cloudflare's network, so a fleet of forty agents and a fleet of
+four cost the same per call, and none of them are contending with the
+machines running the work.
+
+**Where Projektor's own ceiling actually is.** Not the request tier — D1.
+It is one logical SQLite database, so writes serialise, and the
+[system design](/projektor/architecture/system-design/) documents the limits
+that follow: a 100-bound-parameter cap per statement, no interactive
+transactions, a compound-`SELECT` term limit, and a 128 MB isolate budget.
+A workspace whose write rate exceeds what one D1 database will take needs
+sharding by workspace, which is not built.
+
+So the honest form of the claim is narrow but strong: **Projektor's ceiling is
+a property of the deployment, and a local tool's ceiling is a property of
+somebody's laptop.** The first can be raised without changing how anything
+works. The second cannot be raised at all — and it sits well below the point
+where a fleet spanning CI, several machines, and hosted agents becomes
+possible, because that point is not on the local axis in the first place.
+
+This cuts the other way too, and the git-native section below says so: if
+every agent genuinely does share one machine, none of the above is a cost you
+are paying, and the local tool's zero-infrastructure story is a real
+advantage rather than a compromise.
 
 ## Contention telemetry: what "tracks conflicts" actually means
 


### PR DESCRIPTION
Four tickets. The first three were the plan; PROJ-639 and PROJ-637 are defects found and fixed rather than parked.

## PROJ-638 — the parity scanner could not see `index.ts`

`mcp-parity.node.test.ts` scanned `routes/` only, but `index.ts` registers eight endpoints directly and three of them call service functions. So `listProjectsAcrossWorkspaces` read as unwired, the internal-by-construction rule swallowed it, and two `MCP_ONLY` entries claimed no REST equivalent existed when one did. Scanner is now varargs over `routes/` + `index.ts`, with a guard test naming an `index.ts`-only identifier so the regression fails here instead of resurfacing as a false parity gap. A second guard fails loudly if two service files ever export the same function name, since wiring is keyed by bare name.

## PROJ-633 — the six MCP-only exceptions, resolved per entry

Two were false and deleted. Three were real and are now closed with routes: `GET /api/issues/prioritized`, `POST /api/playbooks/:name/compose`, `GET /api/files/:id/metadata`. One (`listProjects`) is justified as permanent — workspace-scoped where REST serves the cross-workspace summary. Names aligned so equivalence no longer needs an alias table: `getAttachmentMetadata` → `getAttachment`, `listUserWorkspaces` → `listWorkspaces`, `listAllProjects` → `listProjectsAcrossWorkspaces`. `MCP_ONLY` is down from six entries to one.

The prioritized route coerces query params rather than forwarding them: `parsePrioritizedFilters` tests `typeof limit === "number"` and `includeBacklog !== false`, so forwarding strings would return 200 while silently ignoring every filter. Compose needed workspace context that `/api/playbooks/*` deliberately lacks; applying `workspaceMiddleware` to the prefix would have made the two global playbook reads 400 without a slug header, so it is scoped to that single path with a test covering the no-slug reads.

## PROJ-639 — no attachment path enforced project visibility

An attachment hangs off an issue or wiki page, and those live in projects that are default-deny under the group-grant model. Nothing resolved that chain, so workspace membership alone got you the filename, size and **bytes** of every attachment in the workspace.

All four read/delete paths were affected, not just the download. The `visibleProjectSqlFragment` calls already present in `getAttachment` and `listAttachments` sit in a `LEFT JOIN` condition: they gate the joined wiki-page columns (PROJ-311/407) and never filter the attachment row. The ticket as originally filed described an asymmetry between the metadata and download paths; that was wrong, and it has been corrected on the ticket.

The guard is "no resolvable owning row is invisible" rather than "the owning row is visible". `entity_id` is deliberately not a foreign key, so free-floating attachments are legal and exercised by existing tests, and they have no project to authorise against — requiring a visible owner would make them vanish from their own uploader's view. Wiki pages with a null `project_id` stay workspace-visible. Owner/admin are unfiltered.

Also closes the write half (planting an attachment on an issue in a project you were never granted) and deletes the R2 object when `recordUpload` rejects, since the route writes bytes before the service can refuse — a failure mode this fix introduced.

12 tests. With both guards stubbed to no-ops, 9 fail; the other 3 are deliberate controls (admin still sees the row, an orphan `entity_id` still lists, a granted upload still 201s).

## PROJ-637 — the intermittent test failures

Two unrelated causes, neither the one the ticket named.

The rate-limit flake is a wall-clock race in the tests. The limiter is D1-backed and batches its write and read in one implicit transaction, so the ticket's "KV read-after-write consistency" diagnosis was wrong. It is a fixed window keyed by `(key, window_start)` whose upsert **resets** the count when the slots disagree, so a request landing in the next 60-second window wiped the seeded cap and was correctly allowed — probability roughly elapsed-time/60s, hence load-dependent. Both feedback rate-limit tests had it; one was ever observed failing.

The timeouts are contention against vitest's 5s default. `testTimeout`/`hookTimeout` raised to 30s on the workers project, with measurements in the config comment per the ticket's requirement that a raised ceiling not hide a slow query: the three heaviest tests run 562ms / 1051ms / 1675ms in isolation against 5266 / 5606 / 15766ms in the full suite.

A third mechanism surfaced during verification and is split to **PROJ-640** rather than folded in: four test *files* failing to start on workerd pool-worker `ECONNRESET`, which also exposed that such a run prints a passing `58 passed (58)` tally while omitting 139 tests that never ran.

## Verification

- `apps/api` full suite: **five consecutive runs, 62/62 files green in each**; 1207 tests
- parity project 14/14 with `MCP_ONLY` at one entry
- `pnpm turbo type-check` 7/7; `pnpm exec biome check .` 366 files clean
- docs build 22 pages, all internal links valid; `pnpm gen:docs` idempotent

Two agent-written assertions were tightened before being trusted: a `>= 400 && < 500` range that a 404 from an unregistered route would satisfy (tightening it is what exposed compose returning 500), and a ranking test asserting only non-emptiness (now seeds low-priority first, so insertion order fails it).

## Docs

`alternatives.md` gains "Local deployment is a ceiling, not a preference", argued on reach rather than throughput — a coordination store on a laptop excludes CI runners, second machines and hosted agents by construction. Two concessions kept, because the strong form is false: a localhost server can be exposed, it just means taking on TLS/auth/uptime; and if the agents share one machine, zero-infrastructure is a real advantage. It also names where Projektor's own ceiling sits (D1 is one logical SQLite database, writes serialise, sharding is not built), since the comparison is only credible next to that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)