### PR TITLE
ci(release): require human approval before publishing a release (PROJ-737)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
     name: Build & publish release artifact
     needs: ci
     runs-on: ubuntu-latest
+    environment: production-release
     env:
       VERSION: ${{ github.event.inputs.version || github.ref_name }}
     steps:


### PR DESCRIPTION
Implements the release gate decided on PROJ-737.

## What changed

One line: the `release` job in `.github/workflows/release.yml` now runs in the `production-release` GitHub environment. That environment (created via the API, not in this diff) has **TAJD as a required reviewer**, so the job halts in a visible pending-approval state until a human approves it in the Actions UI.

## Why it sits on `release` and not elsewhere

The chain is `release-prepare` PR merges → `release-tag.yml` tags → `release.yml` builds, publishes the GitHub Release, and dispatches to the deploy repo → `projektor-workspace/deploy.yml` deploys to Cloudflare.

Gating the `release` job is upstream of the artifact build, the GitHub Release, and the cross-repo dispatch. **One gate therefore covers the whole chain through to the production deploy**, rather than gating only the last hop.

It deliberately does *not* gate the `ci` job. CI still runs unattended, so what you are approving is already known to be green — the approval prompt is a decision, not a wait.

## `prevent_self_review` is set to false, on purpose

TAJD is the sole reviewer. With self-review prevented, every release would deadlock permanently. This is a "make it a separate, deliberate action" gate, not a two-person rule — a two-person rule is not available with one maintainer.

## What this does and does not achieve

It does **not** restrain an agent session directly, and nothing in-repo can: every session shares one `gh` identity, so nothing downstream distinguishes an agent release from a human one (DEV-48 holds that finding). What it does is require an action taken **outside the session**, on a surface the session cannot reach.

It also addresses the concrete risk named on the ticket — that a chat instruction is scoped to a moment, while sessions run for hours across context compactions. "Do another patch update" is unambiguous when said; the same words recalled from a summary three hours later are not.

## Verification

Per the ticket's acceptance criterion, the gate is verified by **attempting the blocked action and confirming refusal**, not by confirming the configuration was applied. Evidence is posted to PROJ-737.

## HUMAN CHECK

**30 seconds:** open <https://github.com/TAJD/projektor/settings/environments> and confirm `production-release` lists TAJD under required reviewers. Then, on the next real release, expect an email and a "Review deployments" button in the Actions run — the release will not publish until you press it.

**Least confident in:** whether `release-tag.yml`'s automatic tag push interacts awkwardly with the gate in practice. The tag is created and pushed regardless; the gate stops the release *artifact* from being built and published. So a rejected or ignored approval leaves a tag on `main` with no corresponding GitHub Release. That is recoverable (delete the tag) but it is a state that did not previously exist, and I have not exercised it end to end.

**To revert:** delete the `environment: production-release` line from `.github/workflows/release.yml`. The environment itself can stay; it has no effect unless a job references it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G9iDH9kYA3oshpoj4U4wf6