### PR TITLE
fix(web): remove GlossaryHelp icons from Sprints/Epics ProjectNav tabs (PROJ-672)

### DIFF
--- a/apps/web/src/islands/ProjectNav.test.tsx
+++ b/apps/web/src/islands/ProjectNav.test.tsx
@@ -137,6 +137,15 @@ describe("ProjectNav", () => {
 		expect(overviewTab.getAttribute("aria-current")).toBe("page");
 	});
 
+	it("renders no GlossaryHelp icon next to the Sprints or Epics tabs", async () => {
+		window.history.pushState({}, "", "/issues?id=p1");
+		mockFetchProject(PROJECT);
+		render(<ProjectNav />);
+		await screen.findByText("Projektor");
+		expect(screen.queryByRole("button", { name: /about sprint/i })).toBeNull();
+		expect(screen.queryByRole("button", { name: /about epic/i })).toBeNull();
+	});
+
 	it("renders a Feedback tab linking to /feedback?projectId", async () => {
 		vi.stubGlobal(
 			"fetch",
@@ -222,6 +231,19 @@ describe("ProjectNav — Priority+ overflow menu", () => {
 
 		fireEvent.click(wikiItem);
 		expect(screen.queryByRole("menu")).toBeNull();
+	});
+
+	it("renders no GlossaryHelp icon for Sprints or Epics inside the More menu", async () => {
+		window.history.pushState({}, "", "/issues?id=p1");
+		mockFetchProject(PROJECT);
+		stubNavMeasurements(340, 90);
+		render(<ProjectNav />);
+		await screen.findByText("Projektor");
+
+		fireEvent.click(screen.getByRole("button", { name: /more/i }));
+		expect(screen.getByRole("menu")).toBeTruthy();
+		expect(screen.queryByRole("button", { name: /about sprint/i })).toBeNull();
+		expect(screen.queryByRole("button", { name: /about epic/i })).toBeNull();
 	});
 
 	it("closes the menu on Escape and on an outside click", async () => {

--- a/apps/web/src/islands/ProjectNav.tsx
+++ b/apps/web/src/islands/ProjectNav.tsx
@@ -20,8 +20,8 @@ const TABS: Array<{ label: string; path: string; glossaryId?: GlossaryTermId }> 
 	{ label: "Overview", path: "/projects/view" },
 	{ label: "Issues", path: "/issues" },
 	{ label: "Wiki", path: "/wiki" },
-	{ label: "Sprints", path: "/sprints", glossaryId: "sprint" },
-	{ label: "Epics", path: "/epics", glossaryId: "epic" },
+	{ label: "Sprints", path: "/sprints" },
+	{ label: "Epics", path: "/epics" },
 	{ label: "Metrics", path: "/metrics" },
 	{ label: "Feedback", path: "/feedback" },
 ];


### PR DESCRIPTION
## Summary
- Drops the `glossaryId` from the Sprints and Epics entries in `ProjectNav.tsx`'s `TABS` array, so the inline `GlossaryHelp` toggletip icon no longer renders next to those tab labels — in both the direct tab list and the "More" overflow menu (they share the same `tabs` array).
- Adds two tests to `ProjectNav.test.tsx` asserting no `GlossaryHelp` trigger (`About Sprint` / `About Epic`) renders, for the direct list and for the overflow menu.

Ref: PROJ-672

## Test plan
- [x] `pnpm --filter @projektor/web test` — 682 tests pass
- [x] `pnpm turbo type-check --filter=@projektor/web` — 0 errors
- [x] `pnpm biome check` on changed files — clean

https://claude.ai/code/session_01STcgXuVyoV8NBFNkSXTnVT