### PR TITLE
chore(web): bump version to 0.6.8 for release

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@projektor/web",
-	"version": "0.6.7",
+	"version": "0.6.8",
 	"private": true,
 	"scripts": {
 		"dev": "astro dev",


### PR DESCRIPTION
Automated version bump ahead of cutting v0.6.8. Merging this will trigger release-tag.yml to tag and publish the release.