### PR TITLE
fix(api): treat KV cache read failures as fail-soft, not fatal (PROJ-735)

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -476,7 +476,12 @@ async function getCfAccessKeys(
 		return inMemoryCertsCache.keys;
 	}
 
-	const cached = await env.KV.get("cf-access-certs", "json");
+	let cached: unknown;
+	try {
+		cached = await env.KV.get("cf-access-certs", "json");
+	} catch (err) {
+		console.error("[auth] failed to read cf-access-certs from KV, fetching fresh:", err);
+	}
 	if (cached) {
 		const keys = cached as JsonWebKey[];
 		inMemoryCertsCache = { keys, expiresAt: Date.now() + CERTS_LOCAL_TTL_MS };

--- a/apps/api/src/services/provisioning.ts
+++ b/apps/api/src/services/provisioning.ts
@@ -200,7 +200,14 @@ async function alreadyProvisioned(env: Env, userId: string): Promise<boolean> {
 	const localExpiry = inMemoryProvisionedCache.get(userId);
 	if (localExpiry && localExpiry > Date.now()) return true;
 
-	if (!(await env.KV.get(provisionedKey(userId)))) return false;
+	let marker: string | null;
+	try {
+		marker = await env.KV.get(provisionedKey(userId));
+	} catch (err) {
+		console.error(`[provisioning] failed to read provisioned marker for ${userId} from KV:`, err);
+		return false;
+	}
+	if (!marker) return false;
 	inMemoryProvisionedCache.set(userId, Date.now() + PROVISIONED_LOCAL_TTL_MS);
 	return true;
 }

--- a/apps/api/src/test/auth.test.ts
+++ b/apps/api/src/test/auth.test.ts
@@ -502,8 +502,57 @@ describe("PROJ-730: JWKS cache write failure doesn't fail auth", () => {
 	});
 });
 
-// ---------------------------------------------------------------------------
-// PROJ-360: last_used_at is a coarse audit field, throttled so bearer/agent
+describe("PROJ-735: JWKS cache read failure falls back to a fresh fetch", () => {
+	it("a KV read error doesn't fail auth — falls through to fetching fresh certs", async () => {
+		const keyPair = (await crypto.subtle.generateKey(
+			{
+				name: "RSASSA-PKCS1-v1_5",
+				modulusLength: 2048,
+				publicExponent: new Uint8Array([1, 0, 1]),
+				hash: "SHA-256",
+			},
+			true,
+			["sign", "verify"]
+		)) as CryptoKeyPair;
+		const publicJwk = (await crypto.subtle.exportKey("jwk", keyPair.publicKey)) as JsonWebKey;
+
+		const domain = `proj-735-${crypto.randomUUID().slice(0, 8)}.example.com`;
+		const audience = "proj-735-audience";
+		env.CF_ACCESS_TEAM_DOMAIN = domain;
+		env.CF_ACCESS_AUDIENCE = audience;
+
+		resetAuthCachesForTests();
+
+		const fetchSpy = vi.fn(async () => {
+			return new Response(JSON.stringify({ keys: [publicJwk] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+		vi.stubGlobal("fetch", fetchSpy);
+		vi.spyOn(env.KV, "get").mockRejectedValueOnce(new Error("KV read failed"));
+
+		try {
+			const jwt = await signTestJwt(keyPair.privateKey, {
+				exp: Math.floor(Date.now() / 1000) + 3600,
+				aud: audience,
+				iss: `https://${domain}`,
+				email: `proj-735-${crypto.randomUUID().slice(0, 8)}@example.com`,
+			});
+
+			const res = await SELF.fetch("http://localhost/auth/me", {
+				headers: { "Cf-Access-Jwt-Assertion": jwt },
+			});
+
+			expect(res.status).toBe(200);
+			expect(fetchSpy).toHaveBeenCalled();
+		} finally {
+			vi.unstubAllGlobals();
+			vi.restoreAllMocks();
+		}
+	});
+});
+
 // traffic (the hottest auth path) doesn't rewrite it on every single request.
 // ---------------------------------------------------------------------------
 

--- a/apps/api/src/test/provisioning.test.ts
+++ b/apps/api/src/test/provisioning.test.ts
@@ -1,6 +1,6 @@
 import { env } from "cloudflare:test";
 import type { Env } from "@projektor/types";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	ensureUserProvisioned,
 	forgetProvisionedForTests,
@@ -339,7 +339,30 @@ describe("PROJ-433: provisioning runs once per user, not per request", () => {
 		expect(await memberRole(ws.id, user.id)).toBe("viewer");
 	});
 
-	// The marker must not record a run that did nothing because the workspace wasn't there
+	it("re-runs safely when the provisioned-marker read fails, instead of throwing", async () => {
+		const slug = "prov-kv-read-fail";
+		const ws = await seedWorkspace(slug);
+		const user = await seedUser("kv-read-fail@example.com");
+		const config = envWith({
+			ADMIN_EMAILS: "",
+			DEFAULT_WORKSPACE_SLUG: slug,
+			AUTO_JOIN_ROLE: "viewer",
+		});
+
+		await ensureUserProvisioned(config, user);
+		await dropMembership(ws.id, user.id);
+		await resetProvisioningCacheForTests();
+
+		vi.spyOn(env.KV, "get").mockRejectedValueOnce(new Error("KV read failed"));
+		try {
+			await ensureUserProvisioned(config, user);
+		} finally {
+			vi.restoreAllMocks();
+		}
+
+		expect(await memberRole(ws.id, user.id)).toBe("viewer");
+	});
+
 	// yet — that user would then stay unprovisioned for the whole TTL after bootstrap.
 	it("does not cache a run that bailed waiting for the default workspace", async () => {
 		const slug = "prov-cache-early-bird";


### PR DESCRIPTION
## Summary
- Follow-up to PROJ-730 (#334), which fixed KV write/delete failures but left two read-side call sites unguarded — same class of bug.
- `middleware/auth.ts`: `getCfAccessKeys`'s KV read now falls back to fetching fresh certs on a read error, instead of erroring out through `AuthUnavailableError` for every request.
- `services/provisioning.ts`: `alreadyProvisioned`'s KV read now treats a read failure as "not provisioned" (idempotent — worst case is a redundant re-provision) instead of throwing out of the whole login flow.

## Test plan
- [x] New test: JWKS cache read failure falls back to a fresh fetch, auth still succeeds (`auth.test.ts`)
- [x] New test: provisioning marker read failure re-runs provisioning safely instead of throwing (`provisioning.test.ts`)
- [x] `pnpm vitest run` — full api suite passes
- [x] `tsc --noEmit` and `biome check` clean

Closes PROJ-735.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s7ri5KXuEUQxKxbBNdfiQ