### PR TITLE
fix: pin claude mcp add argument order with a shared helper (PROJ-620)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,8 +369,8 @@ and in the fleet manifest.
 All tools are available via `POST /mcp/<workspaceId>` (JSON-RPC 2.0). Connect with:
 
 ```bash
-claude mcp add projektor --transport http https://<host>/mcp/<workspaceId> \
-  --header "Authorization: Bearer <token>"
+claude mcp add --transport http --header "Authorization: Bearer <token>" \
+  projektor https://<host>/mcp/<workspaceId>
 ```
 
 **The full tool list is generated from source — do not hand-maintain a copy here.**

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,5 @@
 import type { Env, HonoEnv } from "@projektor/types";
+import { buildMcpAddCommand } from "@projektor/types";
 import type { Context, Next } from "hono";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
@@ -206,9 +207,7 @@ app.get("/bootstrap", async (c) => {
 		user,
 		token,
 		mcpUrl,
-		mcpAddCommand:
-			`claude mcp add --transport http --header "Authorization: Bearer ${token}" ` +
-			`--header "X-Workspace-Slug: ${ws?.slug}" projektor "${mcpUrl}"`,
+		mcpAddCommand: buildMcpAddCommand({ workspaceSlug: ws?.slug ?? "", mcpUrl, token }),
 	});
 });
 

--- a/apps/api/src/services/workspaces.ts
+++ b/apps/api/src/services/workspaces.ts
@@ -1,4 +1,5 @@
 import { drizzle, schema } from "@projektor/db";
+import { buildMcpAddCommand } from "@projektor/types";
 import { and, asc, desc, eq } from "drizzle-orm";
 import { IdSchema } from "../schemas/common";
 import {
@@ -318,11 +319,11 @@ export async function getWorkspaceMcpInfo(
 	mcpAddCommandTemplate: string;
 }> {
 	const mcpUrl = `${origin}/mcp/${workspace.id}`;
-	const mcpAddCommandTemplate =
-		`claude mcp add projektor "${mcpUrl}" ` +
-		`--transport http ` +
-		`--header "Authorization: Bearer {{TOKEN}}" ` +
-		`--header "X-Workspace-Slug: ${workspace.slug}"`;
+	const mcpAddCommandTemplate = buildMcpAddCommand({
+		workspaceSlug: workspace.slug,
+		mcpUrl,
+		token: "{{TOKEN}}",
+	});
 	return {
 		mcpUrl,
 		workspaceId: workspace.id,

--- a/apps/api/src/test/workspaces.test.ts
+++ b/apps/api/src/test/workspaces.test.ts
@@ -476,4 +476,18 @@ describe("GET /api/workspaces/:slug/mcp-info (PROJ-83)", () => {
 		expect(body.mcpAddCommandTemplate).toContain("{{TOKEN}}");
 		expect(body.mcpAddCommandTemplate).toContain(slug);
 	});
+
+	it("mcpAddCommandTemplate puts flags before the name/url positionals (PROJ-620)", async () => {
+		const res = await SELF.fetch(`http://localhost/api/workspaces/${slug}/mcp-info`, {
+			headers: memberHeaders,
+		});
+		const body = (await res.json()) as { mcpAddCommandTemplate: string; mcpUrl: string };
+
+		expect(body.mcpAddCommandTemplate).toBe(
+			`claude mcp add --transport http ` +
+				`--header "Authorization: Bearer {{TOKEN}}" ` +
+				`--header "X-Workspace-Slug: ${slug}" ` +
+				`projektor "${body.mcpUrl}"`
+		);
+	});
 });

--- a/apps/docs/src/content/docs/agents/mcp-connection.md
+++ b/apps/docs/src/content/docs/agents/mcp-connection.md
@@ -52,11 +52,11 @@ The bootstrap endpoint is enabled only when `ENVIRONMENT=development` — any ot
 Mint a token from the UI (Settings → Tokens) or via the API, then add the MCP server:
 
 ```bash
-claude mcp add projektor \
-  "https://<your-worker>.workers.dev/mcp/<workspace-uuid>" \
+claude mcp add \
   --transport http \
   --header "Authorization: Bearer pk_<64 hex chars>" \
-  --header "X-Workspace-Slug: <slug>"
+  --header "X-Workspace-Slug: <slug>" \
+  projektor "https://<your-worker>.workers.dev/mcp/<workspace-uuid>"
 ```
 
 **Finding the workspace ID:** it is returned by `GET /api/workspaces` or shown in the bootstrap response. The slug is the short identifier you chose when creating the workspace (e.g. `projektor`).
@@ -215,13 +215,13 @@ If your projektor instance is behind Cloudflare Access (which it should be in pr
 Pass the service token credentials alongside the API token:
 
 ```bash
-claude mcp add projektor \
-  "https://<your-worker>.workers.dev/mcp/<workspace-uuid>" \
+claude mcp add \
   --transport http \
   --header "Authorization: Bearer pk_<token>" \
   --header "X-Workspace-Slug: <slug>" \
   --header "CF-Access-Client-Id: <client-id>" \
-  --header "CF-Access-Client-Secret: <client-secret>"
+  --header "CF-Access-Client-Secret: <client-secret>" \
+  projektor "https://<your-worker>.workers.dev/mcp/<workspace-uuid>"
 ```
 
 For the **OAuth connector** path (§3b) the operator has separate work to do: Access also sits in front of the OAuth discovery and token endpoints, which no browser session ever reaches. Bypass applications for `/.well-known` and `/oauth/token` are required, and `/oauth/authorize` must stay protected — see [Deploying → Cloudflare Access](/projektor/guides/deploying/#6-cloudflare-access-carve-outs-for-oauth).

--- a/apps/docs/src/content/docs/contributing/conventions.md
+++ b/apps/docs/src/content/docs/contributing/conventions.md
@@ -377,8 +377,8 @@ and in the fleet manifest.
 All tools are available via `POST /mcp/<workspaceId>` (JSON-RPC 2.0). Connect with:
 
 ```bash
-claude mcp add projektor --transport http https://<host>/mcp/<workspaceId> \
-  --header "Authorization: Bearer <token>"
+claude mcp add --transport http --header "Authorization: Bearer <token>" \
+  projektor https://<host>/mcp/<workspaceId>
 ```
 
 **The full tool list is generated from source — do not hand-maintain a copy here.**

--- a/apps/web/src/islands/TokenManager.test.tsx
+++ b/apps/web/src/islands/TokenManager.test.tsx
@@ -4,6 +4,7 @@
 // workspace configured." fallback immediately. When the slug is present it
 // fetches the workspace info and token list via apiFetch (→ global fetch).
 // The pattern: provide workspaceSlug prop, override the stub, await findBy*.
+import { buildMcpAddCommandMultiline } from "@projektor/types";
 import { fireEvent, render, screen } from "@testing-library/preact";
 import { describe, expect, it, vi } from "vitest";
 import TokenManager from "./TokenManager";
@@ -85,5 +86,21 @@ describe("TokenManager", () => {
 		fireEvent.click(screen.getByRole("button", { name: /New token/i }));
 		expect(await screen.findByText("New API token")).toBeTruthy();
 		expect(screen.getByRole("button", { name: /Create token/i })).toBeTruthy();
+	});
+
+	it("mcpAddCommandMultiline puts flags before the name/url positionals (PROJ-620)", () => {
+		const command = buildMcpAddCommandMultiline({
+			workspaceSlug: "my-ws",
+			mcpUrl: "https://example.com/mcp/w1",
+			token: "tok123",
+		});
+		expect(command).toBe(
+			[
+				"claude mcp add --transport http \\",
+				'  --header "Authorization: Bearer tok123" \\',
+				'  --header "X-Workspace-Slug: my-ws" \\',
+				'  projektor "https://example.com/mcp/w1"',
+			].join("\n")
+		);
 	});
 });

--- a/apps/web/src/islands/TokenManager.tsx
+++ b/apps/web/src/islands/TokenManager.tsx
@@ -1,3 +1,4 @@
+import { buildMcpAddCommandMultiline } from "@projektor/types";
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { apiFetch } from "../utils/api-client";
 import { resolveWorkspaceSlug } from "../utils/workspace";
@@ -73,13 +74,7 @@ function buildMcpCommand(
 		return mcpCommandTemplate.replace("{{TOKEN}}", token);
 	}
 	if (!mcpUrl) return "";
-	const lines = [
-		`claude mcp add projektor "${mcpUrl}" \\`,
-		"  --transport http \\",
-		`  --header "Authorization: Bearer ${token}" \\`,
-		`  --header "X-Workspace-Slug: ${workspaceSlug}"`,
-	];
-	return lines.join("\n");
+	return buildMcpAddCommandMultiline({ workspaceSlug, mcpUrl, token });
 }
 
 async function copyToClipboard(text: string) {

--- a/llms.txt
+++ b/llms.txt
@@ -10,7 +10,7 @@
 curl -s https://<worker>.workers.dev/bootstrap \
   -H "X-Bootstrap-Secret: <secret>" | jq -r .mcpAddCommand | sh
 
-# Then use the printed: claude mcp add projektor <url> --transport http ...
+# Then use the printed: claude mcp add --transport http --header ... projektor <url>
 ```
 
 ## MCP endpoint

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,2 +1,4 @@
 export type { Env, HonoEnv, Variables } from "./env";
+export type { McpAddCommandParts } from "./mcp-command";
+export { buildMcpAddCommand, buildMcpAddCommandMultiline } from "./mcp-command";
 export type { MCPTool, Migration, Plugin, PluginContext, Role } from "./plugin";

--- a/packages/types/src/mcp-command.ts
+++ b/packages/types/src/mcp-command.ts
@@ -1,0 +1,27 @@
+export interface McpAddCommandParts {
+	workspaceSlug: string;
+	mcpUrl: string;
+	token: string;
+}
+
+export function buildMcpAddCommand({ workspaceSlug, mcpUrl, token }: McpAddCommandParts): string {
+	return (
+		`claude mcp add --transport http ` +
+		`--header "Authorization: Bearer ${token}" ` +
+		`--header "X-Workspace-Slug: ${workspaceSlug}" ` +
+		`projektor "${mcpUrl}"`
+	);
+}
+
+export function buildMcpAddCommandMultiline({
+	workspaceSlug,
+	mcpUrl,
+	token,
+}: McpAddCommandParts): string {
+	return [
+		`claude mcp add --transport http \\`,
+		`  --header "Authorization: Bearer ${token}" \\`,
+		`  --header "X-Workspace-Slug: ${workspaceSlug}" \\`,
+		`  projektor "${mcpUrl}"`,
+	].join("\n");
+}


### PR DESCRIPTION
## Summary
- Three sites built the `claude mcp add` command string with mutually inconsistent argument order — `apps/api/src/index.ts` put flags before the `name`/`url` positionals, while `apps/api/src/services/workspaces.ts` and `apps/web/src/islands/TokenManager.tsx` put the positionals first.
- Verified against `claude mcp add --help`: usage is `claude mcp add [options] <name> <commandOrUrl>`, and every example in the help text puts flags first. `index.ts` was already correct; the other two were not.
- Added `@projektor/types#buildMcpAddCommand` / `buildMcpAddCommandMultiline` as the single source of truth for this string, now used by all three call sites so the three copies can't drift apart again.
- Fixed the same wrong order in `AGENTS.md` (and its generated mirror `apps/docs/.../conventions.md`) and `apps/docs/.../agents/mcp-connection.md`, plus a doc comment in `llms.txt`.
- Pinned the exact argument order with regression tests in `apps/api/src/test/workspaces.test.ts` and `apps/web/src/islands/TokenManager.test.tsx`.

## Test plan
- [x] `pnpm --filter @projektor/api test` — 66 files / 1302 tests passed
- [x] `pnpm --filter @projektor/web test` — 60 files / 688 tests passed
- [x] `pnpm -w run type-check` — 0 errors across all packages
- [x] `pnpm gen:docs` then `git status` — only the intended doc file changed (conventions.md regenerated from AGENTS.md)
- [x] `pnpm exec biome check --write` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SG7cCb4jxPwPyVXBugC1G