### PR TITLE
fix(api): let the consent approval reach the client's redirect origin (PROJ-666)

### DIFF
--- a/apps/api/src/routes/oauth.ts
+++ b/apps/api/src/routes/oauth.ts
@@ -95,9 +95,28 @@ function page(title: string, body: string): string {
 // alongside for anything that predates CSP level 2. `form-action 'self'` keeps the
 // decision POST from being retargeted, and `default-src 'none'` means the page cannot
 // pull in anything at all — it needs nothing beyond its own inline stylesheet.
+// `form-action` is enforced on the redirect the POST lands on, not only on the URL
+// the form names. Approving sends the browser to the client's redirect_uri — another
+// origin — so 'self' alone blocks the submission outright, and the browser reports it
+// against /oauth/authorize, which is genuinely same-origin and looks like a false
+// positive. The client's redirect origin therefore has to be named here.
+//
+// It is the origin only, and only the one this request already validated: the library
+// checked redirect_uri against the client's registered URIs before this page rendered,
+// so nothing widens the policy that was not already the approved destination.
+function consentCsp(redirectUri?: string): string {
+	let formAction = "'self'";
+	if (redirectUri) {
+		try {
+			formAction += ` ${new URL(redirectUri).origin}`;
+		} catch {
+			// Unparseable means it never passed validation; leave the policy at 'self'.
+		}
+	}
+	return `default-src 'none'; style-src 'unsafe-inline'; form-action ${formAction}; frame-ancestors 'none'; base-uri 'none'`;
+}
+
 const CONSENT_HEADERS = {
-	"Content-Security-Policy":
-		"default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; frame-ancestors 'none'; base-uri 'none'",
 	"X-Frame-Options": "DENY",
 	"Referrer-Policy": "no-referrer",
 	// The URL carries the authorization request; nothing about it should be cached.
@@ -108,9 +127,13 @@ function consentHtml(
 	c: Context<HonoEnv>,
 	title: string,
 	body: string,
-	status: 200 | 400 | 403 | 500 = 200
+	status: 200 | 400 | 403 | 500 = 200,
+	redirectUri?: string
 ) {
-	return c.html(page(title, body), status, { ...CONSENT_HEADERS });
+	return c.html(page(title, body), status, {
+		...CONSENT_HEADERS,
+		"Content-Security-Policy": consentCsp(redirectUri),
+	});
 }
 
 function errorPage(c: Context<HonoEnv>, status: 400 | 403 | 500, heading: string, detail: string) {
@@ -284,7 +307,9 @@ oauthRouter.get("/authorize", async (c) => {
          </div>
        </form>
        <p class="meta">Verified identity: <strong>${escapeHtml(host)}</strong>. The
-       application's name is self-declared; the address above is not.</p>`
+       application's name is self-declared; the address above is not.</p>`,
+		200,
+		authRequest.redirectUri
 	);
 });
 

--- a/apps/api/src/test/oauth.test.ts
+++ b/apps/api/src/test/oauth.test.ts
@@ -1002,6 +1002,31 @@ describe("hardening the consent screen itself", () => {
 		expect(res.headers.get("Cache-Control")).toBe("no-store");
 	});
 
+	it("lets the approval reach the client's redirect origin, and nowhere else", async () => {
+		// form-action is enforced on the redirect the POST lands on, not just the URL
+		// the form names. With 'self' alone the browser blocks the submission and
+		// reports it against /oauth/authorize — which is same-origin, so the report
+		// reads as a false positive while the connector flow is dead in every browser.
+		const csp = (await consentPage()).headers.get("Content-Security-Policy") ?? "";
+
+		expect(csp).toContain(`form-action 'self' ${new URL(CLIENT_REDIRECT).origin}`);
+		// The origin, not the callback path, and nothing wildcarded.
+		expect(csp).not.toContain(CLIENT_REDIRECT);
+		expect(csp).not.toContain("*");
+	});
+
+	it("does not name a redirect origin on a page with no form to submit", async () => {
+		// An error page carries no consent form, so widening its policy would grant
+		// reach that nothing on the page needs.
+		const res = await SELF.fetch(authorizeUrl({ clientId: "nope", challenge: "x" }), {
+			headers: browserHeaders({ "Cf-Access-Jwt-Assertion": await accessJwt(email) }),
+		});
+		const csp = res.headers.get("Content-Security-Policy") ?? "";
+
+		expect(res.status).not.toBe(200);
+		expect(csp).toContain("form-action 'self';");
+	});
+
 	it("refuses to process consent at all when JWT_SECRET is unset", async () => {
 		// Without this the secret stringifies into the HMAC key as "undefined", which
 		// is the same key on every deployment that skipped `wrangler secret put` — and


### PR DESCRIPTION
Pressing **Allow access** did nothing in any browser. `form-action` is enforced against the redirect a form POST lands on, not only the URL the form names — approving redirects to the client's `redirect_uri` on another origin, and `form-action 'self'` blocked it.

The browser reports the violation against `/oauth/authorize`, which is genuinely same-origin, so it reads as a false positive while the flow is dead.

The policy now names the origin of the `redirect_uri` this request already validated against the client's registered URIs. Origin only, no path, no wildcard, and error pages keep `'self'`.

Also the true cause of the `net::ERR_ABORTED` seen during PROJ-660 connector testing, which was wrongly pinned on the trycloudflare tunnel.

Reproduced and verified in Chromium: before, the click produced CSP errors and `net::ERR_ABORTED` with no navigation; after, it navigates to `claude.ai`. Two regression tests added; `oauth.test.ts` 40/40.

Every prior test drove consent via curl or `SELF.fetch`, which don't enforce CSP — and asserted the page *contains* `form-action 'self'`, encoding the bug as correct.

Fixes PROJ-666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vgLtkpR7vVy7aYLYQwC7s