### PR TITLE
fix(mcp): strict schemas + ref/key resolution for issue tools (PROJ-712, PROJ-713)

### DIFF
--- a/apps/api/src/mcp/issue-links.ts
+++ b/apps/api/src/mcp/issue-links.ts
@@ -11,8 +11,14 @@ export const issueLinksTools: MCPTool[] = [
 			type: "object",
 			required: ["sourceIssueId", "targetIssueId", "type"],
 			properties: {
-				sourceIssueId: { type: "string", description: "UUID of the source issue" },
-				targetIssueId: { type: "string", description: "UUID of the target issue" },
+				sourceIssueId: {
+					type: "string",
+					description: "UUID of the source issue, or a ref like PROJ-42",
+				},
+				targetIssueId: {
+					type: "string",
+					description: "UUID of the target issue, or a ref like PROJ-42",
+				},
 				type: {
 					type: "string",
 					enum: ["blocks", "blocked_by", "relates_to", "duplicates"],
@@ -49,7 +55,7 @@ export const issueLinksTools: MCPTool[] = [
 			type: "object",
 			required: ["issueId"],
 			properties: {
-				issueId: { type: "string", description: "UUID of the issue" },
+				issueId: { type: "string", description: "UUID of the issue, or a ref like PROJ-42" },
 			},
 		},
 		handler(input, ctx) {

--- a/apps/api/src/mcp/issues.ts
+++ b/apps/api/src/mcp/issues.ts
@@ -20,7 +20,10 @@ export const issuesTools: MCPTool[] = [
 		inputSchema: {
 			type: "object",
 			properties: {
-				projectId: { type: "string" },
+				projectId: {
+					type: "string",
+					description: "UUID of the project, or a project key like PROJ",
+				},
 				status: {
 					type: "string",
 					enum: ["backlog", "todo", "in_progress", "in_review", "done", "cancelled"],
@@ -46,7 +49,8 @@ export const issuesTools: MCPTool[] = [
 				},
 				parentId: {
 					type: "string",
-					description: "Filter by parent issue ID (returns direct children only)",
+					description:
+						"Filter by parent issue ID, or a ref like PROJ-42 (returns direct children only)",
 				},
 				noParent: {
 					type: "boolean",
@@ -128,7 +132,10 @@ export const issuesTools: MCPTool[] = [
 			type: "object",
 			required: ["projectId", "title"],
 			properties: {
-				projectId: { type: "string" },
+				projectId: {
+					type: "string",
+					description: "UUID of the project, or a project key like PROJ",
+				},
 				title: { type: "string" },
 				body: { type: "string" },
 				priority: { type: "string", enum: ["urgent", "high", "medium", "low", "none"] },
@@ -141,7 +148,7 @@ export const issuesTools: MCPTool[] = [
 				labels: { type: "array", items: { type: "string" } },
 				parentId: {
 					type: "string",
-					description: "UUID of the parent issue (optional; max depth 5)",
+					description: "UUID of the parent issue, or a ref like PROJ-42 (optional; max depth 5)",
 				},
 				typeId: { type: "string", description: "UUID of the task type to assign" },
 			},
@@ -162,7 +169,7 @@ export const issuesTools: MCPTool[] = [
 			type: "object",
 			required: ["id"],
 			properties: {
-				id: { type: "string" },
+				id: { type: "string", description: "UUID of the issue, or a ref like PROJ-42" },
 				title: { type: "string" },
 				body: { type: "string" },
 				status: {
@@ -180,7 +187,7 @@ export const issuesTools: MCPTool[] = [
 				parentId: {
 					type: "string",
 					nullable: true,
-					description: "Set or clear the parent issue (null to remove)",
+					description: "Set or clear the parent issue — UUID or ref like PROJ-42 (null to remove)",
 				},
 				typeId: { type: "string", nullable: true },
 				agentSessionId: {
@@ -216,7 +223,10 @@ export const issuesTools: MCPTool[] = [
 			required: ["query"],
 			properties: {
 				query: { type: "string", minLength: 1 },
-				projectId: { type: "string", description: "Restrict search to a specific project" },
+				projectId: {
+					type: "string",
+					description: "Restrict search to a specific project — UUID or project key like PROJ",
+				},
 				limit: { type: "number", default: 20, description: "Max 50" },
 			},
 		},
@@ -226,11 +236,13 @@ export const issuesTools: MCPTool[] = [
 	},
 	{
 		name: "delete_issue",
-		description: "Delete an issue by ID",
+		description: "Delete an issue by ID or ref (e.g. PROJ-42)",
 		inputSchema: {
 			type: "object",
 			required: ["id"],
-			properties: { id: { type: "string" } },
+			properties: {
+				id: { type: "string", description: "UUID of the issue, or a ref like PROJ-42" },
+			},
 		},
 		handler(input, ctx) {
 			const { id } = input as { id?: string };

--- a/apps/api/src/mcp/playbooks.ts
+++ b/apps/api/src/mcp/playbooks.ts
@@ -1,4 +1,5 @@
 import type { MCPTool } from "@projektor/types";
+import { ValidationError } from "../services/errors";
 import { composePlaybook } from "../services/playbook-compose";
 import { getPlaybook, listPlaybooks } from "../services/playbooks";
 
@@ -27,7 +28,10 @@ export const playbooksTools: MCPTool[] = [
 			required: ["name"],
 		},
 		async handler(input) {
-			const { name } = input as { name: string };
+			const { name } = input as { name?: unknown };
+			if (!name || typeof name !== "string") {
+				throw new ValidationError({ formErrors: ["name is required"], fieldErrors: {} });
+			}
 			return getPlaybook(name);
 		},
 	},

--- a/apps/api/src/schemas/issues.ts
+++ b/apps/api/src/schemas/issues.ts
@@ -2,19 +2,21 @@ import { z } from "zod";
 import { BooleanQueryParam, PriorityEnum, StatusEnum, TaxonomyIdSchema } from "./common";
 import { CustomFieldFilterSchema } from "./custom-fields";
 
-export const CreateIssueSchema = z.object({
-	projectId: z.string().uuid(),
-	title: z.string().min(1).max(500),
-	body: z.string().max(50000).optional(),
-	status: StatusEnum.optional(),
-	statusId: TaxonomyIdSchema.nullable().optional(),
-	priority: PriorityEnum.optional(),
-	assigneeId: z.string().uuid().optional(),
-	labels: z.array(z.string().max(50)).max(20).optional(),
-	parentId: z.string().uuid().nullable().optional(),
-	typeId: TaxonomyIdSchema.nullable().optional(),
-	customFields: z.record(z.string(), z.unknown()).optional(),
-});
+export const CreateIssueSchema = z
+	.object({
+		projectId: z.string(),
+		title: z.string().min(1).max(500),
+		body: z.string().max(50000).optional(),
+		status: StatusEnum.optional(),
+		statusId: TaxonomyIdSchema.nullable().optional(),
+		priority: PriorityEnum.optional(),
+		assigneeId: z.string().uuid().optional(),
+		labels: z.array(z.string().max(50)).max(20).optional(),
+		parentId: z.string().nullable().optional(),
+		typeId: TaxonomyIdSchema.nullable().optional(),
+		customFields: z.record(z.string(), z.unknown()).optional(),
+	})
+	.strict();
 
 // PROJ-254: completion report an agent (or human) submits when entering review /
 // before an issue can be marked done.
@@ -33,78 +35,88 @@ export const UpdateIssueSchema = z
 		priority: PriorityEnum.optional(),
 		assigneeId: z.string().uuid().nullable().optional(),
 		labels: z.array(z.string().max(50)).max(20).optional(),
-		parentId: z.string().uuid().nullable().optional(),
+		parentId: z.string().nullable().optional(),
 		typeId: TaxonomyIdSchema.nullable().optional(),
 		customFields: z.record(z.string(), z.unknown()).optional(),
-		// PROJ-254: review gating. agentSessionId identifies the calling agent (if
-		// any) so the gate can tell agent-initiated transitions from human ones.
 		agentSessionId: z.string().uuid().optional(),
 		completionReport: CompletionReportSchema.optional(),
 	})
+	.strict()
 	.refine((obj) => Object.keys(obj).length > 0, { message: "Nothing to update" });
 
-export const ListIssuesSchema = z.object({
-	status: StatusEnum.optional(),
-	statusId: TaxonomyIdSchema.optional(),
-	statusIds: z.string().optional(),
-	category: z.enum(["todo", "in_progress", "done", "cancelled"]).optional(),
-	priority: PriorityEnum.optional(),
-	priorities: z.string().optional(),
-	projectId: z.string().optional(),
-	// PROJ-444: "me" is a sentinel the service resolves to ctx.userId — kept visible in
-	// the schema (rather than folded silently into z.string()) so both surfaces document it.
-	assignee: z.union([z.literal("me"), z.string()]).optional(),
-	parentId: z.string().uuid().optional(),
-	noParent: BooleanQueryParam.optional(),
-	typeId: TaxonomyIdSchema.optional(),
-	excludeTypeIds: z.string().optional(),
-	sprintId: z.string().uuid().optional(),
-	...CustomFieldFilterSchema.shape,
-	// Date-range filters (PROJ-212), epoch seconds; inclusive bounds.
-	completedAfter: z.coerce.number().optional(),
-	completedBefore: z.coerce.number().optional(),
-	updatedAfter: z.coerce.number().optional(),
-	updatedBefore: z.coerce.number().optional(),
-	// PROJ-375: surface agent-initiated done-closures whose evidence wasn't
-	// externally checkable, for periodic human audit.
-	needsAudit: BooleanQueryParam.optional(),
-	// PROJ-441: compute child rollups for the returned page in one grouped query
-	// (see computeChildRollupsForParents in services/issues.ts) instead of the
-	// frontend fanning out a getIssue call per row.
-	includeRollups: BooleanQueryParam.optional(),
-	// PROJ-442: list items omit `body` by default (it's rarely needed and can be
-	// large); set this to restore it.
-	includeBody: BooleanQueryParam.optional(),
-	cursor: z.coerce.number().optional(),
-	limit: z.coerce.number().min(1).max(100).default(30),
-});
+export const ListIssuesSchema = z
+	.object({
+		status: StatusEnum.optional(),
+		statusId: TaxonomyIdSchema.optional(),
+		statusIds: z.string().optional(),
+		category: z.enum(["todo", "in_progress", "done", "cancelled"]).optional(),
+		priority: PriorityEnum.optional(),
+		priorities: z.string().optional(),
+		projectId: z.string().optional(),
+		// PROJ-444: "me" is a sentinel the service resolves to ctx.userId — kept visible in
+		// the schema (rather than folded silently into z.string()) so both surfaces document it.
+		assignee: z.union([z.literal("me"), z.string()]).optional(),
+		parentId: z.string().optional(),
+		noParent: BooleanQueryParam.optional(),
+		typeId: TaxonomyIdSchema.optional(),
+		excludeTypeIds: z.string().optional(),
+		sprintId: z.string().uuid().optional(),
+		...CustomFieldFilterSchema.shape,
+		// Date-range filters (PROJ-212), epoch seconds; inclusive bounds.
+		completedAfter: z.coerce.number().optional(),
+		completedBefore: z.coerce.number().optional(),
+		updatedAfter: z.coerce.number().optional(),
+		updatedBefore: z.coerce.number().optional(),
+		// PROJ-375: surface agent-initiated done-closures whose evidence wasn't
+		// externally checkable, for periodic human audit.
+		needsAudit: BooleanQueryParam.optional(),
+		// PROJ-441: compute child rollups for the returned page in one grouped query
+		// (see computeChildRollupsForParents in services/issues.ts) instead of the
+		// frontend fanning out a getIssue call per row.
+		includeRollups: BooleanQueryParam.optional(),
+		// PROJ-442: list items omit `body` by default (it's rarely needed and can be
+		// large); set this to restore it.
+		includeBody: BooleanQueryParam.optional(),
+		cursor: z.coerce.number().optional(),
+		limit: z.coerce.number().min(1).max(100).default(30),
+	})
+	.strict();
 
 export const GetIssueSchema = z
 	.object({
 		id: z.string().optional(),
 		ref: z.string().optional(),
 	})
+	.strict()
 	.refine((obj) => obj.id || obj.ref, { message: "Provide either id or ref" });
 
-export const SearchIssuesInputSchema = z.object({
-	query: z.string().min(1),
-	projectId: z.string().uuid().optional(),
-	limit: z.number().int().min(1).max(50).optional().default(20),
-});
+export const SearchIssuesInputSchema = z
+	.object({
+		query: z.string().min(1),
+		projectId: z.string().optional(),
+		limit: z.number().int().min(1).max(50).optional().default(20),
+	})
+	.strict();
 
 export const LinkTypeInputEnum = z.enum(["blocks", "blocked_by", "relates_to", "duplicates"]);
 export const LinkTypeStoredEnum = z.enum(["blocks", "relates_to", "duplicates"]);
 
-export const CreateIssueLinkSchema = z.object({
-	sourceIssueId: z.string().uuid(),
-	targetIssueId: z.string().uuid(),
-	type: LinkTypeInputEnum,
-});
+export const CreateIssueLinkSchema = z
+	.object({
+		sourceIssueId: z.string(),
+		targetIssueId: z.string(),
+		type: LinkTypeInputEnum,
+	})
+	.strict();
 
-export const DeleteIssueLinkSchema = z.object({
-	id: z.string().uuid(),
-});
+export const DeleteIssueLinkSchema = z
+	.object({
+		id: z.string().uuid(),
+	})
+	.strict();
 
-export const ListIssueLinksSchema = z.object({
-	issueId: z.string().uuid(),
-});
+export const ListIssueLinksSchema = z
+	.object({
+		issueId: z.string(),
+	})
+	.strict();

--- a/apps/api/src/services/issue-links.ts
+++ b/apps/api/src/services/issue-links.ts
@@ -11,6 +11,7 @@ import {
 import { canWriteProject, effectiveProjectRole, isWorkspaceAdmin } from "./access";
 import * as cache from "./cache";
 import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from "./errors";
+import { resolveIssueIdParam } from "./issues";
 import { inChunks } from "./sql";
 import type { ServiceCtx } from "./types";
 
@@ -63,7 +64,17 @@ export async function createLink(ctx: ServiceCtx, raw: unknown) {
 	if (ctx.role === "viewer") throw new ForbiddenError("Insufficient permissions");
 	const result = CreateIssueLinkSchema.safeParse(raw);
 	if (!result.success) throw new ValidationError(result.error.flatten());
-	const { sourceIssueId, targetIssueId, type } = result.data;
+	const { type } = result.data;
+	const sourceIssueId = await resolveIssueIdParam(
+		ctx,
+		result.data.sourceIssueId,
+		"Source issue not found"
+	);
+	const targetIssueId = await resolveIssueIdParam(
+		ctx,
+		result.data.targetIssueId,
+		"Target issue not found"
+	);
 
 	if (sourceIssueId === targetIssueId) {
 		throw new ValidationError({ formErrors: ["An issue cannot link to itself"], fieldErrors: {} });
@@ -182,7 +193,7 @@ interface LinkedIssueRow {
 export async function listLinksForIssue(ctx: ServiceCtx, raw: unknown) {
 	const result = ListIssueLinksSchema.safeParse(raw);
 	if (!result.success) throw new ValidationError(result.error.flatten());
-	const { issueId } = result.data;
+	const issueId = await resolveIssueIdParam(ctx, result.data.issueId);
 
 	const orm = drizzle(ctx.db, { schema });
 

--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -49,6 +49,7 @@ import {
 	liveLeasedIssueIds,
 } from "./issue-leases";
 import { listLinksForIssue } from "./issue-links";
+import { resolveProjectIdParam, resolveVisibleProjectIdParam } from "./projects";
 import { inChunks, sanitizeFtsQuery } from "./sql";
 import { resolveStatus } from "./task-statuses";
 import type { ServiceCtx } from "./types";
@@ -75,12 +76,22 @@ async function validateParent(
 	const orm = drizzle(ctx.db, { schema });
 
 	const parentRow = await orm
-		.select({ id: schema.issues.id, parentId: schema.issues.parentId })
+		.select({
+			id: schema.issues.id,
+			parentId: schema.issues.parentId,
+			projectId: schema.issues.projectId,
+		})
 		.from(schema.issues)
 		.where(and(eq(schema.issues.id, parentId), eq(schema.issues.workspaceId, ctx.workspaceId)))
 		.get();
 
 	if (!parentRow) throw new NotFoundError("Parent issue not found");
+	if (
+		!isWorkspaceAdmin(ctx.role) &&
+		(await effectiveProjectRole(ctx, parentRow.projectId)) === null
+	) {
+		throw new NotFoundError("Parent issue not found");
+	}
 
 	// Walk up the ancestor chain: count how many ancestors the parent has.
 	// If the parent already has 5 ancestors, the child would be at depth 6 — exceeds the cap.
@@ -249,7 +260,15 @@ async function buildListIssuesConditions(
 export async function listIssues(ctx: ServiceCtx, raw: unknown) {
 	const result = ListIssuesSchema.safeParse(raw);
 	if (!result.success) throw new ValidationError(result.error.flatten());
-	const filters = result.data;
+	const filters = {
+		...result.data,
+		projectId: result.data.projectId
+			? await resolveVisibleProjectIdParam(ctx, result.data.projectId)
+			: result.data.projectId,
+		parentId: result.data.parentId
+			? await resolveIssueIdParam(ctx, result.data.parentId)
+			: result.data.parentId,
+	};
 	const { limit } = filters;
 
 	const orm = drizzle(ctx.db, { schema });
@@ -445,7 +464,11 @@ export const ISSUE_REF_PATTERN = /^([A-Z][A-Z0-9]*)-(\d{1,9})$/;
  * second place to get it wrong. If you add a caller, confirm that holds for yours too —
  * an id from this function is workspace-scoped and nothing more.
  */
-export async function resolveIssueIdParam(ctx: ServiceCtx, param: string): Promise<string> {
+export async function resolveIssueIdParam(
+	ctx: ServiceCtx,
+	param: string,
+	notFoundMessage = "Issue not found"
+): Promise<string> {
 	const m = param.match(ISSUE_REF_PATTERN);
 	if (!m) return param;
 
@@ -462,7 +485,7 @@ export async function resolveIssueIdParam(ctx: ServiceCtx, param: string): Promi
 			)
 		)
 		.get();
-	if (!row) throw new NotFoundError("Issue not found");
+	if (!row) throw new NotFoundError(notFoundMessage);
 	return row.id;
 }
 
@@ -764,8 +787,12 @@ async function finalizeCreateIssue(
 export async function createIssue(ctx: ServiceCtx, raw: unknown) {
 	const result = CreateIssueSchema.safeParse(raw);
 	if (!result.success) throw new ValidationError(result.error.flatten());
-	const data = result.data;
-	const { projectId, title, body, priority, assigneeId, labels, parentId } = data;
+	const projectId = await resolveProjectIdParam(ctx, result.data.projectId);
+	const parentId = result.data.parentId
+		? await resolveIssueIdParam(ctx, result.data.parentId)
+		: result.data.parentId;
+	const data = { ...result.data, projectId, parentId };
+	const { title, body, priority, assigneeId, labels } = data;
 
 	// PROJ-389: confirm projectId belongs to this workspace BEFORE the admin-bypass
 	// check below, so an owner/admin can't write into another workspace's project.
@@ -1251,10 +1278,14 @@ async function invalidateUpdateCaches(
 	}
 }
 
-export async function updateIssue(ctx: ServiceCtx, id: string, raw: unknown) {
+export async function updateIssue(ctx: ServiceCtx, rawId: string, raw: unknown) {
+	const id = await resolveIssueIdParam(ctx, rawId);
 	const result = UpdateIssueSchema.safeParse(raw);
 	if (!result.success) throw new ValidationError(result.error.flatten());
-	const data = result.data;
+	const data =
+		"parentId" in result.data && result.data.parentId
+			? { ...result.data, parentId: await resolveIssueIdParam(ctx, result.data.parentId) }
+			: result.data;
 
 	if ("parentId" in data && data.parentId) {
 		await validateParent(ctx, data.parentId, id);
@@ -1320,7 +1351,8 @@ export async function updateIssue(ctx: ServiceCtx, id: string, raw: unknown) {
 	return { ok: true };
 }
 
-export async function deleteIssue(ctx: ServiceCtx, id: string) {
+export async function deleteIssue(ctx: ServiceCtx, rawId: string) {
+	const id = await resolveIssueIdParam(ctx, rawId);
 	const idCheck = IdSchema.safeParse(id);
 	if (!idCheck.success)
 		throw new ValidationError({ formErrors: idCheck.error.flatten().formErrors, fieldErrors: {} });
@@ -1516,8 +1548,11 @@ function scoreOpenIssues(
 }
 
 export async function getPrioritizedIssues(ctx: ServiceCtx, raw: unknown) {
-	const { limit, includeBacklog, excludeClaimed, includeNotReady, projectId } =
-		parsePrioritizedFilters(raw);
+	const parsed = parsePrioritizedFilters(raw);
+	const { limit, includeBacklog, excludeClaimed, includeNotReady } = parsed;
+	const projectId = parsed.projectId
+		? await resolveVisibleProjectIdParam(ctx, parsed.projectId)
+		: parsed.projectId;
 
 	const orm = drizzle(ctx.db, { schema });
 
@@ -1561,7 +1596,10 @@ export async function getPrioritizedIssues(ctx: ServiceCtx, raw: unknown) {
 export async function searchIssues(ctx: ServiceCtx, raw: unknown) {
 	const result = SearchIssuesInputSchema.safeParse(raw);
 	if (!result.success) throw new ValidationError(result.error.flatten());
-	const { query, projectId, limit } = result.data;
+	const { query, limit } = result.data;
+	const projectId = result.data.projectId
+		? await resolveVisibleProjectIdParam(ctx, result.data.projectId)
+		: result.data.projectId;
 
 	const ftsQuery = sanitizeFtsQuery(query);
 	if (!ftsQuery) return [];

--- a/apps/api/src/services/projects.ts
+++ b/apps/api/src/services/projects.ts
@@ -106,6 +106,40 @@ export async function listProjectsAcrossWorkspaces(
 	return rows.results;
 }
 
+const PROJECT_KEY_PATTERN = /^[A-Z][A-Z0-9]*$/;
+
+export async function resolveProjectIdParam(ctx: ServiceCtx, param: string): Promise<string> {
+	if (!PROJECT_KEY_PATTERN.test(param)) return param;
+
+	const orm = drizzle(ctx.db, { schema });
+	const row = await orm
+		.select({ id: schema.projects.id })
+		.from(schema.projects)
+		.where(and(eq(schema.projects.key, param), eq(schema.projects.workspaceId, ctx.workspaceId)))
+		.get();
+	if (!row) throw new NotFoundError("Project not found");
+	return row.id;
+}
+
+export async function resolveVisibleProjectIdParam(
+	ctx: ServiceCtx,
+	param: string
+): Promise<string> {
+	if (!PROJECT_KEY_PATTERN.test(param)) return param;
+
+	const orm = drizzle(ctx.db, { schema });
+	const row = await orm
+		.select({ id: schema.projects.id })
+		.from(schema.projects)
+		.where(and(eq(schema.projects.key, param), eq(schema.projects.workspaceId, ctx.workspaceId)))
+		.get();
+	if (!row) return crypto.randomUUID();
+	if (!isWorkspaceAdmin(ctx.role) && (await effectiveProjectRole(ctx, row.id)) === null) {
+		return crypto.randomUUID();
+	}
+	return row.id;
+}
+
 export async function getProject(ctx: ServiceCtx, id: string) {
 	const orm = drizzle(ctx.db, { schema });
 	const project = await orm

--- a/apps/api/src/test/issue-links.test.ts
+++ b/apps/api/src/test/issue-links.test.ts
@@ -1,6 +1,13 @@
 import { env, SELF } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
-import { authHeaders, seedFixture, seedIssue, seedProject, seedWorkspaceRoles } from "./helpers";
+import {
+	authHeaders,
+	seedFixture,
+	seedGroupGrant,
+	seedIssue,
+	seedProject,
+	seedWorkspaceRoles,
+} from "./helpers";
 
 describe("Issue Links API", () => {
 	let token: string;
@@ -316,8 +323,7 @@ describe("PROJ-438 — links accept an issue ref", () => {
 		expect(res.status).toBe(404);
 	});
 
-	// Writes were deliberately left UUID-only — they're never on a first-paint path.
-	it("POST /:ref/links is still rejected — writes did not widen", async () => {
+	it("POST /:ref/links accepts a ref (PROJ-713: write tools resolve refs too)", async () => {
 		const fixture = await seedFixture({ role: "owner" });
 		const project = await seedProject(fixture.workspace.id);
 		await seedIssue(fixture.workspace.id, project.id, fixture.user.id, { title: "A" });
@@ -329,6 +335,40 @@ describe("PROJ-438 — links accept an issue ref", () => {
 			body: JSON.stringify({ targetIssueId: b.id, type: "blocks" }),
 		});
 
-		expect(res.status).toBe(400);
+		expect(res.status).toBe(201);
+	});
+});
+
+describe("createLink target-visibility existence oracle", () => {
+	it("an unresolvable target ref and a target in an unwritable project give the same message", async () => {
+		const roles = await seedWorkspaceRoles();
+		const writableProject = await seedProject(roles.workspace.id, "WRIT");
+		await seedGroupGrant(roles.workspace.id, roles.member.user.id, writableProject.id, "member");
+		const hiddenProject = await seedProject(roles.workspace.id, "HIDE");
+
+		const source = await seedIssue(roles.workspace.id, writableProject.id, roles.owner.user.id, {
+			title: "Source",
+		});
+		const hiddenTarget = await seedIssue(
+			roles.workspace.id,
+			hiddenProject.id,
+			roles.owner.user.id,
+			{ title: "Hidden target" }
+		);
+
+		const missingRes = await SELF.fetch(`http://localhost/api/issues/${source.id}/links`, {
+			method: "POST",
+			headers: authHeaders(roles.member.token, roles.workspace.slug),
+			body: JSON.stringify({ targetIssueId: "NOPE-1", type: "blocks" }),
+		});
+		const unwritableRes = await SELF.fetch(`http://localhost/api/issues/${source.id}/links`, {
+			method: "POST",
+			headers: authHeaders(roles.member.token, roles.workspace.slug),
+			body: JSON.stringify({ targetIssueId: hiddenTarget.id, type: "blocks" }),
+		});
+
+		expect(missingRes.status).toBe(404);
+		expect(unwritableRes.status).toBe(404);
+		expect(await missingRes.json()).toEqual(await unwritableRes.json());
 	});
 });

--- a/apps/api/src/test/issues.test.ts
+++ b/apps/api/src/test/issues.test.ts
@@ -95,7 +95,7 @@ describe("Issues API", () => {
 		const res = await SELF.fetch("http://localhost/api/issues", {
 			method: "POST",
 			headers: authHeaders(token, slug),
-			body: JSON.stringify({ projectId, title: "Author kind test", authorKind: "human" }),
+			body: JSON.stringify({ projectId, title: "Author kind test" }),
 		});
 		expect(res.status).toBe(201);
 		const body = (await res.json()) as { id: string };
@@ -104,6 +104,15 @@ describe("Issues API", () => {
 			.bind(body.id)
 			.first<{ author_kind: string | null }>();
 		expect(row?.author_kind).toBe("agent");
+	});
+
+	it("PROJ-712: rejects an unrecognized field (e.g. a spoofed authorKind) instead of silently ignoring it", async () => {
+		const res = await SELF.fetch("http://localhost/api/issues", {
+			method: "POST",
+			headers: authHeaders(token, slug),
+			body: JSON.stringify({ projectId, title: "Author kind test", authorKind: "human" }),
+		});
+		expect(res.status).toBe(400);
 	});
 
 	it("POST then GET returns the created issue", async () => {
@@ -2158,5 +2167,258 @@ describe("GET /api/issues/prioritized", () => {
 		const titles = body.issues.map((i) => i.title);
 		expect(titles).toContain("In target project");
 		expect(titles).not.toContain("In other project");
+	});
+});
+
+describe("PROJ-712 — unrecognized MCP params are rejected, not silently dropped", () => {
+	let token: string, slug: string, workspaceId: string, projectId: string, userId: string;
+
+	beforeEach(async () => {
+		({ token, slug, workspaceId, userId, projectId } = await seedProjectFixture({
+			role: "owner",
+		}));
+	});
+
+	async function mcpCall(params: unknown) {
+		return callMcpTool(workspaceId, token, slug, params);
+	}
+
+	it("list_issues rejects an unknown param instead of ignoring it", async () => {
+		await seedIssue(workspaceId, projectId, userId, { title: "Some issue" });
+		const res = await mcpCall({ name: "list_issues", arguments: { projectKey: projectId } });
+		expect(res.error).toBeDefined();
+	});
+
+	it("get_issue rejects an unknown param instead of ignoring it", async () => {
+		const createResp = await mcpCall({
+			name: "create_issue",
+			arguments: { projectId, title: "For get_issue" },
+		});
+		const { id } = JSON.parse(createResp.result!.content[0].text) as { id: string };
+
+		const res = await mcpCall({ name: "get_issue", arguments: { id, bogus: "x" } });
+		expect(res.error).toBeDefined();
+	});
+
+	it("create_issue_link rejects an unknown param instead of ignoring it", async () => {
+		const a = await mcpCall({ name: "create_issue", arguments: { projectId, title: "A" } });
+		const b = await mcpCall({ name: "create_issue", arguments: { projectId, title: "B" } });
+		const { id: aId } = JSON.parse(a.result!.content[0].text) as { id: string };
+		const { id: bId } = JSON.parse(b.result!.content[0].text) as { id: string };
+
+		const res = await mcpCall({
+			name: "create_issue_link",
+			arguments: { sourceIssueId: aId, targetIssueId: bId, type: "blocks", extra: "x" },
+		});
+		expect(res.error).toBeDefined();
+	});
+});
+
+describe("PROJ-713 — write tools resolve refs/keys server-side", () => {
+	let token: string,
+		slug: string,
+		workspaceId: string,
+		projectId: string,
+		userId: string,
+		projectKey: string;
+
+	beforeEach(async () => {
+		({ token, slug, workspaceId, userId, projectId } = await seedProjectFixture({
+			role: "owner",
+		}));
+		const row = await env.DB.prepare("SELECT key FROM projects WHERE id = ?")
+			.bind(projectId)
+			.first<{ key: string }>();
+		projectKey = row!.key;
+	});
+
+	async function mcpCall(params: unknown) {
+		return callMcpTool(workspaceId, token, slug, params);
+	}
+
+	it("update_issue accepts a ref in place of id", async () => {
+		const { number } = await seedIssue(workspaceId, projectId, userId, { title: "Ref update" });
+		const ref = `${projectKey}-${number}`;
+
+		const res = await mcpCall({
+			name: "update_issue",
+			arguments: { id: ref, title: "Renamed via ref" },
+		});
+		expect(res.error).toBeUndefined();
+
+		const getRes = await mcpCall({ name: "get_issue", arguments: { ref } });
+		const issue = JSON.parse(getRes.result!.content[0].text) as { title: string };
+		expect(issue.title).toBe("Renamed via ref");
+	});
+
+	it("delete_issue accepts a ref in place of id", async () => {
+		const { number } = await seedIssue(workspaceId, projectId, userId, { title: "Ref delete" });
+		const ref = `${projectKey}-${number}`;
+
+		const res = await mcpCall({ name: "delete_issue", arguments: { id: ref } });
+		expect(res.error).toBeUndefined();
+
+		const getRes = await mcpCall({ name: "get_issue", arguments: { ref } });
+		expect(getRes.error).toBeDefined();
+	});
+
+	it("create_issue_link accepts refs for sourceIssueId/targetIssueId", async () => {
+		const a = await seedIssue(workspaceId, projectId, userId, { title: "A" });
+		const b = await seedIssue(workspaceId, projectId, userId, { title: "B" });
+
+		const res = await mcpCall({
+			name: "create_issue_link",
+			arguments: {
+				sourceIssueId: `${projectKey}-${a.number}`,
+				targetIssueId: `${projectKey}-${b.number}`,
+				type: "blocks",
+			},
+		});
+		expect(res.error).toBeUndefined();
+
+		const linksRes = await mcpCall({ name: "list_issue_links", arguments: { issueId: a.id } });
+		const links = JSON.parse(linksRes.result!.content[0].text) as Array<{ linkedIssueId: string }>;
+		expect(links.map((l) => l.linkedIssueId)).toEqual([b.id]);
+	});
+
+	it("create_issue accepts a project key in place of projectId", async () => {
+		const res = await mcpCall({
+			name: "create_issue",
+			arguments: { projectId: projectKey, title: "Via project key" },
+		});
+		expect(res.error).toBeUndefined();
+		const { id } = JSON.parse(res.result!.content[0].text) as { id: string };
+
+		const getRes = await mcpCall({ name: "get_issue", arguments: { id } });
+		const issue = JSON.parse(getRes.result!.content[0].text) as { project_id: string };
+		expect(issue.project_id).toBe(projectId);
+	});
+
+	it("list_issues accepts a project key in place of projectId", async () => {
+		await seedIssue(workspaceId, projectId, userId, { title: "In project" });
+
+		const res = await mcpCall({ name: "list_issues", arguments: { projectId: projectKey } });
+		expect(res.error).toBeUndefined();
+		const page = JSON.parse(res.result!.content[0].text) as { items: Array<{ title: string }> };
+		expect(page.items.map((i) => i.title)).toContain("In project");
+	});
+
+	it("an unresolvable ref returns NotFoundError, not a silent empty result", async () => {
+		const res = await mcpCall({ name: "update_issue", arguments: { id: "NOPE-1", title: "x" } });
+		expect(res.error).toBeDefined();
+	});
+
+	it("an unresolvable project key returns NotFoundError, not a silent empty result", async () => {
+		const res = await mcpCall({
+			name: "create_issue",
+			arguments: { projectId: "NOPE", title: "x" },
+		});
+		expect(res.error).toBeDefined();
+	});
+
+	it("update_issue with a parentId ref to an invisible project fails the same as an unresolvable ref", async () => {
+		const roles = await seedWorkspaceRoles();
+		const writableProject = await seedProject(roles.workspace.id, "WRIT");
+		await seedGroupGrant(roles.workspace.id, roles.member.user.id, writableProject.id, "member");
+		const hiddenProject = await seedProject(roles.workspace.id, "HIDE");
+
+		const mine = await seedIssue(roles.workspace.id, writableProject.id, roles.owner.user.id, {
+			title: "Mine",
+		});
+		const hidden = await seedIssue(roles.workspace.id, hiddenProject.id, roles.owner.user.id, {
+			title: "Hidden",
+		});
+
+		const missingRes = await callMcpTool(
+			roles.workspace.id,
+			roles.member.token,
+			roles.workspace.slug,
+			{
+				name: "update_issue",
+				arguments: { id: mine.id, parentId: crypto.randomUUID() },
+			}
+		);
+		const invisibleRes = await callMcpTool(
+			roles.workspace.id,
+			roles.member.token,
+			roles.workspace.slug,
+			{ name: "update_issue", arguments: { id: mine.id, parentId: hidden.id } }
+		);
+
+		expect(missingRes.error).toBeDefined();
+		expect(invisibleRes.error).toBeDefined();
+		expect(invisibleRes.error?.message).toBe(missingRes.error?.message);
+	});
+
+	it("list_issues with a project key the caller can't see returns an empty page, not a 404, same as a nonexistent key", async () => {
+		const roles = await seedWorkspaceRoles();
+		const hiddenProject = await seedProject(roles.workspace.id, "HIDE");
+		await seedIssue(roles.workspace.id, hiddenProject.id, roles.owner.user.id, {
+			title: "Hidden",
+		});
+
+		const nonexistentRes = await callMcpTool(
+			roles.workspace.id,
+			roles.member.token,
+			roles.workspace.slug,
+			{ name: "list_issues", arguments: { projectId: "NOPE" } }
+		);
+		const invisibleRes = await callMcpTool(
+			roles.workspace.id,
+			roles.member.token,
+			roles.workspace.slug,
+			{ name: "list_issues", arguments: { projectId: "HIDE" } }
+		);
+
+		expect(nonexistentRes.error).toBeUndefined();
+		expect(invisibleRes.error).toBeUndefined();
+		const nonexistentPage = JSON.parse(nonexistentRes.result!.content[0].text) as {
+			items: unknown[];
+		};
+		const invisiblePage = JSON.parse(invisibleRes.result!.content[0].text) as { items: unknown[] };
+		expect(nonexistentPage.items).toEqual([]);
+		expect(invisiblePage.items).toEqual([]);
+	});
+
+	it("search_issues with a visible project key returns matching results", async () => {
+		const createRes = await mcpCall({
+			name: "create_issue",
+			arguments: { projectId, title: "Findable via key search" },
+		});
+		expect(createRes.error).toBeUndefined();
+
+		const res = await mcpCall({
+			name: "search_issues",
+			arguments: { query: "Findable", projectId: projectKey },
+		});
+		expect(res.error).toBeUndefined();
+		const results = JSON.parse(res.result!.content[0].text) as Array<{ title: string }>;
+		expect(results.map((r) => r.title)).toContain("Findable via key search");
+	});
+
+	it("get_prioritized_issues with a visible project key returns results", async () => {
+		await seedIssue(workspaceId, projectId, userId, {
+			title: "Prioritizable",
+			priority: "urgent",
+		});
+
+		const res = await mcpCall({
+			name: "get_prioritized_issues",
+			arguments: { projectId: projectKey, includeNotReady: true },
+		});
+		expect(res.error).toBeUndefined();
+		const { issues } = JSON.parse(res.result!.content[0].text) as {
+			issues: Array<{ title: string }>;
+		};
+		expect(issues.map((i) => i.title)).toContain("Prioritizable");
+	});
+
+	it("list_issues rejects an unrecognized param with the field name in the error", async () => {
+		const res = await mcpCall({
+			name: "list_issues",
+			arguments: { parentRef: "PROJ-1" },
+		});
+		expect(res.error).toBeDefined();
+		expect(res.error?.message).toContain("parentRef");
 	});
 });

--- a/apps/docs/src/content/docs/agents/tool-catalog.md
+++ b/apps/docs/src/content/docs/agents/tool-catalog.md
@@ -116,7 +116,7 @@ running server.
 | `create_issue` | Create a new issue in a project |
 | `update_issue` | Update an issue — status, priority, title, body, assignee, or labels. Review gating: pass agentSessionId to identify yourself as an agent; entering in_review as an agent requires completionReport. Agents CAN transition directly to done (no human approval gate) — but if the completionReport.verification isn't externally checkable (no CI run/PR/commit link), the issue is flagged needsAudit:true for after-the-fact human review. |
 | `search_issues` | Search issues by keyword in title or body |
-| `delete_issue` | Delete an issue by ID |
+| `delete_issue` | Delete an issue by ID or ref (e.g. PROJ-42) |
 | `get_prioritized_issues` | Return open issues ranked by a composite score: link-network centrality (in-degree) + priority + inverse story points. Useful for deciding what to work on next. By default, issues that fail the definition-of-ready check (missing acceptance criteria, scope/files, or verification) are excluded. |
 
 ### Issue links


### PR DESCRIPTION
## Summary
- PROJ-712: `list_issues` and other MCP tools silently dropped unrecognized filter params (e.g. a typo'd `projectKey`/`parentRef`) instead of erroring — callers had no signal filtering never happened. Added `.strict()` to the affected Zod schemas.
- PROJ-713: write tools (`create_issue`, `update_issue`, `delete_issue`, `create_issue_link`, `list_issue_links`) required raw UUIDs while read tools accepted refs (`PROJ-42`) and project keys (`PROJ`), forcing an extra `get_issue` round trip per call. Refs/keys now resolve server-side transparently under the same param names. Also fixed `get_playbook` leaking "undefined" into its error message when `name` is missing.
- Adversarial review (fable) of the first pass found and this PR fixes three project-visibility gaps the new resolution step introduced: `validateParent` now checks visibility on a ref-resolved `parentId` (closed a cross-project existence oracle + silent re-parenting across the PROJ-311 visibility boundary); read-path project-key resolution now returns an empty page for an invisible-but-real key instead of a 404, matching a nonexistent key; `create_issue_link`'s two not-found paths now produce identical error text.

## Test plan
- [x] `pnpm vitest run` (apps/api, full suite) — 1329/1329 passing
- [x] `tsc --noEmit` (apps/api) — clean
- [x] `pnpm biome check` on touched files — clean
- [x] New regression tests cover: unknown-param rejection, ref/key resolution on write tools, parentId-visibility oracle closure, project-key-visibility oracle closure, create_issue_link error-message parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GrPytKYNRJSDQCuEJkjZa