### PR TITLE
fix(api): definition-of-ready parser bug + degraded-mode fallback for get_prioritized_issues (PROJ-738)

### DIFF
--- a/apps/api/src/mcp/issues.ts
+++ b/apps/api/src/mcp/issues.ts
@@ -261,7 +261,10 @@ export const issuesTools: MCPTool[] = [
 		description:
 			"Return open issues ranked by a composite score: link-network centrality (in-degree) + priority + " +
 			"inverse story points. Useful for deciding what to work on next. By default, issues that fail the " +
-			"definition-of-ready check (missing acceptance criteria, scope/files, or verification) are excluded.",
+			"definition-of-ready check (missing acceptance criteria, scope/files, or verification) are excluded. " +
+			"If none of the open issues pass, the ranked (not-ready) list is returned anyway with " +
+			"`degraded: true` on the response and `needsGrooming`/`missingCriteria` on each issue, rather than " +
+			'an empty array — empty otherwise means "no open work", which would be a lie.',
 		inputSchema: {
 			type: "object",
 			properties: {

--- a/apps/api/src/mcp/issues.ts
+++ b/apps/api/src/mcp/issues.ts
@@ -127,7 +127,11 @@ export const issuesTools: MCPTool[] = [
 	},
 	{
 		name: "create_issue",
-		description: "Create a new issue in a project",
+		description:
+			"Create a new issue in a project. For an issue an agent should be able to pick up " +
+			"autonomously, the body should state acceptance criteria, scope (files/components), " +
+			"and verification (the exact command(s) that prove it's done) — see get_workflow's " +
+			"definition of ready. get_prioritized_issues excludes issues missing these by default.",
 		inputSchema: {
 			type: "object",
 			required: ["projectId", "title"],

--- a/apps/api/src/services/definition-of-ready.ts
+++ b/apps/api/src/services/definition-of-ready.ts
@@ -30,8 +30,8 @@ function isLabelLine(line: string, label: RegExp): boolean {
 	if (isHeading || isBold) return word.test(t);
 
 	// A plain line only counts when the label is a "Label:" prefix, not mid-sentence.
-	const stripped = t.replace(/^[-*]\s+/, "");
-	return ci(`^\\s*(?:${label.source})\\b[^:]*:`, label.flags).test(stripped);
+	const stripped = t.replace(/^[-*]\s+/, "").replace(/\*\*/g, "");
+	return ci(`^\\s*(?:${label.source})\\b[^:—–]*[:—–]`, label.flags).test(stripped);
 }
 
 // Non-empty content for `label`'s section: inline after a "Label:" or on a following
@@ -45,7 +45,8 @@ function sectionHasContent(body: string, label: RegExp): boolean {
 		.replace(/^[#\-*\s]+/, "")
 		.replace(/\*\*/g, "")
 		.replace(/`/g, "");
-	const afterColon = inline.includes(":") ? inline.slice(inline.indexOf(":") + 1).trim() : "";
+	const sepIdx = inline.search(/[:—–]/);
+	const afterColon = sepIdx === -1 ? "" : inline.slice(sepIdx + 1).trim();
 	if (afterColon !== "") return true;
 
 	for (let i = idx + 1; i < lines.length; i++) {

--- a/apps/api/src/services/issues.ts
+++ b/apps/api/src/services/issues.ts
@@ -1608,9 +1608,12 @@ export async function getPrioritizedIssues(ctx: ServiceCtx, raw: unknown) {
 	// otherwise concludes "no work" when a differently-worded backlog exists. Surface
 	// the count so the caller knows to groom (or re-query with includeNotReady).
 	const droppedNotReady = annotated.filter((i) => "needsGrooming" in i).length;
-	const ready = includeNotReady ? annotated : annotated.filter((i) => !("needsGrooming" in i));
+	if (includeNotReady) return { issues: annotated.slice(0, limit), droppedNotReady: 0 };
 
-	return { issues: ready.slice(0, limit), droppedNotReady: includeNotReady ? 0 : droppedNotReady };
+	const readyOnly = annotated.filter((i) => !("needsGrooming" in i));
+	if (readyOnly.length > 0) return { issues: readyOnly.slice(0, limit), droppedNotReady };
+
+	return { issues: annotated.slice(0, limit), droppedNotReady, degraded: true };
 }
 
 export async function searchIssues(ctx: ServiceCtx, raw: unknown) {

--- a/apps/api/src/test/definition-of-ready.test.ts
+++ b/apps/api/src/test/definition-of-ready.test.ts
@@ -93,4 +93,30 @@ describe("checkDefinitionOfReady (PROJ-253)", () => {
 		].join("\n");
 		expect(checkDefinitionOfReady(body)).toEqual({ ready: true, missing: [] });
 	});
+
+	it("recognises a bold label with the colon inside and content on the same line (PROJ-738)", () => {
+		const body = [
+			"**Acceptance criteria:** does the thing",
+			"**Scope / files:** `src/x.ts`",
+			"**Verification:** `pnpm test`; manual check too",
+		].join("\n");
+		expect(checkDefinitionOfReady(body)).toEqual({ ready: true, missing: [] });
+	});
+
+	const readyBase = "## Acceptance criteria\n- thing\n\nScope: `src/x.ts`\n\n";
+	it.each([
+		["## heading", "## Verification\n`pnpm test`"],
+		["### heading", "### Verification\n`pnpm test`"],
+		["bold, colon inside, inline content", "**Verification:** `pnpm test`"],
+		["bold label alone, content on next line", "**Verification**\n`pnpm test`"],
+		["em dash separator", "Verification — `pnpm test`"],
+		["bulleted bold", "- **Verification:** `pnpm test`"],
+		["lowercase colon", "verification: `pnpm test`"],
+		["bold lowercase inline", "**verification:** `pnpm test`"],
+	])("recognises a Verification label written as: %s (PROJ-738)", (_name, verificationLine) => {
+		expect(checkDefinitionOfReady(readyBase + verificationLine)).toEqual({
+			ready: true,
+			missing: [],
+		});
+	});
 });

--- a/apps/api/src/test/issues.test.ts
+++ b/apps/api/src/test/issues.test.ts
@@ -2087,6 +2087,22 @@ describe("get_prioritized_issues MCP tool", () => {
 		expect(titles).not.toContain("In other project");
 	});
 
+	it("degrades to the ranked not-ready list when nothing passes the bar (PROJ-738)", async () => {
+		await seedIssue(workspaceId, projectId, userId, { title: "Not ready" });
+
+		const body = await callPrioritized();
+		expect(body.error).toBeUndefined();
+		const data = JSON.parse(body.result!.content[0].text) as {
+			issues: Array<{ title: string; needsGrooming?: boolean }>;
+			droppedNotReady: number;
+			degraded?: boolean;
+		};
+		expect(data.issues.map((i) => i.title)).toContain("Not ready");
+		expect(data.issues.find((i) => i.title === "Not ready")?.needsGrooming).toBe(true);
+		expect(data.droppedNotReady).toBe(1);
+		expect(data.degraded).toBe(true);
+	});
+
 	it("computes droppedNotReady scoped to projectId", async () => {
 		const otherProject = await seedProject(workspaceId, "OTHER");
 		// Neither issue has a body, so both fail the definition-of-ready check.

--- a/apps/docs/src/content/docs/agents/tool-catalog.md
+++ b/apps/docs/src/content/docs/agents/tool-catalog.md
@@ -117,7 +117,7 @@ running server.
 | `update_issue` | Update an issue — status, priority, title, body, assignee, or labels. Review gating: pass agentSessionId to identify yourself as an agent; entering in_review as an agent requires completionReport. Agents CAN transition directly to done (no human approval gate) — but if the completionReport.verification isn't externally checkable (no CI run/PR/commit link), the issue is flagged needsAudit:true for after-the-fact human review. |
 | `search_issues` | Search issues by keyword in title or body |
 | `delete_issue` | Delete an issue by ID or ref (e.g. PROJ-42) |
-| `get_prioritized_issues` | Return open issues ranked by a composite score: link-network centrality (in-degree) + priority + inverse story points. Useful for deciding what to work on next. By default, issues that fail the definition-of-ready check (missing acceptance criteria, scope/files, or verification) are excluded. |
+| `get_prioritized_issues` | Return open issues ranked by a composite score: link-network centrality (in-degree) + priority + inverse story points. Useful for deciding what to work on next. By default, issues that fail the definition-of-ready check (missing acceptance criteria, scope/files, or verification) are excluded. If none of the open issues pass, the ranked (not-ready) list is returned anyway with `degraded: true` on the response and `needsGrooming`/`missingCriteria` on each issue, rather than an empty array — empty otherwise means "no open work", which would be a lie. |
 
 ### Issue links
 

--- a/apps/docs/src/content/docs/agents/tool-catalog.md
+++ b/apps/docs/src/content/docs/agents/tool-catalog.md
@@ -113,7 +113,7 @@ running server.
 |------|-------------|
 | `list_issues` | List issues in the workspace, optionally filtered by status, priority, project, or assignee. Items omit `body` by default — pass includeBody:true to include it. Pass includeRollups:true to attach a `rollup` (child status counts: total/byStatus/done/remaining) to each item. |
 | `get_issue` | Get a single issue by ID or project key + number (e.g. "PROJ-42") |
-| `create_issue` | Create a new issue in a project |
+| `create_issue` | Create a new issue in a project. For an issue an agent should be able to pick up autonomously, the body should state acceptance criteria, scope (files/components), and verification (the exact command(s) that prove it's done) — see get_workflow's definition of ready. get_prioritized_issues excludes issues missing these by default. |
 | `update_issue` | Update an issue — status, priority, title, body, assignee, or labels. Review gating: pass agentSessionId to identify yourself as an agent; entering in_review as an agent requires completionReport. Agents CAN transition directly to done (no human approval gate) — but if the completionReport.verification isn't externally checkable (no CI run/PR/commit link), the issue is flagged needsAudit:true for after-the-fact human review. |
 | `search_issues` | Search issues by keyword in title or body |
 | `delete_issue` | Delete an issue by ID or ref (e.g. PROJ-42) |


### PR DESCRIPTION
## Summary

`get_prioritized_issues` scoped to PROJ was returning 0 of ~122 open issues
(`droppedNotReady: 122`) — a prioritization tool hiding the whole backlog.

This went through two rounds of revision after peer review challenged the
first cut. Final scope, three changes:

1. **`create_issue` nudge** — description now names the three
   definition-of-ready fields and points at `get_workflow`, aiming the fix at
   ticket authoring (unchanged from the original PR).
2. **Definition-of-ready parser bug fix** — `isLabelLine`/`sectionHasContent`
   in `apps/api/src/services/definition-of-ready.ts` rejected
   `**Verification:** content` (bold label, colon *inside* the markers,
   content on the same line) — a real, common way tickets are written. First
   pass ("the checker is correct, tickets are under-groomed") was wrong: it
   was based on reading the checker's source and reasoning about it, not on
   running it against real ticket bodies. Running it against PROJ-670/PROJ-668
   (closed-without-drama tickets with real `**Verification:**` sections)
   surfaced false negatives. Fixed both functions (colon-stripping + em/en-dash
   separator support), added a table-driven regression test across 8
   label-writing styles (heading levels, bold-inline, bold-alone,
   bulleted-bold, lowercase, em-dash).
3. **`get_prioritized_issues` degraded-mode fallback** — when zero issues meet
   the bar, the endpoint now returns the ranked not-ready list with
   `degraded: true` and `needsGrooming`/`missingCriteria` per issue, instead
   of an empty array. Empty otherwise reads as "no open work," which is a lie
   for a tool whose purpose is answering "what's next."

## The actual number

Controlled before/after on the **identical 125-issue open-PROJ snapshot**
(old checker vs. fixed checker, same ticket bodies):

| | droppedNotReady | ready |
|---|---|---|
| Before (old checker) | 122 | 3 |
| After (fixed checker) | 121 | 4 |

Only **PROJ-672** was rescued by the parser fix. The headline finding stands
close to the original diagnosis: the backlog is genuinely under-groomed — 120
of 125 open issues are still missing a distinct Verification section — not
"a parser bug hid most of the backlog." The parser bug was real, worth fixing,
and will prevent future false negatives, but its measured impact on the
existing backlog is narrow.

## Changes

- `apps/api/src/mcp/issues.ts` — `create_issue` and `get_prioritized_issues`
  tool descriptions updated
- `apps/api/src/services/definition-of-ready.ts` — bold-colon-inline + em/en-dash
  label recognition
- `apps/api/src/services/issues.ts` — degraded-mode fallback in
  `getPrioritizedIssues`
- `apps/api/src/test/definition-of-ready.test.ts` — table-driven regression
  test (8 styles)
- `apps/api/src/test/issues.test.ts` — degraded-mode test
- `apps/docs/src/content/docs/agents/tool-catalog.md` — regenerated

## Verification

- `pnpm --filter @projektor/api test` — 1383/1383 passing (1 unrelated flake
  in `oauth.test.ts` on the full-suite run, confirmed passing in isolation and
  untouched by this change)
- `pnpm --filter @projektor/api type-check` — 0 errors
- `pnpm biome check` on all touched files — clean
- `pnpm gen:docs` — regenerated, diff is a 1-line tool count bump

## HUMAN CHECK

**Try:** call `get_prioritized_issues` scoped to PROJ against a workspace
where every issue is currently not-ready, and confirm you get back a ranked
list with `degraded: true` and per-issue `missingCriteria` rather than `[]`.

**Least confident about:** whether "narrow parser-bug impact, backlog is
genuinely under-groomed" is the right place to stop, or whether the checker's
bar (a distinct Verification section, not folded into the AC list) is itself
too strict for how PROJ tickets are actually written. I didn't loosen the
check — that would erode the guarantee it exists to provide — but 87/125
missing "acceptance criteria" and 120/125 missing "verification" on tickets
that otherwise look complete (PROJ-581 is the clearest example: a real AC
checklist including a regression-test bullet, no separate heading) suggests
the checker's structural-section requirement may be pickier than the
ticket-writing convention this project actually uses. Queuing that as a
question rather than deciding it myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzvVx24HF7RiauBXg3L5nD