### PR TITLE
chore(web): bump nav version to 0.6.2-rc.1

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@projektor/web",
-	"version": "0.6.1",
+	"version": "0.6.2-rc.1",
 	"private": true,
 	"scripts": {
 		"dev": "astro dev",


### PR DESCRIPTION
Release candidate carrying the two consent-screen fixes merged after v0.6.1:

- **PROJ-666** (#288) — `form-action 'self'` blocked the approval redirect, so no browser could complete the connector flow.
- #287 — consent footer broke words mid-letter at phone width.

Cut as an RC rather than v0.6.2 so the connector flow can be confirmed end to end on the dogfood before a real release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vgLtkpR7vVy7aYLYQwC7s