### PR TITLE
fix(web): resolve feedback source detail's project via lookup endpoint, not a cross-project scan (PROJ-726)

### DIFF
--- a/apps/web/src/islands/FeedbackSourceDetail.test.tsx
+++ b/apps/web/src/islands/FeedbackSourceDetail.test.tsx
@@ -24,11 +24,20 @@ const SOURCE_B = {
 	revokedAt: null,
 };
 
-function stubFetch(sources = [SOURCE_A, SOURCE_B]) {
+function stubFetch(sources = [SOURCE_A, SOURCE_B], sourceProjectId = "p1") {
 	vi.stubGlobal(
 		"fetch",
 		vi.fn().mockImplementation((url: string) => {
 			const u = String(url);
+			if (/\/api\/feedback-sources\/[^/]+$/.test(u)) {
+				const found = sources.find((s) => s.id === u.split("/").pop());
+				if (!found)
+					return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) });
+				return Promise.resolve({
+					ok: true,
+					json: () => Promise.resolve({ ...found, projectId: sourceProjectId }),
+				});
+			}
 			if (u.includes("/feedback-sources")) {
 				return Promise.resolve({ ok: true, json: () => Promise.resolve(sources) });
 			}
@@ -37,12 +46,6 @@ function stubFetch(sources = [SOURCE_A, SOURCE_B]) {
 			}
 			if (u.includes("/feedback")) {
 				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
-			}
-			if (u.includes("/api/projects")) {
-				return Promise.resolve({
-					ok: true,
-					json: () => Promise.resolve([{ id: "p1", name: "Project 1" }]),
-				});
 			}
 			return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
 		})
@@ -106,14 +109,27 @@ describe("FeedbackSourceDetail", () => {
 		}
 	});
 
-	it("resolves projectId from localStorage or /api/projects when no projectId prop or query param is present", async () => {
+	it("resolves projectId via GET /api/feedback-sources/:sourceId when no projectId prop is present", async () => {
 		stubFetch();
 		const originalPath = window.location.pathname;
 		window.history.pushState({}, "", "/feedback/s1");
-		localStorage.removeItem("projektor-last-project-id");
 		try {
 			render(<FeedbackSourceDetail workspaceSlug="my-ws" />);
 			expect(await screen.findByRole("heading", { name: "Onboarding survey" })).toBeTruthy();
+		} finally {
+			window.history.pushState({}, "", originalPath);
+		}
+	});
+
+	it("does not write projektor-last-project-id, and resolving a source in project p2 doesn't affect a page reading it", async () => {
+		localStorage.setItem("projektor-last-project-id", "p1");
+		stubFetch([SOURCE_A], "p2");
+		const originalPath = window.location.pathname;
+		window.history.pushState({}, "", "/feedback/s1");
+		try {
+			render(<FeedbackSourceDetail workspaceSlug="my-ws" />);
+			await screen.findByRole("heading", { name: "Onboarding survey" });
+			expect(localStorage.getItem("projektor-last-project-id")).toBe("p1");
 		} finally {
 			window.history.pushState({}, "", originalPath);
 		}

--- a/apps/web/src/islands/FeedbackSourceDetail.tsx
+++ b/apps/web/src/islands/FeedbackSourceDetail.tsx
@@ -1,13 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
-import {
-	currentProject,
-	ensureProjectResolved,
-	projectReady,
-	projectError as storeProjectError,
-} from "../lib/project-context";
 import { safeDecodeURIComponent } from "../lib/urls";
 import { apiFetch } from "../utils/api-client";
-import { persistProjectId } from "../utils/resolve-project-id";
 import FeedbackList from "./FeedbackList";
 import FeedbackSourceSettings, { type FeedbackSource } from "./FeedbackSourceSettings";
 import FeedbackSummary from "./FeedbackSummary";
@@ -157,25 +150,13 @@ export default function FeedbackSourceDetail({
 	projectId: projectIdProp,
 	sourceId: sourceIdProp,
 }: Props) {
-	useEffect(() => {
-		if (!projectIdProp) ensureProjectResolved(workspaceSlug);
-	}, [projectIdProp, workspaceSlug]);
-
-	const resolvedReady = projectIdProp !== undefined || projectReady.value;
-	const resolvedProjectId = projectIdProp ?? currentProject.value?.id ?? "";
-	const resolveError = projectIdProp ? null : storeProjectError.value;
-
-	const [projectId, setProjectId] = useState(projectIdProp ?? "");
-	useEffect(() => {
-		if (resolvedReady) setProjectId(resolvedProjectId);
-	}, [resolvedReady, resolvedProjectId]);
-
 	// Static output can't serve the dynamic /feedback/[sourceId] route directly, so
 	// FeedbackSourceDetail is also rendered by the static /feedback/view?sourceId= page (mirrors
 	// /issues/view.astro). Named "sourceId", not "id", because this page also renders ProjectNav,
 	// which reads ?id= as a *project* id — ?id= here would collide with it.
 	// Resolve sourceId from ?sourceId= first, then from the pretty-URL pathname.
 	const [sourceId, setSourceId] = useState(sourceIdProp ?? "");
+	const [loading, setLoading] = useState(true);
 	useEffect(() => {
 		if (sourceIdProp) return;
 		const fromUrl = new URLSearchParams(window.location.search).get("sourceId");
@@ -186,14 +167,33 @@ export default function FeedbackSourceDetail({
 		const m = window.location.pathname.match(/^\/feedback\/([^/]+)/);
 		if (m) {
 			const decoded = safeDecodeURIComponent(m[1]);
-			if (decoded) setSourceId(decoded);
+			if (decoded) return setSourceId(decoded);
 		}
+		setLoading(false);
 	}, [sourceIdProp]);
 
-	const [sources, setSources] = useState<FeedbackSource[]>([]);
-	const [loading, setLoading] = useState(true);
+	const [projectId, setProjectId] = useState(projectIdProp ?? "");
 	const [fetchError, setFetchError] = useState<string | null>(null);
-	const error = resolveError ?? fetchError;
+
+	useEffect(() => {
+		if (projectIdProp || !sourceId) return;
+		let cancelled = false;
+		apiFetch<{ projectId: string }>(`/api/feedback-sources/${sourceId}`, { workspaceSlug })
+			.then((r) => {
+				if (!cancelled) setProjectId(r.projectId);
+			})
+			.catch((e) => {
+				if (!cancelled) {
+					setFetchError(String(e));
+					setLoading(false);
+				}
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [projectIdProp, sourceId, workspaceSlug]);
+
+	const [sources, setSources] = useState<FeedbackSource[]>([]);
 	const [tab, setTab] = useState<TabId>("items");
 	const tabRefs = useRef<Partial<Record<TabId, HTMLButtonElement | null>>>({});
 
@@ -205,48 +205,18 @@ export default function FeedbackSourceDetail({
 			const data = await apiFetch<FeedbackSource[]>(`/api/projects/${projectId}/feedback-sources`, {
 				workspaceSlug,
 			});
-			const list = Array.isArray(data) ? data : [];
-			if (sourceId && !list.some((s) => s.id === sourceId)) {
-				// The source may belong to another project in the workspace
-				const allProjects = await apiFetch<Array<{ id: string }>>("/api/projects", {
-					workspaceSlug,
-				});
-				if (Array.isArray(allProjects)) {
-					for (const p of allProjects) {
-						if (p.id === projectId) continue;
-						try {
-							const otherSources = await apiFetch<FeedbackSource[]>(
-								`/api/projects/${p.id}/feedback-sources`,
-								{ workspaceSlug }
-							);
-							if (Array.isArray(otherSources) && otherSources.some((s) => s.id === sourceId)) {
-								setProjectId(p.id);
-								persistProjectId(p.id);
-								setSources(otherSources);
-								return;
-							}
-						} catch {
-							// continue search
-						}
-					}
-				}
-			}
-			setSources(list);
+			setSources(Array.isArray(data) ? data : []);
 		} catch (e) {
 			setFetchError(String(e));
 		} finally {
 			setLoading(false);
 		}
-	}, [projectId, sourceId, workspaceSlug]);
+	}, [projectId, workspaceSlug]);
 
 	useEffect(() => {
-		if (!resolvedReady) return;
-		if (!projectId) {
-			setLoading(false);
-			return;
-		}
+		if (!projectId) return;
 		fetchSources();
-	}, [resolvedReady, projectId, fetchSources]);
+	}, [projectId, fetchSources]);
 
 	function focusTab(id: TabId) {
 		tabRefs.current[id]?.focus();
@@ -266,10 +236,10 @@ export default function FeedbackSourceDetail({
 	}
 
 	if (loading) return <p aria-live="polite">Loading source…</p>;
-	if (error) {
+	if (fetchError) {
 		return (
 			<p role="alert" class="text-[var(--danger-text)]">
-				{error}
+				{fetchError}
 			</p>
 		);
 	}


### PR DESCRIPTION
## Summary
- `FeedbackSourceDetail.tsx` no longer scans every project in the workspace to find which one owns a feedback source, and no longer silently overwrites `projektor-last-project-id` as a side effect of visiting a detail page (global state mutated by a read — merely opening one feedback source could change which project every other page resolved to next).
- It now resolves its project via a single `GET /api/feedback-sources/:sourceId` fetch (the workspace-scoped lookup endpoint added in PROJ-724), and no longer touches `project-context.ts`'s module-level store or `localStorage` at all — its resolution is fully independent of, and has no effect on, project resolution anywhere else in the app.
- The `?sourceId=` naming rationale (avoiding collision with `ProjectNav`'s `?id=`) documented at the top of the component is unchanged/still accurate.

## Base branch
This PR targets `wt/proj-728-retire-project-param` (which itself targets `wt/proj-727-signals-project-store`) since this file was already touched by PROJ-727/728's identity work, and the branch includes a merge of `wt/proj-724-feedback-source-lookup` to bring in the `GET /api/feedback-sources/:sourceId` endpoint this ticket depends on.

## Test plan
- [x] Added a regression test: resolving a source in project `p2` while `projektor-last-project-id` is `p1` in localStorage leaves that value untouched (`FeedbackSourceDetail.test.tsx`)
- [x] Updated existing tests to mock the new lookup-endpoint fetch instead of the old cross-project scan
- [x] `astro check` (web + api): 0 errors
- [x] `biome check`: clean
- [x] `vitest run`: web 704/704, api 1363/1363
- [x] `pnpm gen:docs`: no diff
- [x] `astro build`: succeeds
- [x] Browser-verified against the dev server: created a feedback source, navigated directly to `/feedback/view?sourceId=...` with no `?projectId=` hint, confirmed it resolves and renders correctly via the new lookup path with no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)