### PR TITLE
PROJ-670: ProjectNav Priority+ More menu for mobile tab overflow

### DIFF
--- a/apps/web/src/islands/ProjectNav.test.tsx
+++ b/apps/web/src/islands/ProjectNav.test.tsx
@@ -1,13 +1,8 @@
-// ProjectNav island — canonical mock-fetch test.
-//
-// ProjectNav reads the URL (window.location) on mount and, if there's a project
-// id/key in the query, fetches it. The pattern here:
-//   • set the URL with history.pushState before render (jsdom updates location);
-//   • override the default fetch stub from setup.ts with vi.stubGlobal to return
-//     the project payload this case needs;
-//   • await findByText for the async state update after fetch resolves.
-import { render, screen } from "@testing-library/preact";
-import { describe, expect, it, vi } from "vitest";
+// ProjectNav island — canonical mock-fetch test. ProjectNav reads the URL on mount and,
+// if a project id/key is in the query, fetches it — set the URL with history.pushState
+// first, stub fetch with vi.stubGlobal per case, then await findByText for the async update.
+import { fireEvent, render, screen } from "@testing-library/preact";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ProjectNav from "./ProjectNav";
 
 const PROJECT = { id: "p1", key: "PROJ", name: "Projektor", slug: "projektor" };
@@ -17,6 +12,40 @@ function mockFetchProject(project: typeof PROJECT | null) {
 		"fetch",
 		vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(project) })
 	);
+}
+
+// Priority+ overflow: jsdom never computes real layout, so ProjectNav's width/tab
+// measurements (nav.clientWidth, each tab span's offsetWidth) are 0 unless stubbed here.
+// stubNavMeasurements fixes the nav's clientWidth and every tab's offsetWidth so the
+// overflow math in ProjectNav is exercised deterministically.
+let offsetWidthDescriptor: PropertyDescriptor | undefined;
+let clientWidthDescriptor: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+	offsetWidthDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetWidth");
+	clientWidthDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientWidth");
+});
+
+afterEach(() => {
+	if (offsetWidthDescriptor)
+		Object.defineProperty(HTMLElement.prototype, "offsetWidth", offsetWidthDescriptor);
+	if (clientWidthDescriptor)
+		Object.defineProperty(HTMLElement.prototype, "clientWidth", clientWidthDescriptor);
+});
+
+function stubNavMeasurements(containerWidth: number, tabWidth: number) {
+	Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+		configurable: true,
+		get(this: HTMLElement) {
+			return this.getAttribute("aria-label") === "Project sections" ? containerWidth : 0;
+		},
+	});
+	Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+		configurable: true,
+		get(this: HTMLElement) {
+			return this.querySelector?.("a")?.textContent?.trim() ? tabWidth : 0;
+		},
+	});
 }
 
 describe("ProjectNav", () => {
@@ -67,14 +96,11 @@ describe("ProjectNav", () => {
 	// jsdom doesn't compute layout, so this only proves the compacting classes are
 	// present at render time — not that they actually shrink the nav in a real
 	// viewport. See PROJ-346; real-viewport confirmation happens separately.
-	it("applies compact-mobile and horizontal-scroll classes to the header and tab row", async () => {
+	it("applies compact-mobile classes to the header and tab row", async () => {
 		window.history.pushState({}, "", "/issues?id=p1");
 		mockFetchProject(PROJECT);
 		render(<ProjectNav />);
 		await screen.findByText("Projektor");
-
-		const nav = screen.getByRole("navigation", { name: "Project sections" });
-		expect(nav.className).toContain("max-sm:overflow-x-auto");
 
 		const issuesTab = screen.getByRole("link", { name: "Issues" });
 		expect(issuesTab.className).toContain("max-sm:px-2.5");
@@ -128,5 +154,91 @@ describe("ProjectNav", () => {
 		render(<ProjectNav workspaceSlug="my-ws" />);
 		const link = (await screen.findByText("Feedback")) as HTMLAnchorElement;
 		expect(link.getAttribute("href")).toBe("/feedback?projectId=p1");
+	});
+});
+
+describe("ProjectNav — Priority+ overflow menu", () => {
+	it("renders every tab directly with no More trigger when they all fit", async () => {
+		window.history.pushState({}, "", "/issues?id=p1");
+		mockFetchProject(PROJECT);
+		stubNavMeasurements(2000, 80);
+		render(<ProjectNav />);
+		await screen.findByText("Projektor");
+
+		for (const label of ["Overview", "Issues", "Wiki", "Sprints", "Epics", "Metrics", "Feedback"]) {
+			expect(screen.getByRole("link", { name: label })).toBeTruthy();
+		}
+		expect(screen.queryByRole("button", { name: /more/i })).toBeNull();
+	});
+
+	it("moves trailing tabs into the More menu once the nav is too narrow to fit them all", async () => {
+		window.history.pushState({}, "", "/issues?id=p1");
+		mockFetchProject(PROJECT);
+		stubNavMeasurements(340, 90);
+		render(<ProjectNav />);
+		await screen.findByText("Projektor");
+
+		expect(screen.getByRole("link", { name: "Overview" })).toBeTruthy();
+		expect(screen.getByRole("link", { name: "Issues" })).toBeTruthy();
+		expect(screen.queryByRole("link", { name: "Wiki" })).toBeNull();
+		expect(screen.queryByRole("link", { name: "Feedback" })).toBeNull();
+
+		const more = screen.getByRole("button", { name: /more/i });
+		expect(more.getAttribute("aria-haspopup")).toBe("menu");
+		expect(more.getAttribute("aria-expanded")).toBe("false");
+		expect(screen.queryByRole("menu")).toBeNull();
+	});
+
+	it("highlights the More trigger when the active tab has overflowed into the menu", async () => {
+		window.history.pushState({}, "", "/feedback?id=p1");
+		mockFetchProject(PROJECT);
+		stubNavMeasurements(340, 90);
+		render(<ProjectNav />);
+		await screen.findByText("Projektor");
+
+		const more = screen.getByRole("button", { name: /more/i });
+		expect(more.getAttribute("aria-current")).toBe("true");
+
+		fireEvent.click(more);
+		const feedbackItem = screen.getByRole("menuitem", { name: "Feedback" });
+		expect(feedbackItem.getAttribute("aria-current")).toBe("page");
+	});
+
+	it("opens the menu with hidden tabs' correct ?projectId hrefs, and closes it on selection", async () => {
+		window.history.pushState({}, "", "/issues?id=p1");
+		mockFetchProject(PROJECT);
+		stubNavMeasurements(340, 90);
+		render(<ProjectNav />);
+		await screen.findByText("Projektor");
+
+		fireEvent.click(screen.getByRole("button", { name: /more/i }));
+		const menu = screen.getByRole("menu", { name: "More project sections" });
+		expect(menu).toBeTruthy();
+
+		const wikiItem = screen.getByRole("menuitem", { name: "Wiki" });
+		expect(wikiItem.getAttribute("href")).toBe("/wiki?projectId=p1");
+		const feedbackItem = screen.getByRole("menuitem", { name: "Feedback" });
+		expect(feedbackItem.getAttribute("href")).toBe("/feedback?projectId=p1");
+
+		fireEvent.click(wikiItem);
+		expect(screen.queryByRole("menu")).toBeNull();
+	});
+
+	it("closes the menu on Escape and on an outside click", async () => {
+		window.history.pushState({}, "", "/issues?id=p1");
+		mockFetchProject(PROJECT);
+		stubNavMeasurements(340, 90);
+		render(<ProjectNav />);
+		await screen.findByText("Projektor");
+
+		fireEvent.click(screen.getByRole("button", { name: /more/i }));
+		expect(screen.getByRole("menu")).toBeTruthy();
+		fireEvent.keyDown(document, { key: "Escape" });
+		expect(screen.queryByRole("menu")).toBeNull();
+
+		fireEvent.click(screen.getByRole("button", { name: /more/i }));
+		expect(screen.getByRole("menu")).toBeTruthy();
+		fireEvent.mouseDown(document.body);
+		expect(screen.queryByRole("menu")).toBeNull();
 	});
 });

--- a/apps/web/src/islands/ProjectNav.tsx
+++ b/apps/web/src/islands/ProjectNav.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "preact/hooks";
+import { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "preact/hooks";
 import { apiFetch } from "../utils/api-client";
 import { GlossaryHelp } from "./GlossaryHelp";
 import type { GlossaryTermId } from "./glossary-definitions";
@@ -15,9 +15,7 @@ interface Props {
 	pageLabel?: string;
 }
 
-// PROJ-395: glossaryId flags tabs whose label is SDLC jargon a newcomer wouldn't know
-// (Sprints, Epics) — those get an inline GlossaryHelp toggletip; self-explanatory tabs
-// don't, so the nav doesn't get cluttered with icons for power users/agents.
+// PROJ-395: glossaryId marks tabs whose label is SDLC jargon (Sprints, Epics) for an inline GlossaryHelp toggletip.
 const TABS: Array<{ label: string; path: string; glossaryId?: GlossaryTermId }> = [
 	{ label: "Overview", path: "/projects/view" },
 	{ label: "Issues", path: "/issues" },
@@ -45,17 +43,51 @@ function tabClass(active: boolean): string {
 	}`;
 }
 
+function isTabActive(path: string, activePath: string): boolean {
+	if (path === "/projects/view") {
+		return activePath === "/projects/view" || activePath.startsWith("/projects/view/");
+	}
+	return activePath === path;
+}
+
+// Reserved for the "More ▾" trigger's own width — not measured (it's static-content and
+// only ever appears once other tabs are already hidden), just budgeted for up front.
+const MORE_TRIGGER_RESERVE_PX = 72;
+
+function computeVisibleCount(
+	containerWidth: number,
+	tabWidths: number[],
+	moreReserve: number
+): number {
+	const total = tabWidths.reduce((sum, w) => sum + w, 0);
+	if (total <= containerWidth) return tabWidths.length;
+	let sum = 0;
+	let count = 0;
+	for (; count < tabWidths.length; count++) {
+		const next = sum + tabWidths[count];
+		if (next + moreReserve > containerWidth) break;
+		sum = next;
+	}
+	return count;
+}
+
 export default function ProjectNav({ workspaceSlug, pageLabel }: Props) {
 	const [project, setProject] = useState<Project | null>(null);
 	const [activePath, setActivePath] = useState("");
+	const [tabWidths, setTabWidths] = useState<number[] | null>(null);
+	const [containerWidth, setContainerWidth] = useState(0);
+	const [moreOpen, setMoreOpen] = useState(false);
+	const containerRef = useRef<HTMLElement | null>(null);
+	const tabRefs = useRef<Array<HTMLElement | null>>([]);
+	const moreRootRef = useRef<HTMLDivElement | null>(null);
+	const moreTriggerRef = useRef<HTMLButtonElement | null>(null);
+	const moreMenuId = useId();
 
 	useEffect(() => {
 		setActivePath(window.location.pathname);
 
 		const params = new URLSearchParams(window.location.search);
-		// Pretty-URL route (/projects/view/<slug>) falls back to this same page
-		// (see the SPA fallback in apps/api/src/index.ts) — read the slug from the
-		// path when there's no query param.
+		// Pretty-URL route (/projects/view/<slug>, see the SPA fallback in apps/api/src/index.ts) has no query param.
 		const slugMatch = window.location.pathname.match(/^\/projects\/view\/([^/]+)\/?$/);
 		const rawId = params.get("id") || params.get("projectId") || slugMatch?.[1];
 		const rawProject = params.get("project");
@@ -103,6 +135,51 @@ export default function ProjectNav({ workspaceSlug, pageLabel }: Props) {
 		}
 	}, [workspaceSlug]);
 
+	// Measures each tab's natural width once (labels are static), so later resizes only
+	// need to re-run computeVisibleCount against the container's current width.
+	useLayoutEffect(() => {
+		if (!project || tabWidths) return;
+		if (tabRefs.current.length !== TABS.length) return;
+		setTabWidths(tabRefs.current.map((el) => el?.offsetWidth ?? 0));
+	});
+
+	useLayoutEffect(() => {
+		const el = containerRef.current;
+		if (!el) return;
+		setContainerWidth(el.clientWidth);
+		if (typeof ResizeObserver === "undefined") return;
+		const observer = new ResizeObserver((entries) => {
+			const width = entries[0]?.contentRect.width;
+			if (typeof width === "number") setContainerWidth(width);
+		});
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, [project]);
+
+	useEffect(() => {
+		if (!moreOpen) return;
+		function onPointerDown(e: MouseEvent) {
+			if (!(e.target instanceof Node) || !moreRootRef.current?.contains(e.target))
+				setMoreOpen(false);
+		}
+		function onKeyDown(e: KeyboardEvent) {
+			if (e.key !== "Escape") return;
+			setMoreOpen(false);
+			moreTriggerRef.current?.focus();
+		}
+		document.addEventListener("mousedown", onPointerDown);
+		document.addEventListener("keydown", onKeyDown);
+		return () => {
+			document.removeEventListener("mousedown", onPointerDown);
+			document.removeEventListener("keydown", onKeyDown);
+		};
+	}, [moreOpen]);
+
+	const visibleCount = useMemo(() => {
+		if (!tabWidths || containerWidth <= 0) return TABS.length;
+		return computeVisibleCount(containerWidth, tabWidths, MORE_TRIGGER_RESERVE_PX);
+	}, [tabWidths, containerWidth]);
+
 	if (!project) return null;
 
 	const overviewHref = project.slug
@@ -124,6 +201,11 @@ export default function ProjectNav({ workspaceSlug, pageLabel }: Props) {
 		return { ...t, href };
 	});
 
+	const visibleTabs = tabs.slice(0, visibleCount);
+	const overflowTabs = tabs.slice(visibleCount);
+	const activeIndex = tabs.findIndex((t) => isTabActive(t.path, activePath));
+	const activeInOverflow = activeIndex !== -1 && activeIndex >= visibleCount;
+
 	return (
 		<div class="border-b border-border bg-[var(--nav-bg)]">
 			<div class="flex items-center gap-2 px-6 pt-3 pb-[0.375rem] max-sm:px-3 max-sm:pt-1.5 max-sm:pb-1">
@@ -135,16 +217,20 @@ export default function ProjectNav({ workspaceSlug, pageLabel }: Props) {
 				<span class={KEY_BADGE_CLASS}>{project.key}</span>
 			</div>
 			<nav
-				class="flex gap-0.5 px-5 max-sm:px-3 max-sm:overflow-x-auto"
+				ref={containerRef}
+				class="flex flex-nowrap items-center gap-0.5 px-5 max-sm:px-3"
 				aria-label="Project sections"
 			>
-				{tabs.map((tab) => {
-					const active =
-						tab.path === "/projects/view"
-							? activePath === "/projects/view" || activePath.startsWith("/projects/view/")
-							: activePath === tab.path;
+				{visibleTabs.map((tab, i) => {
+					const active = isTabActive(tab.path, activePath);
 					return (
-						<span key={tab.path} class="inline-flex items-center shrink-0">
+						<span
+							key={tab.path}
+							ref={(el) => {
+								tabRefs.current[i] = el;
+							}}
+							class="inline-flex items-center shrink-0"
+						>
 							<a
 								href={tab.href}
 								class={tabClass(active)}
@@ -156,6 +242,47 @@ export default function ProjectNav({ workspaceSlug, pageLabel }: Props) {
 						</span>
 					);
 				})}
+				{overflowTabs.length > 0 && (
+					<div class="relative inline-flex items-center shrink-0" ref={moreRootRef}>
+						<button
+							type="button"
+							ref={moreTriggerRef}
+							class={tabClass(activeInOverflow || moreOpen)}
+							aria-haspopup="menu"
+							aria-expanded={moreOpen}
+							aria-controls={moreOpen ? moreMenuId : undefined}
+							aria-current={activeInOverflow ? "true" : undefined}
+							onClick={() => setMoreOpen((open) => !open)}
+						>
+							More <span aria-hidden="true">▾</span>
+						</button>
+						{moreOpen && (
+							<div
+								id={moreMenuId}
+								role="menu"
+								aria-label="More project sections"
+								class="absolute right-0 top-full z-10 mt-1 flex min-w-[10rem] flex-col rounded-md border border-border bg-bg py-1 shadow-md"
+							>
+								{overflowTabs.map((tab) => {
+									const active = isTabActive(tab.path, activePath);
+									return (
+										<a
+											key={tab.path}
+											role="menuitem"
+											href={tab.href}
+											class="flex min-h-11 items-center gap-1.5 px-3 text-sm font-medium text-text-base no-underline hover:bg-surface"
+											aria-current={active ? "page" : undefined}
+											onClick={() => setMoreOpen(false)}
+										>
+											{tab.label}
+											{tab.glossaryId && <GlossaryHelp id={tab.glossaryId} />}
+										</a>
+									);
+								})}
+							</div>
+						)}
+					</div>
+				)}
 			</nav>
 		</div>
 	);


### PR DESCRIPTION
## Summary
- Replaces the mobile horizontal-scroll tab bar in `ProjectNav` with a Priority+ pattern: as many leading tabs are shown as fit the available width, with the rest collapsed into a "More ▾" menu.
- Measures each tab's natural width once (labels are static) and the nav container's width via `ResizeObserver` (falls back to showing all tabs if measurement is unavailable, e.g. containerWidth is 0 — this also keeps existing/unstubbed tests passing unchanged).
- If the active tab has overflowed into the menu, the "More" trigger gets `aria-current="true"` and active styling so the current section is still indicated.
- Menu items are ≥44px tall tap targets, the trigger exposes `aria-haspopup="menu"`/`aria-expanded`, and the menu closes on selection, outside click, and Escape (focus returns to the trigger).
- Removed the old `max-sm:overflow-x-auto` horizontal scroll class — no more horizontal scrolling of the tab row at any width.

## Design decisions
- Widths are measured once on mount (tab labels are static/fixed) rather than continuously, avoiding a remeasure-after-hide correctness bug (a `display:none` element reports 0 width in real browsers).
- The "More" trigger's own width is a fixed reserve constant rather than measured, since it only ever renders once other tabs are already hidden (avoiding a chicken-and-egg measurement problem).
- Tests stub `clientWidth`/`offsetWidth` on `HTMLElement.prototype` (jsdom doesn't compute real layout) to exercise the overflow math deterministically — see `stubNavMeasurements` in `ProjectNav.test.tsx`.

## Test plan
- [x] `pnpm --filter @projektor/web test` — all 680 tests pass (15 in `ProjectNav.test.tsx`, including 5 new Priority+ overflow tests)
- [x] `pnpm --filter @projektor/web test:coverage` — passes
- [x] `pnpm turbo type-check --filter=@projektor/web` — 0 errors
- [x] `pnpm biome check` on changed files — clean
- [x] `pnpm --filter @projektor/web build` — succeeds
- [ ] Manual check at iPhone-width viewport — not performed this session (browser automation tooling unavailable/unauthenticated); relying on the automated viewport/overflow-simulation tests instead.

Closes PROJ-670.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjWZ86u91ZXsmGKoWC8vbx