### PR TITLE
feat(api): notify the displaced agent on a forced file-claim override (PROJ-635)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,9 +51,10 @@ editing anything:
   not how fast you can ask.
 - **A refused claim tells you who to talk to.** Rejection is all-or-nothing: nothing is
   claimed, and the error names the issue and agent holding the path — message them with
-  `post_message` if you need it. Nothing is pushed to the holder either way, including
-  when you use `force` (that posts an audit message to *your* issue scope, not theirs), so
-  if you override someone, tell them yourself. Every contended path is recorded regardless.
+  `post_message` if you need it. Nothing is pushed to the holder on a plain rejection —
+  its claim didn't change. `force` is different: it posts to both your issue scope (audit)
+  and theirs (PROJ-635), since you just took something they thought they still held. Every
+  contended path is recorded regardless.
 
 This is the mechanism; the mechanical call sequence for this repo is under "Fleet
 coordination protocol" below, and the design rationale (why leases, claims, and the

--- a/apps/api/src/services/file-claims.ts
+++ b/apps/api/src/services/file-claims.ts
@@ -181,19 +181,13 @@ async function overrideConflictingClaims(
 ) {
 	const { workspaceId, issueId, agentId, paths, claimsByPath, now } = params;
 	const overridden: (typeof schema.issueFileClaims.$inferSelect)[] = [];
+	const displacedPaths = new Map<string, string[]>();
 	for (const path of paths) {
 		const existing = claimsByPath.get(path);
 		if (existing) {
-			await postMessage(ctx, {
-				scope: `issue:${issueId}`,
-				agentId: agentId ?? undefined,
-				body: `force-claimed "${path}", overriding issue ${existing.issueId}`,
-			});
-			await postMessage(ctx, {
-				scope: `issue:${existing.issueId}`,
-				agentId: agentId ?? undefined,
-				body: `issue ${issueId} force-claimed "${path}", which this issue held`,
-			});
+			const list = displacedPaths.get(existing.issueId) ?? [];
+			list.push(path);
+			displacedPaths.set(existing.issueId, list);
 			await orm
 				.update(schema.issueFileClaims)
 				.set({ releasedAt: now, releaseReason: "overridden" })
@@ -211,6 +205,19 @@ async function overrideConflictingClaims(
 			});
 			overridden.push({ ...existing, releasedAt: now, releaseReason: "overridden" });
 		}
+	}
+	for (const [displacedIssueId, displacedIssuePaths] of displacedPaths) {
+		const pathList = displacedIssuePaths.map((p) => `"${p}"`).join(", ");
+		await postMessage(ctx, {
+			scope: `issue:${issueId}`,
+			agentId: agentId ?? undefined,
+			body: `force-claimed ${pathList}, overriding issue ${displacedIssueId}`,
+		});
+		await postMessage(ctx, {
+			scope: `issue:${displacedIssueId}`,
+			agentId: agentId ?? undefined,
+			body: `issue ${issueId} force-claimed ${pathList}, which this issue held`,
+		});
 	}
 	return overridden;
 }

--- a/apps/api/src/services/file-claims.ts
+++ b/apps/api/src/services/file-claims.ts
@@ -189,6 +189,11 @@ async function overrideConflictingClaims(
 				agentId: agentId ?? undefined,
 				body: `force-claimed "${path}", overriding issue ${existing.issueId}`,
 			});
+			await postMessage(ctx, {
+				scope: `issue:${existing.issueId}`,
+				agentId: agentId ?? undefined,
+				body: `issue ${issueId} force-claimed "${path}", which this issue held`,
+			});
 			await orm
 				.update(schema.issueFileClaims)
 				.set({ releasedAt: now, releaseReason: "overridden" })

--- a/apps/api/src/test/file-claims.test.ts
+++ b/apps/api/src/test/file-claims.test.ts
@@ -333,9 +333,7 @@ describe("File Claims API", () => {
 		expect(rejectedMessages.items).toHaveLength(0);
 	});
 
-	// PROJ-624: force:true DOES post a message, scoped to the issue that ends up
-	// holding the claim after the override (not the prior holder that lost it).
-	it("PROJ-624: force:true override posts a message scoped to the now-holding issue", async () => {
+	it("PROJ-635/624: force:true override posts a message to both the now-holding and the displaced issue", async () => {
 		await claimFiles({ issueId, paths: ["src/message-on-force.ts"] });
 
 		const issue2 = await seedIssue(workspaceId, projectId, userId, { title: "Force claims" });
@@ -352,7 +350,9 @@ describe("File Claims API", () => {
 		expect(messages.items[0].body).toContain(issueId);
 
 		const priorHolderMessages = await listMessagesForScope(`issue:${issueId}`);
-		expect(priorHolderMessages.items).toHaveLength(0);
+		expect(priorHolderMessages.items).toHaveLength(1);
+		expect(priorHolderMessages.items[0].body).toContain("src/message-on-force.ts");
+		expect(priorHolderMessages.items[0].body).toContain(issue2.id);
 	});
 
 	// PROJ-636: a claim whose holding session stopped heartbeating is reclaimed by the next

--- a/apps/api/src/test/file-claims.test.ts
+++ b/apps/api/src/test/file-claims.test.ts
@@ -355,6 +355,33 @@ describe("File Claims API", () => {
 		expect(priorHolderMessages.items[0].body).toContain(issue2.id);
 	});
 
+	it("PROJ-635: force:true override on multiple paths held by the same issue posts one message per side, not one per path", async () => {
+		await claimFiles({
+			issueId,
+			paths: ["src/multi-a.ts", "src/multi-b.ts", "src/multi-c.ts"],
+		});
+
+		const issue2 = await seedIssue(workspaceId, projectId, userId, { title: "Force claims" });
+		const forceRes = await claimFiles({
+			issueId: issue2.id,
+			paths: ["src/multi-a.ts", "src/multi-b.ts", "src/multi-c.ts"],
+			force: true,
+		});
+		expect(forceRes.status).toBe(201);
+
+		const messages = await listMessagesForScope(`issue:${issue2.id}`);
+		expect(messages.items).toHaveLength(1);
+		expect(messages.items[0].body).toContain("src/multi-a.ts");
+		expect(messages.items[0].body).toContain("src/multi-b.ts");
+		expect(messages.items[0].body).toContain("src/multi-c.ts");
+
+		const priorHolderMessages2 = await listMessagesForScope(`issue:${issueId}`);
+		expect(priorHolderMessages2.items).toHaveLength(1);
+		expect(priorHolderMessages2.items[0].body).toContain("src/multi-a.ts");
+		expect(priorHolderMessages2.items[0].body).toContain("src/multi-b.ts");
+		expect(priorHolderMessages2.items[0].body).toContain("src/multi-c.ts");
+	});
+
 	// PROJ-636: a claim whose holding session stopped heartbeating is reclaimed by the next
 	// claim on that path, the way issue leases already were.
 	//

--- a/apps/docs/src/content/docs/contributing/conventions.md
+++ b/apps/docs/src/content/docs/contributing/conventions.md
@@ -59,9 +59,10 @@ editing anything:
   not how fast you can ask.
 - **A refused claim tells you who to talk to.** Rejection is all-or-nothing: nothing is
   claimed, and the error names the issue and agent holding the path — message them with
-  `post_message` if you need it. Nothing is pushed to the holder either way, including
-  when you use `force` (that posts an audit message to *your* issue scope, not theirs), so
-  if you override someone, tell them yourself. Every contended path is recorded regardless.
+  `post_message` if you need it. Nothing is pushed to the holder on a plain rejection —
+  its claim didn't change. `force` is different: it posts to both your issue scope (audit)
+  and theirs (PROJ-635), since you just took something they thought they still held. Every
+  contended path is recorded regardless.
 
 This is the mechanism; the mechanical call sequence for this repo is under "Fleet
 coordination protocol" below, and the design rationale (why leases, claims, and the

--- a/apps/docs/src/content/docs/philosophy/coordination-model.md
+++ b/apps/docs/src/content/docs/philosophy/coordination-model.md
@@ -141,19 +141,21 @@ talk to, and can do so with `post_message`. Nothing is pushed to the holder: it 
 working and nothing about its claim changed.
 
 **Forced override.** When the caller passes `force`, the existing claim is released as
-`overridden` and `overrideConflictingClaims` posts a message via `postMessage`
-(`apps/api/src/services/agent-messages.ts`). Note the scope: the message goes to
-`issue:<claiming issue>` — the issue that just took the path — naming the displaced issue
-in the body. It is an audit record on the overrider, not a notification to the overridden.
+`overridden` and `overrideConflictingClaims` posts two messages via `postMessage`
+(`apps/api/src/services/agent-messages.ts`, PROJ-635): one to `issue:<claiming issue>` —
+an audit record naming the displaced issue — and one to `issue:<displaced issue>`, so the
+agent that lost the path is told directly rather than discovering it when its own next
+write or claim fails.
 
 So the routing is *informational, not conversational*. Both paths tell the agent doing the
 claiming who it collided with, and both persist the collision as a `claim_conflicts` row.
-Neither pushes anything to the agent that lost the path; that agent finds out when its
-next write or claim fails. A tool built specifically around negotiation — MCP Agent Mail,
-whose agents message each other and pick different files — is genuinely better at this
-particular step, and [how Projektor differs](/projektor/philosophy/alternatives/) says so.
-What Projektor does instead of negotiating is *record*, which is the subject of the next
-section.
+Rejection still pushes nothing to the holder — its claim didn't change, so there's nothing
+for it to react to — but a forced override does, since a live agent's assumption about what
+it owns just became false (PROJ-635's reasoning for treating the two cases differently). A
+tool built specifically around negotiation — MCP Agent Mail, whose agents message each
+other and pick different files — is genuinely better at the rejection step, and
+[how Projektor differs](/projektor/philosophy/alternatives/) says so. What Projektor does
+instead of negotiating there is *record*, which is the subject of the next section.
 
 ## Conflict as an event log
 


### PR DESCRIPTION
## Summary
- Decision recorded on PROJ-635: notify on forced override, stay silent on plain rejection (the ticket's own "middle option" — a forced override changes what a live agent believes it owns; a rejection changes nothing about the caller's existing claim).
- `overrideConflictingClaims` now posts a message to the displaced issue's scope in addition to the existing audit message on the claiming issue.
- Updated (not deleted) the PROJ-624 test asserting the old silent-override behavior; the sibling rejection-silence test is untouched.
- Updated `coordination-model.md` ("Conflict routing") and `AGENTS.md`'s file-claims bullet to describe the new behavior.

## Test plan
- [x] `pnpm --filter @projektor/api exec vitest run file-claims` — 20/20 passed
- [x] `pnpm --filter @projektor/api type-check` — clean
- [x] `pnpm exec biome check` on changed files — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ijHN9yTwScXgev1rE64LM