### PR TITLE
feat: archive projects to hide them from the main view (PROJ-649)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -239,8 +239,9 @@ app.use("/api/workspaces/:slug/*", authMiddleware, workspaceMiddleware);
 // Cross-workspace project list — auth only, no workspace context needed
 app.get("/api/projects", authMiddleware, etagMiddleware, async (c) => {
 	const user = c.get("user") as { id: string };
+	const includeArchived = c.req.query("includeArchived") === "true";
 	try {
-		return c.json(await listProjectsAcrossWorkspaces(user.id, c.env.DB));
+		return c.json(await listProjectsAcrossWorkspaces(user.id, c.env.DB, includeArchived));
 	} catch (e) {
 		return serviceErrToResponse(c, e);
 	}

--- a/apps/api/src/mcp/projects.ts
+++ b/apps/api/src/mcp/projects.ts
@@ -11,10 +11,19 @@ import type { ServiceCtx } from "../services/types";
 export const projectsTools: MCPTool[] = [
 	{
 		name: "list_projects",
-		description: "List all projects in the workspace",
-		inputSchema: { type: "object", properties: {} },
-		async handler(_input, ctx) {
-			return listProjects(ctx as ServiceCtx);
+		description: "List projects in the workspace. Archived projects are excluded by default.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				includeArchived: {
+					type: "boolean",
+					description: "Include archived projects in the results (default false)",
+				},
+			},
+		},
+		async handler(input, ctx) {
+			const { includeArchived } = (input ?? {}) as { includeArchived?: boolean };
+			return listProjects(ctx as ServiceCtx, { includeArchived });
 		},
 	},
 	{
@@ -51,7 +60,8 @@ export const projectsTools: MCPTool[] = [
 	},
 	{
 		name: "update_project",
-		description: "Update a project name or description (owner/admin only)",
+		description:
+			"Update a project name, description, or archived state (owner/admin only). Set archived: true to hide it from the default project list, false to restore it.",
 		inputSchema: {
 			type: "object",
 			required: ["id"],
@@ -59,6 +69,7 @@ export const projectsTools: MCPTool[] = [
 				id: { type: "string", description: "Project ID" },
 				name: { type: "string", description: "New project name" },
 				description: { type: "string", description: "New description" },
+				archived: { type: "boolean", description: "Archive (true) or unarchive (false)" },
 			},
 		},
 		async handler(input, ctx) {

--- a/apps/api/src/schemas/projects.ts
+++ b/apps/api/src/schemas/projects.ts
@@ -15,4 +15,6 @@ export const CreateProjectSchema = z.object({
 	agentWipLimit: z.number().int().min(1).max(100).nullable().optional(),
 });
 
-export const UpdateProjectSchema = CreateProjectSchema.partial();
+export const UpdateProjectSchema = CreateProjectSchema.partial().extend({
+	archived: z.boolean().optional(),
+});

--- a/apps/api/src/services/projects.ts
+++ b/apps/api/src/services/projects.ts
@@ -1,5 +1,5 @@
 import { drizzle, schema } from "@projektor/db";
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, isNull } from "drizzle-orm";
 import { IdSchema } from "../schemas/common";
 import { CreateProjectSchema, UpdateProjectSchema } from "../schemas/projects";
 import { effectiveProjectRole, isWorkspaceAdmin, visibleProjectPredicate } from "./access";
@@ -11,31 +11,41 @@ import type { ServiceCtx } from "./types";
 const WS_META_TTL = 60;
 const PROJECTS_CACHE_KEY = (workspaceId: string) => `ws-meta:${workspaceId}:projects`;
 
-export async function listProjects(ctx: ServiceCtx) {
+export async function listProjects(ctx: ServiceCtx, opts: { includeArchived?: boolean } = {}) {
 	const orm = drizzle(ctx.db, { schema });
 
-	// PROJ-311: owner/admin see every project and share the workspace cache. A
-	// non-admin sees only granted projects; that set is per-user and access can be
-	// revoked at any time, so it is computed per-request (uncached) to keep the
-	// "effective on next request" guarantee — no stale project can linger.
+	// PROJ-311: owner/admin share the cached workspace list; others get an uncached per-user set.
 	const visible = visibleProjectPredicate(ctx, schema.projects.id);
+	const includeArchived = opts.includeArchived ?? false;
 	if (!visible) {
+		if (includeArchived) {
+			return orm
+				.select()
+				.from(schema.projects)
+				.where(eq(schema.projects.workspaceId, ctx.workspaceId))
+				.orderBy(asc(schema.projects.name));
+		}
 		const cacheKey = PROJECTS_CACHE_KEY(ctx.workspaceId);
 		const cached = await cache.get<unknown[]>(ctx.kv, cacheKey);
 		if (cached) return cached;
 		const result = await orm
 			.select()
 			.from(schema.projects)
-			.where(eq(schema.projects.workspaceId, ctx.workspaceId))
+			.where(
+				and(eq(schema.projects.workspaceId, ctx.workspaceId), isNull(schema.projects.archivedAt))
+			)
 			.orderBy(asc(schema.projects.name));
 		await cache.set(ctx.kv, cacheKey, result, WS_META_TTL);
 		return result;
 	}
 
+	const conditions = [eq(schema.projects.workspaceId, ctx.workspaceId), visible];
+	if (!includeArchived) conditions.push(isNull(schema.projects.archivedAt));
+
 	return orm
 		.select()
 		.from(schema.projects)
-		.where(and(eq(schema.projects.workspaceId, ctx.workspaceId), visible))
+		.where(and(...conditions))
 		.orderBy(asc(schema.projects.name));
 }
 
@@ -49,13 +59,15 @@ export interface ProjectSummary {
 	workspace_name: string;
 	workspace_slug: string;
 	open_issue_count: number;
+	archived_at: number | null;
 	created_at: number;
 	updated_at: number;
 }
 
 export async function listProjectsAcrossWorkspaces(
 	userId: string,
-	db: D1Database
+	db: D1Database,
+	includeArchived = false
 ): Promise<ProjectSummary[]> {
 	const rows = await db
 		.prepare(
@@ -65,6 +77,7 @@ export async function listProjectsAcrossWorkspaces(
         p.key,
         p.slug,
         p.description,
+        p.archived_at,
         p.created_at,
         p.updated_at,
         w.id   AS workspace_id,
@@ -78,12 +91,13 @@ export async function listProjectsAcrossWorkspaces(
       LEFT JOIN issues i        ON i.project_id = p.id
       -- PROJ-311: in each workspace the user sees all projects if owner/admin there,
       -- otherwise only projects their groups grant (indexed EXISTS).
-      WHERE wm.role IN ('owner','admin')
+      WHERE (wm.role IN ('owner','admin')
          OR EXISTS (
               SELECT 1 FROM user_group_members ugm
               JOIN group_project_grants gpg ON gpg.group_id = ugm.group_id
-              WHERE ugm.user_id = ? AND gpg.project_id = p.id)
-      GROUP BY p.id, p.name, p.key, p.slug, p.description, p.created_at, p.updated_at,
+              WHERE ugm.user_id = ? AND gpg.project_id = p.id))
+        ${includeArchived ? "" : "AND p.archived_at IS NULL"}
+      GROUP BY p.id, p.name, p.key, p.slug, p.description, p.archived_at, p.created_at, p.updated_at,
                w.id, w.name, w.slug
       ORDER BY w.slug, p.name`
 		)
@@ -198,16 +212,18 @@ export async function updateProject(ctx: ServiceCtx, id: string, input: unknown)
 	const parsed = UpdateProjectSchema.safeParse(input);
 	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
 
+	const now = Math.floor(Date.now() / 1000);
+
 	const setObj: Record<string, unknown> = {};
 	if (parsed.data.name !== undefined) setObj.name = parsed.data.name;
 	if (parsed.data.key !== undefined) setObj.key = parsed.data.key;
 	if (parsed.data.description !== undefined) setObj.description = parsed.data.description;
 	if (parsed.data.agentWipLimit !== undefined) setObj.agentWipLimit = parsed.data.agentWipLimit;
+	if (parsed.data.archived !== undefined) setObj.archivedAt = parsed.data.archived ? now : null;
 
 	if (Object.keys(setObj).length === 0)
 		throw new ValidationError({ formErrors: ["Nothing to update"], fieldErrors: {} });
 
-	const now = Math.floor(Date.now() / 1000);
 	setObj.updatedAt = now;
 
 	const orm = drizzle(ctx.db, { schema });

--- a/apps/api/src/test/migrations.ts
+++ b/apps/api/src/test/migrations.ts
@@ -54,6 +54,7 @@ import m0050 from "../../../../packages/db/migrations/0050_wiki_slug_slash_backf
 import m0051 from "../../../../packages/db/migrations/0051_wiki_trash.sql?raw";
 import m0052 from "../../../../packages/db/migrations/0052_wiki_trash_batch_id.sql?raw";
 import m0053 from "../../../../packages/db/migrations/0053_backfill_templates_page_fts.sql?raw";
+import m0054 from "../../../../packages/db/migrations/0054_project_archived_at.sql?raw";
 
 export const MIGRATIONS = [
 	m0000,
@@ -110,4 +111,5 @@ export const MIGRATIONS = [
 	m0051,
 	m0052,
 	m0053,
+	m0054,
 ];

--- a/apps/api/src/test/projects.test.ts
+++ b/apps/api/src/test/projects.test.ts
@@ -1,4 +1,4 @@
-import { SELF } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
 import { authHeaders, type JsonRpcError, type JsonRpcResult, seedWorkspaceRoles } from "./helpers";
 
@@ -214,6 +214,53 @@ describe("Projects REST", () => {
 		expect(patchRes.status).toBe(403);
 	});
 
+	it("PATCH /api/projects/:id archives and unarchives a project", async () => {
+		const createRes = await SELF.fetch("http://localhost/api/projects", {
+			method: "POST",
+			headers: ownerHeaders,
+			body: JSON.stringify({ name: "Archivable", key: "ARCH1" }),
+		});
+		const { id } = (await createRes.json()) as { id: string };
+
+		const archiveRes = await SELF.fetch(`http://localhost/api/projects/${id}`, {
+			method: "PATCH",
+			headers: ownerHeaders,
+			body: JSON.stringify({ archived: true }),
+		});
+		expect(archiveRes.status).toBe(200);
+
+		const listRes = await SELF.fetch("http://localhost/api/projects", { headers: ownerHeaders });
+		const keys = ((await listRes.json()) as Array<{ key: string }>).map((p) => p.key);
+		expect(keys).not.toContain("ARCH1");
+
+		const includeArchivedRes = await SELF.fetch(
+			"http://localhost/api/projects?includeArchived=true",
+			{ headers: ownerHeaders }
+		);
+		const withArchived = (await includeArchivedRes.json()) as Array<{
+			key: string;
+			archived_at: number | null;
+		}>;
+		const archived = withArchived.find((p) => p.key === "ARCH1");
+		expect(archived).toBeTruthy();
+		expect(archived!.archived_at).not.toBeNull();
+
+		await env.DB.prepare("DELETE FROM rate_limit").run();
+
+		const unarchiveRes = await SELF.fetch(`http://localhost/api/projects/${id}`, {
+			method: "PATCH",
+			headers: ownerHeaders,
+			body: JSON.stringify({ archived: false }),
+		});
+		expect(unarchiveRes.status).toBe(200);
+
+		const afterUnarchive = await SELF.fetch("http://localhost/api/projects", {
+			headers: ownerHeaders,
+		});
+		const afterKeys = ((await afterUnarchive.json()) as Array<{ key: string }>).map((p) => p.key);
+		expect(afterKeys).toContain("ARCH1");
+	});
+
 	it("DELETE /api/projects/:id works for owner", async () => {
 		const createRes = await SELF.fetch("http://localhost/api/projects", {
 			method: "POST",
@@ -417,6 +464,48 @@ describe("Projects MCP", () => {
 		const mcpProjects = JSON.parse(mcpRes.result.content[0].text) as Array<{ key: string }>;
 
 		expect(restProjects.map((p) => p.key)).toEqual(mcpProjects.map((p) => p.key));
+	});
+
+	it("update_project archives a project and list_projects excludes it by default", async () => {
+		const createRes = await mcpCall(
+			workspaceId,
+			"create_project",
+			{ name: "MCP Archivable", key: "MARCH" },
+			ownerHeaders
+		);
+		const { id } = JSON.parse(
+			(createRes as JsonRpcResult<{ content: Array<{ text: string }> }>).result.content[0].text
+		) as { id: string };
+
+		const updateRes = await mcpCall(
+			workspaceId,
+			"update_project",
+			{ id, archived: true },
+			ownerHeaders
+		);
+		expect(isMcpError(updateRes)).toBe(false);
+
+		const listRes = (await mcpCall<{ content: Array<{ text: string }> }>(
+			workspaceId,
+			"list_projects",
+			{},
+			ownerHeaders
+		)) as JsonRpcResult<{ content: Array<{ text: string }> }>;
+		const keys = (JSON.parse(listRes.result.content[0].text) as Array<{ key: string }>).map(
+			(p) => p.key
+		);
+		expect(keys).not.toContain("MARCH");
+
+		const includeArchivedRes = (await mcpCall<{ content: Array<{ text: string }> }>(
+			workspaceId,
+			"list_projects",
+			{ includeArchived: true },
+			ownerHeaders
+		)) as JsonRpcResult<{ content: Array<{ text: string }> }>;
+		const includeArchivedKeys = (
+			JSON.parse(includeArchivedRes.result.content[0].text) as Array<{ key: string }>
+		).map((p) => p.key);
+		expect(includeArchivedKeys).toContain("MARCH");
 	});
 
 	it("REST create_project and MCP create_project enforce the same role guard", async () => {

--- a/apps/docs/src/content/docs/agents/tool-catalog.md
+++ b/apps/docs/src/content/docs/agents/tool-catalog.md
@@ -95,10 +95,10 @@ running server.
 
 | Tool | Description |
 |------|-------------|
-| `list_projects` | List all projects in the workspace |
+| `list_projects` | List projects in the workspace. Archived projects are excluded by default. |
 | `create_project` | Create a new project in the workspace |
 | `get_project` | Get a project by ID |
-| `update_project` | Update a project name or description (owner/admin only) |
+| `update_project` | Update a project name, description, or archived state (owner/admin only). Set archived: true to hide it from the default project list, false to restore it. |
 | `delete_project` | Delete a project and all its issues (owner only) |
 
 ### Project activity

--- a/apps/web/src/islands/ProjectLanding.test.tsx
+++ b/apps/web/src/islands/ProjectLanding.test.tsx
@@ -4,7 +4,7 @@
 // and its wiki pages in parallel via raw fetch + buildHeaders.
 // loading starts true, so the loading state appears immediately.
 // The pattern: set the URL, override the stub, await findBy*.
-import { render, screen } from "@testing-library/preact";
+import { fireEvent, render, screen } from "@testing-library/preact";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ProjectLanding from "./ProjectLanding";
 
@@ -14,6 +14,7 @@ const PROJECT = {
 	key: "PROJ",
 	slug: "projektor",
 	description: "An issue tracker.",
+	archivedAt: null,
 	workspaceId: "w1",
 	createdAt: 0,
 	updatedAt: 0,
@@ -40,25 +41,28 @@ const WIKI_PAGE = {
 function mockFetchProject(
 	issues: readonly (typeof ISSUE)[] = [ISSUE],
 	wiki: readonly unknown[] = [],
-	flowMetrics: unknown = { throughputOverTime: [], cfdOverTime: [] }
+	flowMetrics: unknown = { throughputOverTime: [], cfdOverTime: [] },
+	project: unknown = PROJECT
 ) {
-	vi.stubGlobal(
-		"fetch",
-		vi.fn().mockImplementation((url: string) => {
-			const u = String(url);
-			if (u.includes("/api/issues")) {
-				return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: issues }) });
-			}
-			if (u.includes("/api/wiki")) {
-				return Promise.resolve({ ok: true, json: () => Promise.resolve(wiki) });
-			}
-			if (u.includes("/flow-metrics")) {
-				return Promise.resolve({ ok: true, json: () => Promise.resolve(flowMetrics) });
-			}
-			// project fetch
-			return Promise.resolve({ ok: true, json: () => Promise.resolve(PROJECT) });
-		})
-	);
+	const fetchMock = vi.fn().mockImplementation((url: string, opts?: RequestInit) => {
+		const u = String(url);
+		if (u.includes("/api/issues")) {
+			return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: issues }) });
+		}
+		if (u.includes("/api/wiki")) {
+			return Promise.resolve({ ok: true, json: () => Promise.resolve(wiki) });
+		}
+		if (u.includes("/flow-metrics")) {
+			return Promise.resolve({ ok: true, json: () => Promise.resolve(flowMetrics) });
+		}
+		if (opts?.method === "PATCH") {
+			return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) });
+		}
+		// project fetch
+		return Promise.resolve({ ok: true, json: () => Promise.resolve(project) });
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	return fetchMock;
 }
 
 beforeEach(() => {
@@ -154,5 +158,31 @@ describe("ProjectLanding", () => {
 		await screen.findByRole("heading", { name: "Projektor" });
 		const nav = screen.getByRole("navigation");
 		expect(nav.textContent?.trim()).toBe("Projects/Projektor");
+	});
+});
+
+describe("ProjectLanding — archive/unarchive (PROJ-649)", () => {
+	it("shows an Archive button and archives the project on click", async () => {
+		history.replaceState(null, "", "?id=p1");
+		const fetchMock = mockFetchProject([]);
+		render(<ProjectLanding />);
+		await screen.findByRole("heading", { name: "Projektor" });
+
+		const archiveButton = screen.getByRole("button", { name: "Archive" });
+		fireEvent.click(archiveButton);
+
+		expect(await screen.findByRole("button", { name: "Unarchive" })).toBeTruthy();
+		expect(screen.getByText("Archived")).toBeTruthy();
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/projects/p1",
+			expect.objectContaining({ method: "PATCH", body: JSON.stringify({ archived: true }) })
+		);
+	});
+
+	it("shows Unarchive for an already-archived project", async () => {
+		history.replaceState(null, "", "?id=p1");
+		mockFetchProject([], [], undefined, { ...PROJECT, archivedAt: 1700000000 });
+		render(<ProjectLanding />);
+		expect(await screen.findByRole("button", { name: "Unarchive" })).toBeTruthy();
 	});
 });

--- a/apps/web/src/islands/ProjectLanding.tsx
+++ b/apps/web/src/islands/ProjectLanding.tsx
@@ -11,6 +11,7 @@ interface Project {
 	key: string;
 	slug: string | null;
 	description: string | null;
+	archivedAt: number | null;
 	workspaceId: string;
 	createdAt: number;
 	updatedAt: number;
@@ -365,6 +366,25 @@ export default function ProjectLanding({ workspaceSlug }: Props) {
 		setProject((prev) => (prev ? { ...prev, description } : prev))
 	);
 
+	const [archiving, setArchiving] = useState(false);
+	const toggleArchived = useCallback(async () => {
+		if (!project || archiving) return;
+		setArchiving(true);
+		try {
+			const archived = project.archivedAt == null;
+			await apiFetch(`/api/projects/${project.id}`, {
+				method: "PATCH",
+				workspaceSlug,
+				body: { archived },
+			});
+			setProject((prev) =>
+				prev ? { ...prev, archivedAt: archived ? Math.floor(Date.now() / 1000) : null } : prev
+			);
+		} finally {
+			setArchiving(false);
+		}
+	}, [project, archiving, workspaceSlug]);
+
 	const fetchData = useCallback(
 		async (id: string) => {
 			setLoading(true);
@@ -412,6 +432,16 @@ export default function ProjectLanding({ workspaceSlug }: Props) {
 				<div class="flex items-center gap-3 mb-2">
 					<h1 class="m-0 text-2xl font-bold text-text-base">{project.name}</h1>
 					<span class={KEY_BADGE_CLASS}>{project.key}</span>
+					{project.archivedAt != null && <span class={KEY_BADGE_CLASS}>Archived</span>}
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						onClick={toggleArchived}
+						disabled={archiving}
+					>
+						{project.archivedAt != null ? "Unarchive" : "Archive"}
+					</Button>
 				</div>
 
 				{/* Editable description */}

--- a/apps/web/src/islands/ProjectList.test.tsx
+++ b/apps/web/src/islands/ProjectList.test.tsx
@@ -4,7 +4,7 @@
 // populated states. The pattern: override the default fetch stub from setup.ts per
 // case with vi.stubGlobal, then await findBy* for the async state transition.
 // A never-resolving fetch lets us assert the synchronous loading state.
-import { render, screen } from "@testing-library/preact";
+import { fireEvent, render, screen } from "@testing-library/preact";
 import { describe, expect, it, vi } from "vitest";
 import ProjectList from "./ProjectList";
 
@@ -39,6 +39,7 @@ const PROJECT = {
 	workspace_name: "WS",
 	workspace_slug: "ws",
 	open_issue_count: 3,
+	archived_at: null,
 	created_at: 0,
 	updated_at: 0,
 };
@@ -68,6 +69,35 @@ describe("ProjectList", () => {
 		vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
 		render(<ProjectList />);
 		expect(await screen.findByText(/Failed to load projects/i)).toBeTruthy();
+	});
+});
+
+describe("ProjectList — archived projects (PROJ-649)", () => {
+	it("does not request archived projects by default", async () => {
+		const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([]) });
+		vi.stubGlobal("fetch", fetchMock);
+		render(<ProjectList />);
+		await screen.findByText(/No projects yet/i);
+		expect(fetchMock).toHaveBeenCalledWith("/api/projects", expect.anything());
+	});
+
+	it("refetches with includeArchived when the toggle is checked", async () => {
+		const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([]) });
+		vi.stubGlobal("fetch", fetchMock);
+		render(<ProjectList />);
+		await screen.findByText(/No projects yet/i);
+
+		fireEvent.click(screen.getByLabelText(/Show archived/i));
+
+		await screen.findByText(/No projects yet/i);
+		expect(fetchMock).toHaveBeenCalledWith("/api/projects?includeArchived=true", expect.anything());
+	});
+
+	it("shows an Archived badge for an archived project", async () => {
+		mockFetchOk([{ ...PROJECT, archived_at: 1700000000 }]);
+		render(<ProjectList />);
+		expect(await screen.findByText("Projektor")).toBeTruthy();
+		expect(screen.getByText("Archived")).toBeTruthy();
 	});
 });
 

--- a/apps/web/src/islands/ProjectList.tsx
+++ b/apps/web/src/islands/ProjectList.tsx
@@ -15,6 +15,7 @@ interface Project {
 	workspace_name: string;
 	workspace_slug: string;
 	open_issue_count: number;
+	archived_at: number | null;
 	created_at: number;
 	updated_at: number;
 }
@@ -224,6 +225,7 @@ function useProjectCreateForm(workspaceSlug: string | undefined, onCreated: (p: 
 				key: created.key,
 				slug: created.slug,
 				description: description ?? null,
+				archived_at: null,
 				workspace_id: "",
 				workspace_name: "",
 				workspace_slug: workspaceSlug ?? "",
@@ -260,6 +262,7 @@ function ProjectCard({ project }: { project: Project }) {
 	const count = project.open_issue_count ?? 0;
 	const countLabel =
 		count === 0 ? "No open issues" : `${count} open issue${count !== 1 ? "s" : ""}`;
+	const archived = project.archived_at != null;
 
 	return (
 		<a
@@ -268,11 +271,16 @@ function ProjectCard({ project }: { project: Project }) {
 					? `/projects/view/${encodeURIComponent(project.slug)}`
 					: `/projects/view?id=${project.id}`
 			}
-			class={PROJECT_CARD_CLASS}
+			class={`${PROJECT_CARD_CLASS}${archived ? " opacity-60" : ""}`}
 		>
 			<div class="flex items-center gap-2">
 				<span class="font-bold text-[var(--text)] text-base">{project.name}</span>
 				<span class={KEY_BADGE_CLASS}>{project.key}</span>
+				{archived && (
+					<span class={KEY_BADGE_CLASS} style={{ color: "var(--text-muted)" }}>
+						Archived
+					</span>
+				)}
 			</div>
 			<span class="text-xs text-[var(--text-muted)]">{countLabel}</span>
 			{project.description && (
@@ -311,16 +319,18 @@ export default function ProjectList({ workspaceSlug }: { workspaceSlug?: string 
 	const [projects, setProjects] = useState<Project[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
+	const [showArchived, setShowArchived] = useState(false);
 
 	useEffect(() => {
 		setLoading(true);
 		setError(null);
 
-		apiFetch<Project[]>("/api/projects", { workspaceSlug })
+		const path = showArchived ? "/api/projects?includeArchived=true" : "/api/projects";
+		apiFetch<Project[]>(path, { workspaceSlug })
 			.then((data) => setProjects(Array.isArray(data) ? data : []))
 			.catch((e) => setError(String(e)))
 			.finally(() => setLoading(false));
-	}, [workspaceSlug]);
+	}, [workspaceSlug, showArchived]);
 
 	const gate = useAccessGate(workspaceSlug);
 	const isPublicViewer = usePublicViewer(workspaceSlug);
@@ -340,7 +350,15 @@ export default function ProjectList({ workspaceSlug }: { workspaceSlug?: string 
 
 	return (
 		<>
-			<div class="flex justify-end mb-4">
+			<div class="flex justify-between items-center mb-4">
+				<label class="flex items-center gap-1.5 text-xs text-[var(--text-muted)]">
+					<input
+						type="checkbox"
+						checked={showArchived}
+						onChange={(e) => setShowArchived((e.target as HTMLInputElement).checked)}
+					/>
+					Show archived
+				</label>
 				{isPublicViewer ? (
 					<p class="text-xs text-[var(--text-muted)] m-0">
 						Read-only demo — projects can't be created here.

--- a/packages/db/migrations/0054_project_archived_at.sql
+++ b/packages/db/migrations/0054_project_archived_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE projects ADD COLUMN archived_at INTEGER;

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -20,6 +20,7 @@ export const projects = sqliteTable(
 		// by a partial index (see migrations/0035_project_slug.sql) so NULLs don't
 		// collide.
 		slug: text("slug"),
+		archivedAt: integer("archived_at"),
 	},
 	(t) => ({
 		wsIdx: index("projects_workspace_idx").on(t.workspaceId),


### PR DESCRIPTION
## Summary
- Adds a nullable `projects.archived_at` timestamp (migration 0054) — NULL = active.
- `update_project` (REST `PATCH /api/projects/:id` and MCP) accepts `archived: boolean`; `true` stamps `archived_at = now`, `false` clears it.
- Both list paths (`list_projects` MCP tool, workspace-scoped; `GET /api/projects` REST, cross-workspace, used by the web `ProjectList` island) exclude archived projects by default, with an opt-in `includeArchived` flag/query param to see them.
- `ProjectList` gets a "Show archived" checkbox and archived cards render muted with an "Archived" badge.
- `ProjectLanding` (project detail page) gets an Archive/Unarchive button in the header.

Design decisions and rationale are logged as a comment on PROJ-649 (agent-authored, no prior spec existed on the ticket).

## Test plan
- [x] `pnpm --filter @projektor/db test`
- [x] `pnpm --filter @projektor/api test:coverage` (1301 tests, includes new REST + MCP archive/unarchive tests with rate-limit-safe request budgeting)
- [x] `pnpm --filter @projektor/web test:coverage` (685 tests, includes new ProjectList/ProjectLanding archive tests)
- [x] `pnpm --filter @projektor/web build`
- [x] `pnpm --filter @projektor/docs build`
- [x] `pnpm lint`, `pnpm turbo type-check`
- [x] `pnpm gen:docs` — no diff after commit (MCP tool catalog regenerated for the new `archived`/`includeArchived` params)

Refs: PROJ-649

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FmuoUjhZ3bWbsek6Dtu3yg