### PR TITLE
fix(web): hide project archive/edit-description controls from public viewer (PROJ-580)

### DIFF
--- a/apps/web/src/islands/ConnectorManager.test.tsx
+++ b/apps/web/src/islands/ConnectorManager.test.tsx
@@ -54,4 +54,15 @@ describe("ConnectorManager", () => {
 		expect(await screen.findByText(/No connected applications/i)).toBeTruthy();
 		expect(screen.getByText(/Add this workspace as a connector in Claude/i)).toBeTruthy();
 	});
+
+	it("shows a friendly message instead of a raw ApiError for the public viewer's 403 (PROJ-580)", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({ ok: false, status: 403, json: () => Promise.resolve({}) })
+		);
+		render(<ConnectorManager workspaceSlug="my-ws" />);
+		expect(await screen.findByText(/Signed-in members only/i)).toBeTruthy();
+		expect(screen.queryByText(/ApiError/i)).toBeNull();
+		expect(screen.queryByRole("alert")).toBeNull();
+	});
 });

--- a/apps/web/src/islands/ConnectorManager.tsx
+++ b/apps/web/src/islands/ConnectorManager.tsx
@@ -138,6 +138,7 @@ export default function ConnectorManager({ workspaceSlug: propWorkspaceSlug }: P
 	const [grants, setGrants] = useState<ConnectorGrant[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
+	const [forbidden, setForbidden] = useState(false);
 
 	const [revokeId, setRevokeId] = useState<string | null>(null);
 	const [revoking, setRevoking] = useState(false);
@@ -147,13 +148,18 @@ export default function ConnectorManager({ workspaceSlug: propWorkspaceSlug }: P
 		if (!workspaceSlug) return;
 		setLoading(true);
 		setError(null);
+		setForbidden(false);
 		try {
 			const data = await apiFetch<ConnectorGrant[]>(`/api/workspaces/${workspaceSlug}/connectors`, {
 				workspaceSlug,
 			});
 			setGrants(Array.isArray(data) ? data : []);
 		} catch (e) {
-			setError(String(e));
+			if (String(e).includes(": 403")) {
+				setForbidden(true);
+			} else {
+				setError(String(e));
+			}
 		} finally {
 			setLoading(false);
 		}
@@ -195,6 +201,15 @@ export default function ConnectorManager({ workspaceSlug: propWorkspaceSlug }: P
 
 	if (!workspaceSlug) return null;
 	if (loading) return <p aria-live="polite">Loading connected applications…</p>;
+
+	if (forbidden) {
+		return (
+			<div class="p-4 bg-surface border border-border rounded-md text-text-muted">
+				<strong>Signed-in members only.</strong> Connectors are personal credentials, so the shared
+				read-only demo viewer has none to show.
+			</div>
+		);
+	}
 
 	if (error) {
 		return (

--- a/apps/web/src/islands/ProjectLanding.test.tsx
+++ b/apps/web/src/islands/ProjectLanding.test.tsx
@@ -44,10 +44,17 @@ function mockFetchProject(
 	wiki: readonly unknown[] = [],
 	flowMetrics: unknown = { throughputOverTime: [], cfdOverTime: [] },
 	project: unknown = PROJECT,
-	projectsList: readonly unknown[] = [project]
+	projectsList: readonly unknown[] = [project],
+	meEmail = "real-user@example.com"
 ) {
 	const fetchMock = vi.fn().mockImplementation((url: string, opts?: RequestInit) => {
 		const u = String(url);
+		if (u.includes("/auth/me")) {
+			return Promise.resolve({
+				ok: true,
+				json: () => Promise.resolve({ user: { id: "u1", email: meEmail, name: "User" } }),
+			});
+		}
 		if (u.endsWith("/api/projects")) {
 			return Promise.resolve({ ok: true, json: () => Promise.resolve(projectsList) });
 		}
@@ -63,7 +70,6 @@ function mockFetchProject(
 		if (opts?.method === "PATCH") {
 			return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) });
 		}
-		// project fetch
 		return Promise.resolve({ ok: true, json: () => Promise.resolve(project) });
 	});
 	vi.stubGlobal("fetch", fetchMock);
@@ -205,5 +211,28 @@ describe("ProjectLanding — archive/unarchive (PROJ-649)", () => {
 		mockFetchProject([], [], undefined, { ...PROJECT, archivedAt: 1700000000 });
 		render(<ProjectLanding />);
 		expect(await screen.findByRole("button", { name: "Unarchive" })).toBeTruthy();
+	});
+});
+
+describe("ProjectLanding — public read-only demo viewer (PROJ-580)", () => {
+	it("hides the Archive button and the description-edit affordance for the public viewer", async () => {
+		history.replaceState(null, "", "?id=p1");
+		mockFetchProject([], [], undefined, PROJECT, [PROJECT], "public-viewer@projektor.local");
+		render(<ProjectLanding />);
+		await screen.findByRole("heading", { name: "Projektor" });
+
+		expect(screen.queryByRole("button", { name: "Archive" })).toBeNull();
+		expect(screen.queryByLabelText("Edit project description")).toBeNull();
+		expect(await screen.findByText("An issue tracker.")).toBeTruthy();
+	});
+
+	it("shows the Archive button and the description-edit affordance for a real user", async () => {
+		history.replaceState(null, "", "?id=p1");
+		mockFetchProject([], [], undefined, PROJECT, [PROJECT], "real-user@example.com");
+		render(<ProjectLanding />);
+		await screen.findByRole("heading", { name: "Projektor" });
+
+		expect(await screen.findByRole("button", { name: "Archive" })).toBeTruthy();
+		expect(screen.getByLabelText("Edit project description")).toBeTruthy();
 	});
 });

--- a/apps/web/src/islands/ProjectLanding.tsx
+++ b/apps/web/src/islands/ProjectLanding.tsx
@@ -9,6 +9,7 @@ import {
 } from "../lib/project-context";
 import { statusDisplayName } from "../lib/status";
 import { apiFetch } from "../utils/api-client";
+import { usePublicViewer } from "../utils/public-viewer";
 import ProjectFlowCharts from "./ProjectFlowCharts";
 import { Button } from "./ui/Button";
 
@@ -171,6 +172,7 @@ function DescriptionEditor({
 	onSave,
 	onCancel,
 	onStartEdit,
+	canEdit,
 }: {
 	project: Project;
 	editingDesc: boolean;
@@ -182,6 +184,7 @@ function DescriptionEditor({
 	onSave: () => void;
 	onCancel: () => void;
 	onStartEdit: () => void;
+	canEdit: boolean;
 }) {
 	if (editingDesc) {
 		return (
@@ -196,7 +199,7 @@ function DescriptionEditor({
 			/>
 		);
 	}
-	return <DescriptionView project={project} onStartEdit={onStartEdit} />;
+	return <DescriptionView project={project} onStartEdit={canEdit ? onStartEdit : undefined} />;
 }
 
 function DescriptionEditForm({
@@ -244,7 +247,22 @@ function DescriptionEditForm({
 	);
 }
 
-function DescriptionView({ project, onStartEdit }: { project: Project; onStartEdit: () => void }) {
+function DescriptionView({
+	project,
+	onStartEdit,
+}: {
+	project: Project;
+	onStartEdit: (() => void) | undefined;
+}) {
+	if (!onStartEdit) {
+		return project.description ? (
+			<p class="m-0 text-text-base text-[0.9375rem] leading-[1.6] px-2 py-[0.375rem]">
+				{project.description}
+			</p>
+		) : (
+			<p class="m-0 text-text-muted text-sm italic px-2 py-[0.375rem]">No description.</p>
+		);
+	}
 	return (
 		// biome-ignore lint/a11y/useSemanticElements: div wraps block-level <p>; button can't nest <p>
 		<div
@@ -359,6 +377,7 @@ export default function ProjectLanding({ workspaceSlug }: Props) {
 
 	const projectId = projectReady.value ? (currentProject.value?.id ?? null) : undefined;
 	const resolveError = storeProjectError.value;
+	const isPublicViewer = usePublicViewer(workspaceSlug);
 
 	const [project, setProject] = useState<Project | null>(null);
 	const [recentIssues, setRecentIssues] = useState<RecentIssue[]>([]);
@@ -453,18 +472,19 @@ export default function ProjectLanding({ workspaceSlug }: Props) {
 					<h1 class="m-0 text-2xl font-bold text-text-base">{project.name}</h1>
 					<span class={KEY_BADGE_CLASS}>{project.key}</span>
 					{project.archivedAt != null && <span class={KEY_BADGE_CLASS}>Archived</span>}
-					<Button
-						type="button"
-						variant="outline"
-						size="sm"
-						onClick={toggleArchived}
-						disabled={archiving}
-					>
-						{project.archivedAt != null ? "Unarchive" : "Archive"}
-					</Button>
+					{!isPublicViewer && (
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							onClick={toggleArchived}
+							disabled={archiving}
+						>
+							{project.archivedAt != null ? "Unarchive" : "Archive"}
+						</Button>
+					)}
 				</div>
 
-				{/* Editable description */}
 				<div class="max-w-[640px]">
 					<DescriptionEditor
 						project={project}
@@ -477,6 +497,7 @@ export default function ProjectLanding({ workspaceSlug }: Props) {
 						onSave={saveDesc}
 						onCancel={cancelEditDesc}
 						onStartEdit={startEditDesc}
+						canEdit={!isPublicViewer}
 					/>
 				</div>
 			</header>

--- a/apps/web/src/islands/WikiPage.test.tsx
+++ b/apps/web/src/islands/WikiPage.test.tsx
@@ -27,11 +27,22 @@ const PAGE: WikiPageData = {
 	freshness: null,
 };
 
-function mockFetchWiki(page: WikiPageData | null, ok = true, status = 404) {
+function mockFetchWiki(
+	page: WikiPageData | null,
+	ok = true,
+	status = 404,
+	meEmail = "real-user@example.com"
+) {
 	vi.stubGlobal(
 		"fetch",
 		vi.fn().mockImplementation((url: string) => {
 			const u = String(url);
+			if (u.includes("/auth/me")) {
+				return Promise.resolve({
+					ok: true,
+					json: () => Promise.resolve({ user: { id: "u1", email: meEmail, name: "User" } }),
+				});
+			}
 			if (u.includes("/revisions")) {
 				return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
 			}
@@ -148,6 +159,36 @@ describe("WikiPage", () => {
 			expect(putCall?.[0]).toContain("/api/wiki/my-page");
 			expect(JSON.parse(putCall?.[1].body)).toEqual({ parentId: "w2" });
 		});
+	});
+});
+
+describe("WikiPage — public read-only demo viewer (PROJ-580)", () => {
+	it("hides all write affordances for the public viewer", async () => {
+		mockFetchWiki(PAGE, true, 404, "public-viewer@projektor.local");
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+		await waitFor(() => {
+			expect(screen.queryByRole("button", { name: "+ Child page" })).toBeNull();
+		});
+
+		expect(screen.queryByRole("button", { name: "+ New page" })).toBeNull();
+		expect(screen.queryByRole("button", { name: "Move" })).toBeNull();
+		expect(screen.queryByRole("button", { name: "Edit" })).toBeNull();
+		expect(screen.queryByRole("button", { name: "Delete" })).toBeNull();
+		expect(screen.queryByRole("button", { name: /Attach file/i })).toBeNull();
+	});
+
+	it("shows write affordances for a real user", async () => {
+		mockFetchWiki(PAGE, true, 404, "real-user@example.com");
+		render(<WikiPage slug="my-page" />);
+		await screen.findByText("My Page");
+
+		expect(await screen.findByRole("button", { name: "+ New page" })).toBeTruthy();
+		expect(screen.getByRole("button", { name: "+ Child page" })).toBeTruthy();
+		expect(screen.getByRole("button", { name: "Move" })).toBeTruthy();
+		expect(screen.getByRole("button", { name: "Edit" })).toBeTruthy();
+		expect(screen.getByRole("button", { name: "Delete" })).toBeTruthy();
+		expect(screen.getByRole("button", { name: /Attach file/i })).toBeTruthy();
 	});
 });
 

--- a/apps/web/src/islands/WikiPage.tsx
+++ b/apps/web/src/islands/WikiPage.tsx
@@ -5,6 +5,7 @@ import { safeDecodeURIComponent } from "../lib/urls";
 import { useAccessGate } from "../utils/access-gate";
 import { apiFetch } from "../utils/api-client";
 import { renderMdWithWikilinks, renderMermaidDiagrams, stripFrontmatter } from "../utils/markdown";
+import { usePublicViewer } from "../utils/public-viewer";
 import AccessPending from "./AccessPending";
 import type { ProjectLookup as ProjectOption } from "./board-utils";
 import MarkdownEditor from "./LazyMarkdownEditor";
@@ -242,15 +243,17 @@ function WikiVerifyControls({
 	onVerify,
 	verifying,
 	verifyError,
+	isPublicViewer,
 }: {
 	hasVerificationSignal: boolean;
 	onVerify: () => void;
 	verifying: boolean;
 	verifyError: string | null;
+	isPublicViewer: boolean;
 }) {
 	return (
 		<>
-			{hasVerificationSignal && (
+			{hasVerificationSignal && !isPublicViewer && (
 				<Button variant="outline" size="sm" onClick={onVerify} disabled={verifying}>
 					{verifying ? "Verifying…" : "Verify"}
 				</Button>
@@ -269,11 +272,13 @@ function WikiMetadataCard({
 	onVerify,
 	verifying,
 	verifyError,
+	isPublicViewer,
 }: {
 	page: WikiPageData;
 	onVerify: () => void;
 	verifying: boolean;
 	verifyError: string | null;
+	isPublicViewer: boolean;
 }) {
 	const hasMetadata =
 		Boolean(page.type) ||
@@ -297,6 +302,7 @@ function WikiMetadataCard({
 				onVerify={onVerify}
 				verifying={verifying}
 				verifyError={verifyError}
+				isPublicViewer={isPublicViewer}
 			/>
 		</div>
 	);
@@ -779,12 +785,15 @@ function WikiSidebar({
 		"wiki-sidebar",
 		drawerOpen ? "wiki-sidebar-open" : "",
 	].join(" ");
+	const isPublicViewer = usePublicViewer(workspaceSlug);
 	return (
 		<aside id="wiki-page-tree" class={asideClass} aria-label="Wiki pages" ref={sidebarRef}>
 			<ScopeControl workspaceSlug={workspaceSlug} projectId={projectId} />
-			<Button variant="primary" onClick={onCreate} class="w-full mb-4 max-sm:min-h-[44px]">
-				+ New page
-			</Button>
+			{!isPublicViewer && (
+				<Button variant="primary" onClick={onCreate} class="w-full mb-4 max-sm:min-h-[44px]">
+					+ New page
+				</Button>
+			)}
 			<input
 				type="search"
 				value={searchQuery}
@@ -1189,6 +1198,7 @@ function PageHeader({
 	onStartCreateChild,
 	onStartMove,
 	onDelete,
+	isPublicViewer,
 }: {
 	editing: boolean;
 	pageId: string;
@@ -1202,6 +1212,7 @@ function PageHeader({
 	onStartCreateChild: (pageId: string) => void;
 	onStartMove: () => void;
 	onDelete: () => void;
+	isPublicViewer: boolean;
 }) {
 	const isMobile = useIsMobileViewport();
 	return (
@@ -1219,45 +1230,47 @@ function PageHeader({
 				<h1 class="m-0 text-[1.75rem] font-bold text-text-base">{title}</h1>
 			)}
 
-			<div class="flex gap-2 shrink-0 max-sm:shrink">
-				{editing ? (
-					<>
-						<Button variant="primary" onClick={onSave} disabled={saving}>
-							{saving ? "Saving…" : "Save"}
-						</Button>
-						<Button variant="outline" onClick={onCancelEdit} disabled={saving}>
-							Cancel
-						</Button>
-					</>
-				) : isMobile ? (
-					<>
-						<Button variant="outline" onClick={onStartEdit}>
-							Edit
-						</Button>
-						<PageActionOverflowMenu
-							pageId={pageId}
-							onStartCreateChild={onStartCreateChild}
-							onStartMove={onStartMove}
-							onDelete={onDelete}
-						/>
-					</>
-				) : (
-					<>
-						<Button variant="outline" size="sm" onClick={() => onStartCreateChild(pageId)}>
-							+ Child page
-						</Button>
-						<Button variant="outline" size="sm" onClick={onStartMove}>
-							Move
-						</Button>
-						<Button variant="outline" onClick={onStartEdit}>
-							Edit
-						</Button>
-						<Button variant="danger" onClick={onDelete}>
-							Delete
-						</Button>
-					</>
-				)}
-			</div>
+			{!isPublicViewer && (
+				<div class="flex gap-2 shrink-0 max-sm:shrink">
+					{editing ? (
+						<>
+							<Button variant="primary" onClick={onSave} disabled={saving}>
+								{saving ? "Saving…" : "Save"}
+							</Button>
+							<Button variant="outline" onClick={onCancelEdit} disabled={saving}>
+								Cancel
+							</Button>
+						</>
+					) : isMobile ? (
+						<>
+							<Button variant="outline" onClick={onStartEdit}>
+								Edit
+							</Button>
+							<PageActionOverflowMenu
+								pageId={pageId}
+								onStartCreateChild={onStartCreateChild}
+								onStartMove={onStartMove}
+								onDelete={onDelete}
+							/>
+						</>
+					) : (
+						<>
+							<Button variant="outline" size="sm" onClick={() => onStartCreateChild(pageId)}>
+								+ Child page
+							</Button>
+							<Button variant="outline" size="sm" onClick={onStartMove}>
+								Move
+							</Button>
+							<Button variant="outline" onClick={onStartEdit}>
+								Edit
+							</Button>
+							<Button variant="danger" onClick={onDelete}>
+								Delete
+							</Button>
+						</>
+					)}
+				</div>
+			)}
 		</header>
 	);
 }
@@ -1456,11 +1469,13 @@ function AttachmentEntry({
 	workspaceSlug,
 	referenced,
 	onDelete,
+	isPublicViewer,
 }: {
 	attachment: Attachment;
 	workspaceSlug?: string;
 	referenced: boolean;
 	onDelete: (attachmentId: string) => void;
+	isPublicViewer: boolean;
 }) {
 	const qs = workspaceSlug ? `?workspace=${workspaceSlug}` : "";
 	return (
@@ -1484,14 +1499,16 @@ function AttachmentEntry({
 				{referenced ? "In page" : "Unreferenced"}
 			</span>
 			<span class="text-xs text-text-muted shrink-0">{formatBytes(attachment.size)}</span>
-			<Button
-				size="sm"
-				onClick={() => onDelete(attachment.id)}
-				aria-label={`Delete ${attachment.filename}`}
-				class="bg-transparent border-none text-text-muted px-[0.125rem] leading-none"
-			>
-				×
-			</Button>
+			{!isPublicViewer && (
+				<Button
+					size="sm"
+					onClick={() => onDelete(attachment.id)}
+					aria-label={`Delete ${attachment.filename}`}
+					class="bg-transparent border-none text-text-muted px-[0.125rem] leading-none"
+				>
+					×
+				</Button>
+			)}
 		</div>
 	);
 }
@@ -1565,6 +1582,7 @@ function AttachmentsPanel({
 	onCancelUpload: () => void;
 	onDeleteAttachment: (attachmentId: string) => void;
 }) {
+	const isPublicViewer = usePublicViewer(workspaceSlug);
 	return (
 		<div class="mt-8">
 			<h3 class="text-xs uppercase tracking-[0.05em] text-text-muted font-semibold mb-3 pb-2 border-b border-border">
@@ -1580,30 +1598,32 @@ function AttachmentsPanel({
 							workspaceSlug={workspaceSlug}
 							referenced={isReferenced(a.id, content)}
 							onDelete={onDeleteAttachment}
+							isPublicViewer={isPublicViewer}
 						/>
 					))}
 				</div>
 			)}
 
-			{uploadFormOpen ? (
-				<AttachmentUploadForm
-					uploadFile={uploadFile}
-					uploading={uploading}
-					uploadError={uploadError}
-					onFileChange={onFileChange}
-					onUpload={onUpload}
-					onCancel={onCancelUpload}
-				/>
-			) : (
-				<button
-					type="button"
-					onClick={() => onToggleUploadForm(true)}
-					class="text-sm text-text-muted hover:text-text-base transition-colors flex items-center gap-1"
-				>
-					<span class="text-base leading-none">+</span>
-					<span>Attach file</span>
-				</button>
-			)}
+			{!isPublicViewer &&
+				(uploadFormOpen ? (
+					<AttachmentUploadForm
+						uploadFile={uploadFile}
+						uploading={uploading}
+						uploadError={uploadError}
+						onFileChange={onFileChange}
+						onUpload={onUpload}
+						onCancel={onCancelUpload}
+					/>
+				) : (
+					<button
+						type="button"
+						onClick={() => onToggleUploadForm(true)}
+						class="text-sm text-text-muted hover:text-text-base transition-colors flex items-center gap-1"
+					>
+						<span class="text-base leading-none">+</span>
+						<span>Attach file</span>
+					</button>
+				))}
 		</div>
 	);
 }
@@ -1700,8 +1720,10 @@ function PageArticleMeta(
 		| "draftBanner"
 		| "onRestoreDraft"
 		| "onDiscardDraft"
+		| "workspaceSlug"
 	>
 ) {
+	const isPublicViewer = usePublicViewer(props.workspaceSlug);
 	return (
 		<>
 			<PageBreadcrumbs breadcrumbs={props.breadcrumbs} onNavigate={props.onNavigate} />
@@ -1730,6 +1752,7 @@ function PageArticleMeta(
 				onStartCreateChild={props.onStartCreateChild}
 				onStartMove={props.onStartMove}
 				onDelete={props.onDelete}
+				isPublicViewer={isPublicViewer}
 			/>
 
 			{!props.editing && (
@@ -1738,6 +1761,7 @@ function PageArticleMeta(
 					onVerify={props.onVerify}
 					verifying={props.verifying}
 					verifyError={props.verifyError}
+					isPublicViewer={isPublicViewer}
 				/>
 			)}
 


### PR DESCRIPTION
## Summary

Public-demo UX re-audit for PROJ-580: the anonymous `public-viewer@projektor.local`
identity should never see write affordances, even ones the server already rejects.
Found and fixed three separate surfaces where a control looked actionable but
would silently 403 if clicked (server-side authorization was already correct in
all three cases — this closes UI gaps, not security holes).

## Changes

- **`ProjectLanding.tsx`** — Archive/Unarchive button and the clickable
  "Edit project description" affordance are now hidden for the public viewer
  (mirrors `ProjectList.tsx`'s existing PROJ-568 pattern).
- **`ConnectorManager.tsx`** — the Tokens settings page surfaced a raw
  `ApiError` string to the public viewer on the connectors' server-side 403.
  Now shows the same friendly "Signed-in members only" message pattern already
  used by the sibling `TokenManager.tsx`.
- **`WikiPage.tsx`** — the largest gap: the entire page-header toolbar
  (+Child page / Move / Edit / Delete), the sidebar's "+ New page" button, the
  "Verify" button, and the attachments panel's "+ Attach file" / per-file
  delete "×" controls were all fully visible and enabled for the public
  viewer — directly contradicting the wiki's own "This demo does not allow
  creating or editing content" banner. All now gated behind the existing
  `usePublicViewer` hook.
- Regression tests added for all three components, following the same
  assertion style: absent for `public-viewer@projektor.local`, present for a
  real user.

## Verification

- Full web test suite: 709 tests passing (`pnpm --filter @projektor/web test`).
- `pnpm turbo type-check --filter=@projektor/web`: 0 errors.
- `pnpm biome check` on all changed files: clean.
- Confirmed via `apps/api/src/services/projects.ts` and
  `apps/api/src/routes/workspaces.ts` (`connectorsDenied()`) that the
  underlying mutations were already rejected server-side before touching any
  client code — this PR closes the UI gap, not a live security hole.

## HUMAN CHECK

**Try:** open https://projektor-demo.tajdickson.workers.dev in a private/incognito
window (so you land as the anonymous viewer). Click into any project and confirm
no Archive button / no clickable description. Open its Tokens settings and
confirm the Connectors section shows the friendly message, not a raw error.
Open any wiki page and confirm there's no "+ New page", "+Child page", "Move",
"Edit", "Delete", "Verify", or "+ Attach file" control anywhere — sidebar,
header, or attachments panel. Then compare against a logged-in view to confirm
real users still see all of the above.

**Least confident about:** the wiki surface is the biggest diff in this PR (six
components touched) and I verified it against jsdom tests + a `pnpm turbo
type-check`, but did the actual click-through only via Playwright against the
live demo in an earlier pass, not against this exact final commit — I'd
appreciate a real click-through on the wiki page specifically before merging,
since it has the most surface area of the three fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ijHN9yTwScXgev1rE64LM
