### PR TITLE
fix(api): make KV cache fail-soft, add request-id correlation (PROJ-730)

### DIFF
--- a/apps/api/src/mcp/error-adapter.ts
+++ b/apps/api/src/mcp/error-adapter.ts
@@ -97,7 +97,10 @@ function toMcpServiceErrorWithDetails(
 	return { code: -32000, message: `${message} (${summarizeDetails(details)})`, data: details };
 }
 
-export function toMcpError(err: unknown): { code: number; message: string; data?: unknown } {
+export function toMcpError(
+	err: unknown,
+	requestId: string
+): { code: number; message: string; data?: unknown } {
 	if (err instanceof ValidationError) return toMcpValidationError(err);
 	if (err instanceof ServiceError) {
 		// Only the kinds whose messages are deliberately client-facing are
@@ -120,10 +123,14 @@ export function toMcpError(err: unknown): { code: number; message: string; data?
 					err instanceof ConflictError ? err.details : undefined
 				);
 			default:
-				console.error("[mcp] unhandled ServiceError kind in tools/call:", err.kind, err);
-				return { code: -32000, message: "Internal error" };
+				console.error(`[mcp] unhandled ServiceError kind (request ${requestId}):`, err.kind, err);
+				return {
+					code: -32000,
+					message: `Internal error (request: ${requestId})`,
+					data: { requestId },
+				};
 		}
 	}
-	console.error("[mcp] unhandled error in tools/call:", err);
-	return { code: -32000, message: "Internal error" };
+	console.error(`[mcp] unhandled error in tools/call (request ${requestId}):`, err);
+	return { code: -32000, message: `Internal error (request: ${requestId})`, data: { requestId } };
 }

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -436,7 +436,11 @@ async function fetchAndCacheCfAccessKeys(env: Env): Promise<JsonWebKey[]> {
 	if (!res.ok) throw new Error("Failed to fetch CF Access certs");
 	const { keys } = await res.json<{ keys: JsonWebKey[] }>();
 
-	await env.KV.put("cf-access-certs", JSON.stringify(keys), { expirationTtl: 3600 });
+	try {
+		await env.KV.put("cf-access-certs", JSON.stringify(keys), { expirationTtl: 3600 });
+	} catch (err) {
+		console.error("[auth] failed to cache cf-access-certs in KV, continuing without it:", err);
+	}
 	inMemoryCertsCache = { keys, expiresAt: Date.now() + CERTS_LOCAL_TTL_MS };
 	return keys;
 }
@@ -531,7 +535,14 @@ async function upsertUserByEmail(
 	if (!user) throw new Error("Failed to upsert user");
 
 	if (kv) {
-		await kv.put(`user-by-email:${email}`, JSON.stringify(user), { expirationTtl: 300 });
+		try {
+			await kv.put(`user-by-email:${email}`, JSON.stringify(user), { expirationTtl: 300 });
+		} catch (err) {
+			console.error(
+				`[auth] failed to cache user-by-email:${email} in KV, continuing without it:`,
+				err
+			);
+		}
 	}
 	inMemoryUserCache.set(email, { user, expiresAt: Date.now() + USER_LOCAL_TTL_MS });
 

--- a/apps/api/src/routes/mcp.ts
+++ b/apps/api/src/routes/mcp.ts
@@ -185,7 +185,7 @@ router.post("/:workspaceId", async (c) => {
 					})
 				);
 			} catch (err) {
-				const { code, message, data } = toMcpError(err);
+				const { code, message, data } = toMcpError(err, crypto.randomUUID());
 				return c.json(jsonRpcError(body.id, code, message, data));
 			}
 		}
@@ -213,7 +213,7 @@ router.post("/:workspaceId", async (c) => {
 				const result = await getPrompt(ctx, name, promptArgs ?? {});
 				return c.json(jsonRpcResult(body.id, result));
 			} catch (err) {
-				const { code, message, data } = toMcpError(err);
+				const { code, message, data } = toMcpError(err, crypto.randomUUID());
 				return c.json(jsonRpcError(body.id, code, message, data));
 			}
 		}

--- a/apps/api/src/services/cache.ts
+++ b/apps/api/src/services/cache.ts
@@ -1,5 +1,10 @@
 export async function get<T>(kv: KVNamespace, key: string): Promise<T | null> {
-	return kv.get<T>(key, { type: "json" });
+	try {
+		return await kv.get<T>(key, { type: "json" });
+	} catch (err) {
+		console.error(`[cache] get failed for key "${key}", treating as a cache miss:`, err);
+		return null;
+	}
 }
 
 export async function set<T>(
@@ -8,9 +13,20 @@ export async function set<T>(
 	value: T,
 	ttlSeconds: number
 ): Promise<void> {
-	await kv.put(key, JSON.stringify(value), { expirationTtl: ttlSeconds });
+	try {
+		await kv.put(key, JSON.stringify(value), { expirationTtl: ttlSeconds });
+	} catch (err) {
+		console.error(`[cache] set failed for key "${key}", continuing without caching:`, err);
+	}
 }
 
 export async function invalidate(kv: KVNamespace, key: string): Promise<void> {
-	await kv.delete(key);
+	try {
+		await kv.delete(key);
+	} catch (err) {
+		console.error(
+			`[cache] invalidate failed for key "${key}", entry may be stale until TTL expiry:`,
+			err
+		);
+	}
 }

--- a/apps/api/src/services/provisioning.ts
+++ b/apps/api/src/services/provisioning.ts
@@ -207,7 +207,14 @@ async function alreadyProvisioned(env: Env, userId: string): Promise<boolean> {
 
 async function markProvisioned(env: Env, userId: string): Promise<void> {
 	inMemoryProvisionedCache.set(userId, Date.now() + PROVISIONED_LOCAL_TTL_MS);
-	await env.KV.put(provisionedKey(userId), "1", { expirationTtl: PROVISIONED_KV_TTL_SECS });
+	try {
+		await env.KV.put(provisionedKey(userId), "1", { expirationTtl: PROVISIONED_KV_TTL_SECS });
+	} catch (err) {
+		console.error(
+			`[provisioning] failed to cache provisioned marker for ${userId} in KV, continuing without it:`,
+			err
+		);
+	}
 }
 
 /**

--- a/apps/api/src/test/auth.test.ts
+++ b/apps/api/src/test/auth.test.ts
@@ -442,6 +442,66 @@ describe("PROJ-358: JWKS force-refresh on signature verification failure", () =>
 	});
 });
 
+describe("PROJ-730: JWKS cache write failure doesn't fail auth", () => {
+	it("a successful JWKS fetch still authenticates when caching it in KV fails", async () => {
+		const keyPair = (await crypto.subtle.generateKey(
+			{
+				name: "RSASSA-PKCS1-v1_5",
+				modulusLength: 2048,
+				publicExponent: new Uint8Array([1, 0, 1]),
+				hash: "SHA-256",
+			},
+			true,
+			["sign", "verify"]
+		)) as CryptoKeyPair;
+		const publicJwk = (await crypto.subtle.exportKey("jwk", keyPair.publicKey)) as JsonWebKey;
+
+		const domain = `proj-730-${crypto.randomUUID().slice(0, 8)}.example.com`;
+		const audience = "proj-730-audience";
+		env.CF_ACCESS_TEAM_DOMAIN = domain;
+		env.CF_ACCESS_AUDIENCE = audience;
+
+		resetAuthCachesForTests();
+		await env.KV.delete("cf-access-certs");
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				return new Response(JSON.stringify({ keys: [publicJwk] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			})
+		);
+		const putSpy = vi
+			.spyOn(env.KV, "put")
+			.mockRejectedValueOnce(new Error("10048: your account has reached the free usage limit"));
+
+		try {
+			const jwt = await signTestJwt(keyPair.privateKey, {
+				exp: Math.floor(Date.now() / 1000) + 3600,
+				aud: audience,
+				iss: `https://${domain}`,
+				email: `proj-730-${crypto.randomUUID().slice(0, 8)}@example.com`,
+			});
+
+			const res = await SELF.fetch("http://localhost/auth/me", {
+				headers: { "Cf-Access-Jwt-Assertion": jwt },
+			});
+
+			expect(res.status).toBe(200);
+			expect(putSpy).toHaveBeenCalledWith(
+				"cf-access-certs",
+				expect.any(String),
+				expect.objectContaining({ expirationTtl: 3600 })
+			);
+		} finally {
+			vi.unstubAllGlobals();
+			vi.restoreAllMocks();
+		}
+	});
+});
+
 // ---------------------------------------------------------------------------
 // PROJ-360: last_used_at is a coarse audit field, throttled so bearer/agent
 // traffic (the hottest auth path) doesn't rewrite it on every single request.

--- a/apps/api/src/test/cache.test.ts
+++ b/apps/api/src/test/cache.test.ts
@@ -230,9 +230,9 @@ describe("KV caching", () => {
 			});
 			const issue = await seedIssue(workspaceId, projectId, userId, { title: "Before" });
 
-			vi.spyOn(env.KV, "delete").mockRejectedValueOnce(
-				new Error("10048: your account has reached the free usage limit")
-			);
+			const spy = vi
+				.spyOn(env.KV, "delete")
+				.mockRejectedValueOnce(new Error("10048: your account has reached the free usage limit"));
 
 			const res = await SELF.fetch(`http://localhost/mcp/${workspaceId}`, {
 				method: "POST",
@@ -244,6 +244,7 @@ describe("KV caching", () => {
 					params: { name: "update_issue", arguments: { id: issue.id, title: "After" } },
 				}),
 			});
+			expect(spy).toHaveBeenCalled();
 			expect(res.status).toBe(200);
 			const rpc = (await res.json()) as { result?: unknown; error?: unknown };
 			expect(rpc.error).toBeUndefined();

--- a/apps/api/src/test/cache.test.ts
+++ b/apps/api/src/test/cache.test.ts
@@ -1,5 +1,6 @@
 import { env, SELF } from "cloudflare:test";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as cache from "../services/cache";
 import {
 	authHeaders,
 	seedIssue,
@@ -196,6 +197,65 @@ describe("KV caching", () => {
 			const after = await SELF.fetch(url, { headers: hdrs });
 			const afterBody = (await after.json()) as Array<{ key: string }>;
 			expect(afterBody.some((t) => t.key === "chore")).toBe(false);
+		});
+	});
+
+	describe("KV operation failures (PROJ-730)", () => {
+		function throwingKv(err: unknown): KVNamespace {
+			return {
+				get: () => Promise.reject(err),
+				put: () => Promise.reject(err),
+				delete: () => Promise.reject(err),
+			} as unknown as KVNamespace;
+		}
+
+		it("get() degrades to a cache miss instead of throwing", async () => {
+			const kv = throwingKv(new Error("10048: your account has reached the free usage limit"));
+			await expect(cache.get(kv, "any-key")).resolves.toBeNull();
+		});
+
+		it("set() resolves instead of throwing", async () => {
+			const kv = throwingKv(new Error("10048: your account has reached the free usage limit"));
+			await expect(cache.set(kv, "any-key", { a: 1 }, 60)).resolves.toBeUndefined();
+		});
+
+		it("invalidate() resolves instead of throwing", async () => {
+			const kv = throwingKv(new Error("10048: your account has reached the free usage limit"));
+			await expect(cache.invalidate(kv, "any-key")).resolves.toBeUndefined();
+		});
+
+		it("update_issue's D1 write still lands and is reported as success when the cache invalidate fails", async () => {
+			const { token, slug, workspaceId, projectId, userId } = await seedProjectFixture({
+				role: "owner",
+			});
+			const issue = await seedIssue(workspaceId, projectId, userId, { title: "Before" });
+
+			vi.spyOn(env.KV, "delete").mockRejectedValueOnce(
+				new Error("10048: your account has reached the free usage limit")
+			);
+
+			const res = await SELF.fetch(`http://localhost/mcp/${workspaceId}`, {
+				method: "POST",
+				headers: authHeaders(token, slug),
+				body: JSON.stringify({
+					jsonrpc: "2.0",
+					id: 1,
+					method: "tools/call",
+					params: { name: "update_issue", arguments: { id: issue.id, title: "After" } },
+				}),
+			});
+			expect(res.status).toBe(200);
+			const rpc = (await res.json()) as { result?: unknown; error?: unknown };
+			expect(rpc.error).toBeUndefined();
+
+			const row = await env.DB.prepare("SELECT title FROM issues WHERE id = ?")
+				.bind(issue.id)
+				.first<{ title: string }>();
+			expect(row?.title).toBe("After");
+		});
+
+		afterEach(() => {
+			vi.restoreAllMocks();
 		});
 	});
 });

--- a/apps/api/src/test/errors.test.ts
+++ b/apps/api/src/test/errors.test.ts
@@ -114,7 +114,7 @@ describe("mcp/error-adapter: toMcpError", () => {
 	// JSON-RPC 2.0 `error.data` member instead.
 	it("maps ValidationError to -32602 with the issues in error.data and a message summary", () => {
 		const issues = { formErrors: ["ambiguous heading"], fieldErrors: {} };
-		const result = toMcpError(new ValidationError(issues));
+		const result = toMcpError(new ValidationError(issues), "req-1");
 		expect(result).toEqual({
 			code: -32602,
 			message: "Invalid params (ambiguous heading)",
@@ -123,7 +123,7 @@ describe("mcp/error-adapter: toMcpError", () => {
 	});
 
 	it("maps NotFoundError to -32000 with its client-facing message", () => {
-		expect(toMcpError(new NotFoundError("Issue not found"))).toEqual({
+		expect(toMcpError(new NotFoundError("Issue not found"), "req-1")).toEqual({
 			code: -32000,
 			message: "Issue not found",
 		});
@@ -135,7 +135,8 @@ describe("mcp/error-adapter: toMcpError", () => {
 	// MCP hosts that don't surface `data` to the calling model.
 	it("maps a NotFoundError with details to -32000 with the details in error.data and a message summary", () => {
 		const result = toMcpError(
-			new NotFoundError("Heading 'Nope' not found", { currentHeadings: ["Alpha", "Beta"] })
+			new NotFoundError("Heading 'Nope' not found", { currentHeadings: ["Alpha", "Beta"] }),
+			"req-1"
 		);
 		expect(result).toEqual({
 			code: -32000,
@@ -147,21 +148,21 @@ describe("mcp/error-adapter: toMcpError", () => {
 	// PROJ-508: an empty details object must be treated the same as no details at all —
 	// omit `data` (per the JSON-RPC 2.0 contract) rather than sending `data: {}`.
 	it("treats an empty NotFoundError.details object as no details", () => {
-		expect(toMcpError(new NotFoundError("Issue not found", {}))).toEqual({
+		expect(toMcpError(new NotFoundError("Issue not found", {}), "req-1")).toEqual({
 			code: -32000,
 			message: "Issue not found",
 		});
 	});
 
 	it("maps ForbiddenError to -32000 with its client-facing message", () => {
-		expect(toMcpError(new ForbiddenError("Not allowed"))).toEqual({
+		expect(toMcpError(new ForbiddenError("Not allowed"), "req-1")).toEqual({
 			code: -32000,
 			message: "Not allowed",
 		});
 	});
 
 	it("maps ConflictError to -32000 with its client-facing message", () => {
-		expect(toMcpError(new ConflictError("Slug taken"))).toEqual({
+		expect(toMcpError(new ConflictError("Slug taken"), "req-1")).toEqual({
 			code: -32000,
 			message: "Slug taken",
 		});
@@ -173,7 +174,8 @@ describe("mcp/error-adapter: toMcpError", () => {
 	// folded into `message` as a fallback for MCP hosts that don't surface `data`.
 	it("maps a ConflictError with details to -32000 with the details in error.data and a message summary", () => {
 		const result = toMcpError(
-			new ConflictError("Revision conflict", { currentRevisionId: "rev-2", diff: "..." })
+			new ConflictError("Revision conflict", { currentRevisionId: "rev-2", diff: "..." }),
+			"req-1"
 		);
 		expect(result).toEqual({
 			code: -32000,
@@ -186,7 +188,7 @@ describe("mcp/error-adapter: toMcpError", () => {
 	// summary folded into `message` is truncated; `data` still carries the full value.
 	it("truncates a long detail value in the message summary but not in error.data", () => {
 		const longDiff = "x".repeat(500);
-		const result = toMcpError(new ConflictError("Revision conflict", { diff: longDiff }));
+		const result = toMcpError(new ConflictError("Revision conflict", { diff: longDiff }), "req-1");
 		expect(result.data).toEqual({ diff: longDiff });
 		expect(result.message.length).toBeLessThan(150);
 		expect(result.message).toContain("diff: xxx");
@@ -195,16 +197,17 @@ describe("mcp/error-adapter: toMcpError", () => {
 	// PROJ-508: an empty details object must be treated the same as no details at all —
 	// omit `data` (per the JSON-RPC 2.0 contract) rather than sending `data: {}`.
 	it("treats an empty ConflictError.details object as no details", () => {
-		expect(toMcpError(new ConflictError("Slug taken", {}))).toEqual({
+		expect(toMcpError(new ConflictError("Slug taken", {}), "req-1")).toEqual({
 			code: -32000,
 			message: "Slug taken",
 		});
 	});
 
-	it("maps a non-ServiceError to a generic internal error, not the raw message", () => {
-		expect(toMcpError(new Error("stack trace with secrets"))).toEqual({
-			code: -32000,
-			message: "Internal error",
-		});
+	it("maps a non-ServiceError to a generic internal error carrying the request id, not the raw message", () => {
+		const result = toMcpError(new Error("stack trace with secrets"), "req-42");
+		expect(result.code).toBe(-32000);
+		expect(result.message).toBe("Internal error (request: req-42)");
+		expect(result.message).not.toContain("stack trace with secrets");
+		expect(result.data).toEqual({ requestId: "req-42" });
 	});
 });


### PR DESCRIPTION
## Summary
- Root cause of the "Internal error" wave (PROJ-730/731/732/733) was Workers KV free-plan daily write/delete quota exhaustion (account-wide, 1,000/day each) combined with `cache.ts` having zero error handling — any KV exception propagated unguarded and got collapsed by PROJ-204's generic error handler into a bare "Internal error", even on requests (e.g. `update_issue`) whose D1 write had already committed.
- Verified live against production via a direct Cloudflare API probe (a KV `PUT` against the account's namespace returned `error 10048: your account has reached the free usage limit for this operation for today`), not inferred from source alone.
- `cache.ts`'s `get`/`set`/`invalidate` now catch and log KV failures instead of throwing — the cache is a pure optimization over D1 and must never fail the request it's accelerating.
- `toMcpError`'s two generic-internal-error branches now carry a request id (threaded from `routes/mcp.ts` via `crypto.randomUUID()`) in both the client-facing `message`/`data` and the paired server-side `console.error`, so an opaque "Internal error" can be correlated to full detail in logs — per PROJ-204's own guidance not to revert the leak fix, but to separate client/server audiences instead.
- **Follow-up (found by adversarial review):** three more KV writes outside `cache.ts` had the same defect — `middleware/auth.ts`'s JWKS-cert cache write (a quota failure there turned a *successful* JWKS fetch into a full Cloudflare Access auth outage, worse than the original bug) and its user-upsert cache write, plus `services/provisioning.ts`'s provisioned-marker write. All three now fail-soft the same way.

## Test plan
- [x] New regression tests in `cache.test.ts` covering `get`/`set`/`invalidate` degrading gracefully on KV failure, and an end-to-end `update_issue` case proving the D1 write is reported as success when only the post-commit cache invalidate fails (strengthened to assert the KV delete was actually invoked, so it can't pass vacuously)
- [x] Updated `errors.test.ts` covering the request-id-carrying `Internal error` shape
- [x] New regression test in `auth.test.ts` ("PROJ-730: JWKS cache write failure doesn't fail auth") proving a successful JWKS fetch still authenticates when the KV cache write fails
- [x] Verified all new/changed tests fail against pre-fix code and pass against the fix
- [x] Full suite: 1368/1368 passing
- [x] `pnpm biome check` clean
- [x] `pnpm --filter @projektor/api type-check` clean
- [x] Adversarial opus review of the diff completed, findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s7ri5KXuEUQxKxbBNdfiQ