### PR TITLE
feat(api): add Human checkpoint clause, narrow Decisions log in epic-goal playbook (PROJ-736)

### DIFF
--- a/apps/api/src/mcp/prompts.ts
+++ b/apps/api/src/mcp/prompts.ts
@@ -32,6 +32,11 @@ const PROMPTS: MCPPromptDescriptor[] = [
 			{ name: "variant", description: '"bounded" (default) or "full"', required: false },
 			{ name: "reviewModel", description: 'Review model name, default "opus"', required: false },
 			{ name: "cadence", description: "Ticket review cadence, default 2", required: false },
+			{
+				name: "checkpointInterval",
+				description: "Human checkpoint interval in tickets, default 10",
+				required: false,
+			},
 		],
 	},
 ];
@@ -55,6 +60,7 @@ export async function getPrompt(ctx: PluginContext, name: string, args: Record<s
 			variant: args.variant || undefined,
 			reviewModel: args.reviewModel || undefined,
 			cadence: args.cadence ? Number(args.cadence) : undefined,
+			checkpointInterval: args.checkpointInterval ? Number(args.checkpointInterval) : undefined,
 		},
 	});
 

--- a/apps/api/src/schemas/playbooks.ts
+++ b/apps/api/src/schemas/playbooks.ts
@@ -7,5 +7,6 @@ export const ComposePlaybookSchema = z.object({
 		variant: z.enum(["bounded", "full"]).optional(),
 		reviewModel: z.string().optional(),
 		cadence: z.number().int().positive().optional(),
+		checkpointInterval: z.number().int().positive().optional(),
 	}),
 });

--- a/apps/api/src/services/playbook-compose.ts
+++ b/apps/api/src/services/playbook-compose.ts
@@ -9,11 +9,13 @@ import type { ServiceCtx } from "./types";
 const DEFAULT_VARIANT = "bounded";
 const DEFAULT_REVIEW_MODEL = "opus";
 const DEFAULT_CADENCE = 2;
+const DEFAULT_CHECKPOINT_INTERVAL = 10;
 
 function fillEpicGoalDirective(params: {
 	variant: "bounded" | "full";
 	reviewModel: string;
 	cadence: number;
+	checkpointInterval: number;
 	epicTitle: string;
 	epicRef: string;
 	openChildCount: number;
@@ -36,6 +38,11 @@ function fillEpicGoalDirective(params: {
 			fill(EPIC_GOAL_TEMPLATE.reviewCadence, "{N}", String(params.cadence)),
 			"{MODEL}",
 			params.reviewModel
+		),
+		fill(
+			EPIC_GOAL_TEMPLATE.humanCheckpoint,
+			"{CHECKPOINT_INTERVAL}",
+			String(params.checkpointInterval)
 		),
 		EPIC_GOAL_TEMPLATE.doneWhen[params.variant],
 		EPIC_GOAL_TEMPLATE.decisionsLog,
@@ -69,6 +76,7 @@ export async function composePlaybook(ctx: ServiceCtx, raw: unknown) {
 	const variant = params.variant ?? DEFAULT_VARIANT;
 	const reviewModel = params.reviewModel ?? DEFAULT_REVIEW_MODEL;
 	const cadence = params.cadence ?? DEFAULT_CADENCE;
+	const checkpointInterval = params.checkpointInterval ?? DEFAULT_CHECKPOINT_INTERVAL;
 
 	const issue = (await getIssue(ctx, { ref: params.epicRef })) as {
 		title: string;
@@ -85,6 +93,7 @@ export async function composePlaybook(ctx: ServiceCtx, raw: unknown) {
 		variant,
 		reviewModel,
 		cadence,
+		checkpointInterval,
 		epicTitle: issue.title,
 		epicRef: `${issue.project_key}-${issue.number}`,
 		openChildCount: issue.rollup.remaining,

--- a/apps/api/src/services/playbook-content.ts
+++ b/apps/api/src/services/playbook-content.ts
@@ -43,6 +43,14 @@ export const EPIC_GOAL_TEMPLATE = {
 	reviewCadence:
 		"**Review cadence:** after every {N} completed tickets, run an adversarial {MODEL} review " +
 		"of the accumulated diff; file and fix anything it finds before continuing.",
+	humanCheckpoint:
+		"**Human checkpoint:** every {CHECKPOINT_INTERVAL} completed tickets, or immediately if " +
+		"confidence is genuinely low, stop and give a human something to act on: **Try** — a URL " +
+		"and a 30-second script for what to open, what to do, and what should happen — and **Least " +
+		"confident about** — the one thing in this batch you'd most want a second opinion on, in " +
+		"your own words. This is for the failure a diff review and a green build don't catch; use " +
+		"it for what a human would only find by using the thing. If confidence is genuinely low, do " +
+		"not self-merge even when the diff scope allows it — queue the change and say so.",
 	doneWhen: {
 		bounded:
 			"**Done when:** every ticket on the epic (original + actioned generated) is closed, " +
@@ -52,10 +60,13 @@ export const EPIC_GOAL_TEMPLATE = {
 			"is green, and everything is committed and pushed.",
 	},
 	decisionsLog:
-		"**Decisions log:** instead of asking questions, make the call and record decisions, " +
-		"tradeoffs, and anything needing human judgment as comments on the epic for review at the " +
-		"end. If two reasonable implementations diverge, comment both options on the ticket, pick " +
-		"the simpler, and flag it.",
+		"**Decisions log:** instead of asking questions, make the call — but when you record it " +
+		"depends on the decision. If reversing it later stays cheap, comment it on the epic for " +
+		"review at the end, as before. If it's cheap to reverse now and expensive later — retiring " +
+		"a public endpoint, deleting a directory, changing a data shape, choosing duplication over " +
+		"abstraction — comment it on the epic when you make it, not at the end, so a human can " +
+		"object before the next ticket compounds it. If two reasonable implementations diverge, " +
+		"comment both options on the ticket, pick the simpler, and flag it.",
 } as const;
 
 export const PLAYBOOKS: Playbook[] = [
@@ -82,18 +93,19 @@ those rules, so an agent working an epic normally fetches both.
 \`get_playbook("epic-goal")\` returns this page verbatim, template and all — read it and
 adapt it by hand.
 
-\`compose_playbook("epic-goal", { epicRef, variant, reviewModel, cadence })\` returns just
-the directive, with every placeholder already filled from data the server holds:
+\`compose_playbook("epic-goal", { epicRef, variant, reviewModel, cadence, checkpointInterval })\`
+returns just the directive, with every placeholder already filled from data the server holds:
 
 | Parameter / source | Fills |
 |---|---|
 | \`epicRef\` *(required)* — resolved to the epic's ref and title | the **Goal** clause |
 | \`variant\` — \`bounded\` (default) or \`full\` | the **Self-feed** and **Done when** clauses |
 | \`cadence\` (default 2) and \`reviewModel\` (default \`opus\`) | the **Review cadence** clause |
+| \`checkpointInterval\` (default 10) | the **Human checkpoint** clause |
 | the epic's open child count and the project's agent WIP limit | an extra **Live data** clause |
 
 MCP clients that support the \`prompts\` primitive surface the same composed directive as a
-slash command, with the three optional parameters as prompt arguments.
+slash command, with the four optional parameters as prompt arguments.
 
 ## What each clause is for
 
@@ -110,10 +122,17 @@ slash command, with the three optional parameters as prompt arguments.
   generator rather than a fixed list. This is the only clause the two variants differ on.
 - **Review cadence** — naming the model and the interval up front makes the checkpoint
   something the agent can self-enforce; "review as you go" doesn't survive a long run.
+- **Human checkpoint** — a diff review and a green build catch neither a regression that
+  only shows up when a page actually loads, nor a decision that was wrong on the merits.
+  Naming a URL, a script, and the one thing the agent is least sure about gives a human
+  something to act on instead of a queue of PR titles.
 - **Done when** — a checkable condition (every ticket closed, verification green,
   everything pushed) instead of a judgment call.
-- **Decisions log** — judgment calls land as comments on the epic for review at the end,
-  so an ambiguity doesn't block the run on a question.
+- **Decisions log** — most judgment calls land as comments on the epic for review at the
+  end, so an ambiguity doesn't block the run on a question. The exception is a decision
+  that's cheap to reverse now and expensive later, which is surfaced immediately instead —
+  logging it only at the end would let several more tickets compound a call nobody has
+  actually agreed with yet.
 
 ## Template — bounded variant (default)
 
@@ -126,6 +145,8 @@ slash command, with the three optional parameters as prompt arguments.
 > ${EPIC_GOAL_TEMPLATE.selfFeed.bounded}
 >
 > ${EPIC_GOAL_TEMPLATE.reviewCadence}
+>
+> ${EPIC_GOAL_TEMPLATE.humanCheckpoint}
 >
 > ${EPIC_GOAL_TEMPLATE.doneWhen.bounded}
 >

--- a/apps/api/src/test/mcp-prompts.test.ts
+++ b/apps/api/src/test/mcp-prompts.test.ts
@@ -43,7 +43,13 @@ describe("MCP prompts", () => {
 		const prompt = json.result.prompts.find((p) => p.name === "epic-goal");
 		expect(prompt).toBeDefined();
 		const argNames = prompt!.arguments.map((a) => a.name);
-		expect(argNames).toEqual(["epicRef", "variant", "reviewModel", "cadence"]);
+		expect(argNames).toEqual([
+			"epicRef",
+			"variant",
+			"reviewModel",
+			"cadence",
+			"checkpointInterval",
+		]);
 		expect(prompt!.arguments.find((a) => a.name === "epicRef")?.required).toBe(true);
 		expect(prompt!.arguments.find((a) => a.name === "variant")?.required).toBe(false);
 	});
@@ -61,9 +67,11 @@ describe("MCP prompts", () => {
 		expect(json.result.messages[0].content.type).toBe("text");
 		expect(json.result.messages[0].content.text).toContain("Ship the widget");
 		expect(json.result.messages[0].content.text).toContain("Self-feed (bounded)");
+		expect(json.result.messages[0].content.text).toContain("Human checkpoint");
+		expect(json.result.messages[0].content.text).toContain("every 10 completed tickets");
 	});
 
-	it("prompts/get honors string-valued variant/reviewModel/cadence arguments", async () => {
+	it("prompts/get honors string-valued variant/reviewModel/cadence/checkpointInterval arguments", async () => {
 		const json = (await mcpCall("prompts/get", {
 			name: "epic-goal",
 			arguments: {
@@ -71,12 +79,14 @@ describe("MCP prompts", () => {
 				variant: "full",
 				reviewModel: "sonnet",
 				cadence: "5",
+				checkpointInterval: "3",
 			},
 		})) as JsonRpcResult<{ messages: Array<{ content: { text: string } }> }>;
 		const text = json.result.messages[0].content.text;
 		expect(text).toContain("Self-feed (full)");
 		expect(text).toContain("every 5 completed tickets");
 		expect(text).toContain("adversarial sonnet review");
+		expect(text).toContain("every 3 completed tickets");
 	});
 
 	it("prompts/get on an unresolvable epicRef surfaces the compose error", async () => {

--- a/apps/api/src/test/playbook-compose.test.ts
+++ b/apps/api/src/test/playbook-compose.test.ts
@@ -80,6 +80,10 @@ describe("compose_playbook", () => {
 		expect(body.directive).not.toContain("Self-feed (full)");
 		expect(body.directive).toContain("every 2 completed tickets");
 		expect(body.directive).toContain("adversarial opus review");
+		expect(body.directive).toContain("Human checkpoint");
+		expect(body.directive).toContain("every 10 completed tickets");
+		expect(body.directive).toContain("Least confident about");
+		expect(body.directive).toContain("cheap to reverse now and expensive later");
 		// one open child (Child 1), one done (Child 2) -> rollup.remaining == 1
 		expect(body.directive).toContain("1 open child ticket(s)");
 		expect(body.directive).toContain("WIP limit is 7");
@@ -106,6 +110,14 @@ describe("compose_playbook", () => {
 		expect(body.directive).not.toContain("Self-feed (bounded)");
 		expect(body.directive).toContain("every 5 completed tickets");
 		expect(body.directive).toContain("adversarial sonnet review");
+	});
+
+	it("honors a custom checkpointInterval", async () => {
+		const res = await compose({ epicRef: `PROJ-${epicNumber}`, checkpointInterval: 3 });
+		const json = (await res.json()) as JsonRpcResult<{ content: Array<{ text: string }> }>;
+		const body = JSON.parse(json.result.content[0].text) as { directive: string };
+
+		expect(body.directive).toContain("every 3 completed tickets");
 	});
 
 	it("notes when the epic has no open child tickets yet", async () => {
@@ -148,6 +160,12 @@ describe("compose_playbook", () => {
 
 	it("errors on an invalid cadence", async () => {
 		const res = await compose({ epicRef: `PROJ-${epicNumber}`, cadence: -1 });
+		const json = (await res.json()) as JsonRpcError;
+		expect(json.error.code).toBe(-32602);
+	});
+
+	it("errors on an invalid checkpointInterval", async () => {
+		const res = await compose({ epicRef: `PROJ-${epicNumber}`, checkpointInterval: -1 });
 		const json = (await res.json()) as JsonRpcError;
 		expect(json.error.code).toBe(-32602);
 	});

--- a/apps/docs/src/content/docs/agents/playbooks/epic-goal.md
+++ b/apps/docs/src/content/docs/agents/playbooks/epic-goal.md
@@ -17,18 +17,19 @@ those rules, so an agent working an epic normally fetches both.
 `get_playbook("epic-goal")` returns this page verbatim, template and all — read it and
 adapt it by hand.
 
-`compose_playbook("epic-goal", { epicRef, variant, reviewModel, cadence })` returns just
-the directive, with every placeholder already filled from data the server holds:
+`compose_playbook("epic-goal", { epicRef, variant, reviewModel, cadence, checkpointInterval })`
+returns just the directive, with every placeholder already filled from data the server holds:
 
 | Parameter / source | Fills |
 |---|---|
 | `epicRef` *(required)* — resolved to the epic's ref and title | the **Goal** clause |
 | `variant` — `bounded` (default) or `full` | the **Self-feed** and **Done when** clauses |
 | `cadence` (default 2) and `reviewModel` (default `opus`) | the **Review cadence** clause |
+| `checkpointInterval` (default 10) | the **Human checkpoint** clause |
 | the epic's open child count and the project's agent WIP limit | an extra **Live data** clause |
 
 MCP clients that support the `prompts` primitive surface the same composed directive as a
-slash command, with the three optional parameters as prompt arguments.
+slash command, with the four optional parameters as prompt arguments.
 
 ## What each clause is for
 
@@ -45,10 +46,17 @@ slash command, with the three optional parameters as prompt arguments.
   generator rather than a fixed list. This is the only clause the two variants differ on.
 - **Review cadence** — naming the model and the interval up front makes the checkpoint
   something the agent can self-enforce; "review as you go" doesn't survive a long run.
+- **Human checkpoint** — a diff review and a green build catch neither a regression that
+  only shows up when a page actually loads, nor a decision that was wrong on the merits.
+  Naming a URL, a script, and the one thing the agent is least sure about gives a human
+  something to act on instead of a queue of PR titles.
 - **Done when** — a checkable condition (every ticket closed, verification green,
   everything pushed) instead of a judgment call.
-- **Decisions log** — judgment calls land as comments on the epic for review at the end,
-  so an ambiguity doesn't block the run on a question.
+- **Decisions log** — most judgment calls land as comments on the epic for review at the
+  end, so an ambiguity doesn't block the run on a question. The exception is a decision
+  that's cheap to reverse now and expensive later, which is surfaced immediately instead —
+  logging it only at the end would let several more tickets compound a call nobody has
+  actually agreed with yet.
 
 ## Template — bounded variant (default)
 
@@ -62,9 +70,11 @@ slash command, with the three optional parameters as prompt arguments.
 >
 > **Review cadence:** after every {N} completed tickets, run an adversarial {MODEL} review of the accumulated diff; file and fix anything it finds before continuing.
 >
+> **Human checkpoint:** every {CHECKPOINT_INTERVAL} completed tickets, or immediately if confidence is genuinely low, stop and give a human something to act on: **Try** — a URL and a 30-second script for what to open, what to do, and what should happen — and **Least confident about** — the one thing in this batch you'd most want a second opinion on, in your own words. This is for the failure a diff review and a green build don't catch; use it for what a human would only find by using the thing. If confidence is genuinely low, do not self-merge even when the diff scope allows it — queue the change and say so.
+>
 > **Done when:** every ticket on the epic (original + actioned generated) is closed, verification is green, and everything is committed and pushed.
 >
-> **Decisions log:** instead of asking questions, make the call and record decisions, tradeoffs, and anything needing human judgment as comments on the epic for review at the end. If two reasonable implementations diverge, comment both options on the ticket, pick the simpler, and flag it.
+> **Decisions log:** instead of asking questions, make the call — but when you record it depends on the decision. If reversing it later stays cheap, comment it on the epic for review at the end, as before. If it's cheap to reverse now and expensive later — retiring a public endpoint, deleting a directory, changing a data shape, choosing duplication over abstraction — comment it on the epic when you make it, not at the end, so a human can object before the next ticket compounds it. If two reasonable implementations diverge, comment both options on the ticket, pick the simpler, and flag it.
 
 ## Template — full variant
 


### PR DESCRIPTION
## Summary
- Adds a **Human checkpoint** clause to the `epic-goal` playbook (both bounded and full variants): every `checkpointInterval` completed tickets (default 10) or immediately on low confidence, the agent gives a human a **Try** (URL + 30-second script) and **Least confident about** (one thing it wants a second opinion on), with an explicit no-self-merge-when-unsure rule.
- Narrows the **Decisions log** clause: decisions cheap to reverse later still log at the end as before; decisions cheap to reverse now and expensive later (retiring an endpoint, deleting a directory, a data-shape change, duplication over abstraction) now surface immediately instead of at the end.
- `compose_playbook` and the `epic-goal` MCP prompt both gain a `checkpointInterval` parameter (default 10), following the same fill pattern as `cadence`/`reviewModel`.
- `pnpm gen:docs` regenerated `apps/docs/.../playbooks/epic-goal.md` from the updated content.

Per the ticket's explicit scope note, the controller-side aggregation playbook (batching many workers' checkpoint blocks) is **not** built here — it's called out as a follow-on once the worker-side clause has been used enough to know its shape.

## Test plan
- [x] `pnpm --filter @projektor/api exec vitest run playbook-compose mcp-prompts playbooks` — 25/25 passing, including new coverage asserting the Human checkpoint clause and `checkpointInterval` default/override appear in the *composed directive content* (not just a 200), per the ticket's own point that status-only assertions are the exact failure mode this ticket is about.
- [x] `pnpm --filter @projektor/api type-check` clean
- [x] `pnpm --filter @projektor/api exec biome check` clean on changed files
- [x] `pnpm gen:docs` — only the expected `epic-goal.md` doc changed

## HUMAN CHECK
**Try:** open `/wiki/design-mcp-modern-2026-07-28-protocol-era-adoption-proj-474` (published this session) and, separately, run `compose_playbook("epic-goal", { epicRef: "PROJ-<any epic>" })` via the MCP inspector or `POST /api/playbooks/epic-goal/compose` — confirm the returned directive reads naturally as one prompt (clause order, blockquote formatting) rather than just checking it contains the right substrings.

**Least confident about:** the exact wording boundary in the narrowed Decisions log clause — "cheap to reverse now, expensive later" is inherently judgment-based, and I picked the four examples (endpoint retirement, directory deletion, data-shape change, duplication-over-abstraction) from the ticket's own worked example plus analogous cases. Whether that's the right taxonomy for future runs to self-apply consistently is something only real usage will show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ijHN9yTwScXgev1rE64LM