### PR TITLE
fix(api): redirect /auth/login directly to target redirect URL

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -6,8 +6,13 @@ import { createUserToken, deleteUserToken, getUserWorkspaces } from "../services
 
 const router = new Hono<HonoEnv>();
 
+function isSafeRedirectPath(url: string): boolean {
+	return url.startsWith("/") && !url.startsWith("//");
+}
+
 router.get("/login", (c) => {
-	const redirectUrl = c.req.query("redirect_url") ?? "/";
+	const requested = c.req.query("redirect_url") ?? "/";
+	const redirectUrl = isSafeRedirectPath(requested) ? requested : "/";
 	return c.redirect(redirectUrl, 302);
 });
 

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -8,10 +8,7 @@ const router = new Hono<HonoEnv>();
 
 router.get("/login", (c) => {
 	const redirectUrl = c.req.query("redirect_url") ?? "/";
-	return c.redirect(
-		`https://${c.env.CF_ACCESS_TEAM_DOMAIN}/cdn-cgi/access/login?redirect_url=${encodeURIComponent(redirectUrl)}`,
-		302
-	);
+	return c.redirect(redirectUrl, 302);
 });
 
 router.get("/me", authMiddleware, async (c) => {

--- a/apps/api/src/test/auth.test.ts
+++ b/apps/api/src/test/auth.test.ts
@@ -1101,4 +1101,25 @@ describe("PROJ-430: CF Access certs fetch failure", () => {
 			error: "Authentication temporarily unavailable",
 		});
 	});
+
+	describe("GET /auth/login", () => {
+		it("redirects to default root / with 302 when redirect_url query is omitted", async () => {
+			const res = await SELF.fetch("http://localhost/auth/login", {
+				redirect: "manual",
+			});
+			expect(res.status).toBe(302);
+			expect(res.headers.get("location")).toBe("/");
+		});
+
+		it("redirects to specified redirect_url with 302", async () => {
+			const res = await SELF.fetch(
+				"http://localhost/auth/login?redirect_url=/projects/view/proj-1",
+				{
+					redirect: "manual",
+				}
+			);
+			expect(res.status).toBe(302);
+			expect(res.headers.get("location")).toBe("/projects/view/proj-1");
+		});
+	});
 });

--- a/apps/api/src/test/auth.test.ts
+++ b/apps/api/src/test/auth.test.ts
@@ -1121,5 +1121,31 @@ describe("PROJ-430: CF Access certs fetch failure", () => {
 			expect(res.status).toBe(302);
 			expect(res.headers.get("location")).toBe("/projects/view/proj-1");
 		});
+
+		it("falls back to / for an absolute-URL redirect_url", async () => {
+			const res = await SELF.fetch(
+				"http://localhost/auth/login?redirect_url=https://evil.example.com",
+				{ redirect: "manual" }
+			);
+			expect(res.status).toBe(302);
+			expect(res.headers.get("location")).toBe("/");
+		});
+
+		it("falls back to / for a protocol-relative redirect_url", async () => {
+			const res = await SELF.fetch("http://localhost/auth/login?redirect_url=//evil.example.com", {
+				redirect: "manual",
+			});
+			expect(res.status).toBe(302);
+			expect(res.headers.get("location")).toBe("/");
+		});
+
+		it("falls back to / for a javascript: redirect_url", async () => {
+			const res = await SELF.fetch(
+				`http://localhost/auth/login?redirect_url=${encodeURIComponent("javascript:alert(1)")}`,
+				{ redirect: "manual" }
+			);
+			expect(res.status).toBe(302);
+			expect(res.headers.get("location")).toBe("/");
+		});
 	});
 });

--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -4,8 +4,8 @@
  * Tests:
  *  1. GET /auth/me returns the authenticated user + their workspaces
  *     (dev-bypass auth on the target deployment).
- *  2. GET /auth/login redirects (302) to the Cloudflare Access login URL,
- *     preserving the requested redirect_url.
+ *  2. GET /auth/login redirects (302) to the requested (same-origin) redirect_url,
+ *     letting Cloudflare Access intercept that app-path request at the edge.
  *
  * Prerequisites: globalSetup must have written e2e/.e2e-ctx.json.
  * Target: E2E_BASE_URL pointing at a dev deployment (ENVIRONMENT=development,
@@ -47,16 +47,13 @@ test.describe("Auth flow", () => {
 		expect(body.workspaces.some((w) => w.slug === ctx.workspaceSlug)).toBe(true);
 	});
 
-	test("GET /auth/login redirects to the Cloudflare Access login URL", async ({ request }) => {
+	test("GET /auth/login redirects to the requested redirect_url", async ({ request }) => {
 		test.skip(!process.env.E2E_BASE_URL, "E2E_BASE_URL not set — skipping live deployment test");
 
 		const res = await request.get("/auth/login?redirect_url=%2Fmy-issues", {
 			maxRedirects: 0,
 		});
 		expect(res.status()).toBe(302);
-
-		const location = res.headers().location ?? "";
-		expect(location).toContain("/cdn-cgi/access/login");
-		expect(location).toContain(encodeURIComponent("/my-issues"));
+		expect(res.headers().location ?? "").toBe("/my-issues");
 	});
 });


### PR DESCRIPTION
## Description

Fixes the issue where navigating to `/auth/login` resulted in a 404 from Cloudflare Access.

### Context & Cause:
Previously, `/auth/login` redirected directly to `https://${CF_ACCESS_TEAM_DOMAIN}/cdn-cgi/access/login?redirect_url=...`. Cloudflare Access does not expose this endpoint for direct browser navigation without edge-generated `meta` and `kid` JWT tokens, resulting in a 404 response.

### Fix:
- Updated `GET /auth/login` to redirect (302) directly to `redirectUrl` (defaulting to `/`).
- Navigating to the application path allows Cloudflare Access to natively intercept the request at the edge and coordinate the IdP challenge with all required edge parameters.
- Added unit tests in `apps/api/src/test/auth.test.ts` to test default and custom redirect paths.

Resolves #310
