### PR TITLE
fix(api): pin rate-limit window clock in tests to stop suite-load flakes (PROJ-741)

### DIFF
--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -30,9 +30,11 @@ export async function rateLimitMiddleware(
 	next: Next
 ): Promise<Response | undefined> {
 	const windowSecs = parseInt(c.env.RATE_LIMIT_WINDOW_SECS ?? "60", 10);
-	const nowMs = c.env.RATE_LIMIT_TEST_NOW_MS
-		? parseInt(c.env.RATE_LIMIT_TEST_NOW_MS, 10)
-		: Date.now();
+	const testNow =
+		c.env.ENVIRONMENT !== "production" && c.env.RATE_LIMIT_TEST_NOW_MS
+			? Number(c.env.RATE_LIMIT_TEST_NOW_MS)
+			: NaN;
+	const nowMs = Number.isFinite(testNow) ? testNow : Date.now();
 	const now = Math.floor(nowMs / 1000);
 	const slot = Math.floor(now / windowSecs) * windowSecs; // fixed-window start timestamp
 

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -30,7 +30,10 @@ export async function rateLimitMiddleware(
 	next: Next
 ): Promise<Response | undefined> {
 	const windowSecs = parseInt(c.env.RATE_LIMIT_WINDOW_SECS ?? "60", 10);
-	const now = Math.floor(Date.now() / 1000);
+	const nowMs = c.env.RATE_LIMIT_TEST_NOW_MS
+		? parseInt(c.env.RATE_LIMIT_TEST_NOW_MS, 10)
+		: Date.now();
+	const now = Math.floor(nowMs / 1000);
 	const slot = Math.floor(now / windowSecs) * windowSecs; // fixed-window start timestamp
 
 	const authHeader = c.req.header("Authorization");

--- a/apps/api/src/test/oauth-metadata.test.ts
+++ b/apps/api/src/test/oauth-metadata.test.ts
@@ -1,4 +1,4 @@
-import { SELF } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
 
 // PROJ-655: the two public OAuth discovery documents.
@@ -169,10 +169,12 @@ describe("discovery endpoints are rate-limited", () => {
 		// counter before each test, so the 4th request in this test is the first to
 		// exceed it. Without the /.well-known/* limiter mount these would all be 200:
 		// rateLimitMiddleware was previously mounted on /api/* and /mcp/* only.
+		env.RATE_LIMIT_TEST_NOW_MS = String(Date.now());
 		const ip = { "CF-Connecting-IP": "203.0.113.7" };
 		for (let i = 0; i < 3; i++) {
 			expect((await SELF.fetch(AS_URL, { headers: ip })).status).toBe(200);
 		}
 		expect((await SELF.fetch(AS_URL, { headers: ip })).status).toBe(429);
+		env.RATE_LIMIT_TEST_NOW_MS = undefined;
 	});
 });

--- a/apps/api/src/test/oauth.test.ts
+++ b/apps/api/src/test/oauth.test.ts
@@ -781,14 +781,12 @@ describe("the request limiter keys on the grant, not the token (PROJ-658)", () =
 		const user = await seedUser(email);
 		await seedMember(workspace.id, user.id, "member");
 
+		env.RATE_LIMIT_TEST_NOW_MS = String(Date.now());
 		const { tokens, clientId } = await connect({ email, workspaceId: workspace.id });
 		for (let i = 0; i < API_LIMIT; i++) {
 			expect((await mcpCall(workspace.id, tokens.access_token, "list_projects")).status).toBe(200);
 		}
 
-		// A rotated access token carries the same <userId>:<grantId> prefix, so it lands in
-		// the bucket the previous one filled. Keyed on the whole token, an hourly refresh
-		// would reset the budget and the limit would mean nothing.
 		const refreshed = await exchange({
 			grant_type: "refresh_token",
 			refresh_token: tokens.refresh_token,
@@ -798,6 +796,7 @@ describe("the request limiter keys on the grant, not the token (PROJ-658)", () =
 		const rotated = await refreshed.json<TokenResponse>();
 		expect(rotated.access_token).not.toBe(tokens.access_token);
 		expect((await mcpCall(workspace.id, rotated.access_token, "list_projects")).status).toBe(429);
+		env.RATE_LIMIT_TEST_NOW_MS = undefined;
 
 		// And the other direction: a second connector for the same person gets its own
 		// budget, so one noisy client cannot lock the user out of the rest.

--- a/packages/types/src/env.ts
+++ b/packages/types/src/env.ts
@@ -64,6 +64,7 @@ export interface Env {
 	// Optional: opt-in real-time WebSocket hub (Durable Objects). Omitted for
 	// free-tier/1-click deployments; present when opt-in real-time features are enabled.
 	WORKSPACE_HUB?: DurableObjectNamespace;
+	RATE_LIMIT_TEST_NOW_MS?: string;
 }
 
 export interface RealtimeEvent<T = unknown> {


### PR DESCRIPTION
## Summary
`rateLimitMiddleware`'s fixed-window slot was computed from a live `Date.now()`, so any test that fills a window and expects the next request to 429 was exposed to the window silently rolling over if real wall-clock advanced past the boundary between requests under full-suite contention.

## Why not remove the underlying condition?
The rate limiter *should* use real wall-clock time in production — that's what makes a fixed window actually fixed to real time, and there's no deterministic substitute for that in a live deployment. The flakiness was purely a test-environment problem: a test asserting "these N requests land in the same window" is making a timing assumption that full-suite parallel load can violate, not evidence of a production defect. So the fix pins the clock in the two affected tests, not in production behavior.

## Confirming the mechanism
Ruled out the grant-key-parsing hypothesis (an OAuth-specific alternative explanation): `oauth-metadata.test.ts`'s discovery-endpoint rate-limit test is purely IP-keyed, with zero token-parsing logic in its path, yet failed with the identical `expected 200 to be 429` symptom in the same full-suite run that the PROJ-658 `oauth.test.ts` test did. Two structurally unrelated tests hitting the same symptom, sharing only the fixed-window-on-real-clock design, is strong evidence this is a general wall-clock rollover issue, not something specific to rotated-token grant-key derivation.

## Fix
Added `RATE_LIMIT_TEST_NOW_MS`, an env override read only by `rateLimitMiddleware`, honoured only when `ENVIRONMENT !== "production"` and only when it parses to a finite number (an unparseable value falls back to real `Date.now()` rather than propagating `NaN` into the window-slot key, which would otherwise collapse every request into one permanently-shared bucket). Both affected tests now pin it for the span of their fill-then-check request sequence, making the window boundary deterministic instead of load-dependent. `bumpRateCounter` (the separate auth-failure throttle) is untouched — narrower fix, no reported flake there.

## Known gap
A pre-existing comment above the `refreshed = await exchange(...)` call in `oauth.test.ts` — explaining that a rotated token shares its predecessor's rate-limit bucket, and why that matters (an hourly refresh must not reset the quota) — was inadvertently dropped while instrumenting the original diagnosis and could not be restored via Edit (the repo's comment-count pre-commit hook rejects any edit that nets new comment lines, even a pure revert). Flagged for a human to restore or mark `HUMAN-APPROVED`.

## Test plan
- [x] `pnpm --filter @projektor/api test` — 1383/1383 passing, run multiple times via `rtk proxy` (unfiltered output) with no flake after the fix
- [x] `pnpm --filter @projektor/api type-check` — 0 errors
- [x] `pnpm --filter @projektor/types type-check` — 0 errors
- [x] `pnpm biome check` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzvVx24HF7RiauBXg3L5nD