### PR TITLE
fix(api): stop the consent footer breaking words mid-letter on phones

### DIFF
--- a/apps/api/src/routes/oauth.ts
+++ b/apps/api/src/routes/oauth.ts
@@ -72,7 +72,7 @@ p { margin:0 0 1rem; color:var(--muted); }
 strong { color:var(--fg); }
 ul { margin:0 0 1.25rem; padding-left:1.25rem; }
 li { margin-bottom:.35rem; }
-.meta { font-size:.85rem; border-top:1px solid var(--line); padding-top:1rem; word-break:break-all; }
+.meta { font-size:.85rem; border-top:1px solid var(--line); padding-top:1rem; overflow-wrap:anywhere; }
 .warn { background:rgba(240,170,20,.12); border:1px solid rgba(240,170,20,.4);
   border-radius:8px; padding:.75rem 1rem; margin-bottom:1.25rem; font-size:.9rem; color:var(--fg); }
 .actions { display:flex; flex-wrap:wrap; gap:.75rem; }

--- a/apps/api/src/test/oauth.test.ts
+++ b/apps/api/src/test/oauth.test.ts
@@ -383,6 +383,11 @@ describe("the consent screen", () => {
 		expect(body).toContain("Test Connector");
 		expect(body).toContain("Read issues");
 		expect(body).toContain("Create and change issues");
+		// The footer has to wrap the long client_id and resource URLs, but `break-all`
+		// does it to ordinary prose too — on a phone the sentence beside them breaks
+		// mid-word. `anywhere` only breaks a token that cannot fit on its own.
+		expect(body).toContain("overflow-wrap:anywhere");
+		expect(body).not.toContain("word-break:break-all");
 	});
 
 	it("warns when the client collects its response on the user's own machine", async () => {


### PR DESCRIPTION
Found while checking the OAuth consent screen at 390×844 ahead of testing the Claude mobile app connector flow.

`.meta` carried `word-break:break-all` so the long `client_id` and `resource` URLs wrap inside the card. It applies to the prose beside them too, so at phone width the footer read:

> Verified identity: **claude.ai**. The application's nam
> e is self-declared; the address above is not.

`overflow-wrap:anywhere` still breaks a URL that cannot fit on its own and leaves ordinary words intact.

Only visible below roughly 400px — which is exactly where the Claude mobile app opens this page, and why reading the CSS alone did not catch it.

Verified by rendering the real consent page at 390×844 before and after: no horizontal overflow either way, footer now wraps on the word boundary. Regression assertion added to the existing consent-screen test; `oauth.test.ts` is 38/38 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vgLtkpR7vVy7aYLYQwC7s