### PR TITLE
docs: document feedback source lifecycle, abuse controls & triage (PROJ-669)

### DIFF
--- a/apps/docs/src/content/docs/guides/feedback-widget-integration.md
+++ b/apps/docs/src/content/docs/guides/feedback-widget-integration.md
@@ -34,6 +34,53 @@ token is the trust boundary for the integration: it's deliberately public and sa
 ship in client-side code (the same category as a Sentry DSN or a Stripe publishable
 key), narrow in scope (submit-only), and independently revocable/rotatable per source.
 
+`allowedOrigins` is optional and browser-enforced only — a source created with an
+explicit origin list only returns a CORS header for a matching `Origin`; the token
+still authenticates and inserts feedback from any origin either way. Omit it entirely
+for a server-to-server integration where no browser CORS applies.
+
+### Managing a source's lifecycle
+
+Three distinct, independent controls — use the `feedback-sources` REST endpoints or
+the equivalent MCP tools (`update_feedback_source`, `rotate_feedback_source_token`,
+`revoke_feedback_source`):
+
+- **Pause / resume** (`PATCH .../feedback-sources/:id { isActive: false }`) — a
+  reversible kill switch. While paused, submissions to that source's token get a
+  `403`. Flip `isActive` back to `true` to resume with the same token. Use this for a
+  source you suspect is being spammed or misconfigured and want to stop immediately
+  without losing its identity or history.
+- **Rotate** (`POST .../feedback-sources/:id/rotate`) — issues a new token and
+  invalidates the old one immediately, while keeping the source's `id`, name,
+  description, and submission history untouched. Use this if a token leaks.
+- **Revoke** (`DELETE .../feedback-sources/:id`) — permanently kills the source.
+  History is retained for traceability, but it can never accept another submission;
+  create a new source to replace it.
+
+### Abuse controls
+
+`POST /api/feedback/submit` has its own, source-specific defenses, independent of the
+authenticated API's rate limits:
+
+- **Dual-keyed rate limiting** — both the source's token and the caller's IP are
+  rate-limited independently; either tripping returns `429`.
+- **Per-source CORS allow-list** (`allowedOrigins`, above) — a courtesy signal for
+  browser embeds, not an access-control gate.
+- **The lifecycle controls above** double as abuse levers — pause a source instantly,
+  or rotate/revoke its token if it's actually compromised.
+
+Cloudflare Turnstile / bot-check was considered and deferred; not part of this v1.
+
+### Cloudflare Access prerequisite (self-hosted instances)
+
+If your projektor instance sits behind a Cloudflare Zero Trust Access Application at
+the edge (the default posture for the whole hostname), `POST /api/feedback/submit`
+must be excluded from it — a path-scoped bypass policy, or a separate Access
+Application scoped to just this path — before real external/anonymous traffic can
+reach the endpoint. This is infrastructure configuration in your deploy setup, not
+application code; confirm it's in place before advertising a feedback source as live
+to real end users.
+
 ## 2. Submit feedback from your site
 
 ```ts
@@ -109,7 +156,19 @@ await submitFeedback("https://your-projektor-instance/api/feedback/submit", toke
 
 Submitted feedback shows up on the project's Feedback page
 (`/feedback/?projectId=<projectId>`), where workspace owners/admins can filter it by
-status/source, mark it reviewed, or convert it directly into an issue.
+status/source, mark it reviewed (individually or via multi-select bulk actions), or
+convert it directly into an issue. A submission's `sourceUrl` query-string params (if
+any) render as an expandable context panel — useful for passing app-specific state
+(e.g. which generated content the feedback is about) without projektor needing to
+know what the params mean.
+
+The same read/triage actions (`list_feedback`, `update_feedback_status`,
+`convert_feedback_to_issue`, and their bulk equivalents) are landing as MCP tools so
+an agent can triage conversationally instead of using the web UI; until then, use the
+REST endpoints (`GET`/`PATCH .../feedback`, `POST .../feedback/:id/convert-to-issue`,
+`POST .../feedback/bulk-mark-reviewed`, `POST .../feedback/bulk-convert-to-issue`) or
+the web UI. Feedback source *management* (create/list/update/rotate/revoke, used
+above) already has full MCP parity.
 
 ## See also
 

--- a/apps/docs/src/content/docs/guides/feedback-widget-integration.md
+++ b/apps/docs/src/content/docs/guides/feedback-widget-integration.md
@@ -163,12 +163,11 @@ any) render as an expandable context panel — useful for passing app-specific s
 know what the params mean.
 
 The same read/triage actions (`list_feedback`, `update_feedback_status`,
-`convert_feedback_to_issue`, and their bulk equivalents) are landing as MCP tools so
-an agent can triage conversationally instead of using the web UI; until then, use the
-REST endpoints (`GET`/`PATCH .../feedback`, `POST .../feedback/:id/convert-to-issue`,
-`POST .../feedback/bulk-mark-reviewed`, `POST .../feedback/bulk-convert-to-issue`) or
-the web UI. Feedback source *management* (create/list/update/rotate/revoke, used
-above) already has full MCP parity.
+`convert_feedback_to_issue`) are also available as MCP tools, so an agent can triage
+conversationally instead of using the web UI. Their bulk equivalents are REST-only for
+now (`POST .../feedback/bulk-mark-reviewed`, `POST .../feedback/bulk-convert-to-issue`);
+use those endpoints or the web UI for bulk triage. Feedback source *management*
+(create/list/update/rotate/revoke, used above) already has full MCP parity too.
 
 ## See also
 

--- a/scripts/gen-feedback-example-page.ts
+++ b/scripts/gen-feedback-example-page.ts
@@ -153,12 +153,11 @@ any) render as an expandable context panel — useful for passing app-specific s
 know what the params mean.
 
 The same read/triage actions (\`list_feedback\`, \`update_feedback_status\`,
-\`convert_feedback_to_issue\`, and their bulk equivalents) are landing as MCP tools so
-an agent can triage conversationally instead of using the web UI; until then, use the
-REST endpoints (\`GET\`/\`PATCH .../feedback\`, \`POST .../feedback/:id/convert-to-issue\`,
-\`POST .../feedback/bulk-mark-reviewed\`, \`POST .../feedback/bulk-convert-to-issue\`) or
-the web UI. Feedback source *management* (create/list/update/rotate/revoke, used
-above) already has full MCP parity.
+\`convert_feedback_to_issue\`) are also available as MCP tools, so an agent can triage
+conversationally instead of using the web UI. Their bulk equivalents are REST-only for
+now (\`POST .../feedback/bulk-mark-reviewed\`, \`POST .../feedback/bulk-convert-to-issue\`);
+use those endpoints or the web UI for bulk triage. Feedback source *management*
+(create/list/update/rotate/revoke, used above) already has full MCP parity too.
 
 ## See also
 

--- a/scripts/gen-feedback-example-page.ts
+++ b/scripts/gen-feedback-example-page.ts
@@ -73,6 +73,53 @@ token is the trust boundary for the integration: it's deliberately public and sa
 ship in client-side code (the same category as a Sentry DSN or a Stripe publishable
 key), narrow in scope (submit-only), and independently revocable/rotatable per source.
 
+\`allowedOrigins\` is optional and browser-enforced only — a source created with an
+explicit origin list only returns a CORS header for a matching \`Origin\`; the token
+still authenticates and inserts feedback from any origin either way. Omit it entirely
+for a server-to-server integration where no browser CORS applies.
+
+### Managing a source's lifecycle
+
+Three distinct, independent controls — use the \`feedback-sources\` REST endpoints or
+the equivalent MCP tools (\`update_feedback_source\`, \`rotate_feedback_source_token\`,
+\`revoke_feedback_source\`):
+
+- **Pause / resume** (\`PATCH .../feedback-sources/:id { isActive: false }\`) — a
+  reversible kill switch. While paused, submissions to that source's token get a
+  \`403\`. Flip \`isActive\` back to \`true\` to resume with the same token. Use this for a
+  source you suspect is being spammed or misconfigured and want to stop immediately
+  without losing its identity or history.
+- **Rotate** (\`POST .../feedback-sources/:id/rotate\`) — issues a new token and
+  invalidates the old one immediately, while keeping the source's \`id\`, name,
+  description, and submission history untouched. Use this if a token leaks.
+- **Revoke** (\`DELETE .../feedback-sources/:id\`) — permanently kills the source.
+  History is retained for traceability, but it can never accept another submission;
+  create a new source to replace it.
+
+### Abuse controls
+
+\`POST /api/feedback/submit\` has its own, source-specific defenses, independent of the
+authenticated API's rate limits:
+
+- **Dual-keyed rate limiting** — both the source's token and the caller's IP are
+  rate-limited independently; either tripping returns \`429\`.
+- **Per-source CORS allow-list** (\`allowedOrigins\`, above) — a courtesy signal for
+  browser embeds, not an access-control gate.
+- **The lifecycle controls above** double as abuse levers — pause a source instantly,
+  or rotate/revoke its token if it's actually compromised.
+
+Cloudflare Turnstile / bot-check was considered and deferred; not part of this v1.
+
+### Cloudflare Access prerequisite (self-hosted instances)
+
+If your projektor instance sits behind a Cloudflare Zero Trust Access Application at
+the edge (the default posture for the whole hostname), \`POST /api/feedback/submit\`
+must be excluded from it — a path-scoped bypass policy, or a separate Access
+Application scoped to just this path — before real external/anonymous traffic can
+reach the endpoint. This is infrastructure configuration in your deploy setup, not
+application code; confirm it's in place before advertising a feedback source as live
+to real end users.
+
 ## 2. Submit feedback from your site
 
 \`\`\`ts
@@ -99,7 +146,19 @@ await submitFeedback("https://your-projektor-instance/api/feedback/submit", toke
 
 Submitted feedback shows up on the project's Feedback page
 (\`/feedback/?projectId=<projectId>\`), where workspace owners/admins can filter it by
-status/source, mark it reviewed, or convert it directly into an issue.
+status/source, mark it reviewed (individually or via multi-select bulk actions), or
+convert it directly into an issue. A submission's \`sourceUrl\` query-string params (if
+any) render as an expandable context panel — useful for passing app-specific state
+(e.g. which generated content the feedback is about) without projektor needing to
+know what the params mean.
+
+The same read/triage actions (\`list_feedback\`, \`update_feedback_status\`,
+\`convert_feedback_to_issue\`, and their bulk equivalents) are landing as MCP tools so
+an agent can triage conversationally instead of using the web UI; until then, use the
+REST endpoints (\`GET\`/\`PATCH .../feedback\`, \`POST .../feedback/:id/convert-to-issue\`,
+\`POST .../feedback/bulk-mark-reviewed\`, \`POST .../feedback/bulk-convert-to-issue\`) or
+the web UI. Feedback source *management* (create/list/update/rotate/revoke, used
+above) already has full MCP parity.
 
 ## See also
 


### PR DESCRIPTION
## Summary
- Extends the existing `feedback-widget-integration` docs-site guide with source lifecycle management (pause/resume via `isActive`, rotate, revoke), the submit endpoint's abuse controls (dual-keyed rate limiting, per-source CORS), and the Cloudflare Access edge-bypass prerequisite for self-hosted instances.
- Expands the triage section to mention bulk actions, the `sourceUrl` context panel, and the incoming PROJ-668 read/triage MCP tools (not blocking on them).
- Edits `scripts/gen-feedback-example-page.ts` (the generator source of truth for the guide) rather than the generated `.md` file directly, then regenerates via `pnpm gen:docs`.

Originally drafted this content as a new projektor wiki page per PROJ-669's acceptance criteria, then redirected per user feedback to live on the public docs site instead — the wiki now just links out to this guide, and the wiki page has been deleted.

## Test plan
- [x] `pnpm gen:docs` — no drift after regeneration
- [x] `pnpm biome check --changed` — clean
- [x] `pnpm turbo type-check` — passes
- [x] `pnpm --filter @projektor/db test` — passes
- [x] `pnpm --filter @projektor/api test:coverage` — 1291/1292 pass; the one failure (`custom-fields.test.ts` D1-chunking timeout) reproduces only under full-suite load and passes in isolation (35/35) — pre-existing flake, unrelated to this docs-only change
- [x] `pnpm --filter @projektor/web test:coverage` — passes
- [x] `pnpm --filter @projektor/web build` — passes
- [x] `pnpm --filter @projektor/docs build` — passes, `starlight-links-validator` confirms all internal links valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UPwV66cYXAs6gL5S3HvAj