### PR TITLE
feat(web): retire the internal ?project param, strip ids from same-project nav (PROJ-728)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,17 @@ persists the resolved id back to the address bar via `history.replaceState` (see
 state — reach for it, don't invent a second one, before adding a new island that needs project
 identity.
 
+The identity param is a boundary concern, not a transport mechanism: links between pages that
+stay within the resolved project (`ProjectNav`'s tabs, in-app links to a project's own issues,
+wiki pages, etc.) carry no project param at all — the store survives the `ClientRouter`
+navigation those `<a>` tags trigger, so the destination resolves instantly with no refetch.
+`?projectId=` (the project UUID) is written only where identity actually crosses a boundary: the
+cold-start entry point (`ProjectList`'s project cards), a full non-SPA reload
+(`window.location.href` assignments, which drop all in-memory state), or an explicit project
+switch. `?id=` is reserved for a page's own entity (an issue on `/issues/view`, for example) and
+is never used for project identity in newly-written links — the resolver still accepts it (along
+with `?project=`) on read, for backward compatibility with existing shared URLs.
+
 ## Dev workflow
 
 ```bash

--- a/apps/docs/src/content/docs/contributing/conventions.md
+++ b/apps/docs/src/content/docs/contributing/conventions.md
@@ -240,6 +240,17 @@ persists the resolved id back to the address bar via `history.replaceState` (see
 state — reach for it, don't invent a second one, before adding a new island that needs project
 identity.
 
+The identity param is a boundary concern, not a transport mechanism: links between pages that
+stay within the resolved project (`ProjectNav`'s tabs, in-app links to a project's own issues,
+wiki pages, etc.) carry no project param at all — the store survives the `ClientRouter`
+navigation those `<a>` tags trigger, so the destination resolves instantly with no refetch.
+`?projectId=` (the project UUID) is written only where identity actually crosses a boundary: the
+cold-start entry point (`ProjectList`'s project cards), a full non-SPA reload
+(`window.location.href` assignments, which drop all in-memory state), or an explicit project
+switch. `?id=` is reserved for a page's own entity (an issue on `/issues/view`, for example) and
+is never used for project identity in newly-written links — the resolver still accepts it (along
+with `?project=`) on read, for backward compatibility with existing shared URLs.
+
 ## Dev workflow
 
 ```bash

--- a/apps/web/src/islands/FeedbackSourceGrid.test.tsx
+++ b/apps/web/src/islands/FeedbackSourceGrid.test.tsx
@@ -73,7 +73,7 @@ describe("FeedbackSourceGrid", () => {
 		stubFetch();
 		render(<FeedbackSourceGrid workspaceSlug="my-ws" projectId="p1" />);
 		const link = (await screen.findByText("Onboarding survey")).closest("a");
-		expect(link?.getAttribute("href")).toBe("/feedback/s1?projectId=p1");
+		expect(link?.getAttribute("href")).toBe("/feedback/s1");
 	});
 
 	it("marks a revoked source as Revoked", async () => {

--- a/apps/web/src/islands/FeedbackSourceGrid.tsx
+++ b/apps/web/src/islands/FeedbackSourceGrid.tsx
@@ -39,22 +39,11 @@ const CARD_CLASS =
 	"flex flex-col gap-2 p-4 bg-surface border border-border rounded-lg no-underline shadow-xs " +
 	"transition-all duration-150 hover:border-accent hover:-translate-y-px";
 
-function SourceCard({
-	source,
-	summary,
-	projectId,
-}: {
-	source: FeedbackSource;
-	summary?: SourceSummary;
-	projectId: string;
-}) {
+function SourceCard({ source, summary }: { source: FeedbackSource; summary?: SourceSummary }) {
 	const total = summary?.totalCount ?? 0;
 	const lastSeenAt = summary?.versions.reduce((max, v) => Math.max(max, v.lastSeenAt), 0) ?? 0;
 	return (
-		<a
-			href={`/feedback/${source.id}${projectId ? `?projectId=${projectId}` : ""}`}
-			class={`${CARD_CLASS} ${statusClass(source)}`}
-		>
+		<a href={`/feedback/${source.id}`} class={`${CARD_CLASS} ${statusClass(source)}`}>
 			<div class="flex items-center justify-between gap-2">
 				<span class="font-bold text-text-base">{source.name}</span>
 				<span class="text-[0.7rem] font-medium px-1.5 py-0.5 rounded bg-bg border border-border text-text-muted">
@@ -163,12 +152,7 @@ export default function FeedbackSourceGrid({ workspaceSlug, projectId: projectId
 				style={{ gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))" }}
 			>
 				{sources.map((s) => (
-					<SourceCard
-						key={s.id}
-						source={s}
-						summary={summaryBySource.get(s.id)}
-						projectId={projectId}
-					/>
+					<SourceCard key={s.id} source={s} summary={summaryBySource.get(s.id)} />
 				))}
 				<NewSourceCard onClick={() => setShowCreate(true)} />
 			</div>

--- a/apps/web/src/islands/ProjectLanding.test.tsx
+++ b/apps/web/src/islands/ProjectLanding.test.tsx
@@ -155,12 +155,12 @@ describe("ProjectLanding", () => {
 		expect(screen.getByText("Cumulative flow")).toBeTruthy();
 	});
 
-	it("recent-wiki links preserve projectId so the destination stays scoped (PROJ-352, PROJ-487)", async () => {
+	it("recent-wiki links carry no project param (PROJ-728) — the store carries identity across the ClientRouter nav", async () => {
 		history.replaceState(null, "", "?id=p1");
 		mockFetchProject([ISSUE], [WIKI_PAGE]);
 		render(<ProjectLanding />);
 		const link = (await screen.findByText("Getting Started")).closest("a");
-		expect(link?.getAttribute("href")).toBe("/wiki/getting-started?projectId=p1");
+		expect(link?.getAttribute("href")).toBe("/wiki/getting-started");
 	});
 
 	// PROJ-376: pretty project URLs (/projects/view/<slug>) resolve via the path,

--- a/apps/web/src/islands/ProjectLanding.tsx
+++ b/apps/web/src/islands/ProjectLanding.tsx
@@ -308,7 +308,7 @@ function RecentIssuesSection({ issues }: { issues: RecentIssue[] }) {
 	);
 }
 
-function RecentWikiSection({ pages, projectId }: { pages: RecentWikiPage[]; projectId: string }) {
+function RecentWikiSection({ pages }: { pages: RecentWikiPage[] }) {
 	return (
 		<section class="mb-8" aria-labelledby="recent-wiki-heading">
 			<h2 id="recent-wiki-heading" class={SECTION_HEADING_CLASS}>
@@ -322,10 +322,7 @@ function RecentWikiSection({ pages, projectId }: { pages: RecentWikiPage[]; proj
 						<div key={page.id} class="py-2 border-b border-border last:border-b-0">
 							<div class="flex justify-between items-baseline gap-2">
 								<a
-									href={
-										`/wiki/${encodeURIComponent(page.slug)}` +
-										`${projectId ? `?projectId=${encodeURIComponent(projectId)}` : ""}`
-									}
+									href={`/wiki/${encodeURIComponent(page.slug)}`}
 									class="text-text-base no-underline text-sm hover:underline focus:underline"
 								>
 									{page.title}
@@ -486,7 +483,7 @@ export default function ProjectLanding({ workspaceSlug }: Props) {
 
 			<ProjectFlowCharts workspaceSlug={workspaceSlug} projectId={project.id} />
 			<RecentIssuesSection issues={recentIssues} />
-			<RecentWikiSection pages={recentWiki} projectId={project.id} />
+			<RecentWikiSection pages={recentWiki} />
 		</div>
 	);
 }

--- a/apps/web/src/islands/ProjectList.tsx
+++ b/apps/web/src/islands/ProjectList.tsx
@@ -269,7 +269,7 @@ function ProjectCard({ project }: { project: Project }) {
 			href={
 				project.slug
 					? `/projects/view/${encodeURIComponent(project.slug)}`
-					: `/projects/view?id=${project.id}`
+					: `/projects/view?projectId=${encodeURIComponent(project.id)}`
 			}
 			class={`${PROJECT_CARD_CLASS}${archived ? " opacity-60" : ""}`}
 		>

--- a/apps/web/src/islands/ProjectNav.test.tsx
+++ b/apps/web/src/islands/ProjectNav.test.tsx
@@ -173,7 +173,7 @@ describe("ProjectNav", () => {
 		window.history.pushState({}, "", "/metrics?projectId=p1");
 		render(<ProjectNav workspaceSlug="my-ws" />);
 		const link = (await screen.findByText("Feedback")) as HTMLAnchorElement;
-		expect(link.getAttribute("href")).toBe("/feedback?projectId=p1");
+		expect(link.getAttribute("href")).toBe("/feedback");
 	});
 });
 
@@ -224,7 +224,7 @@ describe("ProjectNav — Priority+ overflow menu", () => {
 		expect(feedbackItem.getAttribute("aria-current")).toBe("page");
 	});
 
-	it("opens the menu with hidden tabs' correct ?projectId hrefs, and closes it on selection", async () => {
+	it("opens the menu with hidden tabs' plain hrefs (no project param), and closes it on selection", async () => {
 		window.history.pushState({}, "", "/issues?id=p1");
 		mockFetchProject(PROJECT);
 		stubNavMeasurements(340, 90);
@@ -236,9 +236,9 @@ describe("ProjectNav — Priority+ overflow menu", () => {
 		expect(menu).toBeTruthy();
 
 		const wikiItem = screen.getByRole("menuitem", { name: "Wiki" });
-		expect(wikiItem.getAttribute("href")).toBe("/wiki?projectId=p1");
+		expect(wikiItem.getAttribute("href")).toBe("/wiki");
 		const feedbackItem = screen.getByRole("menuitem", { name: "Feedback" });
-		expect(feedbackItem.getAttribute("href")).toBe("/feedback?projectId=p1");
+		expect(feedbackItem.getAttribute("href")).toBe("/feedback");
 
 		fireEvent.click(wikiItem);
 		expect(screen.queryByRole("menu")).toBeNull();

--- a/apps/web/src/islands/ProjectNav.tsx
+++ b/apps/web/src/islands/ProjectNav.tsx
@@ -185,22 +185,12 @@ export default function ProjectNav({ workspaceSlug, pageLabel }: Props) {
 
 	const overviewHref = project.slug
 		? `/projects/view/${encodeURIComponent(project.slug)}`
-		: `/projects/view?id=${encodeURIComponent(project.id)}`;
+		: "/projects/view";
 
-	const tabs = TABS.map((t) => {
-		let href: string;
-		switch (t.path) {
-			case "/projects/view":
-				href = overviewHref;
-				break;
-			case "/issues":
-				href = `/issues?project=${encodeURIComponent(project.key)}`;
-				break;
-			default:
-				href = `${t.path}?projectId=${encodeURIComponent(project.id)}`;
-		}
-		return { ...t, href };
-	});
+	const tabs = TABS.map((t) => ({
+		...t,
+		href: t.path === "/projects/view" ? overviewHref : t.path,
+	}));
 
 	const visibleTabs = tabs.slice(0, visibleCount);
 	const overflowTabs = tabs.slice(visibleCount);

--- a/apps/web/src/islands/SprintManager.tsx
+++ b/apps/web/src/islands/SprintManager.tsx
@@ -615,7 +615,7 @@ function SprintBreadcrumb({ project }: { project: Project | null }) {
 				Projects
 			</a>
 			<span class="mx-[0.375rem]">/</span>
-			<a href={`/projects/view?id=${project.id}`} class="text-text-muted no-underline">
+			<a href="/projects/view" class="text-text-muted no-underline">
 				{project.name}
 			</a>
 			<span class="mx-[0.375rem]">/</span>


### PR DESCRIPTION
## Summary
- Standardizes on `?projectId=` as the sole boundary-entry identity param (used only at `ProjectList`'s project cards, and full non-SPA reloads/explicit switches) and reserves `?id=` for a page's own entity, never for project identity in new links.
- Internal same-project navigation (`ProjectNav` tabs, `ProjectLanding`'s recent-wiki links, `FeedbackSourceGrid`'s source cards, `SprintManager`'s breadcrumb) now carries **no** project param at all — the PROJ-727 signals store survives the `ClientRouter` transition those `<a>` tags trigger, so the destination resolves instantly with no refetch and no param-parsing.
- Documents the boundary-vs-transport rule in `AGENTS.md` (regenerates `apps/docs/.../conventions.md` via `gen:docs`).

## Deliberate scope exclusions
- `useFilterUrlSync.ts`'s `?project=` (key) param — this is `IssueList`'s own filter-by-project-key concept, not identity transport; changing its semantics is out of scope.
- `WikiPage.tsx`'s `?projectId=` usages — these are API-fetch query params, not navigation links, plus its scope-switcher's `window.location.href` assignment, which is a genuine full-reload boundary action.
- `FeedbackSourceDetail.tsx`'s source-switcher — same reason, correctly kept as a full-reload boundary action.

## Investigated during verification: dev-only hydration crash (not a regression, not shipped)
While browser-verifying the ClientRouter navigation this ticket relies on, a console error surfaced on every dev-server navigation: `[astro-island] Error hydrating /src/islands/ProjectNav.tsx TypeError: Cannot read properties of null (reading 'map')`, preceded by `InvalidStateError: Transition was aborted because of invalid state`. `git stash` isolation proved this predates this PR (reproduces identically against PROJ-727's shipped `ProjectNav.tsx`). Restarting the dev daemon fresh didn't clear it, ruling out HMR staleness as a *fix*. Testing against a production `astro preview` build showed the hydration crash **does not reproduce** — only the benign `InvalidStateError` fires (a known harmless View Transitions race), and `ProjectNav` renders correctly on every navigation. Conclusion: dev-mode-only artifact (Vite/`@prefresh` HMR interacting with Astro's ClientRouter timing), not a production-affecting bug — no fix needed, noted here for visibility.

## Test plan
- [x] `astro check` (type-check): 0 errors
- [x] `biome check`: clean
- [x] `vitest run`: 703/703 passed
- [x] `pnpm gen:docs`: only the expected `conventions.md` diff
- [x] `astro build`: succeeds
- [x] Browser-verified against a production preview build (localhost:4326): clicked Epics→Metrics and Epics→Sprints, confirmed `ProjectNav` renders correctly with the right project on each destination, URLs carry no stray project param, no hydration crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)