### PR TITLE
chore(web): bump version to 0.5.0 for release

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@projektor/web",
-  "version": "0.4.20",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
Automated version bump ahead of cutting v0.5.0. Merging this will trigger release-tag.yml to tag and publish the release.