### PR TITLE
feat(scripts): add post-release smoke test for the public demo (PROJ-579)

### DIFF
--- a/scripts/smoke-test-demo.sh
+++ b/scripts/smoke-test-demo.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+EXPECTED_VERSION="${1:?usage: smoke-test-demo.sh <expected-version> [demo-url]}"
+DEMO_URL="${2:-https://projektor-demo.tajdickson.workers.dev}"
+
+fail=0
+check() {
+	local desc="$1"
+	shift
+	if "$@"; then
+		echo "OK   - $desc"
+	else
+		echo "FAIL - $desc"
+		fail=1
+	fi
+}
+
+home_body_file="$(mktemp)"
+home_headers="$(curl -sS -m 15 -D - -o "$home_body_file" "$DEMO_URL/")"
+home_html="$(cat "$home_body_file")"
+rm -f "$home_body_file"
+version_line="$(grep -oE '<div class="sidebar-version">[^<]+</div>' <<<"$home_html")"
+version="$(sed -E 's#.*>([^<]+)<.*#\1#' <<<"$version_line")"
+
+check "footer version is $EXPECTED_VERSION (got '${version:-<none found>}')" \
+	test "$version" = "$EXPECTED_VERSION"
+
+check "no Cloudflare Access challenge on /" \
+	bash -c '! grep -qi "cloudflareaccess.com" <<<"$1"' _ "$home_headers$home_html"
+
+projects_response="$(curl -sS -m 15 -w '\n%{http_code}' "$DEMO_URL/api/projects")"
+projects_status="$(tail -n1 <<<"$projects_response")"
+projects_body="$(sed '$d' <<<"$projects_response")"
+
+check "GET /api/projects returns 200 (got $projects_status)" \
+	test "$projects_status" = "200"
+
+check "GET /api/projects returns an empty list (still unseeded)" \
+	bash -c '[[ "$1" == "[]" || "$1" =~ ^\{\"projects\":\[\]  ]]' _ "$projects_body"
+
+if [ "$fail" -ne 0 ]; then
+	echo
+	echo "Demo response bodies for debugging:"
+	echo "  /api/projects: $projects_body"
+fi
+
+exit "$fail"


### PR DESCRIPTION
## Summary
- New `scripts/smoke-test-demo.sh <expected-version> [demo-url]`: curls the public demo and checks footer version, absence of a Cloudflare Access challenge, and that `/api/projects` returns 200 with an empty list.
- Verified against the current live (stale) demo: correctly fails all three checks against `v0.6.0-rc.3` / the `/api/projects` 500.
- Verified the CF-Access check works by pointing it at the dogfood Worker (behind Access) — correctly flags the challenge rather than silently passing.

## Scope note
The "+ New project" button-hiding check from PROJ-579's acceptance criteria needs a real browser: `ProjectList.tsx` fetches and gates that client-side, so it never appears in the raw SSR HTML this script reads. That check stays with PROJ-580's manual click-through.

Not wired into `release.yml` — PROJ-577 (the demo deploy target) is blocked on human sign-off for a live-deploy PR in `projektor-workspace`, so there's no CI step yet to attach this to.

## Test plan
- [x] `bash scripts/smoke-test-demo.sh v0.6.10` against the live demo — fails on version, `/api/projects` status, and emptiness (as expected against stale code)
- [x] `bash scripts/smoke-test-demo.sh v0.6.10 https://projektor.tajdickson.workers.dev` — correctly flags the CF Access challenge
- [x] `pnpm lint` / pre-commit hooks passed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ijHN9yTwScXgev1rE64LM