### PR TITLE
feat(api): opt-in real-time WebSocket event stream

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -37,6 +37,7 @@ import { oauthMetadataRouter } from "./routes/oauth-metadata";
 import { playbooksRouter } from "./routes/playbooks";
 import { projectActivityRouter } from "./routes/project-activity";
 import { projectsRouter } from "./routes/projects";
+import { realtimeRouter } from "./routes/realtime";
 import { shareIssuesRouter, sharePublicRouter } from "./routes/share";
 import { sprintsRouter } from "./routes/sprints";
 import { taskStatusesRouter } from "./routes/task-statuses";
@@ -330,6 +331,7 @@ app.route("/api/file-claims", fileClaimsRouter);
 app.route("/api/agent-messages", agentMessagesRouter);
 app.route("/api/workflow", workflowRouter);
 app.route("/api/playbooks", playbooksRouter);
+app.route("/api", realtimeRouter);
 
 // PROJ-487 fix-up: /wiki is a static asset (wiki/index.html) that Cloudflare serves
 // directly without ever invoking the Worker — so the legacy `?slug=` query param can
@@ -485,3 +487,5 @@ export default {
 	},
 	scheduled,
 } satisfies ExportedHandler<Env>;
+
+export { WorkspaceHub } from "./realtime/workspace-hub";

--- a/apps/api/src/realtime/workspace-hub.ts
+++ b/apps/api/src/realtime/workspace-hub.ts
@@ -20,6 +20,22 @@ export class WorkspaceHub {
 	}
 
 	async fetch(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+		if (url.pathname === "/broadcast" && request.method === "POST") {
+			try {
+				const event = (await request.json()) as RealtimeEvent;
+				const result = await this.broadcast(event);
+				return new Response(JSON.stringify(result), {
+					headers: { "Content-Type": "application/json" },
+				});
+			} catch {
+				return new Response(JSON.stringify({ error: "Invalid broadcast payload" }), {
+					status: 400,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+		}
+
 		const upgradeHeader = request.headers.get("Upgrade");
 		if (upgradeHeader !== "websocket") {
 			return new Response("Expected Upgrade: websocket", { status: 426 });

--- a/apps/api/src/realtime/workspace-hub.ts
+++ b/apps/api/src/realtime/workspace-hub.ts
@@ -1,0 +1,126 @@
+import { DurableObject } from "cloudflare:workers";
+import type { Env, RealtimeEvent } from "@projektor/types";
+
+export interface SubscriptionFilters {
+	projects?: string[];
+	eventTypes?: string[];
+}
+
+export interface SocketAttachment {
+	subscribedAt: number;
+	filters?: SubscriptionFilters;
+}
+
+export class WorkspaceHub extends DurableObject<Env> {
+	async fetch(request: Request): Promise<Response> {
+		const upgradeHeader = request.headers.get("Upgrade");
+		if (upgradeHeader !== "websocket") {
+			return new Response("Expected Upgrade: websocket", { status: 426 });
+		}
+
+		const pair = new WebSocketPair();
+		const [client, server] = Object.values(pair);
+
+		this.ctx.acceptWebSocket(server);
+
+		const initialAttachment: SocketAttachment = {
+			subscribedAt: Math.floor(Date.now() / 1000),
+		};
+		server.serializeAttachment(initialAttachment);
+
+		return new Response(null, {
+			status: 101,
+			webSocket: client,
+		});
+	}
+
+	async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
+		if (typeof message !== "string") return;
+
+		try {
+			const data = JSON.parse(message) as {
+				action?: string;
+				projects?: string[];
+				eventTypes?: string[];
+			};
+
+			if (data.action === "ping") {
+				ws.send(JSON.stringify({ type: "pong", timestamp: Math.floor(Date.now() / 1000) }));
+				return;
+			}
+
+			if (data.action === "subscribe") {
+				const attachment = (ws.deserializeAttachment() as SocketAttachment | null) ?? {
+					subscribedAt: Math.floor(Date.now() / 1000),
+				};
+
+				const filters: SubscriptionFilters = {
+					projects: Array.isArray(data.projects) ? data.projects : undefined,
+					eventTypes: Array.isArray(data.eventTypes) ? data.eventTypes : undefined,
+				};
+
+				ws.serializeAttachment({
+					...attachment,
+					filters,
+				});
+
+				ws.send(
+					JSON.stringify({
+						type: "subscribed",
+						filters,
+						timestamp: Math.floor(Date.now() / 1000),
+					})
+				);
+			}
+		} catch {
+			// Ignore malformed client JSON
+		}
+	}
+
+	async webSocketClose(ws: WebSocket, code: number, reason: string, wasClean: boolean): Promise<void> {
+		ws.close(code, "Closed");
+	}
+
+	async webSocketError(ws: WebSocket, error: unknown): Promise<void> {
+		ws.close(1011, "Internal error");
+	}
+
+	async broadcast(event: RealtimeEvent): Promise<{ recipientCount: number }> {
+		const sockets = this.ctx.getWebSockets();
+		let recipientCount = 0;
+		const payload = JSON.stringify(event);
+
+		for (const ws of sockets) {
+			try {
+				const attachment = ws.deserializeAttachment() as SocketAttachment | null;
+				const filters = attachment?.filters;
+
+				if (filters?.projects && filters.projects.length > 0 && event.projectId) {
+					if (!filters.projects.includes(event.projectId)) {
+						continue;
+					}
+				}
+
+				if (filters?.eventTypes && filters.eventTypes.length > 0) {
+					const matched = filters.eventTypes.some((pattern) => {
+						if (pattern.endsWith(".*")) {
+							const prefix = pattern.slice(0, -2);
+							return event.type.startsWith(`${prefix}.`) || event.type === prefix;
+						}
+						return pattern === event.type;
+					});
+					if (!matched) {
+						continue;
+					}
+				}
+
+				ws.send(payload);
+				recipientCount++;
+			} catch {
+				// Socket closed or failed to send
+			}
+		}
+
+		return { recipientCount };
+	}
+}

--- a/apps/api/src/realtime/workspace-hub.ts
+++ b/apps/api/src/realtime/workspace-hub.ts
@@ -1,4 +1,6 @@
-import type { Env, RealtimeEvent } from "@projektor/types";
+import type { Env, RealtimeEvent, Role } from "@projektor/types";
+import { visibleProjectIds } from "../services/access";
+import type { ServiceCtx } from "../services/types";
 
 export interface SubscriptionFilters {
 	projects?: string[];
@@ -6,8 +8,20 @@ export interface SubscriptionFilters {
 }
 
 export interface SocketAttachment {
+	userId: string;
+	workspaceId: string;
+	role: Role;
+	visibleProjectIds: string[];
 	subscribedAt: number;
 	filters?: SubscriptionFilters;
+}
+
+const INTERNAL_USER_ID_HEADER = "X-Internal-User-Id";
+const INTERNAL_WORKSPACE_ID_HEADER = "X-Internal-Workspace-Id";
+const INTERNAL_ROLE_HEADER = "X-Internal-Role";
+
+function isWorkspaceAdmin(role: Role | undefined): boolean {
+	return role === "owner" || role === "admin";
 }
 
 export class WorkspaceHub {
@@ -41,12 +55,23 @@ export class WorkspaceHub {
 			return new Response("Expected Upgrade: websocket", { status: 426 });
 		}
 
+		const identity = this.resolveIdentity(request);
+		if (!identity) {
+			return new Response("Unauthorized", { status: 401 });
+		}
+
+		const visibleIds = await this.loadVisibleProjectIds(identity);
+
 		const pair = new WebSocketPair();
 		const [client, server] = Object.values(pair);
 
 		this.ctx.acceptWebSocket(server);
 
 		const initialAttachment: SocketAttachment = {
+			userId: identity.userId,
+			workspaceId: identity.workspaceId,
+			role: identity.role,
+			visibleProjectIds: visibleIds,
 			subscribedAt: Math.floor(Date.now() / 1000),
 		};
 		server.serializeAttachment(initialAttachment);
@@ -57,14 +82,40 @@ export class WorkspaceHub {
 		});
 	}
 
+	private resolveIdentity(
+		request: Request
+	): { userId: string; workspaceId: string; role: Role } | null {
+		const userId = request.headers.get(INTERNAL_USER_ID_HEADER);
+		const workspaceId = request.headers.get(INTERNAL_WORKSPACE_ID_HEADER);
+		const role = request.headers.get(INTERNAL_ROLE_HEADER) as Role | null;
+		if (!userId || !workspaceId || !role) return null;
+		return { userId, workspaceId, role };
+	}
+
+	private async loadVisibleProjectIds(identity: {
+		userId: string;
+		workspaceId: string;
+		role: Role;
+	}): Promise<string[]> {
+		const ctx: ServiceCtx = {
+			db: this.env.DB,
+			kv: this.env.KV,
+			r2: this.env.R2,
+			workspaceId: identity.workspaceId,
+			userId: identity.userId,
+			role: identity.role,
+		};
+		return visibleProjectIds(ctx);
+	}
+
 	async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
 		if (typeof message !== "string") return;
 
 		try {
 			const data = JSON.parse(message) as {
 				action?: string;
-				projects?: string[];
-				eventTypes?: string[];
+				projects?: unknown[];
+				eventTypes?: unknown[];
 			};
 
 			if (data.action === "ping") {
@@ -73,13 +124,29 @@ export class WorkspaceHub {
 			}
 
 			if (data.action === "subscribe") {
-				const attachment = (ws.deserializeAttachment() as SocketAttachment | null) ?? {
-					subscribedAt: Math.floor(Date.now() / 1000),
-				};
+				const attachment = ws.deserializeAttachment() as SocketAttachment | null;
+				if (!attachment) return;
+
+				const allowedProjects = new Set(attachment.visibleProjectIds);
+				const requestedProjects = Array.isArray(data.projects)
+					? data.projects.filter((id): id is string => typeof id === "string")
+					: undefined;
+
+				let effectiveProjects: string[] | undefined;
+				if (requestedProjects) {
+					// Intersect the client-supplied list with the server-side visible set.
+					effectiveProjects = requestedProjects.filter((id) => allowedProjects.has(id));
+				} else if (!isWorkspaceAdmin(attachment.role)) {
+					// Non-admin with no explicit filter defaults to their visible set,
+					// never "every project in the workspace".
+					effectiveProjects = attachment.visibleProjectIds;
+				}
 
 				const filters: SubscriptionFilters = {
-					projects: Array.isArray(data.projects) ? data.projects : undefined,
-					eventTypes: Array.isArray(data.eventTypes) ? data.eventTypes : undefined,
+					projects: effectiveProjects,
+					eventTypes: Array.isArray(data.eventTypes)
+						? data.eventTypes.filter((t): t is string => typeof t === "string")
+						: undefined,
 				};
 
 				ws.serializeAttachment({
@@ -121,8 +188,21 @@ export class WorkspaceHub {
 		for (const ws of sockets) {
 			try {
 				const attachment = ws.deserializeAttachment() as SocketAttachment | null;
-				const filters = attachment?.filters;
+				if (!attachment) continue;
 
+				// Server-side project visibility check: never broadcast project-scoped
+				// events to a socket that cannot see the project.
+				if (event.projectId && !isWorkspaceAdmin(attachment.role)) {
+					const visible = new Set(attachment.visibleProjectIds);
+					if (!visible.has(event.projectId)) {
+						continue;
+					}
+				}
+
+				const filters = attachment.filters;
+
+				// Apply the client-requested project filter (already intersected with
+				// visibility at subscribe time, but re-checking is cheap and robust).
 				if (filters?.projects && filters.projects.length > 0 && event.projectId) {
 					if (!filters.projects.includes(event.projectId)) {
 						continue;

--- a/apps/api/src/realtime/workspace-hub.ts
+++ b/apps/api/src/realtime/workspace-hub.ts
@@ -137,7 +137,7 @@ export class WorkspaceHub {
 			)
 			.get();
 
-		const role = (membership?.role as Role | undefined) ?? attachment.role;
+		const role = membership ? (membership.role as Role) : undefined;
 		const visibleProjectIds = membership
 			? await this.loadVisibleProjectIds({
 					userId: attachment.userId,

--- a/apps/api/src/realtime/workspace-hub.ts
+++ b/apps/api/src/realtime/workspace-hub.ts
@@ -1,4 +1,6 @@
+import { drizzle, schema } from "@projektor/db";
 import type { Env, RealtimeEvent, Role } from "@projektor/types";
+import { and, eq } from "drizzle-orm";
 import { visibleProjectIds } from "../services/access";
 import type { ServiceCtx } from "../services/types";
 
@@ -10,15 +12,20 @@ export interface SubscriptionFilters {
 export interface SocketAttachment {
 	userId: string;
 	workspaceId: string;
-	role: Role;
+	role?: Role;
 	visibleProjectIds: string[];
 	subscribedAt: number;
+	snapshotAt: number;
 	filters?: SubscriptionFilters;
 }
 
 const INTERNAL_USER_ID_HEADER = "X-Internal-User-Id";
 const INTERNAL_WORKSPACE_ID_HEADER = "X-Internal-Workspace-Id";
 const INTERNAL_ROLE_HEADER = "X-Internal-Role";
+
+// How long a visibility/role snapshot is trusted on a hibernated socket before
+// it is refreshed from D1. Bounds stale access after admin demotion or removal.
+const SNAPSHOT_TTL_SECONDS = 300;
 
 function isWorkspaceAdmin(role: Role | undefined): boolean {
 	return role === "owner" || role === "admin";
@@ -67,12 +74,14 @@ export class WorkspaceHub {
 
 		this.ctx.acceptWebSocket(server);
 
+		const now = Math.floor(Date.now() / 1000);
 		const initialAttachment: SocketAttachment = {
 			userId: identity.userId,
 			workspaceId: identity.workspaceId,
 			role: identity.role,
 			visibleProjectIds: visibleIds,
-			subscribedAt: Math.floor(Date.now() / 1000),
+			subscribedAt: now,
+			snapshotAt: now,
 		};
 		server.serializeAttachment(initialAttachment);
 
@@ -92,12 +101,12 @@ export class WorkspaceHub {
 		return { userId, workspaceId, role };
 	}
 
-	private async loadVisibleProjectIds(identity: {
+	private buildServiceCtx(identity: {
 		userId: string;
 		workspaceId: string;
-		role: Role;
-	}): Promise<string[]> {
-		const ctx: ServiceCtx = {
+		role?: Role;
+	}): ServiceCtx {
+		return {
 			db: this.env.DB,
 			kv: this.env.KV,
 			r2: this.env.R2,
@@ -105,7 +114,48 @@ export class WorkspaceHub {
 			userId: identity.userId,
 			role: identity.role,
 		};
-		return visibleProjectIds(ctx);
+	}
+
+	private async loadVisibleProjectIds(identity: {
+		userId: string;
+		workspaceId: string;
+		role?: Role;
+	}): Promise<string[]> {
+		return visibleProjectIds(this.buildServiceCtx(identity));
+	}
+
+	private async refreshSnapshot(attachment: SocketAttachment): Promise<SocketAttachment> {
+		const orm = drizzle(this.env.DB, { schema });
+		const membership = await orm
+			.select({ role: schema.workspaceMembers.role })
+			.from(schema.workspaceMembers)
+			.where(
+				and(
+					eq(schema.workspaceMembers.workspaceId, attachment.workspaceId),
+					eq(schema.workspaceMembers.userId, attachment.userId)
+				)
+			)
+			.get();
+
+		const role = (membership?.role as Role | undefined) ?? attachment.role;
+		const visibleProjectIds = membership
+			? await this.loadVisibleProjectIds({
+					userId: attachment.userId,
+					workspaceId: attachment.workspaceId,
+					role,
+				})
+			: [];
+
+		return {
+			...attachment,
+			role,
+			visibleProjectIds,
+			snapshotAt: Math.floor(Date.now() / 1000),
+		};
+	}
+
+	private isSnapshotStale(attachment: SocketAttachment): boolean {
+		return Math.floor(Date.now() / 1000) - attachment.snapshotAt > SNAPSHOT_TTL_SECONDS;
 	}
 
 	async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
@@ -118,15 +168,20 @@ export class WorkspaceHub {
 				eventTypes?: unknown[];
 			};
 
+			let attachment = ws.deserializeAttachment() as SocketAttachment | null;
+			if (!attachment) return;
+
+			if (this.isSnapshotStale(attachment)) {
+				attachment = await this.refreshSnapshot(attachment);
+				ws.serializeAttachment(attachment);
+			}
+
 			if (data.action === "ping") {
 				ws.send(JSON.stringify({ type: "pong", timestamp: Math.floor(Date.now() / 1000) }));
 				return;
 			}
 
 			if (data.action === "subscribe") {
-				const attachment = ws.deserializeAttachment() as SocketAttachment | null;
-				if (!attachment) return;
-
 				const allowedProjects = new Set(attachment.visibleProjectIds);
 				const requestedProjects = Array.isArray(data.projects)
 					? data.projects.filter((id): id is string => typeof id === "string")
@@ -190,9 +245,11 @@ export class WorkspaceHub {
 				const attachment = ws.deserializeAttachment() as SocketAttachment | null;
 				if (!attachment) continue;
 
-				// Server-side project visibility check: never broadcast project-scoped
-				// events to a socket that cannot see the project.
-				if (event.projectId && !isWorkspaceAdmin(attachment.role)) {
+				// Server-side project visibility check: non-admins must receive only
+				// events scoped to a project they can see. Missing projectId is treated
+				// as "deny" for non-admins (fail-closed).
+				if (!isWorkspaceAdmin(attachment.role)) {
+					if (!event.projectId) continue;
 					const visible = new Set(attachment.visibleProjectIds);
 					if (!visible.has(event.projectId)) {
 						continue;

--- a/apps/api/src/realtime/workspace-hub.ts
+++ b/apps/api/src/realtime/workspace-hub.ts
@@ -77,11 +77,16 @@ export class WorkspaceHub extends DurableObject<Env> {
 		}
 	}
 
-	async webSocketClose(ws: WebSocket, code: number, reason: string, wasClean: boolean): Promise<void> {
+	async webSocketClose(
+		ws: WebSocket,
+		code: number,
+		_reason: string,
+		_wasClean: boolean
+	): Promise<void> {
 		ws.close(code, "Closed");
 	}
 
-	async webSocketError(ws: WebSocket, error: unknown): Promise<void> {
+	async webSocketError(ws: WebSocket, _error: unknown): Promise<void> {
 		ws.close(1011, "Internal error");
 	}
 

--- a/apps/api/src/realtime/workspace-hub.ts
+++ b/apps/api/src/realtime/workspace-hub.ts
@@ -1,4 +1,3 @@
-import { DurableObject } from "cloudflare:workers";
 import type { Env, RealtimeEvent } from "@projektor/types";
 
 export interface SubscriptionFilters {
@@ -11,7 +10,15 @@ export interface SocketAttachment {
 	filters?: SubscriptionFilters;
 }
 
-export class WorkspaceHub extends DurableObject<Env> {
+export class WorkspaceHub {
+	ctx: DurableObjectState;
+	env: Env;
+
+	constructor(ctx: DurableObjectState, env: Env) {
+		this.ctx = ctx;
+		this.env = env;
+	}
+
 	async fetch(request: Request): Promise<Response> {
 		const upgradeHeader = request.headers.get("Upgrade");
 		if (upgradeHeader !== "websocket") {

--- a/apps/api/src/routes/realtime.ts
+++ b/apps/api/src/routes/realtime.ts
@@ -1,0 +1,57 @@
+import type { HonoEnv } from "@projektor/types";
+import { Hono } from "hono";
+import { authMiddleware } from "../middleware/auth";
+import { workspaceMiddleware } from "../middleware/workspace";
+
+const router = new Hono<HonoEnv>();
+
+// GET /api/workspaces/:slug/realtime
+// Opens an opt-in WebSocket connection to the workspace's Durable Object hub.
+router.get("/workspaces/:slug/realtime", authMiddleware, workspaceMiddleware, async (c) => {
+	if (!c.env.WORKSPACE_HUB) {
+		return c.json(
+			{
+				error:
+					"Realtime WebSockets are not enabled on this instance. Configure WORKSPACE_HUB in wrangler.toml to enable.",
+			},
+			501
+		);
+	}
+
+	const upgradeHeader = c.req.header("Upgrade");
+	if (upgradeHeader !== "websocket") {
+		return c.text("Expected Upgrade: websocket", 426);
+	}
+
+	const workspace = c.get("workspace");
+	const id = c.env.WORKSPACE_HUB.idFromName(workspace.id);
+	const stub = c.env.WORKSPACE_HUB.get(id);
+
+	return stub.fetch(c.req.raw);
+});
+
+// GET /api/realtime (workspace resolved via header or fallback query param)
+router.get("/realtime", authMiddleware, workspaceMiddleware, async (c) => {
+	if (!c.env.WORKSPACE_HUB) {
+		return c.json(
+			{
+				error:
+					"Realtime WebSockets are not enabled on this instance. Configure WORKSPACE_HUB in wrangler.toml to enable.",
+			},
+			501
+		);
+	}
+
+	const upgradeHeader = c.req.header("Upgrade");
+	if (upgradeHeader !== "websocket") {
+		return c.text("Expected Upgrade: websocket", 426);
+	}
+
+	const workspace = c.get("workspace");
+	const id = c.env.WORKSPACE_HUB.idFromName(workspace.id);
+	const stub = c.env.WORKSPACE_HUB.get(id);
+
+	return stub.fetch(c.req.raw);
+});
+
+export { router as realtimeRouter };

--- a/apps/api/src/routes/realtime.ts
+++ b/apps/api/src/routes/realtime.ts
@@ -1,7 +1,40 @@
 import type { HonoEnv } from "@projektor/types";
+import type { Context } from "hono";
 import { Hono } from "hono";
 import { authMiddleware } from "../middleware/auth";
 import { workspaceMiddleware } from "../middleware/workspace";
+
+const INTERNAL_USER_ID_HEADER = "X-Internal-User-Id";
+const INTERNAL_WORKSPACE_ID_HEADER = "X-Internal-Workspace-Id";
+const INTERNAL_ROLE_HEADER = "X-Internal-Role";
+
+/**
+ * Build the request forwarded to the Durable Object stub.
+ *
+ * The DO runs in the same isolate and cannot be reached directly by clients,
+ * so we safely inject the already-authenticated caller identity as internal
+ * headers. Any client-supplied internal headers are stripped first to prevent
+ * spoofing.
+ */
+function buildHubRequest(c: Context<HonoEnv>): Request {
+	const headers = new Headers(c.req.raw.headers);
+	headers.delete(INTERNAL_USER_ID_HEADER);
+	headers.delete(INTERNAL_WORKSPACE_ID_HEADER);
+	headers.delete(INTERNAL_ROLE_HEADER);
+
+	const user = c.get("user");
+	const workspace = c.get("workspace");
+	const role = c.get("role");
+
+	headers.set(INTERNAL_USER_ID_HEADER, user.id);
+	headers.set(INTERNAL_WORKSPACE_ID_HEADER, workspace.id);
+	if (role) headers.set(INTERNAL_ROLE_HEADER, role);
+
+	return new Request(c.req.raw.url, {
+		method: c.req.raw.method,
+		headers,
+	});
+}
 
 const router = new Hono<HonoEnv>();
 
@@ -27,7 +60,7 @@ router.get("/workspaces/:slug/realtime", authMiddleware, workspaceMiddleware, as
 	const id = c.env.WORKSPACE_HUB.idFromName(workspace.id);
 	const stub = c.env.WORKSPACE_HUB.get(id);
 
-	return stub.fetch(c.req.raw);
+	return stub.fetch(buildHubRequest(c));
 });
 
 // GET /api/realtime (workspace resolved via header or fallback query param)
@@ -51,7 +84,7 @@ router.get("/realtime", authMiddleware, workspaceMiddleware, async (c) => {
 	const id = c.env.WORKSPACE_HUB.idFromName(workspace.id);
 	const stub = c.env.WORKSPACE_HUB.get(id);
 
-	return stub.fetch(c.req.raw);
+	return stub.fetch(buildHubRequest(c));
 });
 
 export { router as realtimeRouter };

--- a/apps/api/src/services/access.ts
+++ b/apps/api/src/services/access.ts
@@ -154,3 +154,41 @@ export function visibleProjectSqlFragment(
 		params: [ctx.userId],
 	};
 }
+
+/**
+ * Return every project ID visible to the caller inside their workspace.
+ * - owner/admin: every project in the workspace.
+ * - everyone else: the union of project grants held by the caller's groups
+ *   (default-deny; scoped by workspace_id through both user_groups and projects).
+ */
+export async function visibleProjectIds(ctx: ServiceCtx): Promise<string[]> {
+	const orm = drizzle(ctx.db, { schema });
+
+	if (isWorkspaceAdmin(ctx.role)) {
+		const rows = await orm
+			.select({ id: schema.projects.id })
+			.from(schema.projects)
+			.where(eq(schema.projects.workspaceId, ctx.workspaceId))
+			.all();
+		return rows.map((r) => r.id);
+	}
+
+	const rows = await orm
+		.selectDistinct({ id: schema.groupProjectGrants.projectId })
+		.from(schema.groupProjectGrants)
+		.innerJoin(
+			schema.userGroupMembers,
+			eq(schema.userGroupMembers.groupId, schema.groupProjectGrants.groupId)
+		)
+		.innerJoin(schema.userGroups, eq(schema.userGroups.id, schema.groupProjectGrants.groupId))
+		.innerJoin(schema.projects, eq(schema.projects.id, schema.groupProjectGrants.projectId))
+		.where(
+			and(
+				eq(schema.userGroupMembers.userId, ctx.userId),
+				eq(schema.userGroups.workspaceId, ctx.workspaceId),
+				eq(schema.projects.workspaceId, ctx.workspaceId)
+			)
+		)
+		.all();
+	return rows.map((r) => r.id);
+}

--- a/apps/api/src/services/comments.ts
+++ b/apps/api/src/services/comments.ts
@@ -24,7 +24,7 @@ interface CommentRow {
 // PROJ-311: a comment is reachable only if its issue's project is visible to the
 // user (owner/admin bypass). Throw the issue-not-found error to avoid leaking that
 // an issue exists in a project the user was never granted.
-async function assertIssueVisible(ctx: ServiceCtx, issueId: string): Promise<void> {
+async function assertIssueVisible(ctx: ServiceCtx, issueId: string): Promise<string> {
 	const orm = drizzle(ctx.db, { schema });
 	const issue = await orm
 		.select({ projectId: schema.issues.projectId })
@@ -35,6 +35,7 @@ async function assertIssueVisible(ctx: ServiceCtx, issueId: string): Promise<voi
 	if (!isWorkspaceAdmin(ctx.role) && (await effectiveProjectRole(ctx, issue.projectId)) === null) {
 		throw new NotFoundError("Issue not found");
 	}
+	return issue.projectId;
 }
 
 export async function listComments(ctx: ServiceCtx, input: unknown): Promise<CommentRow[]> {
@@ -73,7 +74,7 @@ export async function addComment(ctx: ServiceCtx, input: unknown): Promise<{ id:
 	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
 	const { issueId, body } = parsed.data;
 
-	await assertIssueVisible(ctx, issueId);
+	const projectId = await assertIssueVisible(ctx, issueId);
 	if (ctx.role === "viewer") throw new ForbiddenError("Insufficient permissions");
 
 	const id = crypto.randomUUID();
@@ -94,6 +95,7 @@ export async function addComment(ctx: ServiceCtx, input: unknown): Promise<{ id:
 
 	await broadcastWorkspaceEvent(ctx, {
 		type: "comment.created",
+		projectId,
 		data: { id, issueId, authorId: ctx.userId },
 	});
 
@@ -105,7 +107,7 @@ export async function updateComment(ctx: ServiceCtx, input: unknown): Promise<{ 
 	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
 	const { issueId, commentId, body } = parsed.data;
 
-	await assertIssueVisible(ctx, issueId);
+	const projectId = await assertIssueVisible(ctx, issueId);
 
 	const orm = drizzle(ctx.db, { schema });
 	const comment = await orm
@@ -124,6 +126,7 @@ export async function updateComment(ctx: ServiceCtx, input: unknown): Promise<{ 
 
 	await broadcastWorkspaceEvent(ctx, {
 		type: "comment.updated",
+		projectId,
 		data: { id: commentId, issueId },
 	});
 
@@ -135,7 +138,7 @@ export async function deleteComment(ctx: ServiceCtx, input: unknown): Promise<{ 
 	if (!parsed.success) throw new ValidationError(parsed.error.flatten());
 	const { issueId, commentId } = parsed.data;
 
-	await assertIssueVisible(ctx, issueId);
+	const projectId = await assertIssueVisible(ctx, issueId);
 
 	const orm = drizzle(ctx.db, { schema });
 	const comment = await orm
@@ -153,6 +156,7 @@ export async function deleteComment(ctx: ServiceCtx, input: unknown): Promise<{ 
 
 	await broadcastWorkspaceEvent(ctx, {
 		type: "comment.deleted",
+		projectId,
 		data: { id: commentId, issueId },
 	});
 

--- a/apps/api/src/services/comments.ts
+++ b/apps/api/src/services/comments.ts
@@ -8,6 +8,7 @@ import {
 } from "../schemas/comments";
 import { effectiveProjectRole, isWorkspaceAdmin } from "./access";
 import { ForbiddenError, NotFoundError, ValidationError } from "./errors";
+import { broadcastWorkspaceEvent } from "./realtime";
 import type { ServiceCtx } from "./types";
 
 interface CommentRow {
@@ -91,6 +92,11 @@ export async function addComment(ctx: ServiceCtx, input: unknown): Promise<{ id:
 		authorKind: ctx.authKind ?? null,
 	});
 
+	await broadcastWorkspaceEvent(ctx, {
+		type: "comment.created",
+		data: { id, issueId, authorId: ctx.userId },
+	});
+
 	return { id };
 }
 
@@ -116,6 +122,11 @@ export async function updateComment(ctx: ServiceCtx, input: unknown): Promise<{ 
 		.set({ body, updatedAt: Math.floor(Date.now() / 1000) })
 		.where(eq(schema.issueComments.id, commentId));
 
+	await broadcastWorkspaceEvent(ctx, {
+		type: "comment.updated",
+		data: { id: commentId, issueId },
+	});
+
 	return { ok: true };
 }
 
@@ -139,6 +150,11 @@ export async function deleteComment(ctx: ServiceCtx, input: unknown): Promise<{ 
 	if (!canDelete) throw new ForbiddenError("Forbidden");
 
 	await orm.delete(schema.issueComments).where(eq(schema.issueComments.id, commentId));
+
+	await broadcastWorkspaceEvent(ctx, {
+		type: "comment.deleted",
+		data: { id: commentId, issueId },
+	});
 
 	return { ok: true };
 }

--- a/apps/api/src/services/file-claims.ts
+++ b/apps/api/src/services/file-claims.ts
@@ -4,6 +4,7 @@ import { ClaimFilesSchema, ListFileClaimsSchema, ReleaseFilesSchema } from "../s
 import { visibleProjectPredicate } from "./access";
 import { postMessage } from "./agent-messages";
 import { ConflictError, NotFoundError, ValidationError } from "./errors";
+import { broadcastWorkspaceEvent } from "./realtime";
 import { inChunks } from "./sql";
 import type { ServiceCtx } from "./types";
 
@@ -293,6 +294,11 @@ export async function claimFiles(ctx: ServiceCtx, raw: unknown) {
 		now,
 	});
 
+	await broadcastWorkspaceEvent(ctx, {
+		type: "claims.created",
+		data: { issueId, agentId, paths, count: created.length },
+	});
+
 	return { created, overridden, reclaimed };
 }
 
@@ -345,6 +351,11 @@ export async function releaseFiles(ctx: ServiceCtx, raw: unknown) {
 	const released = await inChunks(releaseIds, (chunk) =>
 		orm.select().from(schema.issueFileClaims).where(inArray(schema.issueFileClaims.id, chunk))
 	);
+
+	await broadcastWorkspaceEvent(ctx, {
+		type: "claims.released",
+		data: { issueId, paths, count: released.length },
+	});
 
 	return { released, count: released.length };
 }

--- a/apps/api/src/services/file-claims.ts
+++ b/apps/api/src/services/file-claims.ts
@@ -12,13 +12,14 @@ async function assertIssueInWorkspace(
 	orm: ReturnType<typeof drizzle>,
 	workspaceId: string,
 	issueId: string
-) {
+): Promise<string> {
 	const issue = await orm
-		.select({ id: schema.issues.id })
+		.select({ projectId: schema.issues.projectId })
 		.from(schema.issues)
 		.where(and(eq(schema.issues.id, issueId), eq(schema.issues.workspaceId, workspaceId)))
 		.get();
 	if (!issue) throw new NotFoundError("Issue not found");
+	return issue.projectId;
 }
 
 async function assertAgentInWorkspace(
@@ -250,7 +251,7 @@ export async function claimFiles(ctx: ServiceCtx, raw: unknown) {
 
 	const orm = drizzle(ctx.db, { schema });
 
-	await assertIssueInWorkspace(orm, ctx.workspaceId, issueId);
+	const projectId = await assertIssueInWorkspace(orm, ctx.workspaceId, issueId);
 	if (agentId) {
 		await assertAgentInWorkspace(orm, ctx.workspaceId, agentId);
 	}
@@ -296,6 +297,7 @@ export async function claimFiles(ctx: ServiceCtx, raw: unknown) {
 
 	await broadcastWorkspaceEvent(ctx, {
 		type: "claims.created",
+		projectId,
 		data: { issueId, agentId, paths, count: created.length },
 	});
 
@@ -352,10 +354,37 @@ export async function releaseFiles(ctx: ServiceCtx, raw: unknown) {
 		orm.select().from(schema.issueFileClaims).where(inArray(schema.issueFileClaims.id, chunk))
 	);
 
-	await broadcastWorkspaceEvent(ctx, {
-		type: "claims.released",
-		data: { issueId, paths, count: released.length },
-	});
+	// Stamp projectId on the broadcast. When issueId is provided there is exactly one
+	// project; otherwise released rows may span projects, so fan out one event per project.
+	if (issueId) {
+		const projectId = await assertIssueInWorkspace(orm, ctx.workspaceId, issueId);
+		await broadcastWorkspaceEvent(ctx, {
+			type: "claims.released",
+			projectId,
+			data: { issueId, paths, count: released.length },
+		});
+	} else {
+		const releasedByProject = await inChunks(releaseIds, (chunk) =>
+			orm
+				.select({ projectId: schema.issues.projectId, path: schema.issueFileClaims.path })
+				.from(schema.issueFileClaims)
+				.innerJoin(schema.issues, eq(schema.issueFileClaims.issueId, schema.issues.id))
+				.where(inArray(schema.issueFileClaims.id, chunk))
+		);
+		const grouped = new Map<string, string[]>();
+		for (const row of releasedByProject) {
+			const list = grouped.get(row.projectId) ?? [];
+			list.push(row.path);
+			grouped.set(row.projectId, list);
+		}
+		for (const [projectId, projectPaths] of grouped) {
+			await broadcastWorkspaceEvent(ctx, {
+				type: "claims.released",
+				projectId,
+				data: { issueId, paths: projectPaths, count: projectPaths.length },
+			});
+		}
+	}
 
 	return { released, count: released.length };
 }

--- a/apps/api/src/services/issue-leases.ts
+++ b/apps/api/src/services/issue-leases.ts
@@ -7,6 +7,7 @@ import {
 } from "../schemas/issue-leases";
 import { visibleProjectPredicate } from "./access";
 import { ConflictError, NotFoundError, ValidationError } from "./errors";
+import { broadcastWorkspaceEvent } from "./realtime";
 import type { ServiceCtx } from "./types";
 
 // Mirrors ACTIVE_TTL in services/agents.ts: a session (and therefore its leases)
@@ -218,6 +219,13 @@ export async function claimIssue(ctx: ServiceCtx, raw: unknown) {
 		.from(schema.issueLeases)
 		.where(eq(schema.issueLeases.id, id))
 		.get();
+
+	await broadcastWorkspaceEvent(ctx, {
+		type: "lease.claimed",
+		projectId,
+		data: { issueId, agentId, id },
+	});
+
 	// biome-ignore lint/style/noNonNullAssertion: row was just inserted; SELECT immediately after guarantees it exists
 	return row!;
 }
@@ -249,6 +257,11 @@ export async function releaseIssue(ctx: ServiceCtx, raw: unknown) {
 		.update(schema.issueLeases)
 		.set({ releasedAt: now, releaseReason: "released" })
 		.where(eq(schema.issueLeases.id, active.id));
+
+	await broadcastWorkspaceEvent(ctx, {
+		type: "lease.released",
+		data: { issueId, agentId },
+	});
 
 	return { ok: true };
 }

--- a/apps/api/src/services/issue-leases.ts
+++ b/apps/api/src/services/issue-leases.ts
@@ -253,6 +253,13 @@ export async function releaseIssue(ctx: ServiceCtx, raw: unknown) {
 		.get();
 	if (!active) throw new NotFoundError("No active lease on this issue");
 
+	const issue = await orm
+		.select({ projectId: schema.issues.projectId })
+		.from(schema.issues)
+		.where(and(eq(schema.issues.id, issueId), eq(schema.issues.workspaceId, ctx.workspaceId)))
+		.get();
+	if (!issue) throw new NotFoundError("Issue not found");
+
 	await orm
 		.update(schema.issueLeases)
 		.set({ releasedAt: now, releaseReason: "released" })
@@ -260,6 +267,7 @@ export async function releaseIssue(ctx: ServiceCtx, raw: unknown) {
 
 	await broadcastWorkspaceEvent(ctx, {
 		type: "lease.released",
+		projectId: issue.projectId,
 		data: { issueId, agentId },
 	});
 

--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -49,6 +49,7 @@ import {
 	liveLeasedIssueIds,
 } from "./issue-leases";
 import { listLinksForIssue } from "./issue-links";
+import { broadcastWorkspaceEvent } from "./realtime";
 import { inChunks, sanitizeFtsQuery } from "./sql";
 import { resolveStatus } from "./task-statuses";
 import type { ServiceCtx } from "./types";
@@ -805,6 +806,12 @@ export async function createIssue(ctx: ServiceCtx, raw: unknown) {
 
 	const row = await finalizeCreateIssue(ctx, orm, id, parentId, cfWrites);
 
+	await broadcastWorkspaceEvent(ctx, {
+		type: "issue.created",
+		projectId: data.projectId,
+		data: { id, number: row?.number, title: data.title, status: resolvedStatusKey ?? "todo" },
+	});
+
 	return { id, number: row?.number };
 }
 
@@ -1317,6 +1324,13 @@ export async function updateIssue(ctx: ServiceCtx, id: string, raw: unknown) {
 
 	await invalidateUpdateCaches(ctx, id, data, existing);
 
+	const isStatusChange = data.status !== undefined || data.statusId !== undefined;
+	await broadcastWorkspaceEvent(ctx, {
+		type: isStatusChange ? "issue.status_changed" : "issue.updated",
+		projectId: existing.projectId ?? undefined,
+		data: { id, updates: data },
+	});
+
 	return { ok: true };
 }
 
@@ -1352,6 +1366,12 @@ export async function deleteIssue(ctx: ServiceCtx, id: string) {
 	if (existing?.parentId) {
 		await cache.invalidate(ctx.kv, `issue:${ctx.workspaceId}:${existing.parentId}`);
 	}
+
+	await broadcastWorkspaceEvent(ctx, {
+		type: "issue.deleted",
+		projectId: existing?.projectId ?? undefined,
+		data: { id },
+	});
 
 	return { ok: true };
 }

--- a/apps/api/src/services/realtime.ts
+++ b/apps/api/src/services/realtime.ts
@@ -20,8 +20,12 @@ export async function broadcastWorkspaceEvent(ctx: ServiceCtx, event: EventInput
 
 	try {
 		const stub = ctx.workspaceHub.get(ctx.workspaceHub.idFromName(ctx.workspaceId));
-		const sendPromise = (stub as unknown as { broadcast: (e: RealtimeEvent) => Promise<unknown> })
-			.broadcast(fullEvent)
+		const sendPromise = stub
+			.fetch("http://do/broadcast", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(fullEvent),
+			})
 			.catch(() => {
 				// Prevent broadcast errors from affecting the calling service
 			});

--- a/apps/api/src/services/realtime.ts
+++ b/apps/api/src/services/realtime.ts
@@ -1,0 +1,37 @@
+import type { RealtimeEvent } from "@projektor/types";
+import type { ServiceCtx } from "./types";
+
+export type EventInput = Omit<RealtimeEvent, "workspaceId" | "timestamp">;
+
+/**
+ * Dispatches a realtime event to the workspace's Durable Object hub.
+ *
+ * If WORKSPACE_HUB is not configured (e.g. 1-click or free-tier deployments),
+ * this function is a no-op and completes immediately.
+ */
+export async function broadcastWorkspaceEvent(ctx: ServiceCtx, event: EventInput): Promise<void> {
+	if (!ctx.workspaceHub) return;
+
+	const fullEvent: RealtimeEvent = {
+		...event,
+		workspaceId: ctx.workspaceId,
+		timestamp: Math.floor(Date.now() / 1000),
+	};
+
+	try {
+		const stub = ctx.workspaceHub.get(ctx.workspaceHub.idFromName(ctx.workspaceId));
+		const sendPromise = (stub as unknown as { broadcast: (e: RealtimeEvent) => Promise<unknown> })
+			.broadcast(fullEvent)
+			.catch(() => {
+				// Prevent broadcast errors from affecting the calling service
+			});
+
+		if (ctx.waitUntil) {
+			ctx.waitUntil(sendPromise);
+		} else {
+			await sendPromise;
+		}
+	} catch {
+		// Durable Object dispatch failed or unavailable; swallow silently to preserve DB write integrity
+	}
+}

--- a/apps/api/src/services/types.ts
+++ b/apps/api/src/services/types.ts
@@ -11,6 +11,8 @@ export interface ServiceCtx {
 	// PROJ-328: which auth path authenticated this request ("human" = Cloudflare Access
 	// JWT / dev bypass, "agent" = Bearer API token). See middleware/auth.ts.
 	authKind?: "human" | "agent";
+	workspaceHub?: DurableObjectNamespace;
+	waitUntil?: (promise: Promise<unknown>) => void;
 }
 
 export function ctxFromHono(c: Context<HonoEnv>): ServiceCtx {
@@ -26,5 +28,7 @@ export function ctxFromHono(c: Context<HonoEnv>): ServiceCtx {
 		userId: user.id,
 		role,
 		authKind,
+		workspaceHub: c.env.WORKSPACE_HUB,
+		waitUntil: c.executionCtx?.waitUntil ? (p) => c.executionCtx.waitUntil(p) : undefined,
 	};
 }

--- a/apps/api/src/test/access-enforcement.test.ts
+++ b/apps/api/src/test/access-enforcement.test.ts
@@ -1,5 +1,6 @@
-import { SELF } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
+import { visibleProjectIds } from "../services/access";
 import { authHeaders, seedGroupGrant, seedIssue, seedProject, seedWorkspaceRoles } from "./helpers";
 
 // PROJ-311: group-based project access. Authorization lives entirely in projektor:
@@ -151,5 +152,64 @@ describe("PROJ-311 group-based project access", () => {
 			headers: authHeaders(roles.member.token, slug),
 		});
 		expect(getRes.status).toBe(200);
+	});
+});
+
+describe("visibleProjectIds helper", () => {
+	it("returns every project for owner and admin", async () => {
+		const roles = await seedWorkspaceRoles();
+		const p1 = await seedProject(roles.workspace.id, "P1");
+		const p2 = await seedProject(roles.workspace.id, "P2");
+
+		const ownerCtx = {
+			db: env.DB,
+			kv: env.KV,
+			r2: env.R2,
+			workspaceId: roles.workspace.id,
+			userId: roles.owner.user.id,
+			role: "owner" as const,
+		};
+
+		const ids = await visibleProjectIds(ownerCtx);
+		expect(ids.sort()).toEqual([p1.id, p2.id].sort());
+
+		const adminCtx = { ...ownerCtx, userId: roles.owner.user.id, role: "admin" as const };
+		expect((await visibleProjectIds(adminCtx)).sort()).toEqual([p1.id, p2.id].sort());
+	});
+
+	it("returns only granted projects for a non-admin member", async () => {
+		const roles = await seedWorkspaceRoles();
+		const granted = await seedProject(roles.workspace.id, "SEEN");
+		await seedProject(roles.workspace.id, "HID");
+		await seedGroupGrant(roles.workspace.id, roles.member.user.id, granted.id, "member");
+
+		const ctx = {
+			db: env.DB,
+			kv: env.KV,
+			r2: env.R2,
+			workspaceId: roles.workspace.id,
+			userId: roles.member.user.id,
+			role: "member" as const,
+		};
+
+		const ids = await visibleProjectIds(ctx);
+		expect(ids).toEqual([granted.id]);
+	});
+
+	it("returns an empty list for a member with no grants", async () => {
+		const roles = await seedWorkspaceRoles();
+		await seedProject(roles.workspace.id, "LONE");
+
+		const ctx = {
+			db: env.DB,
+			kv: env.KV,
+			r2: env.R2,
+			workspaceId: roles.workspace.id,
+			userId: roles.member.user.id,
+			role: "member" as const,
+		};
+
+		const ids = await visibleProjectIds(ctx);
+		expect(ids).toEqual([]);
 	});
 });

--- a/apps/api/src/test/realtime.test.ts
+++ b/apps/api/src/test/realtime.test.ts
@@ -417,6 +417,54 @@ describe("Realtime WebSockets (Opt-In)", () => {
 		expect(mockWs.send).toHaveBeenCalledWith(expect.stringContaining('"type":"pong"'));
 	});
 
+	it("WorkspaceHub drops a removed admin's stale elevated access on refresh", async () => {
+		const roles = await seedWorkspaceRoles();
+		await env.DB.prepare("DELETE FROM workspace_members WHERE workspace_id = ? AND user_id = ?")
+			.bind(roles.workspace.id, roles.owner.user.id)
+			.run();
+
+		const serializeAttachment = vi.fn();
+		let attachment = {
+			userId: roles.owner.user.id,
+			workspaceId: roles.workspace.id,
+			role: "owner",
+			visibleProjectIds: [],
+			subscribedAt: 1,
+			snapshotAt: 1,
+		};
+		const mockWs = {
+			send: vi.fn(),
+			serializeAttachment: serializeAttachment.mockImplementation((next) => {
+				attachment = next;
+			}),
+			deserializeAttachment: vi.fn().mockImplementation(() => attachment),
+			close: vi.fn(),
+		};
+
+		const state = {
+			acceptWebSocket: vi.fn(),
+			getWebSockets: vi.fn().mockReturnValue([mockWs]),
+		};
+		const hub = new WorkspaceHub(state as unknown as DurableObjectState, env as unknown as Env);
+
+		await hub.webSocketMessage(mockWs as unknown as WebSocket, JSON.stringify({ action: "ping" }));
+
+		expect(serializeAttachment).toHaveBeenCalledWith(
+			expect.objectContaining({ role: undefined, visibleProjectIds: [] })
+		);
+
+		const { recipientCount } = await hub.broadcast({
+			type: "workspace.event",
+			workspaceId: roles.workspace.id,
+			data: { id: "should-not-reach-removed-admin" },
+			timestamp: Math.floor(Date.now() / 1000),
+		});
+		expect(recipientCount).toBe(0);
+		expect(mockWs.send).not.toHaveBeenCalledWith(
+			expect.stringContaining("should-not-reach-removed-admin")
+		);
+	});
+
 	it("WorkspaceHub.fetch computes visibleProjectIds from the database on upgrade", async () => {
 		const roles = await seedWorkspaceRoles();
 		const grantedProject = await seedProject(roles.workspace.id, "SEEN");

--- a/apps/api/src/test/realtime.test.ts
+++ b/apps/api/src/test/realtime.test.ts
@@ -106,6 +106,7 @@ describe("Realtime WebSockets (Opt-In)", () => {
 				role: "owner",
 				visibleProjectIds: [projectId],
 				subscribedAt: 12345,
+				snapshotAt: 12345,
 			}),
 			close: vi.fn(),
 		};
@@ -143,6 +144,7 @@ describe("Realtime WebSockets (Opt-In)", () => {
 				role: "member",
 				visibleProjectIds: [projectId],
 				subscribedAt: 12345,
+				snapshotAt: 12345,
 			}),
 			close: vi.fn(),
 		};
@@ -184,6 +186,7 @@ describe("Realtime WebSockets (Opt-In)", () => {
 				workspaceId,
 				role: "member",
 				visibleProjectIds: [projectId],
+				snapshotAt: 12345,
 				filters: {
 					projects: [projectId],
 					eventTypes: ["issue.*"],
@@ -198,6 +201,7 @@ describe("Realtime WebSockets (Opt-In)", () => {
 				workspaceId,
 				role: "member",
 				visibleProjectIds: ["other-project-id"],
+				snapshotAt: 12345,
 				filters: {
 					projects: ["other-project-id"],
 					eventTypes: ["issue.*"],
@@ -212,6 +216,7 @@ describe("Realtime WebSockets (Opt-In)", () => {
 				workspaceId,
 				role: "member",
 				visibleProjectIds: [projectId],
+				snapshotAt: 12345,
 				filters: {
 					projects: [projectId],
 					eventTypes: ["comment.*"],
@@ -248,6 +253,7 @@ describe("Realtime WebSockets (Opt-In)", () => {
 				workspaceId,
 				role: "member",
 				visibleProjectIds: [projectId],
+				snapshotAt: 12345,
 				filters: {},
 			}),
 		};
@@ -259,6 +265,7 @@ describe("Realtime WebSockets (Opt-In)", () => {
 				workspaceId,
 				role: "member",
 				visibleProjectIds: ["allowed-but-other"],
+				snapshotAt: 12345,
 				filters: {},
 			}),
 		};
@@ -270,6 +277,7 @@ describe("Realtime WebSockets (Opt-In)", () => {
 				workspaceId,
 				role: "owner",
 				visibleProjectIds: [projectId],
+				snapshotAt: 12345,
 				filters: {},
 			}),
 		};
@@ -303,6 +311,7 @@ describe("Realtime WebSockets (Opt-In)", () => {
 				workspaceId,
 				role: "member",
 				visibleProjectIds: ["some-other-project"],
+				snapshotAt: 12345,
 				filters: {
 					projects: [projectId],
 				},
@@ -326,6 +335,86 @@ describe("Realtime WebSockets (Opt-In)", () => {
 
 		expect(result.recipientCount).toBe(0);
 		expect(spyWs.send).not.toHaveBeenCalled();
+	});
+
+	it("WorkspaceHub.broadcast fails closed for non-admins when projectId is missing", async () => {
+		const memberWs = {
+			send: vi.fn(),
+			deserializeAttachment: vi.fn().mockReturnValue({
+				userId,
+				workspaceId,
+				role: "member",
+				visibleProjectIds: [projectId],
+				snapshotAt: 12345,
+				filters: {},
+			}),
+		};
+
+		const adminWs = {
+			send: vi.fn(),
+			deserializeAttachment: vi.fn().mockReturnValue({
+				userId,
+				workspaceId,
+				role: "owner",
+				visibleProjectIds: [projectId],
+				snapshotAt: 12345,
+				filters: {},
+			}),
+		};
+
+		const state = {
+			acceptWebSocket: vi.fn(),
+			getWebSockets: vi.fn().mockReturnValue([memberWs, adminWs]),
+		};
+
+		const hub = new WorkspaceHub(state as unknown as DurableObjectState, env as unknown as Env);
+
+		const result = await hub.broadcast({
+			type: "workspace.announcement",
+			workspaceId,
+			data: { id: "announcement-1" },
+			timestamp: Math.floor(Date.now() / 1000),
+		});
+
+		expect(result.recipientCount).toBe(1);
+		expect(memberWs.send).not.toHaveBeenCalled();
+		expect(adminWs.send).toHaveBeenCalled();
+	});
+
+	it("WorkspaceHub refreshes a stale visibility snapshot on ping", async () => {
+		const roles = await seedWorkspaceRoles();
+		const grantedProject = await seedProject(roles.workspace.id, "SEEN");
+		await seedGroupGrant(roles.workspace.id, roles.member.user.id, grantedProject.id, "member");
+
+		const serializeAttachment = vi.fn();
+		const mockWs = {
+			send: vi.fn(),
+			serializeAttachment,
+			deserializeAttachment: vi.fn().mockReturnValue({
+				userId: roles.member.user.id,
+				workspaceId: roles.workspace.id,
+				role: "member",
+				visibleProjectIds: [],
+				subscribedAt: 1,
+				snapshotAt: 1,
+			}),
+			close: vi.fn(),
+		};
+
+		const state = {
+			acceptWebSocket: vi.fn(),
+			getWebSockets: vi.fn().mockReturnValue([]),
+		};
+		const hub = new WorkspaceHub(state as unknown as DurableObjectState, env as unknown as Env);
+
+		await hub.webSocketMessage(mockWs as unknown as WebSocket, JSON.stringify({ action: "ping" }));
+
+		expect(serializeAttachment).toHaveBeenCalledWith(
+			expect.objectContaining({
+				visibleProjectIds: [grantedProject.id],
+			})
+		);
+		expect(mockWs.send).toHaveBeenCalledWith(expect.stringContaining('"type":"pong"'));
 	});
 
 	it("WorkspaceHub.fetch computes visibleProjectIds from the database on upgrade", async () => {

--- a/apps/api/src/test/realtime.test.ts
+++ b/apps/api/src/test/realtime.test.ts
@@ -5,7 +5,13 @@ import { WorkspaceHub } from "../realtime/workspace-hub";
 import { createIssue } from "../services/issues";
 import { broadcastWorkspaceEvent } from "../services/realtime";
 import type { ServiceCtx } from "../services/types";
-import { authHeaders, seedProjectFixture } from "./helpers";
+import {
+	authHeaders,
+	seedGroupGrant,
+	seedProject,
+	seedProjectFixture,
+	seedWorkspaceRoles,
+} from "./helpers";
 
 describe("Realtime WebSockets (Opt-In)", () => {
 	let token: string;
@@ -48,6 +54,22 @@ describe("Realtime WebSockets (Opt-In)", () => {
 		).resolves.toBeUndefined();
 	});
 
+	it("WorkspaceHub rejects WebSocket upgrades without internal identity headers", async () => {
+		const state = {
+			acceptWebSocket: vi.fn(),
+			getWebSockets: vi.fn().mockReturnValue([]),
+		};
+
+		const hub = new WorkspaceHub(state as unknown as DurableObjectState, env as unknown as Env);
+
+		const wsReq = new Request("http://localhost/realtime", {
+			headers: { Upgrade: "websocket" },
+		});
+		const wsRes = await hub.fetch(wsReq);
+		expect(wsRes.status).toBe(401);
+		expect(state.acceptWebSocket).not.toHaveBeenCalled();
+	});
+
 	it("WorkspaceHub handles WebSocket upgrade, ping/pong, and subscription filtering", async () => {
 		const state = {
 			acceptWebSocket: vi.fn(),
@@ -61,9 +83,14 @@ describe("Realtime WebSockets (Opt-In)", () => {
 		const httpRes = await hub.fetch(httpReq);
 		expect(httpRes.status).toBe(426);
 
-		// WebSocket upgrade request
+		// WebSocket upgrade request with identity headers
 		const wsReq = new Request("http://localhost/realtime", {
-			headers: { Upgrade: "websocket" },
+			headers: {
+				Upgrade: "websocket",
+				"X-Internal-User-Id": userId,
+				"X-Internal-Workspace-Id": workspaceId,
+				"X-Internal-Role": "owner",
+			},
 		});
 		const wsRes = await hub.fetch(wsReq);
 		expect(wsRes.status).toBe(101);
@@ -73,7 +100,13 @@ describe("Realtime WebSockets (Opt-In)", () => {
 		const mockWs = {
 			send: vi.fn(),
 			serializeAttachment: vi.fn(),
-			deserializeAttachment: vi.fn().mockReturnValue({ subscribedAt: 12345 }),
+			deserializeAttachment: vi.fn().mockReturnValue({
+				userId,
+				workspaceId,
+				role: "owner",
+				visibleProjectIds: [projectId],
+				subscribedAt: 12345,
+			}),
 			close: vi.fn(),
 		};
 
@@ -100,10 +133,57 @@ describe("Realtime WebSockets (Opt-In)", () => {
 		expect(mockWs.send).toHaveBeenCalledWith(expect.stringContaining('"type":"subscribed"'));
 	});
 
+	it("WorkspaceHub.subscribe intersects requested projects with the caller's visible set", async () => {
+		const mockWs = {
+			send: vi.fn(),
+			serializeAttachment: vi.fn(),
+			deserializeAttachment: vi.fn().mockReturnValue({
+				userId,
+				workspaceId,
+				role: "member",
+				visibleProjectIds: [projectId],
+				subscribedAt: 12345,
+			}),
+			close: vi.fn(),
+		};
+
+		const state = {
+			acceptWebSocket: vi.fn(),
+			getWebSockets: vi.fn().mockReturnValue([]),
+		};
+		const hub = new WorkspaceHub(state as unknown as DurableObjectState, env as unknown as Env);
+
+		await hub.webSocketMessage(
+			mockWs as unknown as WebSocket,
+			JSON.stringify({
+				action: "subscribe",
+				projects: [projectId, "forbidden-project-id"],
+				eventTypes: ["issue.*"],
+			})
+		);
+
+		expect(mockWs.serializeAttachment).toHaveBeenCalledWith(
+			expect.objectContaining({
+				filters: {
+					projects: [projectId],
+					eventTypes: ["issue.*"],
+				},
+			})
+		);
+		const subscribedCall = mockWs.send.mock.calls.find((call) =>
+			String(call[0]).includes('"type":"subscribed"')
+		);
+		expect(subscribedCall).toBeTruthy();
+	});
+
 	it("WorkspaceHub.broadcast sends events to matching sockets and filters non-matching", async () => {
 		const matchingWs = {
 			send: vi.fn(),
 			deserializeAttachment: vi.fn().mockReturnValue({
+				userId,
+				workspaceId,
+				role: "member",
+				visibleProjectIds: [projectId],
 				filters: {
 					projects: [projectId],
 					eventTypes: ["issue.*"],
@@ -114,6 +194,10 @@ describe("Realtime WebSockets (Opt-In)", () => {
 		const otherProjectWs = {
 			send: vi.fn(),
 			deserializeAttachment: vi.fn().mockReturnValue({
+				userId,
+				workspaceId,
+				role: "member",
+				visibleProjectIds: ["other-project-id"],
 				filters: {
 					projects: ["other-project-id"],
 					eventTypes: ["issue.*"],
@@ -124,6 +208,10 @@ describe("Realtime WebSockets (Opt-In)", () => {
 		const otherTypeWs = {
 			send: vi.fn(),
 			deserializeAttachment: vi.fn().mockReturnValue({
+				userId,
+				workspaceId,
+				role: "member",
+				visibleProjectIds: [projectId],
 				filters: {
 					projects: [projectId],
 					eventTypes: ["comment.*"],
@@ -150,6 +238,149 @@ describe("Realtime WebSockets (Opt-In)", () => {
 		expect(matchingWs.send).toHaveBeenCalledWith(expect.stringContaining('"type":"issue.created"'));
 		expect(otherProjectWs.send).not.toHaveBeenCalled();
 		expect(otherTypeWs.send).not.toHaveBeenCalled();
+	});
+
+	it("WorkspaceHub.broadcast enforces server-side visibility even without a client filter", async () => {
+		const allowedWs = {
+			send: vi.fn(),
+			deserializeAttachment: vi.fn().mockReturnValue({
+				userId,
+				workspaceId,
+				role: "member",
+				visibleProjectIds: [projectId],
+				filters: {},
+			}),
+		};
+
+		const forbiddenWs = {
+			send: vi.fn(),
+			deserializeAttachment: vi.fn().mockReturnValue({
+				userId,
+				workspaceId,
+				role: "member",
+				visibleProjectIds: ["allowed-but-other"],
+				filters: {},
+			}),
+		};
+
+		const adminWs = {
+			send: vi.fn(),
+			deserializeAttachment: vi.fn().mockReturnValue({
+				userId,
+				workspaceId,
+				role: "owner",
+				visibleProjectIds: [projectId],
+				filters: {},
+			}),
+		};
+
+		const state = {
+			acceptWebSocket: vi.fn(),
+			getWebSockets: vi.fn().mockReturnValue([allowedWs, forbiddenWs, adminWs]),
+		};
+
+		const hub = new WorkspaceHub(state as unknown as DurableObjectState, env as unknown as Env);
+
+		const result = await hub.broadcast({
+			type: "issue.created",
+			workspaceId,
+			projectId,
+			data: { id: "issue-123" },
+			timestamp: Math.floor(Date.now() / 1000),
+		});
+
+		expect(result.recipientCount).toBe(2);
+		expect(allowedWs.send).toHaveBeenCalled();
+		expect(forbiddenWs.send).not.toHaveBeenCalled();
+		expect(adminWs.send).toHaveBeenCalled();
+	});
+
+	it("WorkspaceHub.broadcast drops events for projects the socket cannot see", async () => {
+		const spyWs = {
+			send: vi.fn(),
+			deserializeAttachment: vi.fn().mockReturnValue({
+				userId,
+				workspaceId,
+				role: "member",
+				visibleProjectIds: ["some-other-project"],
+				filters: {
+					projects: [projectId],
+				},
+			}),
+		};
+
+		const state = {
+			acceptWebSocket: vi.fn(),
+			getWebSockets: vi.fn().mockReturnValue([spyWs]),
+		};
+
+		const hub = new WorkspaceHub(state as unknown as DurableObjectState, env as unknown as Env);
+
+		const result = await hub.broadcast({
+			type: "issue.created",
+			workspaceId,
+			projectId,
+			data: { id: "issue-123" },
+			timestamp: Math.floor(Date.now() / 1000),
+		});
+
+		expect(result.recipientCount).toBe(0);
+		expect(spyWs.send).not.toHaveBeenCalled();
+	});
+
+	it("WorkspaceHub.fetch computes visibleProjectIds from the database on upgrade", async () => {
+		const roles = await seedWorkspaceRoles();
+		const grantedProject = await seedProject(roles.workspace.id, "SEEN");
+		await seedProject(roles.workspace.id, "HID");
+		await seedGroupGrant(roles.workspace.id, roles.member.user.id, grantedProject.id, "member");
+
+		const acceptWebSocket = vi.fn();
+		const state = {
+			acceptWebSocket,
+			getWebSockets: vi.fn().mockReturnValue([]),
+		};
+
+		const hub = new WorkspaceHub(state as unknown as DurableObjectState, env as unknown as Env);
+
+		const req = new Request("http://localhost/realtime", {
+			headers: {
+				Upgrade: "websocket",
+				"X-Internal-User-Id": roles.member.user.id,
+				"X-Internal-Workspace-Id": roles.workspace.id,
+				"X-Internal-Role": "member",
+			},
+		});
+
+		const res = await hub.fetch(req);
+		expect(res.status).toBe(101);
+		expect(acceptWebSocket).toHaveBeenCalled();
+	});
+
+	it("WorkspaceHub.fetch computes all project IDs for owner/admin on upgrade", async () => {
+		const roles = await seedWorkspaceRoles();
+		await seedProject(roles.workspace.id, "P1");
+		await seedProject(roles.workspace.id, "P2");
+
+		const acceptWebSocket = vi.fn();
+		const state = {
+			acceptWebSocket,
+			getWebSockets: vi.fn().mockReturnValue([]),
+		};
+
+		const hub = new WorkspaceHub(state as unknown as DurableObjectState, env as unknown as Env);
+
+		const req = new Request("http://localhost/realtime", {
+			headers: {
+				Upgrade: "websocket",
+				"X-Internal-User-Id": roles.owner.user.id,
+				"X-Internal-Workspace-Id": roles.workspace.id,
+				"X-Internal-Role": "owner",
+			},
+		});
+
+		const res = await hub.fetch(req);
+		expect(res.status).toBe(101);
+		expect(acceptWebSocket).toHaveBeenCalled();
 	});
 
 	it("dispatches broadcast event when creating an issue with WORKSPACE_HUB stub", async () => {

--- a/apps/api/src/test/realtime.test.ts
+++ b/apps/api/src/test/realtime.test.ts
@@ -153,9 +153,11 @@ describe("Realtime WebSockets (Opt-In)", () => {
 	});
 
 	it("dispatches broadcast event when creating an issue with WORKSPACE_HUB stub", async () => {
-		const broadcastMock = vi.fn().mockResolvedValue({ recipientCount: 1 });
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValue(new Response(JSON.stringify({ recipientCount: 1 })));
 		const mockStub = {
-			broadcast: broadcastMock,
+			fetch: fetchMock,
 		};
 		const mockHubNamespace = {
 			idFromName: vi.fn().mockReturnValue("mock-do-id"),
@@ -178,15 +180,11 @@ describe("Realtime WebSockets (Opt-In)", () => {
 		});
 
 		expect(created.id).toBeTruthy();
-		expect(broadcastMock).toHaveBeenCalledWith(
+		expect(fetchMock).toHaveBeenCalledWith(
+			"http://do/broadcast",
 			expect.objectContaining({
-				type: "issue.created",
-				workspaceId,
-				projectId,
-				data: expect.objectContaining({
-					id: created.id,
-					title: "Realtime test issue",
-				}),
+				method: "POST",
+				body: expect.stringContaining('"type":"issue.created"'),
 			})
 		);
 	});

--- a/apps/api/src/test/realtime.test.ts
+++ b/apps/api/src/test/realtime.test.ts
@@ -1,0 +1,193 @@
+import { env, SELF } from "cloudflare:test";
+import type { Env } from "@projektor/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WorkspaceHub } from "../realtime/workspace-hub";
+import { createIssue } from "../services/issues";
+import { broadcastWorkspaceEvent } from "../services/realtime";
+import type { ServiceCtx } from "../services/types";
+import { authHeaders, seedProjectFixture } from "./helpers";
+
+describe("Realtime WebSockets (Opt-In)", () => {
+	let token: string;
+	let slug: string;
+	let workspaceId: string;
+	let userId: string;
+	let projectId: string;
+
+	beforeEach(async () => {
+		({ token, slug, workspaceId, userId, projectId } = await seedProjectFixture({ role: "owner" }));
+	});
+
+	it("returns 501 when WORKSPACE_HUB is not configured (graceful degradation)", async () => {
+		const res = await SELF.fetch(`http://localhost/api/workspaces/${slug}/realtime`, {
+			headers: {
+				...authHeaders(token, slug),
+				Upgrade: "websocket",
+			},
+		});
+		expect(res.status).toBe(501);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toContain("Realtime WebSockets are not enabled");
+	});
+
+	it("broadcastWorkspaceEvent is a silent no-op when WORKSPACE_HUB is undefined", async () => {
+		const ctx: ServiceCtx = {
+			db: env.DB,
+			kv: env.KV,
+			r2: env.R2,
+			workspaceId,
+			userId,
+		};
+
+		await expect(
+			broadcastWorkspaceEvent(ctx, {
+				type: "issue.created",
+				projectId,
+				data: { id: "test-id" },
+			})
+		).resolves.toBeUndefined();
+	});
+
+	it("WorkspaceHub handles WebSocket upgrade, ping/pong, and subscription filtering", async () => {
+		const state = {
+			acceptWebSocket: vi.fn(),
+			getWebSockets: vi.fn().mockReturnValue([]),
+		};
+
+		const hub = new WorkspaceHub(state as unknown as DurableObjectState, env as unknown as Env);
+
+		// Non-websocket request
+		const httpReq = new Request("http://localhost/realtime");
+		const httpRes = await hub.fetch(httpReq);
+		expect(httpRes.status).toBe(426);
+
+		// WebSocket upgrade request
+		const wsReq = new Request("http://localhost/realtime", {
+			headers: { Upgrade: "websocket" },
+		});
+		const wsRes = await hub.fetch(wsReq);
+		expect(wsRes.status).toBe(101);
+		expect(state.acceptWebSocket).toHaveBeenCalled();
+
+		// Test ping message
+		const mockWs = {
+			send: vi.fn(),
+			serializeAttachment: vi.fn(),
+			deserializeAttachment: vi.fn().mockReturnValue({ subscribedAt: 12345 }),
+			close: vi.fn(),
+		};
+
+		await hub.webSocketMessage(mockWs as unknown as WebSocket, JSON.stringify({ action: "ping" }));
+		expect(mockWs.send).toHaveBeenCalledWith(expect.stringContaining('"type":"pong"'));
+
+		// Test subscribe message
+		await hub.webSocketMessage(
+			mockWs as unknown as WebSocket,
+			JSON.stringify({
+				action: "subscribe",
+				projects: [projectId],
+				eventTypes: ["issue.*"],
+			})
+		);
+		expect(mockWs.serializeAttachment).toHaveBeenCalledWith(
+			expect.objectContaining({
+				filters: {
+					projects: [projectId],
+					eventTypes: ["issue.*"],
+				},
+			})
+		);
+		expect(mockWs.send).toHaveBeenCalledWith(expect.stringContaining('"type":"subscribed"'));
+	});
+
+	it("WorkspaceHub.broadcast sends events to matching sockets and filters non-matching", async () => {
+		const matchingWs = {
+			send: vi.fn(),
+			deserializeAttachment: vi.fn().mockReturnValue({
+				filters: {
+					projects: [projectId],
+					eventTypes: ["issue.*"],
+				},
+			}),
+		};
+
+		const otherProjectWs = {
+			send: vi.fn(),
+			deserializeAttachment: vi.fn().mockReturnValue({
+				filters: {
+					projects: ["other-project-id"],
+					eventTypes: ["issue.*"],
+				},
+			}),
+		};
+
+		const otherTypeWs = {
+			send: vi.fn(),
+			deserializeAttachment: vi.fn().mockReturnValue({
+				filters: {
+					projects: [projectId],
+					eventTypes: ["comment.*"],
+				},
+			}),
+		};
+
+		const state = {
+			acceptWebSocket: vi.fn(),
+			getWebSockets: vi.fn().mockReturnValue([matchingWs, otherProjectWs, otherTypeWs]),
+		};
+
+		const hub = new WorkspaceHub(state as unknown as DurableObjectState, env as unknown as Env);
+
+		const result = await hub.broadcast({
+			type: "issue.created",
+			workspaceId,
+			projectId,
+			data: { id: "issue-123", title: "Test" },
+			timestamp: Math.floor(Date.now() / 1000),
+		});
+
+		expect(result.recipientCount).toBe(1);
+		expect(matchingWs.send).toHaveBeenCalledWith(expect.stringContaining('"type":"issue.created"'));
+		expect(otherProjectWs.send).not.toHaveBeenCalled();
+		expect(otherTypeWs.send).not.toHaveBeenCalled();
+	});
+
+	it("dispatches broadcast event when creating an issue with WORKSPACE_HUB stub", async () => {
+		const broadcastMock = vi.fn().mockResolvedValue({ recipientCount: 1 });
+		const mockStub = {
+			broadcast: broadcastMock,
+		};
+		const mockHubNamespace = {
+			idFromName: vi.fn().mockReturnValue("mock-do-id"),
+			get: vi.fn().mockReturnValue(mockStub),
+		};
+
+		const ctx: ServiceCtx = {
+			db: env.DB,
+			kv: env.KV,
+			r2: env.R2,
+			workspaceId,
+			userId,
+			role: "owner",
+			workspaceHub: mockHubNamespace as unknown as DurableObjectNamespace,
+		};
+
+		const created = await createIssue(ctx, {
+			projectId,
+			title: "Realtime test issue",
+		});
+
+		expect(created.id).toBeTruthy();
+		expect(broadcastMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: "issue.created",
+				workspaceId,
+				projectId,
+				data: expect.objectContaining({
+					id: created.id,
+					title: "Realtime test issue",
+				}),
+			})
+		);
+	});
+});

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -48,6 +48,15 @@ id = "REPLACE_WITH_YOUR_OAUTH_KV_NAMESPACE_ID"
 binding = "R2"
 bucket_name = "projektor-files"
 
+# [durable_objects]
+# bindings = [
+#   { name = "WORKSPACE_HUB", class_name = "WorkspaceHub" }
+# ]
+#
+# [[migrations]]
+# tag = "v1"
+# new_classes = ["WorkspaceHub"]
+
 [vars]
 ENVIRONMENT = "development"
 CF_ACCESS_TEAM_DOMAIN = ""

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -55,7 +55,7 @@ bucket_name = "projektor-files"
 #
 # [[migrations]]
 # tag = "v1"
-# new_classes = ["WorkspaceHub"]
+# new_sqlite_classes = ["WorkspaceHub"]
 
 [vars]
 ENVIRONMENT = "development"

--- a/apps/docs/src/content/docs/guides/deploying.md
+++ b/apps/docs/src/content/docs/guides/deploying.md
@@ -205,7 +205,24 @@ alongside `/api/*`, `/mcp/*` and `/wiki`. Without it the static-asset handler
 answers discovery requests with the SPA shell and the client reports the server
 as not supporting OAuth at all.
 
-### 7. Deploy
+### 7. Realtime WebSockets (Optional, Workers Paid)
+
+To enable live event streaming over `/api/workspaces/:slug/realtime` (for external dashboards and status boards), bind the `WorkspaceHub` Durable Object in your `wrangler.toml`:
+
+```toml
+[durable_objects]
+bindings = [
+  { name = "WORKSPACE_HUB", class_name = "WorkspaceHub" }
+]
+
+[[migrations]]
+tag = "v1"
+new_classes = ["WorkspaceHub"]
+```
+
+If omitted, the Worker operates in standard polling mode with zero overhead.
+
+### 8. Deploy
 
 ```bash
 ./deploy.sh          # locally (wrangler OAuth), or

--- a/apps/docs/src/content/docs/guides/deploying.md
+++ b/apps/docs/src/content/docs/guides/deploying.md
@@ -217,7 +217,7 @@ bindings = [
 
 [[migrations]]
 tag = "v1"
-new_classes = ["WorkspaceHub"]
+new_sqlite_classes = ["WorkspaceHub"]
 ```
 
 If omitted, the Worker operates in standard polling mode with zero overhead.

--- a/packages/types/src/env.ts
+++ b/packages/types/src/env.ts
@@ -61,6 +61,17 @@ export interface Env {
 	// Independent of whether CF Access is configured. Honored truthy values
 	// (case-insensitive, whitespace-trimmed): "true", "1", "yes".
 	PUBLIC_READ_ONLY?: string;
+	// Optional: opt-in real-time WebSocket hub (Durable Objects). Omitted for
+	// free-tier/1-click deployments; present when opt-in real-time features are enabled.
+	WORKSPACE_HUB?: DurableObjectNamespace;
+}
+
+export interface RealtimeEvent<T = unknown> {
+	type: string;
+	workspaceId: string;
+	projectId?: string | null;
+	data: T;
+	timestamp: number;
 }
 
 export interface Variables {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,4 @@
-export type { Env, HonoEnv, Variables } from "./env";
+export type { Env, HonoEnv, RealtimeEvent, Variables } from "./env";
 export type { McpAddCommandParts } from "./mcp-command";
 export { buildMcpAddCommand, buildMcpAddCommandMultiline } from "./mcp-command";
 export type { MCPTool, Migration, Plugin, PluginContext, Role } from "./plugin";

--- a/scripts/release-assets/wrangler.example.toml
+++ b/scripts/release-assets/wrangler.example.toml
@@ -86,7 +86,7 @@ bucket_name = "projektor-files"
 #
 # [[migrations]]
 # tag = "v1"
-# new_classes = ["WorkspaceHub"]
+# new_sqlite_classes = ["WorkspaceHub"]
 
 # ─── Static vars (non-secret) ──────────────────────────────────
 [vars]

--- a/scripts/release-assets/wrangler.example.toml
+++ b/scripts/release-assets/wrangler.example.toml
@@ -76,6 +76,18 @@ id = "REPLACE_WITH_YOUR_OAUTH_KV_NAMESPACE_ID"
 binding = "R2"
 bucket_name = "projektor-files"
 
+# ─── Real-Time WebSocket Hub (Optional, requires Workers Paid) ─
+# Enables live event streaming across /api/workspaces/:slug/realtime (Durable Objects).
+# Uncomment these blocks if your Cloudflare account is on Workers Paid.
+# [durable_objects]
+# bindings = [
+#   { name = "WORKSPACE_HUB", class_name = "WorkspaceHub" }
+# ]
+#
+# [[migrations]]
+# tag = "v1"
+# new_classes = ["WorkspaceHub"]
+
 # ─── Static vars (non-secret) ──────────────────────────────────
 [vars]
 ENVIRONMENT = "production"


### PR DESCRIPTION
## Description

This PR implements an opt-in, real-time WebSocket (WSS) event stream for Projektor instances, as proposed and discussed in #311.

### Key Highlights:

1. **Opt-In with Graceful Degradation:**
   - Durable Objects are purely optional. Deployments without the `WORKSPACE_HUB` binding boot normally and return `501 Not Implemented` on `/api/workspaces/:slug/realtime`, allowing clients to transparently fall back to standard HTTP polling.
   - Standard 1-click and free-tier deployments continue to operate with zero configuration changes.

2. **Durable Object with WebSocket Hibernation:**
   - Implements `WorkspaceHub` using Cloudflare's WebSocket Hibernation API.
   - Idle connections incur $0 compute charges.
   - Supports client subscription filtering (`projects`, `eventTypes`) and `ping`/`pong` heartbeats.

3. **Service-Layer Integration (Respecting AGENTS.md):**
   - Dispatches originate within domain services (`issues.ts`, `issue-leases.ts`, `comments.ts`, and `file-claims.ts`).
   - Mutations made via the web UI, MCP tools, or REST API emit consistent events across the WebSocket stream.

4. **Testing & Documentation:**
   - Comprehensive test suite added in `apps/api/src/test/realtime.test.ts` covering 501 degradation, upgrade validation, subscription filtering, and end-to-end mutation dispatches.
   - Deployment documentation updated with example `wrangler.toml` snippets using `new_sqlite_classes`.

Resolves #311
