### PR TITLE
feat: ship Idea Discovery as a default reusable playbook (PROJ-667)

### DIFF
--- a/apps/api/src/services/playbook-content.ts
+++ b/apps/api/src/services/playbook-content.ts
@@ -158,4 +158,82 @@ keeps the others off it. That is why the composed directive reports the project'
 WIP limit, the cap on how many tickets one worker may hold at a time.
 `,
 	},
+	{
+		name: "idea-discovery",
+		title: "Idea discovery",
+		description:
+			"A domain-agnostic research process for turning a domain description into a sequenced, " +
+			"falsification-tested list of buildable product ideas.",
+		whenToUse:
+			'Exploring a new domain or application area for viable products — "what could we build ' +
+			'in X", "find gaps in Y" — before committing to any single idea. Best when the founder is ' +
+			"solo/technical, favours free data sources, and needs a clear distribution channel per idea.",
+		sidebarOrder: 2,
+		body: `A prompt pattern for taking a one-paragraph domain description and working it through to
+a sequenced, evidence-tested set of product ideas — without reconstructing the process
+from scratch each time.
+
+It's deliberately domain-agnostic: the steps below have been run on maritime data
+businesses, but nothing in them is maritime-specific.
+
+## Getting the directive
+
+\`get_playbook("idea-discovery")\` returns this page verbatim — read it and adapt it by
+hand, filling in the domain description.
+
+## Input
+
+A one-paragraph description of the domain or application area to explore.
+
+## Constraints applied throughout
+
+- **Free/open data sources only** — verify licences permit commercial reuse before relying
+  on a source. A promising idea built on a data source you can't legally use commercially
+  is not a promising idea.
+- **Every idea needs a clear distribution channel** — a press cycle, SEO, an existing
+  community, or a developer channel. An idea with no plausible way to reach users is not
+  worth qualifying further, however novel.
+- **Solo technical founder** — favour products buildable as an app or API on serverless
+  infrastructure. Ideas that need a team, capital, or bespoke infra to stand up don't fit
+  the constraint and should be discarded early, not qualified.
+
+## Steps
+
+Web search at every stage. Pause for a decision at each transition — don't run straight
+through to idea generation without confirming the frontier, assets, and landscape are
+right.
+
+1. **Research frontier** — recent advances (roughly the last 3 years) in the domain's
+   literature. Skip this step entirely if the domain isn't research-driven.
+2. **Assets** — open datasets, records, feeds, and registries available in the domain;
+   their licences; what can be inferred from them beyond their stated purpose.
+3. **Landscape** — incumbents in tiers (raw data providers → enterprise intelligence →
+   vertical tools), with pricing. Note who is served at what price point, and who isn't
+   served at all.
+4. **Gap hypotheses** — propose gaps between what the landscape serves and what the
+   assets/frontier make possible, then actively try to falsify each one with further
+   searches. Report kills explicitly — a dead hypothesis is progress, not a wasted step.
+5. **Idea generation** — batches of roughly 10 ideas. Each idea gets exactly three
+   attributes: novelty, free data source(s) it relies on, and its distribution channel.
+   No idea without all three.
+6. **Qualification** — for ideas on the shortlist: product shape, user story, similar
+   existing products, and the unserved niche it targets. Then pressure-test the
+   load-bearing assumption — usually licensing, legal exposure, or moat — the one
+   assumption that kills the idea if it's wrong.
+7. **Sequencing** — a build order that exploits shared infrastructure across ideas (a
+   dataset pipeline or API client one idea needs is often reusable by the next). Name the
+   cheapest first experiment explicitly.
+
+## Principles
+
+- **Cheap evidence before commitment** — a falsifying search costs minutes; a shipped
+  product costs weeks. Spend the cheap evidence first.
+- **Be honest when a space is saturated** — a landscape step that finds five well-funded
+  incumbents at every price tier is a valid, useful outcome. Don't force a gap that isn't
+  there.
+- **Desk validation is not buyer validation** — qualification and sequencing narrow the
+  field on desk research alone. They are not a substitute for talking to a real buyer
+  before building.
+`,
+	},
 ];

--- a/apps/api/src/test/playbooks.test.ts
+++ b/apps/api/src/test/playbooks.test.ts
@@ -21,6 +21,7 @@ describe("Playbooks", () => {
 		expect(res.status).toBe(200);
 		const body = (await res.json()) as Array<{ name: string; title: string }>;
 		expect(body.find((p) => p.name === "epic-goal")).toBeTruthy();
+		expect(body.find((p) => p.name === "idea-discovery")).toBeTruthy();
 	});
 
 	// PROJ-633: the playbook reads are deliberately global — no workspace. Adding the
@@ -69,6 +70,18 @@ describe("Playbooks", () => {
 		expect(body.content).toContain("bounded variant");
 		expect(body.content).toContain("full variant");
 		expect(body.content).toContain("Audit first");
+	});
+
+	it("GET /api/playbooks/idea-discovery returns the full playbook", async () => {
+		const res = await SELF.fetch("http://localhost/api/playbooks/idea-discovery", {
+			headers: authHeaders(token, slug),
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { name: string; content: string };
+		expect(body.name).toBe("idea-discovery");
+		expect(body.content).toContain("Research frontier");
+		expect(body.content).toContain("Gap hypotheses");
+		expect(body.content).toContain("Free/open data sources only");
 	});
 
 	it("MCP get_playbook returns the same content as REST", async () => {

--- a/apps/docs/src/content/docs/agents/playbooks/idea-discovery.md
+++ b/apps/docs/src/content/docs/agents/playbooks/idea-discovery.md
@@ -1,0 +1,71 @@
+---
+title: "Idea discovery"
+description: "A domain-agnostic research process for turning a domain description into a sequenced, falsification-tested list of buildable product ideas."
+sidebar:
+  order: 2
+---
+A prompt pattern for taking a one-paragraph domain description and working it through to
+a sequenced, evidence-tested set of product ideas — without reconstructing the process
+from scratch each time.
+
+It's deliberately domain-agnostic: the steps below have been run on maritime data
+businesses, but nothing in them is maritime-specific.
+
+## Getting the directive
+
+`get_playbook("idea-discovery")` returns this page verbatim — read it and adapt it by
+hand, filling in the domain description.
+
+## Input
+
+A one-paragraph description of the domain or application area to explore.
+
+## Constraints applied throughout
+
+- **Free/open data sources only** — verify licences permit commercial reuse before relying
+  on a source. A promising idea built on a data source you can't legally use commercially
+  is not a promising idea.
+- **Every idea needs a clear distribution channel** — a press cycle, SEO, an existing
+  community, or a developer channel. An idea with no plausible way to reach users is not
+  worth qualifying further, however novel.
+- **Solo technical founder** — favour products buildable as an app or API on serverless
+  infrastructure. Ideas that need a team, capital, or bespoke infra to stand up don't fit
+  the constraint and should be discarded early, not qualified.
+
+## Steps
+
+Web search at every stage. Pause for a decision at each transition — don't run straight
+through to idea generation without confirming the frontier, assets, and landscape are
+right.
+
+1. **Research frontier** — recent advances (roughly the last 3 years) in the domain's
+   literature. Skip this step entirely if the domain isn't research-driven.
+2. **Assets** — open datasets, records, feeds, and registries available in the domain;
+   their licences; what can be inferred from them beyond their stated purpose.
+3. **Landscape** — incumbents in tiers (raw data providers → enterprise intelligence →
+   vertical tools), with pricing. Note who is served at what price point, and who isn't
+   served at all.
+4. **Gap hypotheses** — propose gaps between what the landscape serves and what the
+   assets/frontier make possible, then actively try to falsify each one with further
+   searches. Report kills explicitly — a dead hypothesis is progress, not a wasted step.
+5. **Idea generation** — batches of roughly 10 ideas. Each idea gets exactly three
+   attributes: novelty, free data source(s) it relies on, and its distribution channel.
+   No idea without all three.
+6. **Qualification** — for ideas on the shortlist: product shape, user story, similar
+   existing products, and the unserved niche it targets. Then pressure-test the
+   load-bearing assumption — usually licensing, legal exposure, or moat — the one
+   assumption that kills the idea if it's wrong.
+7. **Sequencing** — a build order that exploits shared infrastructure across ideas (a
+   dataset pipeline or API client one idea needs is often reusable by the next). Name the
+   cheapest first experiment explicitly.
+
+## Principles
+
+- **Cheap evidence before commitment** — a falsifying search costs minutes; a shipped
+  product costs weeks. Spend the cheap evidence first.
+- **Be honest when a space is saturated** — a landscape step that finds five well-funded
+  incumbents at every price tier is a valid, useful outcome. Don't force a gap that isn't
+  there.
+- **Desk validation is not buyer validation** — qualification and sequencing narrow the
+  field on desk research alone. They are not a substitute for talking to a real buyer
+  before building.

--- a/apps/docs/src/content/docs/agents/playbooks/index.md
+++ b/apps/docs/src/content/docs/agents/playbooks/index.md
@@ -7,9 +7,11 @@ sidebar:
 
 A playbook is a generic, reusable working pattern — not specific to projektor's own
 rules (that's [the workflow spec](/projektor/agents/workflow-spec/)), but a prompt
-pattern for how an agent should approach a class of task. The first one,
-[`epic-goal`](/projektor/agents/playbooks/epic-goal/), is a template for pointing an
-agent at an epic and having it work autonomously to completion.
+pattern for how an agent should approach a class of task.
+[`epic-goal`](/projektor/agents/playbooks/epic-goal/) is a template for pointing an
+agent at an epic and having it work autonomously to completion;
+[`idea-discovery`](/projektor/agents/playbooks/idea-discovery/) is a research process
+for turning a domain description into a sequenced list of product ideas.
 
 ## Why playbooks, not just prompts you copy-paste
 
@@ -61,6 +63,7 @@ request time. See the full ingredient list and both template variants on the
 | Playbook | What it's for |
 |---|---|
 | [`epic-goal`](/projektor/agents/playbooks/epic-goal/) | Work through an epic (or ticket list) autonomously until it's fully done. |
+| [`idea-discovery`](/projektor/agents/playbooks/idea-discovery/) | Turn a domain description into a sequenced, falsification-tested list of product ideas. |
 
 More will land here as they're extracted from real working sessions — the whole
 point of a playbook is that it started as something that actually worked, not a


### PR DESCRIPTION
## Summary
- Adds `idea-discovery` to the shipped `PLAYBOOKS` registry in `apps/api/src/services/playbook-content.ts`, following the `epic-goal` entry's shape — domain-agnostic research playbook (frontier → assets → landscape → gap falsification → batched ideation → qualification → sequencing).
- Regenerates the CI-gated docs page (`apps/docs/.../playbooks/idea-discovery.md`) via `pnpm gen:playbooks`, and updates the hand-authored playbooks index page to list it.
- Adds test coverage in `apps/api/src/test/playbooks.test.ts` for the new entry via `list_playbooks`/`get_playbook` (REST).

## Design decision
`compose_playbook`/MCP `prompts/*` remain `epic-goal`-only. `idea-discovery` has no live server-side data to fill in (unlike `epic-goal`'s epic title/open-child-count/WIP-limit), so a generic compose dispatch isn't worth building for a single non-composable case — matches the acceptance criteria, which only requires default `list_playbooks`/`get_playbook` availability and calls compose support optional. Recorded as a decision comment on PROJ-667.

## Test plan
- [x] `pnpm --filter @projektor/api test` — 1302/1302 passing
- [x] `pnpm gen:docs` — clean diff (idempotent regen)
- [x] `pnpm --filter @projektor/api exec biome check` on changed files
- [x] `tsc --noEmit` on `apps/api`

Closes PROJ-667

https://claude.ai/code/session_01ERPMxwxW68pnfkC3aUDrK9