### PR TITLE
docs: add Google Search Console site verification meta tag

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -17,6 +17,15 @@ export default defineConfig({
 			description:
 				"A self-hosted, MCP-native Jira + wiki that runs in a single Cloudflare Worker.",
 			customCss: ["./src/styles/projektor.css"],
+			head: [
+				{
+					tag: "meta",
+					attrs: {
+						name: "google-site-verification",
+						content: "ZfOIYTNW_MPgzvPKsmWx2GIYCAOzVdWi5QXcNL4ihT4",
+					},
+				},
+			],
 			components: {
 				Footer: "./src/components/Footer.astro",
 			},


### PR DESCRIPTION
## Summary
- Adds a `google-site-verification` meta tag (via Starlight's `head` config) to every page of the docs site, so the homepage carries it for Search Console's URL-prefix verification of `https://tajd.github.io/projektor/`.

## Test plan
- [x] `pnpm build` in `apps/docs` succeeds
- [x] Verified the meta tag renders in `dist/index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhXZEqSYYFHaZ4W7Vnp772