### PR TITLE
fix(api): reclaim file claims whose holding session went stale (PROJ-636)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,10 +38,12 @@ editing anything:
   `apps/api/src/services/issue-leases.ts`) is **120 seconds**. Register, then go quiet for
   two minutes without a `heartbeat_agent` call, and your session goes stale — you must
   heartbeat again before you can claim.
-- **Leases self-heal; file claims do not.** An issue lease held by a stale session is
-  reclaimed by the next claimer in the same call. File claims have no TTL: they release
-  only on `release_files`, on `end_agent`, or when someone claims with `force`. So call
-  `end_agent` when you finish, or your paths stay locked behind you.
+- **Both tiers self-heal.** An issue lease or file claim held by a stale session is
+  reclaimed by the next claimer in the same call (`release_reason: "expired"`). Still call
+  `release_files` and `end_agent` when you finish: reclaim only happens when someone else
+  wants the path, so until then your claims sit there looking held, and a clean exit is
+  what distinguishes you from a crash in the health data. A claim with no `agent_id` has no
+  heartbeat to judge and is never auto-reclaimed — `force` is the only way past it.
 - **There's a per-project cap on concurrently leased issues** —
   `DEFAULT_AGENT_WIP_LIMIT = 3` in `apps/api/src/services/issue-leases.ts`,
   overridable per project via `projects.agent_wip_limit`. It's admission control on

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ the claim is on the file, in one schema behind one auth boundary:
 - **File claims** — path-level claims stop two agents editing the same code. A refused
   claim is rejected whole and names the issue and agent already holding the path, so the
   blocked agent knows who to talk to, and every contended path is recorded.
-- **Liveness** — an issue lease is derived from its holder's heartbeat, so a lease whose
+- **Liveness** — both tiers derive from the holder's heartbeat, so a lease or claim whose
   agent stopped reporting is reclaimed by the next claim in the same call. An agent that
-  crashes mid-ticket does not deadlock the backlog behind it. File claims are released on
-  session end or explicitly, not by TTL — the
+  crashes mid-ticket does not deadlock the backlog, or the files, behind it. Reclaiming a
+  dead holder is not logged as contention — the
   [coordination model](https://tajd.github.io/projektor/philosophy/coordination-model/)
-  is explicit about that asymmetry.
+  covers why, and the one case that still needs a manual `force`.
 
 And because it is deployed rather than local, the fleet is not limited to one machine.
 A coordination store on somebody's laptop can only be consulted by processes on that

--- a/apps/api/src/services/file-claims.ts
+++ b/apps/api/src/services/file-claims.ts
@@ -35,16 +35,40 @@ async function assertAgentInWorkspace(
 	if (!agent) throw new NotFoundError("Agent session not found");
 }
 
+// PROJ-636: mirrors SESSION_TTL_SECONDS in services/issue-leases.ts, which in turn mirrors
+// ACTIVE_TTL in services/agents.ts. Kept local for the same reason theirs are: agents.ts
+// already imports releaseClaimsForAgent from here, so importing back would cycle.
+const SESSION_TTL_SECONDS = 120;
+
+const liveCutoff = () => Math.floor(Date.now() / 1000) - SESSION_TTL_SECONDS;
+
+type ActiveClaim = typeof schema.issueFileClaims.$inferSelect & { live: boolean };
+
 // inChunks keeps each query under D1's 100-bound-parameter cap. See services/sql.ts.
 async function loadActiveClaimsByPath(
 	orm: ReturnType<typeof drizzle>,
 	workspaceId: string,
-	paths: string[]
-) {
+	paths: string[],
+	cutoff: number
+): Promise<Map<string, ActiveClaim>> {
 	const activeClaims = await inChunks(paths, (chunk) =>
 		orm
-			.select()
+			// Columns enumerated rather than `.select()` because the session fields have to
+			// come along; LEFT JOIN, not INNER, so an agentless claim still appears.
+			.select({
+				id: schema.issueFileClaims.id,
+				workspaceId: schema.issueFileClaims.workspaceId,
+				issueId: schema.issueFileClaims.issueId,
+				agentId: schema.issueFileClaims.agentId,
+				path: schema.issueFileClaims.path,
+				claimedAt: schema.issueFileClaims.claimedAt,
+				releasedAt: schema.issueFileClaims.releasedAt,
+				releaseReason: schema.issueFileClaims.releaseReason,
+				sessionStatus: schema.agentSessions.status,
+				sessionHeartbeat: schema.agentSessions.lastHeartbeatAt,
+			})
 			.from(schema.issueFileClaims)
+			.leftJoin(schema.agentSessions, eq(schema.issueFileClaims.agentId, schema.agentSessions.id))
 			.where(
 				and(
 					eq(schema.issueFileClaims.workspaceId, workspaceId),
@@ -53,7 +77,52 @@ async function loadActiveClaimsByPath(
 				)
 			)
 	);
-	return new Map(activeClaims.map((c) => [c.path, c]));
+	return new Map(
+		activeClaims.map(({ sessionStatus, sessionHeartbeat, ...claim }) => [
+			claim.path,
+			{
+				...claim,
+				// agentId is nullable — a claim can be made without a session, and the
+				// agent_id FK is ON DELETE SET NULL. There is no heartbeat to judge those by,
+				// so they are treated as live and stay reclaimable only via `force`. Inferring
+				// staleness from claim age instead would reintroduce the TTL that this tier
+				// deliberately does not have.
+				live:
+					claim.agentId === null ||
+					(sessionStatus === "active" && (sessionHeartbeat ?? 0) > cutoff),
+			},
+		])
+	);
+}
+
+/**
+ * Release claims whose holding session stopped heartbeating, and drop them from the map so
+ * every downstream step sees only genuinely-held paths.
+ *
+ * PROJ-636: this is the file-claim twin of `reclaimStaleLeaseOrThrow` in
+ * services/issue-leases.ts. Before it, an agent that died without calling `end_agent` —
+ * crash, OOM, killed terminal, closed worktree tab — held its paths forever, and for
+ * spawned workers dying without a clean exit is the normal case rather than the exception.
+ *
+ * Deliberately does NOT write to `claim_conflicts`. That log feeds the heatmap's contention
+ * mode, whose whole claim is that a repeatedly-contended path says something about how the
+ * work was sliced. Superseding a dead agent's abandoned claim is not two live agents
+ * colliding, and recording it as such would inflate the signal with fleet mortality.
+ */
+async function reclaimStaleClaims(
+	orm: ReturnType<typeof drizzle>,
+	claimsByPath: Map<string, ActiveClaim>,
+	now: number
+): Promise<ActiveClaim[]> {
+	const stale = [...claimsByPath.values()].filter((c) => !c.live);
+	for (const claim of stale) {
+		await orm
+			.update(schema.issueFileClaims)
+			.set({ releasedAt: now, releaseReason: "expired" })
+			.where(eq(schema.issueFileClaims.id, claim.id));
+		claimsByPath.delete(claim.path);
+	}
+	return stale.map((c) => ({ ...c, releasedAt: now, releaseReason: "expired" }));
 }
 
 async function assertNoConflicts(
@@ -186,9 +255,14 @@ export async function claimFiles(ctx: ServiceCtx, raw: unknown) {
 	}
 
 	// Pre-check all paths for active claims — all-or-nothing on conflict.
-	const claimsByPath = await loadActiveClaimsByPath(orm, ctx.workspaceId, paths);
+	const claimsByPath = await loadActiveClaimsByPath(orm, ctx.workspaceId, paths, liveCutoff());
 
 	const now = Math.floor(Date.now() / 1000);
+
+	// Before conflict evaluation, so a dead holder neither blocks the claim nor lands in
+	// claim_conflicts. Removing them from the map is what keeps the two steps below
+	// unchanged — they only ever see live holders.
+	const reclaimed = await reclaimStaleClaims(orm, claimsByPath, now);
 
 	if (!force) {
 		await assertNoConflicts(orm, {
@@ -219,7 +293,7 @@ export async function claimFiles(ctx: ServiceCtx, raw: unknown) {
 		now,
 	});
 
-	return { created, overridden };
+	return { created, overridden, reclaimed };
 }
 
 export async function releaseFiles(ctx: ServiceCtx, raw: unknown) {
@@ -302,19 +376,46 @@ export async function listFileClaims(ctx: ServiceCtx, raw: unknown) {
 	);
 	if (vis) conditions.push(vis);
 
-	const items = await orm
-		.select()
+	// PROJ-636: carries `live` for the same reason listIssueLeases does — false means the
+	// holder stopped heartbeating and the next claim on that path will reclaim it. Without
+	// it a reclaimable claim is indistinguishable from a held one, which would make the
+	// self-healing the docs now describe unobservable.
+	const cutoff = liveCutoff();
+	const rows = await orm
+		.select({
+			id: schema.issueFileClaims.id,
+			workspaceId: schema.issueFileClaims.workspaceId,
+			issueId: schema.issueFileClaims.issueId,
+			agentId: schema.issueFileClaims.agentId,
+			path: schema.issueFileClaims.path,
+			claimedAt: schema.issueFileClaims.claimedAt,
+			releasedAt: schema.issueFileClaims.releasedAt,
+			releaseReason: schema.issueFileClaims.releaseReason,
+			sessionStatus: schema.agentSessions.status,
+			sessionHeartbeat: schema.agentSessions.lastHeartbeatAt,
+		})
 		.from(schema.issueFileClaims)
+		.leftJoin(schema.agentSessions, eq(schema.issueFileClaims.agentId, schema.agentSessions.id))
 		.where(and(...conditions))
 		.orderBy(schema.issueFileClaims.claimedAt);
+
+	const items = rows.map(({ sessionStatus, sessionHeartbeat, ...claim }) => ({
+		...claim,
+		live:
+			claim.agentId === null || (sessionStatus === "active" && (sessionHeartbeat ?? 0) > cutoff),
+	}));
 
 	return { items };
 }
 
 // PROJ-334: "abandoned claim" for the factory-health tile — released because the
-// agent's session ended, not because the work was released deliberately. There's no
-// separate expiry sweep for file claims (unlike issue_leases), so agent-end is the
-// only abandonment path today.
+// agent's session ended, not because the work was released deliberately.
+//
+// PROJ-636: this is no longer the only abandonment path. A claim whose holder stopped
+// heartbeating is reclaimed as `expired` by the next claim on the same path, so a crashed
+// agent no longer deadlocks its paths. Agent-end remains the *eager* path — it frees the
+// claim immediately rather than leaving it to the next claimant — and it is the one that
+// records `agent_ended` for the health tile, which distinguishes a clean exit from a crash.
 export async function releaseClaimsForAgent(ctx: ServiceCtx, agentId: string) {
 	const orm = drizzle(ctx.db, { schema });
 	const now = Math.floor(Date.now() / 1000);

--- a/apps/api/src/test/file-claims.test.ts
+++ b/apps/api/src/test/file-claims.test.ts
@@ -355,4 +355,181 @@ describe("File Claims API", () => {
 		const priorHolderMessages = await listMessagesForScope(`issue:${issueId}`);
 		expect(priorHolderMessages.items).toHaveLength(0);
 	});
+
+	// PROJ-636: a claim whose holding session stopped heartbeating is reclaimed by the next
+	// claim on that path, the way issue leases already were.
+	//
+	// The distinction that matters throughout: a *crashed* agent keeps status 'active' with a
+	// stale heartbeat, because status only becomes 'ended' when it calls end_agent — which by
+	// definition it didn't. B4b above covers the clean-exit path; none of these do.
+	describe("PROJ-636: stale-holder reclaim", () => {
+		async function seedSession(
+			opts: Readonly<{ status?: string; heartbeatAgeSecs?: number; name?: string }> = {}
+		): Promise<string> {
+			const id = crypto.randomUUID();
+			const now = Math.floor(Date.now() / 1000);
+			await env.DB.prepare(
+				`INSERT INTO agent_sessions
+	         (id, workspace_id, issue_id, token_id, name, kind, status, started_at,
+	          last_heartbeat_at, ended_at)
+	       VALUES (?, ?, NULL, NULL, ?, 'agent', ?, ?, ?, NULL)`
+			)
+				.bind(
+					id,
+					workspaceId,
+					opts.name ?? "crashed-agent",
+					opts.status ?? "active",
+					now,
+					now - (opts.heartbeatAgeSecs ?? 0)
+				)
+				.run();
+			return id;
+		}
+
+		async function claimRow(path: string) {
+			return env.DB.prepare(
+				"SELECT released_at, release_reason FROM issue_file_claims WHERE path = ? AND workspace_id = ?"
+			)
+				.bind(path, workspaceId)
+				.first<{ released_at: number | null; release_reason: string | null }>();
+		}
+
+		it("a crashed agent's claim no longer blocks another issue", async () => {
+			// 200s > the 120s TTL. Status stays 'active' — that is the whole point.
+			const dead = await seedSession({ heartbeatAgeSecs: 200 });
+			expect(
+				(await claimFiles({ issueId, agentId: dead, paths: ["src/abandoned.ts"] })).status
+			).toBe(201);
+
+			const issue2 = await seedIssue(workspaceId, projectId, userId, { title: "Takes over" });
+			const res = await claimFiles({ issueId: issue2.id, paths: ["src/abandoned.ts"] });
+			expect(res.status).toBe(201);
+
+			const body = (await res.json()) as {
+				created: Array<{ issueId: string }>;
+				reclaimed: Array<{ path: string; releaseReason: string }>;
+			};
+			expect(body.created[0].issueId).toBe(issue2.id);
+			// Reported, not silent: an agent that took over an abandoned path should be able to
+			// tell that from an uncontested first claim.
+			expect(body.reclaimed.map((r) => r.path)).toEqual(["src/abandoned.ts"]);
+			expect(body.reclaimed[0].releaseReason).toBe("expired");
+		});
+
+		it("marks the reclaimed claim expired, distinct from agent_ended", async () => {
+			const dead = await seedSession({ heartbeatAgeSecs: 200 });
+			await claimFiles({ issueId, agentId: dead, paths: ["src/reason.ts"] });
+
+			const issue2 = await seedIssue(workspaceId, projectId, userId, { title: "Takes over" });
+			await claimFiles({ issueId: issue2.id, paths: ["src/reason.ts"] });
+
+			// Two rows now share this path; the released one is the original holder's.
+			const released = await env.DB.prepare(
+				"SELECT release_reason FROM issue_file_claims WHERE path = ? AND released_at IS NOT NULL"
+			)
+				.bind("src/reason.ts")
+				.first<{ release_reason: string }>();
+			// Not 'agent_ended' — the factory-health tile uses that to mean a clean exit, and a
+			// crash reported as a clean exit would hide exactly the failure this ticket is about.
+			expect(released?.release_reason).toBe("expired");
+		});
+
+		it("a live agent's claim still blocks, and is not silently expired", async () => {
+			// The control. Without this, a bug that expired every claim regardless of heartbeat
+			// would satisfy every other test in this block.
+			const live = await seedSession({ heartbeatAgeSecs: 5, name: "live-agent" });
+			await claimFiles({ issueId, agentId: live, paths: ["src/held.ts"] });
+
+			const issue2 = await seedIssue(workspaceId, projectId, userId, { title: "Blocked" });
+			expect((await claimFiles({ issueId: issue2.id, paths: ["src/held.ts"] })).status).toBe(409);
+			expect((await claimRow("src/held.ts"))?.released_at).toBeNull();
+		});
+
+		it("an agentless claim is never auto-reclaimed", async () => {
+			// No session means no heartbeat to judge, so these stay held and `force` remains the
+			// only way past them. Guards the deliberate choice not to fall back on claim age.
+			await claimFiles({ issueId, paths: ["src/no-agent.ts"] });
+
+			const issue2 = await seedIssue(workspaceId, projectId, userId, { title: "Blocked" });
+			expect((await claimFiles({ issueId: issue2.id, paths: ["src/no-agent.ts"] })).status).toBe(
+				409
+			);
+		});
+
+		it("does not record a conflict when superseding a dead holder", async () => {
+			const dead = await seedSession({ heartbeatAgeSecs: 200 });
+			await claimFiles({ issueId, agentId: dead, paths: ["src/no-conflict.ts"] });
+
+			const issue2 = await seedIssue(workspaceId, projectId, userId, { title: "Takes over" });
+			await claimFiles({ issueId: issue2.id, paths: ["src/no-conflict.ts"] });
+
+			// claim_conflicts drives the heatmap's contention mode, whose argument is that a
+			// repeatedly-hot path says something about how the work was sliced. Fleet mortality
+			// is not contention, so counting it there would corrupt the signal.
+			const conflicts = await env.DB.prepare(
+				"SELECT COUNT(*) AS n FROM claim_conflicts WHERE path = ?"
+			)
+				.bind("src/no-conflict.ts")
+				.first<{ n: number }>();
+			expect(conflicts?.n).toBe(0);
+		});
+
+		it("still records a conflict when the holder is live", async () => {
+			// The paired control for the assertion above: proves the zero there comes from the
+			// holder being dead, not from conflict recording having been broken outright.
+			const live = await seedSession({ heartbeatAgeSecs: 5 });
+			await claimFiles({ issueId, agentId: live, paths: ["src/live-conflict.ts"] });
+
+			const issue2 = await seedIssue(workspaceId, projectId, userId, { title: "Rejected" });
+			await claimFiles({ issueId: issue2.id, paths: ["src/live-conflict.ts"] });
+
+			const conflicts = await env.DB.prepare(
+				"SELECT COUNT(*) AS n FROM claim_conflicts WHERE path = ?"
+			)
+				.bind("src/live-conflict.ts")
+				.first<{ n: number }>();
+			expect(conflicts?.n).toBe(1);
+		});
+
+		it("reclaims only the stale paths in a mixed multi-path claim", async () => {
+			// Claims are all-or-nothing, so a request spanning a dead holder and a live one must
+			// still be refused whole — and must not expire the dead one as a side effect of a
+			// request that failed.
+			const dead = await seedSession({ heartbeatAgeSecs: 200 });
+			const live = await seedSession({ heartbeatAgeSecs: 5 });
+			await claimFiles({ issueId, agentId: dead, paths: ["src/dead-path.ts"] });
+			const issue2 = await seedIssue(workspaceId, projectId, userId, { title: "Live holder" });
+			await claimFiles({ issueId: issue2.id, agentId: live, paths: ["src/live-path.ts"] });
+
+			const issue3 = await seedIssue(workspaceId, projectId, userId, { title: "Wants both" });
+			const res = await claimFiles({
+				issueId: issue3.id,
+				paths: ["src/dead-path.ts", "src/live-path.ts"],
+			});
+			expect(res.status).toBe(409);
+
+			// The live path is untouched.
+			expect((await claimRow("src/live-path.ts"))?.released_at).toBeNull();
+			// The dead one was released on the way through. Documenting the actual behaviour
+			// rather than asserting the tidier alternative: reclaim happens before conflict
+			// evaluation, so a refused request can still have freed an abandoned path. That is
+			// harmless — the path was reclaimable by anyone — but it is a real ordering
+			// consequence and worth pinning so a future change to it is a visible decision.
+			expect((await claimRow("src/dead-path.ts"))?.release_reason).toBe("expired");
+		});
+
+		it("list_file_claims flags a stale holder as not live", async () => {
+			const dead = await seedSession({ heartbeatAgeSecs: 200 });
+			await claimFiles({ issueId, agentId: dead, paths: ["src/listed-dead.ts"] });
+			const live = await seedSession({ heartbeatAgeSecs: 5 });
+			const issue2 = await seedIssue(workspaceId, projectId, userId, { title: "Live" });
+			await claimFiles({ issueId: issue2.id, agentId: live, paths: ["src/listed-live.ts"] });
+
+			const listRes = await listFileClaims();
+			const body = (await listRes.json()) as { items: Array<{ path: string; live: boolean }> };
+			const byPath = new Map(body.items.map((i) => [i.path, i.live]));
+			expect(byPath.get("src/listed-dead.ts")).toBe(false);
+			expect(byPath.get("src/listed-live.ts")).toBe(true);
+		});
+	});
 });

--- a/apps/docs/src/content/docs/contributing/conventions.md
+++ b/apps/docs/src/content/docs/contributing/conventions.md
@@ -46,10 +46,12 @@ editing anything:
   `apps/api/src/services/issue-leases.ts`) is **120 seconds**. Register, then go quiet for
   two minutes without a `heartbeat_agent` call, and your session goes stale — you must
   heartbeat again before you can claim.
-- **Leases self-heal; file claims do not.** An issue lease held by a stale session is
-  reclaimed by the next claimer in the same call. File claims have no TTL: they release
-  only on `release_files`, on `end_agent`, or when someone claims with `force`. So call
-  `end_agent` when you finish, or your paths stay locked behind you.
+- **Both tiers self-heal.** An issue lease or file claim held by a stale session is
+  reclaimed by the next claimer in the same call (`release_reason: "expired"`). Still call
+  `release_files` and `end_agent` when you finish: reclaim only happens when someone else
+  wants the path, so until then your claims sit there looking held, and a clean exit is
+  what distinguishes you from a crash in the health data. A claim with no `agent_id` has no
+  heartbeat to judge and is never auto-reclaimed — `force` is the only way past it.
 - **There's a per-project cap on concurrently leased issues** —
   `DEFAULT_AGENT_WIP_LIMIT = 3` in `apps/api/src/services/issue-leases.ts`,
   overridable per project via `projects.agent_wip_limit`. It's admission control on

--- a/apps/docs/src/content/docs/philosophy/coordination-model.md
+++ b/apps/docs/src/content/docs/philosophy/coordination-model.md
@@ -95,18 +95,38 @@ claim proceeds in the same call. There is no separate expiry job, no manual "for
 release" step, and no permanently stuck issue: a crashed agent can never leave a lease
 that outlives it by more than the TTL.
 
-**The two tiers are not symmetric here, and this is the layer's weakest point.** Issue
-leases are reclaimed from liveness, as above. File claims are not: there is no TTL-based
-expiry for them at all. A claim is released when the agent calls `release_files`, or when
-its session formally ends and `releaseClaimsForAgent` marks the rows
-`release_reason: "agent_ended"` (`file-claims.ts`, PROJ-334). An agent that dies without
-ending its session — the crash case the lease tier handles cleanly — leaves its file
-claims held indefinitely, and the only way out is a `force` claim by someone else. The
-comment on `releaseClaimsForAgent` says as much: agent-end is the only abandonment path
-today.
+**File claims work the same way** (`reclaimStaleClaims` in `file-claims.ts`, PROJ-636). The
+next `claim_files` on a contested path checks the holding claim's session the way the lease
+tier checks the holding lease's: if that session stopped heartbeating, the claim is released
+with `release_reason: "expired"` and the new claim proceeds. A crashed agent frees both its
+ticket and its files.
 
-So a crashed agent frees its ticket automatically but not its files. Worth knowing before
-relying on claims as the only guard in a long-running fleet.
+This was not always true, and the asymmetry is worth recording because it shaped the design.
+File claims originally had no expiry of any kind: they released on `release_files`, on a
+formal session end via `releaseClaimsForAgent` (`release_reason: "agent_ended"`, PROJ-334),
+or on someone else's `force`. An agent that died without ending its session — the crash case
+the lease tier already handled — held its paths indefinitely. For spawned workers, dying
+without a clean exit is the normal case rather than the exception, so the tier that was
+supposed to prevent deadlock was the one that could cause it.
+
+Two consequences of closing it that are easy to miss:
+
+- **`agent_ended` and `expired` mean different things, deliberately.** A clean `end_agent`
+  still releases eagerly and still records `agent_ended`; only an abandoned claim records
+  `expired`. Collapsing them would make a crash indistinguishable from a tidy exit in the
+  factory-health data, which is precisely the signal you want when a fleet is misbehaving.
+- **Reclaiming a dead holder is not recorded as contention.** No `claim_conflicts` row is
+  written when a claim supersedes a stale one. The contention log exists to say something
+  about how the work was sliced (see below); fleet mortality is not a collision between two
+  live agents, and counting it as one would inflate the heatmap with deaths rather than
+  disagreements.
+
+One case remains outside liveness: a claim with no `agent_id` — made without a session, or
+orphaned because the `agent_id` foreign key is `ON DELETE SET NULL`. There is no heartbeat to
+judge those by, so they are treated as held and `force` is still the only way past them.
+Falling back on claim age would work, but it would reintroduce exactly the wall-clock TTL
+this tier is built to avoid, and it would apply that TTL only to the minority of claims that
+happen to lack a session — an inconsistency worse than the gap it closes.
 
 ## Conflict routing
 


### PR DESCRIPTION
Closes PROJ-636.

File claims had no expiry of any kind: they released on `release_files`, on a formal
`end_agent` via `releaseClaimsForAgent` (`agent_ended`), or on someone else's `force`.
An agent that died *without* ending its session — the crash case the lease tier already
handled — held its paths indefinitely. For spawned workers that is the normal exit, so
the tier meant to prevent deadlock was the one that could cause it.

`reclaimStaleClaims` mirrors `reclaimStaleLeaseOrThrow`: `loadActiveClaimsByPath` now
LEFT JOINs `agent_sessions` and derives a `live` flag from `status = 'active'` and a
heartbeat inside the 120s TTL, and the next `claim_files` on a contested path releases a
stale holder as `expired` before conflict evaluation — so `assertNoConflicts` and
`overrideConflictingClaims` are untouched and only ever see live holders. LEFT rather
than INNER join so agentless claims still appear.

Three judgement calls, recorded on the epic:

- **No `claim_conflicts` row when superseding a dead holder.** Fleet mortality is not
  contention, and that log feeds the heatmap whose whole argument rests on contention
  meaning something.
- **Agentless claims are never auto-reclaimed.** No heartbeat to judge them by, and an
  age fallback would reintroduce the wall-clock TTL this tier exists without — applied
  only to the minority of claims lacking a session.
- **`expired` stays distinct from `agent_ended`**, so health data can still tell a crash
  from a tidy exit.

Also adds `live` to `list_file_claims` (not in the ACs, but the docs now claim
self-healing and without it a reclaimable claim is indistinguishable from a held one),
and fixes the docs that said file claims have no TTL: `coordination-model.md` now records
the asymmetry as history plus the two easy-to-miss consequences, and README/AGENTS.md
were both wrong.

## Verification

Eight new tests. Stubbing the stale filter to an empty array fails exactly four of them —
the reclaim assertions; the other four are controls (live holder still blocks and is not
silently expired, agentless claim still blocks, live holder still records a conflict, list
flags `live` correctly) that pass either way by design.

- `apps/api` suite: 62 files / 1215 tests green (up 8)
- `pnpm turbo type-check` 7/7
- biome clean over 366 files
- docs build passes (includes `starlight-links-validator`); `pnpm gen:docs` idempotent by md5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7BN9JBdhFp5Pkk7kV9JJf